### PR TITLE
Integration of fast Rust-based tokenizers for WordPiece models

### DIFF
--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -176,7 +176,10 @@ class SentenceTransformer(nn.Sequential):
         return self._first_module().tokenize(text)
 
     def batch_tokenize(self, batch):
-        return self._first_module().tokenizer.batch_encode_plus(batch, return_attention_mask=False)["input_ids"]
+        if hasattr(self._first_module().tokenizer, "batch_encode_plus"):
+            return self._first_module().tokenizer.batch_encode_plus(batch, return_attention_mask=False)["input_ids"]
+        else:
+            return [self._first_module().tokenizer.tokenize(text) for text in batch]
 
     def get_sentence_features(self, *features):
         return self._first_module().get_sentence_features(*features)

--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -175,6 +175,9 @@ class SentenceTransformer(nn.Sequential):
     def tokenize(self, text):
         return self._first_module().tokenize(text)
 
+    def batch_tokenize(self, batch):
+        return self._first_module().tokenizer.batch_encode_plus(batch, return_attention_mask=False)["input_ids"]
+
     def get_sentence_features(self, *features):
         return self._first_module().get_sentence_features(*features)
 

--- a/sentence_transformers/models/BERT.py
+++ b/sentence_transformers/models/BERT.py
@@ -1,5 +1,5 @@
 from torch import nn
-from transformers import BertModel, BertTokenizer
+from transformers import BertModel, BertTokenizerFast
 import json
 from typing import List, Dict, Optional
 import os
@@ -25,7 +25,7 @@ class BERT(nn.Module):
             tokenizer_args['do_lower_case'] = do_lower_case
 
         self.bert = BertModel.from_pretrained(model_name_or_path, **model_args)
-        self.tokenizer = BertTokenizer.from_pretrained(model_name_or_path, **tokenizer_args)
+        self.tokenizer = BertTokenizerFast.from_pretrained(model_name_or_path, **tokenizer_args)
 
 
     def forward(self, features):
@@ -47,7 +47,7 @@ class BERT(nn.Module):
         """
         Tokenizes a text and maps tokens to token-ids
         """
-        return self.tokenizer.convert_tokens_to_ids(self.tokenizer.tokenize(text))
+        return self.tokenizer.encode(text)
 
     def get_sentence_features(self, tokens: List[int], pad_seq_length: int):
         """
@@ -61,7 +61,7 @@ class BERT(nn.Module):
         """
         pad_seq_length = min(pad_seq_length, self.max_seq_length) + 2  ##Add Space for CLS + SEP token
 
-        return self.tokenizer.prepare_for_model(tokens, max_length=pad_seq_length, pad_to_max_length=True, return_tensors='pt')
+        return self.tokenizer.prepare_for_model(tokens, max_length=pad_seq_length, pad_to_max_length=True, return_tensors='pt', add_special_tokens = False)
 
 
     def get_config_dict(self):

--- a/sentence_transformers/models/DistilBERT.py
+++ b/sentence_transformers/models/DistilBERT.py
@@ -1,6 +1,6 @@
 from torch import Tensor
 from torch import nn
-from transformers import DistilBertModel, DistilBertTokenizer
+from transformers import DistilBertModel, DistilBertTokenizerFast
 import json
 from typing import Union, Tuple, List, Dict, Optional
 import os
@@ -26,7 +26,7 @@ class DistilBERT(nn.Module):
             tokenizer_args['do_lower_case'] = do_lower_case
 
         self.bert = DistilBertModel.from_pretrained(model_name_or_path, **model_args)
-        self.tokenizer = DistilBertTokenizer.from_pretrained(model_name_or_path,  **tokenizer_args)
+        self.tokenizer = DistilBertTokenizerFast.from_pretrained(model_name_or_path, **tokenizer_args)
 
     def forward(self, features):
         """Returns token_embeddings, cls_token"""
@@ -49,7 +49,7 @@ class DistilBERT(nn.Module):
         """
         Tokenizes a text and maps tokens to token-ids
         """
-        return self.tokenizer.convert_tokens_to_ids(self.tokenizer.tokenize(text))
+        return self.tokenizer.encode(text)
 
     def get_sentence_features(self, tokens: List[int], pad_seq_length: int):
         """
@@ -62,7 +62,7 @@ class DistilBERT(nn.Module):
         :return: embedding ids, segment ids and mask for the sentence
         """
         pad_seq_length = min(pad_seq_length, self.max_seq_length) + 2 #Add space for special tokens
-        return self.tokenizer.prepare_for_model(tokens, max_length=pad_seq_length, pad_to_max_length=True, return_tensors='pt')
+        return self.tokenizer.prepare_for_model(tokens, max_length=pad_seq_length, pad_to_max_length=True, return_tensors='pt', add_special_tokens=False)
 
     def get_config_dict(self):
         return {key: self.__dict__[key] for key in self.config_keys}

--- a/sentence_transformers/models/RoBERTa.py
+++ b/sentence_transformers/models/RoBERTa.py
@@ -1,6 +1,6 @@
 from torch import Tensor
 from torch import nn
-from transformers import RobertaModel, RobertaTokenizer
+from transformers import RobertaModel, RobertaTokenizerFast
 import json
 from typing import Union, Tuple, List, Dict, Optional
 import os
@@ -26,7 +26,7 @@ class RoBERTa(nn.Module):
             tokenizer_args['do_lower_case'] = do_lower_case
 
         self.roberta = RobertaModel.from_pretrained(model_name_or_path, **model_args)
-        self.tokenizer = RobertaTokenizer.from_pretrained(model_name_or_path, **tokenizer_args)
+        self.tokenizer = RobertaTokenizerFast.from_pretrained(model_name_or_path, **tokenizer_args)
 
 
     def forward(self, features):
@@ -48,7 +48,7 @@ class RoBERTa(nn.Module):
         """
         Tokenizes a text and maps tokens to token-ids
         """
-        return self.tokenizer.convert_tokens_to_ids(self.tokenizer.tokenize(text))
+        return self.tokenizer.encode(text)
 
     def get_sentence_features(self, tokens: List[int], pad_seq_length: int):
         """
@@ -61,7 +61,7 @@ class RoBERTa(nn.Module):
         :return: embedding ids, segment ids and mask for the sentence
         """
         pad_seq_length = min(pad_seq_length, self.max_seq_length) + 2 ##Add Space for CLS + SEP token
-        return self.tokenizer.prepare_for_model(tokens, max_length=pad_seq_length, pad_to_max_length=True, return_tensors='pt')
+        return self.tokenizer.prepare_for_model(tokens, max_length=pad_seq_length, pad_to_max_length=True, return_tensors='pt', add_special_tokens = False)
 
     def get_config_dict(self):
         return {key: self.__dict__[key] for key in self.config_keys}

--- a/sentence_transformers/models/Transformer.py
+++ b/sentence_transformers/models/Transformer.py
@@ -17,7 +17,7 @@ class Transformer(nn.Module):
 
         config = AutoConfig.from_pretrained(model_name_or_path, **model_args, cache_dir=cache_dir)
         self.auto_model = AutoModel.from_pretrained(model_name_or_path, config=config, cache_dir=cache_dir)
-        self.tokenizer = AutoTokenizer.from_pretrained(model_name_or_path, cache_dir=cache_dir)
+        self.tokenizer = AutoTokenizer.from_pretrained(model_name_or_path, use_fast=True, cache_dir=cache_dir)
 
 
     def forward(self, features):
@@ -45,7 +45,7 @@ class Transformer(nn.Module):
         """
         Tokenizes a text and maps tokens to token-ids
         """
-        return self.tokenizer.convert_tokens_to_ids(self.tokenizer.tokenize(text))
+        return self.tokenizer.encode(text)
 
     def get_sentence_features(self, tokens: List[int], pad_seq_length: int):
         """
@@ -58,7 +58,7 @@ class Transformer(nn.Module):
         :return: embedding ids, segment ids and mask for the sentence
         """
         pad_seq_length = min(pad_seq_length, self.max_seq_length) + 3 #Add space for special tokens
-        return self.tokenizer.prepare_for_model(tokens, max_length=pad_seq_length, pad_to_max_length=True, return_tensors='pt')
+        return self.tokenizer.prepare_for_model(tokens, max_length=pad_seq_length, pad_to_max_length=True, return_tensors='pt', add_special_tokens=False)
 
     def get_config_dict(self):
         return {key: self.__dict__[key] for key in self.config_keys}


### PR DESCRIPTION
Hello, I have rewritten the tokenization for WordPiece-based models to make them use the Fast versions of Huggingface tokenizers (the Fast versions are implemented in Rust rather than pure Python) - this yields ~10x improvement in speed for longer texts.

The Fast tokenizers also allow for multi-threaded tokenization on batches - this required changes in the SentencesDataset loop to make it batched. I observed that using 15 CPU cores, it runs around 60x faster in my use-case than the current master branch.

There are some interesting considerations:

- I was able to replicate the results you have in Github Readme. In fact, the results are now even better. Running `/examples/evaluation/evaluation_stsbenchmark.py` for Bert/Distilbert replicates the table in "Trained on NLI Data" section, but Roberta has around 0.5 higher score. Likewise, I tried running `/examples/training_transformers/training_stsbenchmark.py` with both bert-base-uncased and albert-base-v1 (which does not even have a Fast tokenizer available) and in both cases, my branch has 0.5-1 point higher score on STS eval than the current master branch.

- I also ran the Clustering/Semantic search examples - the semantic search results seem significantly improved in the sense that the difference between relevant/non-relevant sentences is much bigger

- I tried running the tests but it did not work for me even on master

- _Technical details_ - The Fast and Slow versions have non-uniform interfaces. In order to support both, I had to make changes to the tokenization methods, but it seems to work well as it is now. For example, `BertTokenizerFast.tokenize` already inserts special tokens while the slow versions do not. In my branch, the `SentenceTransformer.tokenize` outputs the special tokens as well (which is not the case for master) but they are not added in `SentenceTransformer.get_sentence_features` (again opposite of master). It thus cancels out. 

I thought it would be possible to add `add_special_tokens=False `to the Fast tokenizer initialization and to calls to `.encode` which would maintain the current behavior, but then DistilbertTokenizerFast was failing for some reason (BertTokenizerFast was fine however; there is some internal difference between them in how they handle the parameters I think)



It seems to me that the tokenizers overall have some slight inconsistencies/bugs, and the current tokenization loop works better now for unknown reasons.

In any case, I hope you will find this useful.

Best regards



