### PR TITLE
Add option to pass params to tokenizer.

### DIFF
--- a/sentence_transformers/models/Transformer.py
+++ b/sentence_transformers/models/Transformer.py
@@ -9,15 +9,21 @@ import logging
 class Transformer(nn.Module):
     """Huggingface AutoModel to generate token embeddings.
     Loads the correct class, e.g. BERT / RoBERTa etc.
+
+    :param tokenizer_args: Dict with parameters which are passed to the tokenizer.
     """
-    def __init__(self, model_name_or_path: str, max_seq_length: int = 128, model_args: Dict = {}, cache_dir: Optional[str] = None ):
+    def __init__(self, model_name_or_path: str, max_seq_length: int = 128,
+                 model_args: Dict = {}, cache_dir: Optional[str] = None,
+                 tokenizer_args: Dict = {}):
         super(Transformer, self).__init__()
         self.config_keys = ['max_seq_length']
         self.max_seq_length = max_seq_length
 
         config = AutoConfig.from_pretrained(model_name_or_path, **model_args, cache_dir=cache_dir)
         self.auto_model = AutoModel.from_pretrained(model_name_or_path, config=config, cache_dir=cache_dir)
-        self.tokenizer = AutoTokenizer.from_pretrained(model_name_or_path, cache_dir=cache_dir)
+        self.tokenizer = AutoTokenizer.from_pretrained(model_name_or_path,
+                                                       cache_dir=cache_dir,
+                                                       **tokenizer_args)
 
 
     def forward(self, features):


### PR DESCRIPTION
This adds the option to pass parameters to the tokenizer that is created with the `Pooling` `__init__` constructor. This way it is possible to use fast tokenizers or change the tokenizer to upper case for example.

This option was implemented on other places:

https://github.com/UKPLab/sentence-transformers/blob/c6f8c542378dc979a55355bd562c8f1401e62f14/sentence_transformers/models/BERT.py#L14-L28

... but somehow forgotten here.