### PR TITLE
Always store best_score

### DIFF
--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -604,9 +604,10 @@ class SentenceTransformer(nn.Sequential):
             score = evaluator(self, output_path=output_path, epoch=epoch, steps=steps)
             if callback is not None:
                 callback(score, epoch, steps)
-            if score > self.best_score and save_best_model:
-                self.save(output_path)
+            if score > self.best_score:
                 self.best_score = score
+                if save_best_model:
+                    self.save(output_path)
 
 
     def _get_scheduler(self, optimizer, scheduler: str, warmup_steps: int, t_total: int):


### PR DESCRIPTION
This is just a small fix.

- the best_score during training had been stored only when save_best_model was true
- now best_score is always stored