### PR TITLE
fix(forward): detach tensors from computationnal graph to release gpu…

### DIFF
--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -157,7 +157,7 @@ class SentenceTransformer(nn.Sequential):
                     embeddings = embeddings * input_mask_expanded
 
                 if convert_to_numpy:
-                    embeddings = embeddings.to('cpu').numpy()
+                    embeddings = np.copy(embeddings.cpu().detach().numpy())
 
                 all_embeddings.extend(embeddings)
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", mode="r", encoding="utf-8") as readme_file:
 
 setup(
     name="sentence-transformers",
-    version="0.2.6.2",
+    version="0.2.6.2.prevision",
     author="Nils Reimers, Gregor Geigle",
     author_email="Rnils@web.de",
     description="Sentence Embeddings using BERT / RoBERTa / XLNet",


### PR DESCRIPTION
detach tensors from computationnal graph to release gpu memory during forward pass.
this limits the needs for GPU to maintain batched embeddings tensors output of shape = [ batch_size, 768]