### PR TITLE
Changed label logic to better identify integers

### DIFF
--- a/sentence_transformers/datasets/SentencesDataset.py
+++ b/sentence_transformers/datasets/SentencesDataset.py
@@ -1,3 +1,4 @@
+import numpy as np
 from torch.utils.data import Dataset
 from typing import List
 import torch
@@ -25,7 +26,7 @@ class SentencesDataset(Dataset):
         """
         self.model = model
         self.examples = examples
-        self.label_type = torch.long if isinstance(self.examples[0].label, int) else torch.float
+        self.label_type = torch.long if isinstance(self.examples[0].label, np.integer) else torch.float
 
 
     def __getitem__(self, item):


### PR DESCRIPTION
Added this change to better identify integers, the earlier method cannot did not consider numpy integers (np.int16/32/64, signed, longlong, ...) as valid integers, creating errors in subsequent pipeline
classification problems where expected dtype is integer but is processed as long, where label type was np.int16/32/ ...