### PR TITLE
fix unnecessary "is" to "==" for avoiding SyntaxWarning in python 3.8

### DIFF
--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -48,7 +48,7 @@ class SentenceTransformer(nn.Sequential):
                 os.makedirs(model_path, exist_ok=True)
 
                 if not os.listdir(model_path):
-                    if model_url[-1] is "/":
+                    if model_url[-1] == "/":
                         model_url = model_url[:-1]
                     logging.info("Downloading sentence transformer model from {} and saving it at {}".format(model_url, model_path))
                     try:


### PR DESCRIPTION
the current code results following SyntaxWarning.
I replaced "is" with "==" to avoid this warning.

~/.pyenv/versions/3.8.1/lib/python3.8/site-packages/sentence_transformers-0.2.5-py3.8.egg/sentence_transformers/SentenceTransformer.py:52: SyntaxWarning: "is" with a literal. Did you mean "=="?