### PR TITLE
add device selector to Dense

### DIFF
--- a/sentence_transformers/models/Dense.py
+++ b/sentence_transformers/models/Dense.py
@@ -41,5 +41,6 @@ class Dense(nn.Module):
 
         config['activation_function'] = import_from_string(config['activation_function'])()
         model = Dense(**config)
-        model.load_state_dict(torch.load(os.path.join(input_path, 'pytorch_model.bin')))
+        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        model.load_state_dict(torch.load(os.path.join(input_path, 'pytorch_model.bin'), map_location=device))
         return model


### PR DESCRIPTION
I ran into an issue when tried to load the distiluse-base-multilingual-cased model using CPU only. This fix adds the device selector. This PR is safe to merge. Looking forward to use the updated package.