### PR TITLE
Add autonotebook to fix training in colab

### DIFF
--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -13,7 +13,7 @@ from numpy import ndarray
 from torch import nn, Tensor
 from torch.optim import Optimizer
 from torch.utils.data import DataLoader
-from tqdm import tqdm, trange
+from tqdm.autonotebook import tqdm, trange
 
 from . import __DOWNLOAD_SERVER__
 from .evaluation import SentenceEvaluator


### PR DESCRIPTION
tqdm's default console progress produces millions of lines, which slows down a Colab page specifically.

So I added auto check.