### PR TITLE
Fix tripletLoss

### DIFF
--- a/sentence_transformers/losses/BatchHardTripletLoss.py
+++ b/sentence_transformers/losses/BatchHardTripletLoss.py
@@ -90,7 +90,9 @@ class BatchHardTripletLoss(nn.Module):
 
     def forward(self, sentence_features: Iterable[Dict[str, Tensor]], labels: Tensor):
         reps = [self.sentence_embedder(sentence_feature)['sentence_embedding'] for sentence_feature in sentence_features]
-        return self.batch_hard_triplet_loss(labels, reps[0])
+        repss = torch.cat(reps)
+        labels = labels.repeat(len(reps))
+        return self.batch_hard_triplet_loss(labels, repss)
 
 
     # Hard Triplet Loss


### PR DESCRIPTION
fix #391 

[this line of the code](https://github.com/UKPLab/sentence-transformers/blob/master/sentence_transformers/losses/BatchHardTripletLoss.py#L93) break the loss. You cannot only take the first one of the return. If you put all instances of one class in a InputExample, this line made the code only use the first example to train. And in the following procedure, the in-class distance will be taken as 0, which make it much smaller than the distance between different classes. Gradient will be 0, and network won't converge.

`        return self.batch_hard_triplet_loss(labels, reps[0])
`
My fix ignore the situation which use label as `the true distance between instances`,  like the implement in #448

I have not tested the other class which  inherit `BatchHardTripletLoss`.
