### PR TITLE
SentenceDataset.convert_input_examples docstring fix

### DIFF
--- a/sentence_transformers/datasets/SentencesDataset.py
+++ b/sentence_transformers/datasets/SentencesDataset.py
@@ -35,8 +35,6 @@ class SentencesDataset(Dataset):
             the input examples for the training
         :param model
             the Sentence BERT model for the conversion
-        :return: a SmartBatchingDataset usable to train the model with SentenceTransformer.smart_batching_collate as the collate_fn
-            for the DataLoader
         """
         num_texts = len(examples[0].texts)
         inputs = [[] for _ in range(num_texts)]


### PR DESCRIPTION
SentenceDataset.convert_input_examples doesn't return a SmartBatchingDataset. Remove return statement from `convert_input_examples`'s Docstring.