### PR TITLE
Adding support for more triplet losses

### DIFF
--- a/examples/training_transformers/training_batch_hard_trec_continue_training.py
+++ b/examples/training_transformers/training_batch_hard_trec_continue_training.py
@@ -18,6 +18,10 @@ which sentence with another label is the closest (hard negative example). It the
 all sentences with the same label should be close and sentences for different labels should be clearly seperated.
 """
 
+import sys
+mypath = "/home/cdimachkie/projects/sentence-transformers/"
+sys.path.insert(0, mypath)
+
 from sentence_transformers import (
     SentenceTransformer,
     SentenceLabelDataset,
@@ -120,7 +124,17 @@ dataset_train = SentenceLabelDataset(
     provide_negative=False,
 )
 train_dataloader = DataLoader(dataset_train, shuffle=True, batch_size=train_batch_size)
-train_loss = losses.BatchHardTripletLoss(sentence_embedder=model)
+
+### Triplet losses ####################
+### There are 3 triplet loss variants:
+### - BatchHardTripletLoss
+### - BatchHardSoftMarginTripletLoss
+### - BatchSemiHardTripletLoss
+#######################################
+
+#train_loss = losses.BatchHardTripletLoss(sentence_embedder=model)
+#train_loss = losses.BatchHardSoftMarginTripletLoss(sentence_embedder=model)
+train_loss = losses.BatchSemiHardTripletLoss(sentence_embedder=model)
 
 logging.info("Read TREC val dataset")
 dataset_dev = SentenceLabelDataset(examples=val, model=model)

--- a/examples/training_transformers/training_batch_hard_trec_continue_training.py
+++ b/examples/training_transformers/training_batch_hard_trec_continue_training.py
@@ -18,10 +18,6 @@ which sentence with another label is the closest (hard negative example). It the
 all sentences with the same label should be close and sentences for different labels should be clearly seperated.
 """
 
-import sys
-mypath = "/home/cdimachkie/projects/sentence-transformers/"
-sys.path.insert(0, mypath)
-
 from sentence_transformers import (
     SentenceTransformer,
     SentenceLabelDataset,

--- a/sentence_transformers/losses/BatchHardSoftMarginTripletLoss.py
+++ b/sentence_transformers/losses/BatchHardSoftMarginTripletLoss.py
@@ -19,6 +19,16 @@ class BatchHardSoftMarginTripletLoss(BatchHardTripletLoss):
     # Paper: In Defense of the Triplet Loss for Person Re-Identification, https://arxiv.org/abs/1703.07737
     @staticmethod
     def batch_hard_triplet_soft_margin_loss(labels: Tensor, embeddings: Tensor, squared: bool = False) -> Tensor:
+        """Build the triplet loss over a batch of embeddings.
+        For each anchor, we get the hardest positive and hardest negative to form a triplet.
+        Args:
+            labels: labels of the batch, of size (batch_size,)
+            embeddings: tensor of shape (batch_size, embed_dim)
+            squared: Boolean. If true, output is the pairwise squared euclidean distance matrix.
+                     If false, output is the pairwise euclidean distance matrix.
+        Returns:
+            Label_Sentence_Triplet: scalar tensor containing the triplet loss
+        """
         # Get the pairwise distance matrix
         pairwise_dist = BatchHardTripletLoss._pairwise_distances(embeddings, squared=squared)
         #pairwise_dist = BatchHardTripletLoss._cosine_distance(embeddings)

--- a/sentence_transformers/losses/BatchHardSoftMarginTripletLoss.py
+++ b/sentence_transformers/losses/BatchHardSoftMarginTripletLoss.py
@@ -1,0 +1,22 @@
+import torch
+from torch import nn, Tensor
+from typing import Union, Tuple, List, Iterable, Dict
+
+from .BatchHardTripletLoss import BatchHardTripletLoss
+
+class BatchHardSoftMarginTripletLoss(BatchHardTripletLoss):
+    def __init__(self, sentence_embedder):
+        super(BatchHardSoftMarginTripletLoss, self).__init__(sentence_embedder)
+        self.sentence_embedder = sentence_embedder
+
+    def forward(self, sentence_features: Iterable[Dict[str, Tensor]], labels: Tensor):
+        reps = [self.sentence_embedder(sentence_feature)['sentence_embedding'] for sentence_feature in sentence_features]
+
+        return BatchHardSoftMarginTripletLoss.batch_hard_triplet_soft_margin_loss(labels, reps[0])
+
+
+    # Hard Triplet Loss with Soft Margin
+    # Paper: In Defense of the Triplet Loss for Person Re-Identification, https://arxiv.org/abs/1703.07737
+    @staticmethod
+    def batch_hard_triplet_soft_margin_loss(labels: Tensor, embeddings: Tensor, squared: bool = False) -> Tensor:
+        pass

--- a/sentence_transformers/losses/BatchHardSoftMarginTripletLoss.py
+++ b/sentence_transformers/losses/BatchHardSoftMarginTripletLoss.py
@@ -19,4 +19,35 @@ class BatchHardSoftMarginTripletLoss(BatchHardTripletLoss):
     # Paper: In Defense of the Triplet Loss for Person Re-Identification, https://arxiv.org/abs/1703.07737
     @staticmethod
     def batch_hard_triplet_soft_margin_loss(labels: Tensor, embeddings: Tensor, squared: bool = False) -> Tensor:
-        pass
+        # Get the pairwise distance matrix
+        pairwise_dist = BatchHardTripletLoss._pairwise_distances(embeddings, squared=squared)
+        #pairwise_dist = BatchHardTripletLoss._cosine_distance(embeddings)
+
+        # For each anchor, get the hardest positive
+        # First, we need to get a mask for every valid positive (they should have same label)
+        mask_anchor_positive = BatchHardTripletLoss._get_anchor_positive_triplet_mask(labels).float()
+
+        # We put to 0 any element where (a, p) is not valid (valid if a != p and label(a) == label(p))
+        anchor_positive_dist = mask_anchor_positive * pairwise_dist
+
+        # shape (batch_size, 1)
+        hardest_positive_dist, _ = anchor_positive_dist.max(1, keepdim=True)
+
+        # For each anchor, get the hardest negative
+        # First, we need to get a mask for every valid negative (they should have different labels)
+        mask_anchor_negative = BatchHardTripletLoss._get_anchor_negative_triplet_mask(labels).float()
+
+        # We add the maximum value in each row to the invalid negatives (label(a) == label(n))
+        max_anchor_negative_dist, _ = pairwise_dist.max(1, keepdim=True)
+        anchor_negative_dist = pairwise_dist + max_anchor_negative_dist * (1.0 - mask_anchor_negative)
+
+        # shape (batch_size,)
+        hardest_negative_dist, _ = anchor_negative_dist.min(1, keepdim=True)
+
+        # Combine biggest d(a, p) and smallest d(a, n) into final triplet loss with soft margin
+        #tl = hardest_positive_dist - hardest_negative_dist + margin
+        #tl[tl < 0] = 0
+        tl = torch.log1p(torch.exp(hardest_positive_dist - hardest_negative_dist))
+        triplet_loss = tl.mean()
+
+        return triplet_loss

--- a/sentence_transformers/losses/BatchSemiHardTripletLoss.py
+++ b/sentence_transformers/losses/BatchSemiHardTripletLoss.py
@@ -1,0 +1,22 @@
+import torch
+from torch import nn, Tensor
+from typing import Union, Tuple, List, Iterable, Dict
+
+
+class BatchSemiHardTripletLoss(nn.Module):
+    def __init__(self, sentence_embedder, triplet_margin: float = 1):
+        super(BatchSemiHardTripletLoss, self).__init__()
+        self.sentence_embedder = sentence_embedder
+        self.triplet_margin = triplet_margin
+
+    def forward(self, sentence_features: Iterable[Dict[str, Tensor]], labels: Tensor):
+        reps = [self.sentence_embedder(sentence_feature)['sentence_embedding'] for sentence_feature in sentence_features]
+
+        return BatchSemiHardTripletLoss.batch_semi_hard_triplet_loss(labels, reps[0], margin=self.triplet_margin)
+
+
+    # Semi-Hard Triplet Loss
+    # Paper: In Defense of the Triplet Loss for Person Re-Identification, https://arxiv.org/abs/1703.07737
+    @staticmethod
+    def batch_semi_hard_triplet_loss(labels: Tensor, embeddings: Tensor, margin: float, squared: bool = False) -> Tensor:
+        pass

--- a/sentence_transformers/losses/BatchSemiHardTripletLoss.py
+++ b/sentence_transformers/losses/BatchSemiHardTripletLoss.py
@@ -16,10 +16,21 @@ class BatchSemiHardTripletLoss(nn.Module):
 
 
     # Semi-Hard Triplet Loss
-    # https://github.com/tensorflow/addons/blob/master/tensorflow_addons/losses/triplet.py#L71
+    # Based on: https://github.com/tensorflow/addons/blob/master/tensorflow_addons/losses/triplet.py#L71
     # Paper: FaceNet: A Unified Embedding for Face Recognition and Clustering: https://arxiv.org/pdf/1503.03832.pdf
     @staticmethod
     def batch_semi_hard_triplet_loss(labels: Tensor, embeddings: Tensor, margin: float, squared: bool = False) -> Tensor:
+        """Build the triplet loss over a batch of embeddings.
+        We generate all the valid triplets and average the loss over the positive ones.
+        Args:
+            labels: labels of the batch, of size (batch_size,)
+            embeddings: tensor of shape (batch_size, embed_dim)
+            margin: margin for triplet loss
+            squared: Boolean. If true, output is the pairwise squared euclidean distance matrix.
+                     If false, output is the pairwise euclidean distance matrix.
+        Returns:
+            Label_Sentence_Triplet: scalar tensor containing the triplet loss
+        """
         labels = labels.unsqueeze(1)
 
         pdist_matrix = BatchSemiHardTripletLoss._pairwise_distances(embeddings, squared)

--- a/sentence_transformers/losses/BatchSemiHardTripletLoss.py
+++ b/sentence_transformers/losses/BatchSemiHardTripletLoss.py
@@ -16,7 +16,93 @@ class BatchSemiHardTripletLoss(nn.Module):
 
 
     # Semi-Hard Triplet Loss
-    # Paper: In Defense of the Triplet Loss for Person Re-Identification, https://arxiv.org/abs/1703.07737
+    # https://github.com/tensorflow/addons/blob/master/tensorflow_addons/losses/triplet.py#L71
+    # Paper: FaceNet: A Unified Embedding for Face Recognition and Clustering: https://arxiv.org/pdf/1503.03832.pdf
     @staticmethod
     def batch_semi_hard_triplet_loss(labels: Tensor, embeddings: Tensor, margin: float, squared: bool = False) -> Tensor:
-        pass
+        labels = labels.unsqueeze(1)
+
+        pdist_matrix = BatchSemiHardTripletLoss._pairwise_distances(embeddings, squared)
+        #pdist_matrix = BatchSemiHardTripletLoss._cosine_distance(embeddings)
+
+        adjacency = labels == labels.t()
+        adjacency_not = ~adjacency
+
+        batch_size = torch.numel(labels)
+        pdist_matrix_tile = pdist_matrix.repeat([batch_size, 1])
+
+        mask = adjacency_not.repeat([batch_size, 1]) & (pdist_matrix_tile > torch.reshape(pdist_matrix.t(), [-1, 1]))
+
+        mask_final = torch.reshape(torch.sum(mask, 1, keepdims=True) > 0.0, [batch_size, batch_size])
+        mask_final = mask_final.t()
+
+        negatives_outside = torch.reshape(BatchSemiHardTripletLoss._masked_minimum(pdist_matrix_tile, mask), [batch_size, batch_size])
+        negatives_outside = negatives_outside.t()
+
+        negatives_inside = BatchSemiHardTripletLoss._masked_maximum(pdist_matrix, adjacency_not)
+        negatives_inside = negatives_inside.repeat([1, batch_size])
+
+        semi_hard_negatives = torch.where(mask_final, negatives_outside, negatives_inside)
+
+        loss_mat = (pdist_matrix - semi_hard_negatives) + margin
+
+        mask_positives = adjacency.float().cuda() - torch.eye(batch_size).cuda()
+        mask_positives = mask_positives.cuda()
+        num_positives = torch.sum(mask_positives)
+
+        triplet_loss = torch.sum(torch.max(loss_mat * mask_positives, torch.tensor([0.0]).cuda())) / num_positives
+
+        return triplet_loss
+
+    @staticmethod
+    def _masked_minimum(data, mask, dim=1):
+        axis_maximums, _ = data.max(dim, keepdims=True)
+        masked_minimums = (data - axis_maximums) * mask
+        masked_minimums, _ = masked_minimums.min(dim, keepdims=True)
+        masked_minimums += axis_maximums
+
+        return masked_minimums
+
+    @staticmethod
+    def _masked_maximum(data, mask, dim=1):
+        axis_minimums, _ = data.min(dim, keepdims=True)
+        masked_maximums = (data - axis_minimums) * mask
+        masked_maximums, _ = masked_maximums.max(dim, keepdims=True)
+        masked_maximums += axis_minimums
+
+        return masked_maximums
+
+    @staticmethod
+    def _pairwise_distances(embeddings, squared=False):
+        """Compute the 2D matrix of distances between all the embeddings.
+        Args:
+            embeddings: tensor of shape (batch_size, embed_dim)
+            squared: Boolean. If true, output is the pairwise squared euclidean distance matrix.
+                     If false, output is the pairwise euclidean distance matrix.
+        Returns:
+            pairwise_distances: tensor of shape (batch_size, batch_size)
+        """
+        dot_product = torch.matmul(embeddings, embeddings.t())
+
+        # Get squared L2 norm for each embedding. We can just take the diagonal of `dot_product`.
+        # This also provides more numerical stability (the diagonal of the result will be exactly 0).
+        # shape (batch_size,)
+        square_norm = torch.diag(dot_product)
+
+        # Compute the pairwise distance matrix as we have:
+        # ||a - b||^2 = ||a||^2  - 2 <a, b> + ||b||^2
+        # shape (batch_size, batch_size)
+        distances = square_norm.unsqueeze(0) - 2.0 * dot_product + square_norm.unsqueeze(1)
+
+        # Because of computation errors, some distances might be negative so we put everything >= 0.0
+        distances[distances < 0] = 0
+
+        if not squared:
+            # Because the gradient of sqrt is infinite when distances == 0.0 (ex: on the diagonal)
+            # we need to add a small epsilon where distances == 0.0
+            mask = distances.eq(0).float()
+            distances = distances + mask * 1e-16
+
+            distances = (1.0 - mask) * torch.sqrt(distances)
+
+        return distances

--- a/sentence_transformers/losses/__init__.py
+++ b/sentence_transformers/losses/__init__.py
@@ -1,6 +1,7 @@
 from .CosineSimilarityLoss import *
 from .SoftmaxLoss import *
 from .BatchHardTripletLoss import *
+from .BatchHardSoftMarginTripletLoss import *
 from .MultipleNegativesRankingLoss import *
 from .TripletLoss import *
 from .MSELoss import *

--- a/sentence_transformers/losses/__init__.py
+++ b/sentence_transformers/losses/__init__.py
@@ -1,7 +1,9 @@
 from .CosineSimilarityLoss import *
 from .SoftmaxLoss import *
-from .BatchHardTripletLoss import *
-from .BatchHardSoftMarginTripletLoss import *
 from .MultipleNegativesRankingLoss import *
 from .TripletLoss import *
 from .MSELoss import *
+# Triplet losses
+from .BatchHardTripletLoss import *
+from .BatchHardSoftMarginTripletLoss import *
+from .BatchSemiHardTripletLoss import *


### PR DESCRIPTION
As requested in #279, I'm contributing the improved triplet loss functions I've been using to train my models with great success.

The new losses are drop-in replacements for **BatchHardTripletLoss**, so they are very easy to use:

- **BatchHardSoftMarginTripletLoss**: A soft-margin variant that doesn't require setting a margin
- **BatchSemiHardTripletLoss**: Uses a semi-hard margin as described in the paper [_FaceNet: A Unified Embedding for Face Recognition and Clustering_](https://arxiv.org/pdf/1503.03832.pdf)

A quick benchmark on the TREC dataset (and easily reproducible with the example in `examples/training_transformers/training_batch_hard_trec_continue_training.py`) shows:

- **BatchHardTripletLoss**: _Accuracy Euclidean Distance:_ 0.9600
- **BatchHardSoftMarginTripletLoss**: _Accuracy Euclidean Distance:_ 0.9620 (very close to BatchHardTripletLoss but **doesn't need to set a margin manually**)
- **BatchSemiHardTripletLoss**: _Accuracy Euclidean Distance:_ **0.9740** (gives even better results thanks to semi-hard triplets)

Hope this helps those having issues with making BatchHardTripletLoss stable.

Resolves #279 