### PR TITLE
Bugfix for input_mask

### DIFF
--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -152,7 +152,7 @@ class SentenceTransformer(nn.Sequential):
 
                 if output_value == 'token_embeddings':
                     #Set token embeddings to 0 for padding tokens
-                    input_mask = out_features['input_mask']
+                    input_mask = out_features['attention_mask']
                     input_mask_expanded = input_mask.unsqueeze(-1).expand(embeddings.size()).float()
                     embeddings = embeddings * input_mask_expanded
 


### PR DESCRIPTION
Hello, 

I was trying to run the basic example using output_value="token_embeddings" as documented in the SentenceTransformers class. It fails because input_mask is missing in the features dictionary, but works as expected with attention_mask instead. See below


```
from sentence_transformers import SentenceTransformer
model = SentenceTransformer('bert-base-nli-mean-tokens')

sentences = ['This framework generates embeddings for each input sentence',
    'Sentences are passed as a list of string.', 
    'The quick brown fox jumps over the lazy dog.']
sentence_embeddings = model.encode(sentences, output_value="token_embeddings")


~/projects/sentence_transformers/sentence_transformers/SentenceTransformer.py in encode(self, sentences, batch_size, show_progress_bar, output_value, convert_to_numpy)
    153                 if output_value == 'token_embeddings':
    154                     #Set token embeddings to 0 for padding tokens
--> 155                     input_mask = out_features['input_mask']
    156                     input_mask_expanded = input_mask.unsqueeze(-1).expand(embeddings.size()).float()
    157                     embeddings = embeddings * input_mask_expanded

KeyError: 'input_mask'
```