### PR TITLE
Per Module Logger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea
+.vscode
 *.pyc
 *.gz
 *.tsv

--- a/examples/evaluation/evaluation_translation_matching.py
+++ b/examples/evaluation/evaluation_translation_matching.py
@@ -34,6 +34,8 @@ logging.basicConfig(format='%(asctime)s - %(message)s',
                     level=logging.INFO,
                     handlers=[LoggingHandler()])
 
+logger = logging.getLogger(__name__)
+
 model_name = sys.argv[1]
 filepaths = sys.argv[2:]
 inference_batch_size = 32
@@ -51,7 +53,7 @@ for filepath in filepaths:
                 src_sentences.append(splits[0])
                 trg_sentences.append(splits[1])
 
-    logging.info(os.path.basename(filepath)+": "+str(len(src_sentences))+" sentence pairs")
+    logger.info(os.path.basename(filepath)+": "+str(len(src_sentences))+" sentence pairs")
     dev_trans_acc = evaluation.TranslationEvaluator(src_sentences, trg_sentences, name=os.path.basename(filepath), batch_size=inference_batch_size)
     dev_trans_acc(model)
 

--- a/examples/training/avg_word_embeddings/training_stsbenchmark_avg_word_embeddings.py
+++ b/examples/training/avg_word_embeddings/training_stsbenchmark_avg_word_embeddings.py
@@ -19,8 +19,9 @@ from datetime import datetime
 #### Just some code to print debug information to stdout
 logging.basicConfig(format='%(asctime)s - %(message)s',
                     datefmt='%Y-%m-%d %H:%M:%S',
-                    level=logging.INFO,
+                    level=logging.info,
                     handlers=[LoggingHandler()])
+logger = logging.getLogger(__name__)
 #### /print debug information to stdout
 
 # Read the dataset
@@ -48,18 +49,18 @@ model = SentenceTransformer(modules=[word_embedding_model, pooling_model, dan1, 
 
 
 # Convert the dataset to a DataLoader ready for training
-logging.info("Read STSbenchmark train dataset")
+logger.info("Read STSbenchmark train dataset")
 train_data = SentencesDataset(sts_reader.get_examples('sts-train.csv'), model=model)
 train_dataloader = DataLoader(train_data, shuffle=True, batch_size=batch_size)
 train_loss = losses.CosineSimilarityLoss(model=model)
 
-logging.info("Read STSbenchmark dev dataset")
+logger.info("Read STSbenchmark dev dataset")
 evaluator = EmbeddingSimilarityEvaluator.from_input_examples(sts_reader.get_examples('sts-dev.csv'))
 
 # Configure the training
 num_epochs = 10
 warmup_steps = math.ceil(len(train_data) * num_epochs / batch_size * 0.1) #10% of train data for warm-up
-logging.info("Warmup-steps: {}".format(warmup_steps))
+logger.info("Warmup-steps: {}".format(warmup_steps))
 
 # Train the model
 model.fit(train_objectives=[(train_dataloader, train_loss)],

--- a/examples/training/avg_word_embeddings/training_stsbenchmark_bilstm.py
+++ b/examples/training/avg_word_embeddings/training_stsbenchmark_bilstm.py
@@ -19,6 +19,7 @@ logging.basicConfig(format='%(asctime)s - %(message)s',
                     datefmt='%Y-%m-%d %H:%M:%S',
                     level=logging.INFO,
                     handlers=[LoggingHandler()])
+logger = logging.getLogger(__name__)
 #### /print debug information to stdout
 
 # Read the dataset
@@ -44,18 +45,18 @@ model = SentenceTransformer(modules=[word_embedding_model, lstm, pooling_model])
 
 
 # Convert the dataset to a DataLoader ready for training
-logging.info("Read STSbenchmark train dataset")
+logger.info("Read STSbenchmark train dataset")
 train_data = SentencesDataset(sts_reader.get_examples('sts-train.csv'), model=model)
 train_dataloader = DataLoader(train_data, shuffle=True, batch_size=batch_size)
 train_loss = losses.CosineSimilarityLoss(model=model)
 
-logging.info("Read STSbenchmark dev dataset")
+logger.info("Read STSbenchmark dev dataset")
 evaluator = EmbeddingSimilarityEvaluator.from_input_examples(sts_reader.get_examples('sts-dev.csv'))
 
 # Configure the training
 num_epochs = 10
 warmup_steps = math.ceil(len(train_data) * num_epochs / batch_size * 0.1) #10% of train data for warm-up
-logging.info("Warmup-steps: {}".format(warmup_steps))
+logger.info("Warmup-steps: {}".format(warmup_steps))
 
 # Train the model
 model.fit(train_objectives=[(train_dataloader, train_loss)],

--- a/examples/training/avg_word_embeddings/training_stsbenchmark_bow.py
+++ b/examples/training/avg_word_embeddings/training_stsbenchmark_bow.py
@@ -20,6 +20,7 @@ logging.basicConfig(format='%(asctime)s - %(message)s',
                     datefmt='%Y-%m-%d %H:%M:%S',
                     level=logging.INFO,
                     handlers=[LoggingHandler()])
+logger = logging.getLogger(__name__)
 #### /print debug information to stdout
 
 # Read the dataset
@@ -63,18 +64,18 @@ model = SentenceTransformer(modules=[bow, dan1, dan2])
 
 
 # Convert the dataset to a DataLoader ready for training
-logging.info("Read STSbenchmark train dataset")
+logger.info("Read STSbenchmark train dataset")
 train_data = SentencesDataset(sts_reader.get_examples('sts-train.csv'), model=model)
 train_dataloader = DataLoader(train_data, shuffle=True, batch_size=batch_size)
 train_loss = losses.CosineSimilarityLoss(model=model)
 
-logging.info("Read STSbenchmark dev dataset")
+logger.info("Read STSbenchmark dev dataset")
 evaluator = EmbeddingSimilarityEvaluator.from_input_examples(sts_reader.get_examples('sts-dev.csv'))
 
 # Configure the training
 num_epochs = 10
 warmup_steps = math.ceil(len(train_data) * num_epochs / batch_size * 0.1) #10% of train data for warm-up
-logging.info("Warmup-steps: {}".format(warmup_steps))
+logger.info("Warmup-steps: {}".format(warmup_steps))
 
 # Train the model
 model.fit(train_objectives=[(train_dataloader, train_loss)],

--- a/examples/training/avg_word_embeddings/training_stsbenchmark_cnn.py
+++ b/examples/training/avg_word_embeddings/training_stsbenchmark_cnn.py
@@ -19,6 +19,7 @@ logging.basicConfig(format='%(asctime)s - %(message)s',
                     datefmt='%Y-%m-%d %H:%M:%S',
                     level=logging.INFO,
                     handlers=[LoggingHandler()])
+logger = logging.getLogger(__name__)
 #### /print debug information to stdout
 
 # Read the dataset
@@ -44,18 +45,18 @@ model = SentenceTransformer(modules=[word_embedding_model, cnn, pooling_model])
 
 
 # Convert the dataset to a DataLoader ready for training
-logging.info("Read STSbenchmark train dataset")
+logger.info("Read STSbenchmark train dataset")
 train_data = SentencesDataset(sts_reader.get_examples('sts-train.csv'), model=model)
 train_dataloader = DataLoader(train_data, shuffle=True, batch_size=batch_size)
 train_loss = losses.CosineSimilarityLoss(model=model)
 
-logging.info("Read STSbenchmark dev dataset")
+logger.info("Read STSbenchmark dev dataset")
 evaluator = EmbeddingSimilarityEvaluator.from_input_examples(sts_reader.get_examples('sts-dev.csv'))
 
 # Configure the training
 num_epochs = 10
 warmup_steps = math.ceil(len(train_data) * num_epochs / batch_size * 0.1) #10% of train data for warm-up
-logging.info("Warmup-steps: {}".format(warmup_steps))
+logger.info("Warmup-steps: {}".format(warmup_steps))
 
 # Train the model
 model.fit(train_objectives=[(train_dataloader, train_loss)],

--- a/examples/training/avg_word_embeddings/training_stsbenchmark_tf-idf_word_embeddings.py
+++ b/examples/training/avg_word_embeddings/training_stsbenchmark_tf-idf_word_embeddings.py
@@ -23,6 +23,7 @@ logging.basicConfig(format='%(asctime)s - %(message)s',
                     datefmt='%Y-%m-%d %H:%M:%S',
                     level=logging.INFO,
                     handlers=[LoggingHandler()])
+logger = logging.getLogger(__name__)
 #### /print debug information to stdout
 
 # Read the dataset
@@ -68,18 +69,18 @@ model = SentenceTransformer(modules=[word_embedding_model, word_weights, pooling
 
 
 # Convert the dataset to a DataLoader ready for training
-logging.info("Read STSbenchmark train dataset")
+logger.info("Read STSbenchmark train dataset")
 train_data = SentencesDataset(sts_reader.get_examples('sts-train.csv'), model=model)
 train_dataloader = DataLoader(train_data, shuffle=True, batch_size=batch_size)
 train_loss = losses.CosineSimilarityLoss(model=model)
 
-logging.info("Read STSbenchmark dev dataset")
+logger.info("Read STSbenchmark dev dataset")
 evaluator = EmbeddingSimilarityEvaluator.from_input_examples(sts_reader.get_examples('sts-dev.csv'))
 
 # Configure the training
 num_epochs = 10
 warmup_steps = math.ceil(len(train_data) * num_epochs / batch_size * 0.1) #10% of train data for warm-up
-logging.info("Warmup-steps: {}".format(warmup_steps))
+logger.info("Warmup-steps: {}".format(warmup_steps))
 
 # Train the model
 model.fit(train_objectives=[(train_dataloader, train_loss)],

--- a/examples/training/cross-encoder/training_nli.py
+++ b/examples/training/cross-encoder/training_nli.py
@@ -24,6 +24,7 @@ logging.basicConfig(format='%(asctime)s - %(message)s',
                     datefmt='%Y-%m-%d %H:%M:%S',
                     level=logging.INFO,
                     handlers=[LoggingHandler()])
+logger = logging.getLogger(__name__)
 #### /print debug information to stdout
 
 
@@ -36,7 +37,7 @@ if not os.path.exists(nli_dataset_path):
 
 
 # Read the AllNLI.tsv.gz file and create the training dataset
-logging.info("Read AllNLI train dataset")
+logger.info("Read AllNLI train dataset")
 
 label2int = {"contradiction": 0, "entailment": 1, "neutral": 2}
 train_samples = []
@@ -67,7 +68,7 @@ evaluator = CESoftmaxAccuracyEvaluator.from_input_examples(dev_samples, name='Al
 
 
 warmup_steps = math.ceil(len(train_dataloader) * num_epochs * 0.1) #10% of train data for warm-up
-logging.info("Warmup-steps: {}".format(warmup_steps))
+logger.info("Warmup-steps: {}".format(warmup_steps))
 
 
 # Train the model

--- a/examples/training/cross-encoder/training_quora_duplicate_questions.py
+++ b/examples/training/cross-encoder/training_quora_duplicate_questions.py
@@ -26,6 +26,7 @@ logging.basicConfig(format='%(asctime)s - %(message)s',
                     datefmt='%Y-%m-%d %H:%M:%S',
                     level=logging.INFO,
                     handlers=[LoggingHandler()])
+logger = logging.getLogger(__name__)
 #### /print debug information to stdout
 
 
@@ -34,7 +35,7 @@ logging.basicConfig(format='%(asctime)s - %(message)s',
 dataset_path = 'quora-dataset/'
 
 if not os.path.exists(dataset_path):
-    logging.info("Dataset not found. Download")
+    logger.info("Dataset not found. Download")
     zip_save_path = 'quora-IR-dataset.zip'
     util.http_get(url='https://sbert.net/datasets/quora-IR-dataset.zip', path=zip_save_path)
     with ZipFile(zip_save_path, 'r') as zip:
@@ -42,7 +43,7 @@ if not os.path.exists(dataset_path):
 
 
 # Read the quora dataset split for classification
-logging.info("Read train dataset")
+logger.info("Read train dataset")
 train_samples = []
 with open(os.path.join(dataset_path, 'classification', 'train_pairs.tsv'), 'r', encoding='utf8') as fIn:
     reader = csv.DictReader(fIn, delimiter='\t', quoting=csv.QUOTE_NONE)
@@ -51,7 +52,7 @@ with open(os.path.join(dataset_path, 'classification', 'train_pairs.tsv'), 'r', 
         train_samples.append(InputExample(texts=[row['question2'], row['question1']], label=int(row['is_duplicate'])))
 
 
-logging.info("Read dev dataset")
+logger.info("Read dev dataset")
 dev_samples = []
 with open(os.path.join(dataset_path, 'classification', 'dev_pairs.tsv'), 'r', encoding='utf8') as fIn:
     reader = csv.DictReader(fIn, delimiter='\t', quoting=csv.QUOTE_NONE)
@@ -78,7 +79,7 @@ evaluator = CEBinaryClassificationEvaluator.from_input_examples(dev_samples, nam
 
 # Configure the training
 warmup_steps = math.ceil(len(train_dataloader) * num_epochs * 0.1) #10% of train data for warm-up
-logging.info("Warmup-steps: {}".format(warmup_steps))
+logger.info("Warmup-steps: {}".format(warmup_steps))
 
 
 # Train the model

--- a/examples/training/cross-encoder/training_stsbenchmark.py
+++ b/examples/training/cross-encoder/training_stsbenchmark.py
@@ -25,6 +25,7 @@ logging.basicConfig(format='%(asctime)s - %(message)s',
                     datefmt='%Y-%m-%d %H:%M:%S',
                     level=logging.INFO,
                     handlers=[LoggingHandler()])
+logger = logging.getLogger(__name__)
 #### /print debug information to stdout
 
 
@@ -48,7 +49,7 @@ model = CrossEncoder('distilroberta-base', num_labels=1)
 
 
 # Read STSb dataset
-logging.info("Read STSbenchmark train dataset")
+logger.info("Read STSbenchmark train dataset")
 
 train_samples = []
 dev_samples = []
@@ -78,7 +79,7 @@ evaluator = CECorrelationEvaluator.from_input_examples(dev_samples, name='sts-de
 
 # Configure the training
 warmup_steps = math.ceil(len(train_dataloader) * num_epochs * 0.1) #10% of train data for warm-up
-logging.info("Warmup-steps: {}".format(warmup_steps))
+logger.info("Warmup-steps: {}".format(warmup_steps))
 
 
 # Train the model

--- a/examples/training/data_augmentation/train_sts_indomain_semantic.py
+++ b/examples/training/data_augmentation/train_sts_indomain_semantic.py
@@ -1,12 +1,12 @@
 """
 The script shows how to train Augmented SBERT (In-Domain) strategy for STSb dataset with Semantic Search Sampling.
-For Simplicity, we use a pre-trained SBERT (bert-base-nli-stsb-mean-tokens) for the example shown below. 
+For Simplicity, we use a pre-trained SBERT (bert-base-nli-stsb-mean-tokens) for the example shown below.
 In theory, you can also train a bi-encoder (SBERT) on STSb gold dataset and use for semantic search.
 
 Methodology:
-Three steps are followed for AugSBERT data-augmentation strategy with Semantic Search - 
+Three steps are followed for AugSBERT data-augmentation strategy with Semantic Search -
     1. Fine-tune cross-encoder (BERT) on gold STSb dataset
-    2. Fine-tuned Cross-encoder is used to label on Sem. Search sampled unlabeled pairs (silver STSb dataset) 
+    2. Fine-tuned Cross-encoder is used to label on Sem. Search sampled unlabeled pairs (silver STSb dataset)
     3. Bi-encoder (SBERT) is finally fine-tuned on both gold + silver STSb dataset
 
 Citation: https://arxiv.org/abs/2010.08240
@@ -41,6 +41,7 @@ logging.basicConfig(format='%(asctime)s - %(message)s',
                     datefmt='%Y-%m-%d %H:%M:%S',
                     level=logging.INFO,
                     handlers=[LoggingHandler()])
+logger = logging.getLogger(__name__)
 #### /print debug information to stdout
 
 
@@ -64,13 +65,13 @@ cross_encoder_path = 'output/cross-encoder/stsb_indomain_'+model_name.replace("/
 bi_encoder_path = 'output/bi-encoder/stsb_augsbert_SS_'+model_name.replace("/", "-")+'-'+datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
 
 ###### Cross-encoder (simpletransformers) ######
-logging.info("Loading cross-encoder model: {}".format(model_name))
+logger.info("Loading cross-encoder model: {}".format(model_name))
 # Use Huggingface/transformers model (like BERT, RoBERTa, XLNet, XLM-R) for cross-encoder model
 cross_encoder = CrossEncoder(model_name, num_labels=1)
 
 
 ###### Bi-encoder (sentence-transformers) ######
-logging.info("Loading bi-encoder model: {}".format(model_name))
+logger.info("Loading bi-encoder model: {}".format(model_name))
 # Use Huggingface/transformers model (like BERT, RoBERTa, XLNet, XLM-R) for mapping tokens to embeddings
 word_embedding_model = models.Transformer(model_name, max_seq_length=max_seq_length)
 
@@ -89,7 +90,7 @@ bi_encoder = SentenceTransformer(modules=[word_embedding_model, pooling_model])
 #
 #####################################################
 
-logging.info("Step 1: Train cross-encoder: {} with STSbenchmark (gold dataset)".format(model_name))
+logger.info("Step 1: Train cross-encoder: {} with STSbenchmark (gold dataset)".format(model_name))
 
 gold_samples = []
 dev_samples = []
@@ -119,7 +120,7 @@ evaluator = CECorrelationEvaluator.from_input_examples(dev_samples, name='sts-de
 
 # Configure the training
 warmup_steps = math.ceil(len(train_dataloader) * num_epochs * 0.1) #10% of train data for warm-up
-logging.info("Warmup-steps: {}".format(warmup_steps))
+logger.info("Warmup-steps: {}".format(warmup_steps))
 
 # Train the cross-encoder model
 cross_encoder.fit(train_dataloader=train_dataloader,
@@ -138,7 +139,7 @@ cross_encoder.fit(train_dataloader=train_dataloader,
 #### Top k similar sentences to be retrieved ####
 #### Larger the k, bigger the silver dataset ####
 
-logging.info("Step 2.1: Generate STSbenchmark (silver dataset) using pretrained SBERT \
+logger.info("Step 2.1: Generate STSbenchmark (silver dataset) using pretrained SBERT \
     model and top-{} semantic search combinations".format(top_k))
 
 silver_data = []
@@ -155,12 +156,12 @@ duplicates = set((sent2idx[data.texts[0]], sent2idx[data.texts[1]]) for data in 
 # For simplicity we use a pretrained model
 semantic_model_name = 'bert-base-nli-stsb-mean-tokens'
 semantic_search_model = SentenceTransformer(semantic_model_name)
-logging.info("Encoding unique sentences with semantic search model: {}".format(semantic_model_name))
+logger.info("Encoding unique sentences with semantic search model: {}".format(semantic_model_name))
 
 # encoding all unique sentences present in the training dataset
 embeddings = semantic_search_model.encode(sentences, batch_size=batch_size, convert_to_tensor=True)
 
-logging.info("Retrieve top-{} with semantic search model: {}".format(top_k, semantic_model_name))
+logger.info("Retrieve top-{} with semantic search model: {}".format(top_k, semantic_model_name))
 
 # retrieving top-k sentences given a sentence from the dataset
 progress = tqdm.tqdm(unit="docs", total=len(sent2idx))
@@ -172,7 +173,7 @@ for idx in range(len(sentences)):
 
     #We use torch.topk to find the highest 5 scores
     top_results = torch.topk(cos_scores, k=top_k+1)
-    
+
     for score, iid in zip(top_results[0], top_results[1]):
         if iid != idx and (iid, idx) not in duplicates:
             silver_data.append((sentences[idx], sentences[iid]))
@@ -181,8 +182,8 @@ for idx in range(len(sentences)):
 progress.reset()
 progress.close()
 
-logging.info("Length of silver_dataset generated: {}".format(len(silver_data)))
-logging.info("Step 2.2: Label STSbenchmark (silver dataset) with cross-encoder: {}".format(model_name))
+logger.info("Length of silver_dataset generated: {}".format(len(silver_data)))
+logger.info("Step 2.2: Label STSbenchmark (silver dataset) with cross-encoder: {}".format(model_name))
 cross_encoder = CrossEncoder(cross_encoder_path)
 silver_scores = cross_encoder.predict(silver_data)
 
@@ -195,10 +196,10 @@ assert all(0.0 <= score <= 1.0 for score in silver_scores)
 #
 ############################################################################################
 
-logging.info("Step 3: Train bi-encoder: {} with STSbenchmark (gold + silver dataset)".format(model_name))
+logger.info("Step 3: Train bi-encoder: {} with STSbenchmark (gold + silver dataset)".format(model_name))
 
 # Convert the dataset to a DataLoader ready for training
-logging.info("Read STSbenchmark gold and silver train dataset")
+logger.info("Read STSbenchmark gold and silver train dataset")
 silver_samples = list(InputExample(texts=[data[0], data[1]], label=score) for \
     data, score in zip(silver_data, silver_scores))
 
@@ -206,12 +207,12 @@ train_dataset = SentencesDataset(gold_samples + silver_samples, bi_encoder)
 train_dataloader = DataLoader(train_dataset, shuffle=True, batch_size=batch_size)
 train_loss = losses.CosineSimilarityLoss(model=bi_encoder)
 
-logging.info("Read STSbenchmark dev dataset")
+logger.info("Read STSbenchmark dev dataset")
 evaluator = EmbeddingSimilarityEvaluator.from_input_examples(dev_samples, name='sts-dev')
 
 # Configure the training.
 warmup_steps = math.ceil(len(train_dataset) * num_epochs / batch_size * 0.1) #10% of train data for warm-up
-logging.info("Warmup-steps: {}".format(warmup_steps))
+logger.info("Warmup-steps: {}".format(warmup_steps))
 
 # Train the bi-encoder model
 bi_encoder.fit(train_objectives=[(train_dataloader, train_loss)],

--- a/examples/training/data_augmentation/train_sts_seed_optimization.py
+++ b/examples/training/data_augmentation/train_sts_seed_optimization.py
@@ -4,13 +4,13 @@ We apply early stopping and evaluate the models over the dev set, to find out th
 
 For more details refer to -
 Fine-Tuning Pretrained Language Models:
-Weight Initializations, Data Orders, and Early Stopping by Dodge et al. 2020 
+Weight Initializations, Data Orders, and Early Stopping by Dodge et al. 2020
 https://arxiv.org/pdf/2002.06305.pdf
 
 Why Seed Optimization?
-Dodge et al. (2020) show a high dependence on the random seed for transformer based models like BERT, 
-as it converges to different minima that generalize differently to unseen data. This is especially the 
-case for small training datasets. 
+Dodge et al. (2020) show a high dependence on the random seed for transformer based models like BERT,
+as it converges to different minima that generalize differently to unseen data. This is especially the
+case for small training datasets.
 
 Citation: https://arxiv.org/abs/2010.08240
 
@@ -42,6 +42,7 @@ logging.basicConfig(format='%(asctime)s - %(message)s',
                     datefmt='%Y-%m-%d %H:%M:%S',
                     level=logging.INFO,
                     handlers=[LoggingHandler()])
+logger = logging.getLogger(__name__)
 #### /print debug information to stdout
 
 
@@ -59,16 +60,16 @@ model_name = sys.argv[1] if len(sys.argv) > 1 else 'bert-base-uncased'
 seed_count = int(sys.argv[2]) if len(sys.argv) > 2 else 10
 stop_after = float(sys.argv[3]) if len(sys.argv) > 3 else 0.3
 
-logging.info("Train and Evaluate: {} Random Seeds".format(seed_count))
+logger.info("Train and Evaluate: {} Random Seeds".format(seed_count))
 
 for seed in range(seed_count):
 
     # Setting seed for all random initializations
-    logging.info("##### Seed {} #####".format(seed))
+    logger.info("##### Seed {} #####".format(seed))
     random.seed(seed)
     np.random.seed(seed)
     torch.manual_seed(seed)
-    
+
     # Read the dataset
     train_batch_size = 16
     num_epochs = 1
@@ -86,7 +87,7 @@ for seed in range(seed_count):
     model = SentenceTransformer(modules=[word_embedding_model, pooling_model])
 
     # Convert the dataset to a DataLoader ready for training
-    logging.info("Read STSbenchmark train dataset")
+    logger.info("Read STSbenchmark train dataset")
 
     train_samples = []
     dev_samples = []
@@ -109,20 +110,20 @@ for seed in range(seed_count):
     train_loss = losses.CosineSimilarityLoss(model=model)
 
 
-    logging.info("Read STSbenchmark dev dataset")
+    logger.info("Read STSbenchmark dev dataset")
     evaluator = EmbeddingSimilarityEvaluator.from_input_examples(dev_samples, name='sts-dev')
 
 
     # Configure the training. We skip evaluation in this example
     warmup_steps = math.ceil(len(train_dataset) * num_epochs / train_batch_size * 0.1) #10% of train data for warm-up
-    
+
     # Stopping and Evaluating after 30% of training data (less than 1 epoch)
     # We find from (Dodge et al.) that 20-30% is often ideal for convergence of random seed
-    steps_per_epoch = math.ceil( len(train_dataset) / train_batch_size * stop_after ) 
-    
-    logging.info("Warmup-steps: {}".format(warmup_steps))
+    steps_per_epoch = math.ceil( len(train_dataset) / train_batch_size * stop_after )
 
-    logging.info("Early-stopping: {}% of the training-data".format(int(stop_after*100)))
+    logger.info("Warmup-steps: {}".format(warmup_steps))
+
+    logger.info("Early-stopping: {}% of the training-data".format(int(stop_after*100)))
 
 
     # Train the model

--- a/examples/training/distillation/dimensionality_reduction.py
+++ b/examples/training/distillation/dimensionality_reduction.py
@@ -29,6 +29,7 @@ logging.basicConfig(format='%(asctime)s - %(message)s',
                     datefmt='%Y-%m-%d %H:%M:%S',
                     level=logging.INFO,
                     handlers=[LoggingHandler()])
+logger = logging.getLogger(__name__)
 #### /print debug information to stdout
 
 #Model for which we apply dimensionality reduction
@@ -53,7 +54,7 @@ if not os.path.exists(sts_dataset_path):
 
 # We measure the performance of the original model
 # and later we will measure the performance with the reduces dimension size
-logging.info("Read STSbenchmark test dataset")
+logger.info("Read STSbenchmark test dataset")
 eval_examples = []
 with gzip.open(sts_dataset_path, 'rt', encoding='utf8') as fIn:
     reader = csv.DictReader(fIn, delimiter='\t', quoting=csv.QUOTE_NONE)
@@ -65,7 +66,7 @@ with gzip.open(sts_dataset_path, 'rt', encoding='utf8') as fIn:
 # Evaluate the original model on the STS benchmark dataset
 stsb_evaluator = evaluation.EmbeddingSimilarityEvaluator.from_input_examples(eval_examples, name='sts-benchmark-test')
 
-logging.info("Original model performance:")
+logger.info("Original model performance:")
 stsb_evaluator(model)
 
 ######## Reduce the embedding dimensions ########
@@ -97,7 +98,7 @@ dense.linear.weight = torch.nn.Parameter(torch.tensor(pca_comp))
 model.add_module('dense', dense)
 
 # Evaluate the model with the reduce embedding size
-logging.info("Model with {} dimensions:".format(new_dimension))
+logger.info("Model with {} dimensions:".format(new_dimension))
 stsb_evaluator(model)
 
 

--- a/examples/training/multilingual/make_multilingual.py
+++ b/examples/training/multilingual/make_multilingual.py
@@ -37,6 +37,7 @@ logging.basicConfig(format='%(asctime)s - %(message)s',
                     datefmt='%Y-%m-%d %H:%M:%S',
                     level=logging.INFO,
                     handlers=[LoggingHandler()])
+logger = logging.getLogger(__name__)
 
 
 teacher_model_name = 'bert-base-nli-stsb-mean-tokens'   #Our monolingual teacher model, we want to convert to multiple languages
@@ -128,11 +129,11 @@ if len(files_to_create) > 0:
 
 
 ######## Start the extension of the teacher model to multiple languages ########
-logging.info("Load teacher model")
+logger.info("Load teacher model")
 teacher_model = SentenceTransformer(teacher_model_name)
 
 
-logging.info("Create student model from scratch")
+logger.info("Create student model from scratch")
 word_embedding_model = models.Transformer(student_model_name, max_seq_length=max_seq_length)
 # Apply mean pooling to get one fixed sized sentence vector
 pooling_model = models.Pooling(word_embedding_model.get_word_embedding_dimension())
@@ -153,7 +154,7 @@ train_loss = losses.MSELoss(model=student_model)
 evaluators = []         #evaluators has a list of different evaluator classes we call periodically
 
 for dev_file in dev_files:
-    logging.info("Create evaluator for " + dev_file)
+    logger.info("Create evaluator for " + dev_file)
     src_sentences = []
     trg_sentences = []
     with gzip.open(dev_file, 'rt', encoding='utf8') as fIn:

--- a/examples/training/multilingual/make_multilingual_sys.py
+++ b/examples/training/multilingual/make_multilingual_sys.py
@@ -47,6 +47,7 @@ logging.basicConfig(format='%(asctime)s - %(message)s',
                     datefmt='%Y-%m-%d %H:%M:%S',
                     level=logging.INFO,
                     handlers=[LoggingHandler()])
+logger = logging.getLogger(__name__)
 
 
 teacher_model_name = 'bert-base-nli-stsb-mean-tokens'   #Our monolingual teacher model, we want to convert to multiple languages
@@ -93,15 +94,15 @@ if len(train_files) == 0:
     exit()
 
 
-logging.info("Train files: {}".format(", ".join(train_files)))
-logging.info("Dev files: {}".format(", ".join(dev_files)))
+logger.info("Train files: {}".format(", ".join(train_files)))
+logger.info("Dev files: {}".format(", ".join(dev_files)))
 
 ######## Start the extension of the teacher model to multiple languages ########
-logging.info("Load teacher model")
+logger.info("Load teacher model")
 teacher_model = SentenceTransformer(teacher_model_name)
 
 
-logging.info("Create student model from scratch")
+logger.info("Create student model from scratch")
 word_embedding_model = models.Transformer(student_model_name, max_seq_length=max_seq_length)
 # Apply mean pooling to get one fixed sized sentence vector
 pooling_model = models.Pooling(word_embedding_model.get_word_embedding_dimension())
@@ -122,7 +123,7 @@ train_loss = losses.MSELoss(model=student_model)
 evaluators = []         #evaluators has a list of different evaluator classes we call periodically
 
 for dev_file in dev_files:
-    logging.info("Create evaluator for " + dev_file)
+    logger.info("Create evaluator for " + dev_file)
     src_sentences = []
     trg_sentences = []
     with gzip.open(dev_file, 'rt', encoding='utf8') if dev_file.endswith('.gz') else open(dev_file, encoding='utf8') as fIn:

--- a/examples/training/nli/training_nli.py
+++ b/examples/training/nli/training_nli.py
@@ -26,6 +26,7 @@ logging.basicConfig(format='%(asctime)s - %(message)s',
                     datefmt='%Y-%m-%d %H:%M:%S',
                     level=logging.INFO,
                     handlers=[LoggingHandler()])
+logger = logging.getLogger(__name__)
 #### /print debug information to stdout
 
 #Check if dataset exsist. If not, download and extract  it
@@ -62,7 +63,7 @@ model = SentenceTransformer(modules=[word_embedding_model, pooling_model])
 
 
 # Read the AllNLI.tsv.gz file and create the training dataset
-logging.info("Read AllNLI train dataset")
+logger.info("Read AllNLI train dataset")
 
 label2int = {"contradiction": 0, "entailment": 1, "neutral": 2}
 train_samples = []
@@ -80,7 +81,7 @@ train_loss = losses.SoftmaxLoss(model=model, sentence_embedding_dimension=model.
 
 
 #Read STSbenchmark dataset and use it as development set
-logging.info("Read STSbenchmark dev dataset")
+logger.info("Read STSbenchmark dev dataset")
 dev_samples = []
 with gzip.open(sts_dataset_path, 'rt', encoding='utf8') as fIn:
     reader = csv.DictReader(fIn, delimiter='\t', quoting=csv.QUOTE_NONE)
@@ -95,7 +96,7 @@ dev_evaluator = EmbeddingSimilarityEvaluator.from_input_examples(dev_samples, ba
 num_epochs = 1
 
 warmup_steps = math.ceil(len(train_dataset) * num_epochs / train_batch_size * 0.1) #10% of train data for warm-up
-logging.info("Warmup-steps: {}".format(warmup_steps))
+logger.info("Warmup-steps: {}".format(warmup_steps))
 
 
 

--- a/examples/training/other/training_batch_hard_trec_continue_training.py
+++ b/examples/training/other/training_batch_hard_trec_continue_training.py
@@ -36,6 +36,12 @@ import urllib.request
 import random
 from collections import defaultdict
 
+logging.basicConfig(format='%(asctime)s - %(message)s',
+                    datefmt='%Y-%m-%d %H:%M:%S',
+                    level=logging.INFO,
+                    handlers=[LoggingHandler()])
+logger = logging.getLogger(__name__)
+
 # Inspired from torchnlp
 def trec_dataset(
     directory="datasets/trec/",
@@ -61,7 +67,7 @@ def trec_dataset(
         for line in open(full_path, "rb"):
             # there is one non-ASCII byte: sisterBADBYTEcity; replaced with space
             label, _, text = line.replace(b"\xf0", b" ").strip().decode().partition(" ")
-            
+
             # We extract the upper category (e.g. DESC from DESC:def)
             label, _, _ = label.partition(":")
 
@@ -137,7 +143,7 @@ output_path = (
 )
 num_epochs = 1
 
-logging.info("Loading TREC dataset")
+logger.info("Loading TREC dataset")
 train_set, dev_set, test_set = trec_dataset()
 
 
@@ -145,7 +151,7 @@ train_set, dev_set, test_set = trec_dataset()
 # Load pretrained model
 model = SentenceTransformer(model_name)
 
-logging.info("Read TREC train dataset")
+logger.info("Read TREC train dataset")
 train_dataset = SentenceLabelDataset(
     examples=train_set,
     model=model,
@@ -168,10 +174,10 @@ train_loss = losses.BatchAllTripletLoss(model=model)
 #train_loss = losses.BatchSemiHardTripletLoss(model=model)
 
 
-logging.info("Read TREC val dataset")
+logger.info("Read TREC val dataset")
 dev_evaluator = TripletEvaluator.from_input_examples(dev_set, name='dev')
 
-logging.info("Performance before fine-tuning:")
+logger.info("Performance before fine-tuning:")
 dev_evaluator(model)
 
 warmup_steps = int(
@@ -194,6 +200,6 @@ model.fit(
 #
 ##############################################################################
 
-logging.info("Evaluating model on test set")
+logger.info("Evaluating model on test set")
 test_evaluator = TripletEvaluator.from_input_examples(test_set, name='test')
 model.evaluate(test_evaluator)

--- a/examples/training/other/training_multi-task.py
+++ b/examples/training/other/training_multi-task.py
@@ -20,6 +20,7 @@ logging.basicConfig(format='%(asctime)s - %(message)s',
                     datefmt='%Y-%m-%d %H:%M:%S',
                     level=logging.INFO,
                     handlers=[LoggingHandler()])
+logger = logging.getLogger(__name__)
 #### /print debug information to stdout
 
 # Read the dataset
@@ -53,7 +54,7 @@ model = SentenceTransformer(modules=[word_embedding_model, pooling_model])
 
 
 # Convert the dataset to a DataLoader ready for training
-logging.info("Read AllNLI train dataset")
+logger.info("Read AllNLI train dataset")
 label2int = {"contradiction": 0, "entailment": 1, "neutral": 2}
 train_nli_samples = []
 with gzip.open(nli_dataset_path, 'rt', encoding='utf8') as fIn:
@@ -67,7 +68,7 @@ train_data_nli = SentencesDataset(train_nli_samples, model=model)
 train_dataloader_nli = DataLoader(train_data_nli, shuffle=True, batch_size=batch_size)
 train_loss_nli = losses.SoftmaxLoss(model=model, sentence_embedding_dimension=model.get_sentence_embedding_dimension(), num_labels=len(label2int))
 
-logging.info("Read STSbenchmark train dataset")
+logger.info("Read STSbenchmark train dataset")
 train_sts_samples = []
 dev_sts_samples = []
 test_sts_samples = []
@@ -89,14 +90,14 @@ train_dataloader_sts = DataLoader(train_data_sts, shuffle=True, batch_size=batch
 train_loss_sts = losses.CosineSimilarityLoss(model=model)
 
 
-logging.info("Read STSbenchmark dev dataset")
+logger.info("Read STSbenchmark dev dataset")
 evaluator = EmbeddingSimilarityEvaluator.from_input_examples(dev_sts_samples, name='sts-dev')
 
 # Configure the training
 num_epochs = 4
 
 warmup_steps = math.ceil(len(train_data_sts) * num_epochs / batch_size * 0.1) #10% of train data for warm-up
-logging.info("Warmup-steps: {}".format(warmup_steps))
+logger.info("Warmup-steps: {}".format(warmup_steps))
 
 
 # Here we define the two train objectives: train_dataloader_nli with train_loss_nli (i.e., SoftmaxLoss for NLI data)

--- a/examples/training/other/training_wikipedia_sections.py
+++ b/examples/training/other/training_wikipedia_sections.py
@@ -19,7 +19,7 @@ logging.basicConfig(format='%(asctime)s - %(message)s',
                     datefmt='%Y-%m-%d %H:%M:%S',
                     level=logging.INFO,
                     handlers=[LoggingHandler()])
-
+logger = logging.getLogger(__name__)
 
 #You can specify any huggingface/transformers pre-trained model here, for example, bert-base-uncased, roberta-base, xlm-roberta-base
 model_name = 'distilbert-base-uncased'
@@ -52,7 +52,7 @@ pooling_model = models.Pooling(word_embedding_model.get_word_embedding_dimension
 model = SentenceTransformer(modules=[word_embedding_model, pooling_model])
 
 
-logging.info("Read Triplet train dataset")
+logger.info("Read Triplet train dataset")
 train_examples = []
 with open(os.path.join(dataset_path, 'train.csv'), encoding="utf-8") as fIn:
     reader = csv.DictReader(fIn, delimiter=',', quoting=csv.QUOTE_MINIMAL)
@@ -64,7 +64,7 @@ train_dataset = SentencesDataset(train_examples, model=model)
 train_dataloader = DataLoader(train_dataset, shuffle=True, batch_size=train_batch_size)
 train_loss = losses.TripletLoss(model=model)
 
-logging.info("Read Wikipedia Triplet dev dataset")
+logger.info("Read Wikipedia Triplet dev dataset")
 dev_examples = []
 with open(os.path.join(dataset_path, 'validation.csv'), encoding="utf-8") as fIn:
     reader = csv.DictReader(fIn, delimiter=',', quoting=csv.QUOTE_MINIMAL)
@@ -94,7 +94,7 @@ model.fit(train_objectives=[(train_dataloader, train_loss)],
 #
 ##############################################################################
 
-logging.info("Read test examples")
+logger.info("Read test examples")
 test_examples = []
 with open(os.path.join(dataset_path, 'test.csv'), encoding="utf-8") as fIn:
     reader = csv.DictReader(fIn, delimiter=',', quoting=csv.QUOTE_MINIMAL)

--- a/examples/training/quora_duplicate_questions/training_MultipleNegativesRankingLoss.py
+++ b/examples/training/quora_duplicate_questions/training_MultipleNegativesRankingLoss.py
@@ -27,6 +27,7 @@ logging.basicConfig(format='%(asctime)s - %(message)s',
                     datefmt='%Y-%m-%d %H:%M:%S',
                     level=logging.INFO,
                     handlers=[LoggingHandler()])
+logger = logging.getLogger(__name__)
 #### /print debug information to stdout
 
 
@@ -48,7 +49,7 @@ os.makedirs(model_save_path, exist_ok=True)
 
 # Check if the dataset exists. If not, download and extract
 if not os.path.exists(dataset_path):
-    logging.info("Dataset not found. Download")
+    logger.info("Dataset not found. Download")
     zip_save_path = 'quora-IR-dataset.zip'
     util.http_get(url='https://sbert.net/datasets/quora-IR-dataset.zip', path=zip_save_path)
     with ZipFile(zip_save_path, 'r') as zip:
@@ -178,7 +179,7 @@ evaluators.append(ir_evaluator)
 seq_evaluator = evaluation.SequentialEvaluator(evaluators, main_score_function=lambda scores: scores[-1])
 
 
-logging.info("Evaluate model without training")
+logger.info("Evaluate model without training")
 seq_evaluator(model, epoch=0, steps=0, output_path=model_save_path)
 
 

--- a/examples/training/quora_duplicate_questions/training_OnlineConstrativeLoss.py
+++ b/examples/training/quora_duplicate_questions/training_OnlineConstrativeLoss.py
@@ -25,6 +25,7 @@ logging.basicConfig(format='%(asctime)s - %(message)s',
                     datefmt='%Y-%m-%d %H:%M:%S',
                     level=logging.INFO,
                     handlers=[LoggingHandler()])
+logger = logging.getLogger(__name__)
 #### /print debug information to stdout
 
 
@@ -46,7 +47,7 @@ os.makedirs(model_save_path, exist_ok=True)
 
 # Check if the dataset exists. If not, download and extract
 if not os.path.exists(dataset_path):
-    logging.info("Dataset not found. Download")
+    logger.info("Dataset not found. Download")
     zip_save_path = 'quora-IR-dataset.zip'
     util.http_get(url='https://sbert.net/datasets/quora-IR-dataset.zip', path=zip_save_path)
     with ZipFile(zip_save_path, 'r') as zip:
@@ -176,7 +177,7 @@ evaluators.append(ir_evaluator)
 seq_evaluator = evaluation.SequentialEvaluator(evaluators, main_score_function=lambda scores: scores[-1])
 
 
-logging.info("Evaluate model without training")
+logger.info("Evaluate model without training")
 seq_evaluator(model, epoch=0, steps=0, output_path=model_save_path)
 
 

--- a/examples/training/quora_duplicate_questions/training_multi-task-learning.py
+++ b/examples/training/quora_duplicate_questions/training_multi-task-learning.py
@@ -27,6 +27,7 @@ logging.basicConfig(format='%(asctime)s - %(message)s',
                     datefmt='%Y-%m-%d %H:%M:%S',
                     level=logging.INFO,
                     handlers=[LoggingHandler()])
+logger = logging.getLogger(__name__)
 #### /print debug information to stdout
 
 
@@ -54,7 +55,7 @@ os.makedirs(model_save_path, exist_ok=True)
 
 # Check if the dataset exists. If not, download and extract
 if not os.path.exists(dataset_path):
-    logging.info("Dataset not found. Download")
+    logger.info("Dataset not found. Download")
     zip_save_path = 'quora-IR-dataset.zip'
     util.http_get(url='https://sbert.net/datasets/quora-IR-dataset.zip', path=zip_save_path)
     with ZipFile(zip_save_path, 'r') as zip:
@@ -196,7 +197,7 @@ evaluators.append(ir_evaluator)
 seq_evaluator = evaluation.SequentialEvaluator(evaluators, main_score_function=lambda scores: scores[-1])
 
 
-logging.info("Evaluate model without training")
+logger.info("Evaluate model without training")
 seq_evaluator(model, epoch=0, steps=0, output_path=model_save_path)
 
 

--- a/examples/training/sts/training_stsbenchmark.py
+++ b/examples/training/sts/training_stsbenchmark.py
@@ -25,6 +25,7 @@ logging.basicConfig(format='%(asctime)s - %(message)s',
                     datefmt='%Y-%m-%d %H:%M:%S',
                     level=logging.INFO,
                     handlers=[LoggingHandler()])
+logger = logging.getLogger(__name__)
 #### /print debug information to stdout
 
 
@@ -57,7 +58,7 @@ pooling_model = models.Pooling(word_embedding_model.get_word_embedding_dimension
 model = SentenceTransformer(modules=[word_embedding_model, pooling_model])
 
 # Convert the dataset to a DataLoader ready for training
-logging.info("Read STSbenchmark train dataset")
+logger.info("Read STSbenchmark train dataset")
 
 train_samples = []
 dev_samples = []
@@ -80,13 +81,13 @@ train_dataloader = DataLoader(train_dataset, shuffle=True, batch_size=train_batc
 train_loss = losses.CosineSimilarityLoss(model=model)
 
 
-logging.info("Read STSbenchmark dev dataset")
+logger.info("Read STSbenchmark dev dataset")
 evaluator = EmbeddingSimilarityEvaluator.from_input_examples(dev_samples, name='sts-dev')
 
 
 # Configure the training. We skip evaluation in this example
 warmup_steps = math.ceil(len(train_dataset) * num_epochs / train_batch_size * 0.1) #10% of train data for warm-up
-logging.info("Warmup-steps: {}".format(warmup_steps))
+logger.info("Warmup-steps: {}".format(warmup_steps))
 
 
 # Train the model

--- a/examples/training/sts/training_stsbenchmark_continue_training.py
+++ b/examples/training/sts/training_stsbenchmark_continue_training.py
@@ -20,6 +20,7 @@ logging.basicConfig(format='%(asctime)s - %(message)s',
                     datefmt='%Y-%m-%d %H:%M:%S',
                     level=logging.INFO,
                     handlers=[LoggingHandler()])
+logger = logging.getLogger(__name__)
 #### /print debug information to stdout
 
 #Check if dataset exsist. If not, download and extract  it
@@ -43,7 +44,7 @@ model_save_path = 'output/training_stsbenchmark_continue_training-'+model_name+'
 model = SentenceTransformer(model_name)
 
 # Convert the dataset to a DataLoader ready for training
-logging.info("Read STSbenchmark train dataset")
+logger.info("Read STSbenchmark train dataset")
 
 train_samples = []
 dev_samples = []
@@ -68,13 +69,13 @@ train_loss = losses.CosineSimilarityLoss(model=model)
 
 
 # Development set: Measure correlation between cosine score and gold labels
-logging.info("Read STSbenchmark dev dataset")
+logger.info("Read STSbenchmark dev dataset")
 evaluator = EmbeddingSimilarityEvaluator.from_input_examples(dev_samples, name='sts-dev')
 
 
 # Configure the training. We skip evaluation in this example
 warmup_steps = math.ceil(len(train_dataset) * num_epochs / train_batch_size * 0.1) #10% of train data for warm-up
-logging.info("Warmup-steps: {}".format(warmup_steps))
+logger.info("Warmup-steps: {}".format(warmup_steps))
 
 
 # Train the model

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ numpy
 scikit-learn
 scipy
 nltk
+coloredlogs

--- a/sentence_transformers/LoggingHandler.py
+++ b/sentence_transformers/LoggingHandler.py
@@ -14,3 +14,43 @@ class LoggingHandler(logging.Handler):
             raise
         except:
             self.handleError(record)
+
+
+def install_logger(
+    given_logger, level = logging.WARNING, fmt="%(levelname)s:%(name)s:%(message)s"
+):
+    """ Configures the given logger; format, logging level, style, etc """
+    import coloredlogs
+
+    def add_notice_log_level():
+        """ Creates a new 'notice' logging level """
+        # inspired by:
+        # https://stackoverflow.com/questions/2183233/how-to-add-a-custom-loglevel-to-pythons-logging-facility
+        NOTICE_LEVEL_NUM = 25
+        logging.addLevelName(NOTICE_LEVEL_NUM, "NOTICE")
+
+        def notice(self, message, *args, **kws):
+            if self.isEnabledFor(NOTICE_LEVEL_NUM):
+                self._log(NOTICE_LEVEL_NUM, message, args, **kws)
+
+        logging.Logger.notice = notice
+
+    # Add an extra logging level above INFO and below WARNING
+    add_notice_log_level()
+
+    # More style info at:
+    # https://coloredlogs.readthedocs.io/en/latest/api.html
+    field_styles = coloredlogs.DEFAULT_FIELD_STYLES.copy()
+    field_styles["asctime"] = {}
+    level_styles = coloredlogs.DEFAULT_LEVEL_STYLES.copy()
+    level_styles["debug"] = {"color": "white", "faint": True}
+    level_styles["notice"] = {"color": "cyan", "bold": True}
+
+    coloredlogs.install(
+        logger=given_logger,
+        level=level,
+        use_chroot=False,
+        fmt=fmt,
+        level_styles=level_styles,
+        field_styles=field_styles,
+    )

--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -25,6 +25,8 @@ from .datasets.EncodeDataset import EncodeDataset
 from .models import Transformer, Pooling
 from . import __version__
 
+logger = logging.getLogger(__name__)
+
 class SentenceTransformer(nn.Sequential):
     """
     Loads or create a SentenceTransformer model, that can be used to map sentences / text to embeddings.
@@ -35,17 +37,17 @@ class SentenceTransformer(nn.Sequential):
     """
     def __init__(self, model_name_or_path: str = None, modules: Iterable[nn.Module] = None, device: str = None):
         if model_name_or_path is not None and model_name_or_path != "":
-            logging.info("Load pretrained SentenceTransformer: {}".format(model_name_or_path))
+            logger.info("Load pretrained SentenceTransformer: {}".format(model_name_or_path))
             model_path = model_name_or_path
 
             if not os.path.isdir(model_path) and not model_path.startswith('http://') and not model_path.startswith('https://'):
-                logging.info("Did not find folder {}".format(model_path))
+                logger.info("Did not find folder {}".format(model_path))
 
                 if '\\' in model_path or model_path.count('/') > 1:
                     raise AttributeError("Path {} not found".format(model_path))
 
                 model_path = __DOWNLOAD_SERVER__ + model_path + '.zip'
-                logging.info("Try to download model from server: {}".format(model_path))
+                logger.info("Try to download model from server: {}".format(model_path))
 
             if model_path.startswith('http://') or model_path.startswith('https://'):
                 model_url = model_path
@@ -64,7 +66,7 @@ class SentenceTransformer(nn.Sequential):
                 if not os.path.exists(model_path) or not os.listdir(model_path):
                     if model_url[-1] == "/":
                         model_url = model_url[:-1]
-                    logging.info("Downloading sentence transformer model from {} and saving it at {}".format(model_url, model_path))
+                    logger.info("Downloading sentence transformer model from {} and saving it at {}".format(model_url, model_path))
 
                     model_path_tmp = model_path.rstrip("/").rstrip("\\")+"_part"
                     try:
@@ -77,8 +79,8 @@ class SentenceTransformer(nn.Sequential):
                     except requests.exceptions.HTTPError as e:
                         shutil.rmtree(model_path_tmp)
                         if e.response.status_code == 404:
-                            logging.warning('SentenceTransformer-Model {} not found. Try to create it from scratch'.format(model_url))
-                            logging.warning('Try to create Transformer Model {} with mean pooling'.format(model_name_or_path))
+                            logger.warning('SentenceTransformer-Model {} not found. Try to create it from scratch'.format(model_url))
+                            logger.warning('Try to create Transformer Model {} with mean pooling'.format(model_name_or_path))
 
                             model_path = None
                             transformer_model = Transformer(model_name_or_path)
@@ -94,13 +96,13 @@ class SentenceTransformer(nn.Sequential):
 
             #### Load from disk
             if model_path is not None:
-                logging.info("Load SentenceTransformer from folder: {}".format(model_path))
+                logger.info("Load SentenceTransformer from folder: {}".format(model_path))
 
                 if os.path.exists(os.path.join(model_path, 'config.json')):
                     with open(os.path.join(model_path, 'config.json')) as fIn:
                         config = json.load(fIn)
                         if config['__version__'] > __version__:
-                            logging.warning("You try to use a model that was created with version {}, however, your version is {}. This might cause unexpected behavior or errors. In that case, try to update to the latest version.\n\n\n".format(config['__version__'], __version__))
+                            logger.warning("You try to use a model that was created with version {}, however, your version is {}. This might cause unexpected behavior or errors. In that case, try to update to the latest version.\n\n\n".format(config['__version__'], __version__))
 
                 with open(os.path.join(model_path, 'modules.json')) as fIn:
                     contained_modules = json.load(fIn)
@@ -118,7 +120,7 @@ class SentenceTransformer(nn.Sequential):
         super().__init__(modules)
         if device is None:
             device = "cuda" if torch.cuda.is_available() else "cpu"
-            logging.info("Use pytorch device: {}".format(device))
+            logger.info("Use pytorch device: {}".format(device))
 
         self._target_device = torch.device(device)
 
@@ -222,10 +224,10 @@ class SentenceTransformer(nn.Sequential):
             if torch.cuda.is_available():
                 target_devices = ['cuda:{}'.format(i) for i in range(torch.cuda.device_count())]
             else:
-                logging.info("CUDA is not available. Start 4 CPU worker")
+                logger.info("CUDA is not available. Start 4 CPU worker")
                 target_devices = ['cpu']*4
 
-        logging.info("Start multi-process pool on devices: {}".format(', '.join(map(str, target_devices))))
+        logger.info("Start multi-process pool on devices: {}".format(', '.join(map(str, target_devices))))
 
         ctx = mp.get_context('spawn')
         input_queue = ctx.Queue()
@@ -272,7 +274,7 @@ class SentenceTransformer(nn.Sequential):
         if chunk_size is None:
             chunk_size = min(math.ceil(len(sentences) / len(pool["processes"]) / 10), 5000)
 
-        logging.info("Chunk data into packages of size {}".format(chunk_size))
+        logger.info("Chunk data into packages of size {}".format(chunk_size))
 
         input_queue = pool['input']
         last_chunk_id = 0
@@ -350,7 +352,7 @@ class SentenceTransformer(nn.Sequential):
 
         os.makedirs(path, exist_ok=True)
 
-        logging.info("Save model to {}".format(path))
+        logger.info("Save model to {}".format(path))
         contained_modules = []
 
         for idx, name in enumerate(self._modules):
@@ -560,7 +562,7 @@ class SentenceTransformer(nn.Sequential):
                     try:
                         data = next(data_iterator)
                     except StopIteration:
-                        #logging.info("Restart data_iterator")
+                        #logger.info("Restart data_iterator")
                         data_iterator = iter(dataloaders[train_idx])
                         data_iterators[train_idx] = data_iterator
                         data = next(data_iterator)

--- a/sentence_transformers/__init__.py
+++ b/sentence_transformers/__init__.py
@@ -1,8 +1,16 @@
 __version__ = "0.3.9"
+
 __DOWNLOAD_SERVER__ = 'https://sbert.net/models/'
+
+import logging
+
 from .datasets import SentencesDataset, SentenceLabelDataset, ParallelSentencesDataset
 from .LoggingHandler import LoggingHandler
 from .SentenceTransformer import SentenceTransformer
 from .readers import InputExample
 from .cross_encoder.CrossEncoder import CrossEncoder
+
+
+logger = logging.getLogger(__name__)
+
 

--- a/sentence_transformers/__init__.py
+++ b/sentence_transformers/__init__.py
@@ -2,15 +2,21 @@ __version__ = "0.3.9"
 
 __DOWNLOAD_SERVER__ = 'https://sbert.net/models/'
 
+import os
 import logging
 
 from .datasets import SentencesDataset, SentenceLabelDataset, ParallelSentencesDataset
 from .LoggingHandler import LoggingHandler
+from .LoggingHandler import install_logger
 from .SentenceTransformer import SentenceTransformer
 from .readers import InputExample
 from .cross_encoder.CrossEncoder import CrossEncoder
 
-
 logger = logging.getLogger(__name__)
+
+
+# configure the library logger from which all other loggers will inherit
+install_logger(logger, level=os.environ.get("ST_LOG_LEVEL", logging.WARNING))
+
 
 

--- a/sentence_transformers/cross_encoder/CrossEncoder.py
+++ b/sentence_transformers/cross_encoder/CrossEncoder.py
@@ -14,6 +14,9 @@ from .. import SentenceTransformer
 from ..evaluation import SentenceEvaluator
 
 
+logger = logging.getLogger(__name__)
+
+
 class CrossEncoder():
     def __init__(self, model_name:str, num_labels:int = None, max_length:int = None, device:str = None, use_fast_tokenizer:bool = None):
         """
@@ -52,7 +55,7 @@ class CrossEncoder():
 
         if device is None:
             device = "cuda" if torch.cuda.is_available() else "cpu"
-            logging.info("Use pytorch device: {}".format(device))
+            logger.info("Use pytorch device: {}".format(device))
 
         self._target_device = torch.device(device)
 
@@ -298,7 +301,7 @@ class CrossEncoder():
         if path is None:
             return
 
-        logging.info("Save model to {}".format(path))
+        logger.info("Save model to {}".format(path))
         self.model.save_pretrained(path)
         self.tokenizer.save_pretrained(path)
 

--- a/sentence_transformers/cross_encoder/evaluation/CEBinaryClassificationEvaluator.py
+++ b/sentence_transformers/cross_encoder/evaluation/CEBinaryClassificationEvaluator.py
@@ -8,6 +8,9 @@ import csv
 from ... import InputExample
 from ...evaluation import BinaryClassificationEvaluator
 
+
+logger = logging.getLogger(__name__)
+
 class CEBinaryClassificationEvaluator:
     """
     This evaluator can be used with the CrossEncoder class. Given sentence pairs and binary labels (0 and 1),
@@ -44,18 +47,18 @@ class CEBinaryClassificationEvaluator:
         else:
             out_txt = ":"
 
-        logging.info("CEBinaryClassificationEvaluator: Evaluating the model on " + self.name + " dataset" + out_txt)
+        logger.info("CEBinaryClassificationEvaluator: Evaluating the model on " + self.name + " dataset" + out_txt)
         pred_scores = model.predict(self.sentence_pairs, convert_to_numpy=True, show_progress_bar=False)
 
         acc, acc_threshold = BinaryClassificationEvaluator.find_best_acc_and_threshold(pred_scores, self.labels, True)
         f1, precision, recall, f1_threshold = BinaryClassificationEvaluator.find_best_f1_and_threshold(pred_scores, self.labels, True)
         ap = average_precision_score(self.labels, pred_scores)
 
-        logging.info("Accuracy:           {:.2f}\t(Threshold: {:.4f})".format(acc * 100, acc_threshold))
-        logging.info("F1:                 {:.2f}\t(Threshold: {:.4f})".format(f1 * 100, f1_threshold))
-        logging.info("Precision:          {:.2f}".format(precision * 100))
-        logging.info("Recall:             {:.2f}".format(recall * 100))
-        logging.info("Average Precision:  {:.2f}\n".format(ap * 100))
+        logger.info("Accuracy:           {:.2f}\t(Threshold: {:.4f})".format(acc * 100, acc_threshold))
+        logger.info("F1:                 {:.2f}\t(Threshold: {:.4f})".format(f1 * 100, f1_threshold))
+        logger.info("Precision:          {:.2f}".format(precision * 100))
+        logger.info("Recall:             {:.2f}".format(recall * 100))
+        logger.info("Average Precision:  {:.2f}\n".format(ap * 100))
 
         if output_path is not None:
             csv_path = os.path.join(output_path, self.csv_file)

--- a/sentence_transformers/cross_encoder/evaluation/CECorrelationEvaluator.py
+++ b/sentence_transformers/cross_encoder/evaluation/CECorrelationEvaluator.py
@@ -5,6 +5,9 @@ import os
 import csv
 from ... import InputExample
 
+
+logger = logging.getLogger(__name__)
+
 class CECorrelationEvaluator:
     """
     This evaluator can be used with the CrossEncoder class. Given sentence pairs and continuous scores,
@@ -38,14 +41,14 @@ class CECorrelationEvaluator:
         else:
             out_txt = ":"
 
-        logging.info("CECorrelationEvaluator: Evaluating the model on " + self.name + " dataset" + out_txt)
+        logger.info("CECorrelationEvaluator: Evaluating the model on " + self.name + " dataset" + out_txt)
         pred_scores = model.predict(self.sentence_pairs, convert_to_numpy=True, show_progress_bar=False)
 
 
         eval_pearson, _ = pearsonr(self.scores, pred_scores)
         eval_spearman, _ = spearmanr(self.scores, pred_scores)
 
-        logging.info("Correlation:\tPearson: {:.4f}\tSpearman: {:.4f}".format(eval_pearson, eval_spearman))
+        logger.info("Correlation:\tPearson: {:.4f}\tSpearman: {:.4f}".format(eval_pearson, eval_spearman))
 
         if output_path is not None:
             csv_path = os.path.join(output_path, self.csv_file)

--- a/sentence_transformers/cross_encoder/evaluation/CESoftmaxAccuracyEvaluator.py
+++ b/sentence_transformers/cross_encoder/evaluation/CESoftmaxAccuracyEvaluator.py
@@ -5,6 +5,9 @@ from typing import List
 from ... import InputExample
 import numpy as np
 
+
+logger = logging.getLogger(__name__)
+
 class CESoftmaxAccuracyEvaluator:
     """
     This evaluator can be used with the CrossEncoder class.
@@ -39,7 +42,7 @@ class CESoftmaxAccuracyEvaluator:
         else:
             out_txt = ":"
 
-        logging.info("CESoftmaxAccuracyEvaluator: Evaluating the model on " + self.name + " dataset" + out_txt)
+        logger.info("CESoftmaxAccuracyEvaluator: Evaluating the model on " + self.name + " dataset" + out_txt)
         pred_scores = model.predict(self.sentence_pairs, convert_to_numpy=True, show_progress_bar=False)
         pred_labels = np.argmax(pred_scores, axis=1)
 
@@ -47,7 +50,7 @@ class CESoftmaxAccuracyEvaluator:
 
         acc = np.sum(pred_labels == self.labels) / len(self.labels)
 
-        logging.info("Accuracy: {:.2f}".format(acc*100))
+        logger.info("Accuracy: {:.2f}".format(acc*100))
 
         if output_path is not None:
             csv_path = os.path.join(output_path, self.csv_file)

--- a/sentence_transformers/datasets/ParallelSentencesDataset.py
+++ b/sentence_transformers/datasets/ParallelSentencesDataset.py
@@ -6,6 +6,9 @@ from .. import SentenceTransformer
 from typing import List
 import random
 
+
+logger = logging.getLogger(__name__)
+
 class ParallelSentencesDataset(Dataset):
     """
     This dataset reader can be used to read-in parallel sentences, i.e., it reads in a file with tab-seperated sentences with the same
@@ -54,7 +57,7 @@ class ParallelSentencesDataset(Dataset):
         :return:
         """
 
-        logging.info("Load "+filepath)
+        logger.info("Load "+filepath)
         parallel_sentences = []
 
         with gzip.open(filepath, 'rt', encoding='utf8') if filepath.endswith('.gz') else open(filepath, encoding='utf8') as fIn:

--- a/sentence_transformers/datasets/SentenceLabelDataset.py
+++ b/sentence_transformers/datasets/SentenceLabelDataset.py
@@ -10,6 +10,9 @@ from ..readers.InputExample import InputExample
 from multiprocessing import Pool, cpu_count
 import multiprocessing
 
+
+logger = logging.getLogger(__name__)
+
 class SentenceLabelDataset(Dataset):
     """
     Dataset for training with triplet loss.
@@ -66,7 +69,7 @@ class SentenceLabelDataset(Dataset):
 
         if self.parallel_tokenization:
             if multiprocessing.get_start_method() != 'fork':
-                logging.info("Parallel tokenization is only available on Unix systems which allow to fork processes. Fall back to sequential tokenization")
+                logger.info("Parallel tokenization is only available on Unix systems which allow to fork processes. Fall back to sequential tokenization")
                 self.parallel_tokenization = False
 
         self.convert_input_examples(examples, model)
@@ -101,11 +104,11 @@ class SentenceLabelDataset(Dataset):
         too_long = 0
         label_type = None
 
-        logging.info("Start tokenization")
+        logger.info("Start tokenization")
         if not self.parallel_tokenization or self.max_processes == 1 or len(examples) <= self.chunk_size:
             tokenized_texts = [self.tokenize_example(example) for example in examples]
         else:
-            logging.info("Use multi-process tokenization with {} processes".format(self.max_processes))
+            logger.info("Use multi-process tokenization with {} processes".format(self.max_processes))
             self.model.to('cpu')
             with Pool(self.max_processes) as p:
                 tokenized_texts = list(p.imap(self.tokenize_example, examples, chunksize=self.chunk_size))
@@ -143,9 +146,9 @@ class SentenceLabelDataset(Dataset):
                 self.num_labels += 1
 
         self.grouped_labels = torch.tensor(self.grouped_labels, dtype=label_type)
-        logging.info("Num sentences: %d" % (len(self.grouped_inputs)))
-        logging.info("Sentences longer than max_seqence_length: {}".format(too_long))
-        logging.info("Number of labels with >1 examples: {}".format(len(distinct_labels)))
+        logger.info("Num sentences: %d" % (len(self.grouped_inputs)))
+        logger.info("Sentences longer than max_seqence_length: {}".format(too_long))
+        logger.info("Number of labels with >1 examples: {}".format(len(distinct_labels)))
 
 
     def tokenize_example(self, example):

--- a/sentence_transformers/evaluation/BinaryClassificationEvaluator.py
+++ b/sentence_transformers/evaluation/BinaryClassificationEvaluator.py
@@ -8,6 +8,9 @@ import numpy as np
 from typing import List
 from ..readers import InputExample
 
+
+logger = logging.getLogger(__name__)
+
 class BinaryClassificationEvaluator(SentenceEvaluator):
     """
     Evaluate a model based on the similarity of the embeddings by calculating the accuracy of identifying similar and
@@ -73,7 +76,7 @@ class BinaryClassificationEvaluator(SentenceEvaluator):
         else:
             out_txt = ":"
 
-        logging.info("Binary Accuracy Evaluation of the model on " + self.name + " dataset" + out_txt)
+        logger.info("Binary Accuracy Evaluation of the model on " + self.name + " dataset" + out_txt)
         embeddings1 = model.encode(self.sentences1, batch_size=self.batch_size,
                                    show_progress_bar=self.show_progress_bar, convert_to_numpy=True)
         embeddings2 = model.encode(self.sentences2, batch_size=self.batch_size,
@@ -94,11 +97,11 @@ class BinaryClassificationEvaluator(SentenceEvaluator):
             f1, precision, recall, f1_threshold = self.find_best_f1_and_threshold(scores, labels, reverse)
             ap = average_precision_score(labels, scores * (1 if reverse else -1))
 
-            logging.info("Accuracy with {}:           {:.2f}\t(Threshold: {:.4f})".format(name, acc * 100, acc_threshold))
-            logging.info("F1 with {}:                 {:.2f}\t(Threshold: {:.4f})".format(name, f1 * 100, f1_threshold))
-            logging.info("Precision with {}:          {:.2f}".format(name, precision * 100))
-            logging.info("Recall with {}:             {:.2f}".format(name, recall * 100))
-            logging.info("Average Precision with {}:  {:.2f}\n".format(name, ap * 100))
+            logger.info("Accuracy with {}:           {:.2f}\t(Threshold: {:.4f})".format(name, acc * 100, acc_threshold))
+            logger.info("F1 with {}:                 {:.2f}\t(Threshold: {:.4f})".format(name, f1 * 100, f1_threshold))
+            logger.info("Precision with {}:          {:.2f}".format(name, precision * 100))
+            logger.info("Recall with {}:             {:.2f}".format(name, recall * 100))
+            logger.info("Average Precision with {}:  {:.2f}\n".format(name, ap * 100))
 
             file_output_data.extend([acc, acc_threshold, f1, precision, recall, f1_threshold, ap])
 

--- a/sentence_transformers/evaluation/EmbeddingSimilarityEvaluator.py
+++ b/sentence_transformers/evaluation/EmbeddingSimilarityEvaluator.py
@@ -8,6 +8,9 @@ import numpy as np
 from typing import List
 from ..readers import InputExample
 
+
+logger = logging.getLogger(__name__)
+
 class EmbeddingSimilarityEvaluator(SentenceEvaluator):
     """
     Evaluate a model based on the similarity of the embeddings by calculating the Spearman and Pearson rank correlation
@@ -71,7 +74,7 @@ class EmbeddingSimilarityEvaluator(SentenceEvaluator):
         else:
             out_txt = ":"
 
-        logging.info("EmbeddingSimilarityEvaluator: Evaluating the model on " + self.name + " dataset" + out_txt)
+        logger.info("EmbeddingSimilarityEvaluator: Evaluating the model on " + self.name + " dataset" + out_txt)
 
         embeddings1 = model.encode(self.sentences1, batch_size=self.batch_size, show_progress_bar=self.show_progress_bar, convert_to_numpy=True)
         embeddings2 = model.encode(self.sentences2, batch_size=self.batch_size, show_progress_bar=self.show_progress_bar, convert_to_numpy=True)
@@ -95,13 +98,13 @@ class EmbeddingSimilarityEvaluator(SentenceEvaluator):
         eval_pearson_dot, _ = pearsonr(labels, dot_products)
         eval_spearman_dot, _ = spearmanr(labels, dot_products)
 
-        logging.info("Cosine-Similarity :\tPearson: {:.4f}\tSpearman: {:.4f}".format(
+        logger.info("Cosine-Similarity :\tPearson: {:.4f}\tSpearman: {:.4f}".format(
             eval_pearson_cosine, eval_spearman_cosine))
-        logging.info("Manhattan-Distance:\tPearson: {:.4f}\tSpearman: {:.4f}".format(
+        logger.info("Manhattan-Distance:\tPearson: {:.4f}\tSpearman: {:.4f}".format(
             eval_pearson_manhattan, eval_spearman_manhattan))
-        logging.info("Euclidean-Distance:\tPearson: {:.4f}\tSpearman: {:.4f}".format(
+        logger.info("Euclidean-Distance:\tPearson: {:.4f}\tSpearman: {:.4f}".format(
             eval_pearson_euclidean, eval_spearman_euclidean))
-        logging.info("Dot-Product-Similarity:\tPearson: {:.4f}\tSpearman: {:.4f}".format(
+        logger.info("Dot-Product-Similarity:\tPearson: {:.4f}\tSpearman: {:.4f}".format(
             eval_pearson_dot, eval_spearman_dot))
 
         if output_path is not None:

--- a/sentence_transformers/evaluation/InformationRetrievalEvaluator.py
+++ b/sentence_transformers/evaluation/InformationRetrievalEvaluator.py
@@ -8,6 +8,8 @@ import numpy as np
 from typing import List, Tuple, Dict, Set
 
 
+logger = logging.getLogger(__name__)
+
 class InformationRetrievalEvaluator(SentenceEvaluator):
     """
     This class evaluates an Information Retrieval (IR) setting.
@@ -81,7 +83,7 @@ class InformationRetrievalEvaluator(SentenceEvaluator):
         else:
             out_txt = ":"
 
-        logging.info("Information Retrieval Evaluation on " + self.name + " dataset" + out_txt)
+        logger.info("Information Retrieval Evaluation on " + self.name + " dataset" + out_txt)
 
         max_k = max(max(self.mrr_at_k), max(self.ndcg_at_k), max(self.accuracy_at_k), max(self.precision_recall_at_k), max(self.map_at_k))
 
@@ -125,8 +127,8 @@ class InformationRetrievalEvaluator(SentenceEvaluator):
         self.output_scores(scores)
 
 
-        logging.info("Queries: {}".format(len(self.queries)))
-        logging.info("Corpus: {}\n".format(len(self.corpus)))
+        logger.info("Queries: {}".format(len(self.queries)))
+        logger.info("Corpus: {}\n".format(len(self.corpus)))
 
         if output_path is not None:
             csv_path = os.path.join(output_path, self.csv_file)
@@ -249,22 +251,22 @@ class InformationRetrievalEvaluator(SentenceEvaluator):
 
     def output_scores(self, scores):
         for k in scores['accuracy@k']:
-            logging.info("Accuracy@{}: {:.2f}%".format(k, scores['accuracy@k'][k]*100))
+            logger.info("Accuracy@{}: {:.2f}%".format(k, scores['accuracy@k'][k]*100))
 
         for k in scores['precision@k']:
-            logging.info("Precision@{}: {:.2f}%".format(k, scores['precision@k'][k]*100))
+            logger.info("Precision@{}: {:.2f}%".format(k, scores['precision@k'][k]*100))
 
         for k in scores['recall@k']:
-            logging.info("Recall@{}: {:.2f}%".format(k, scores['recall@k'][k]*100))
+            logger.info("Recall@{}: {:.2f}%".format(k, scores['recall@k'][k]*100))
 
         for k in scores['mrr@k']:
-            logging.info("MRR@{}: {:.4f}".format(k, scores['mrr@k'][k]))
+            logger.info("MRR@{}: {:.4f}".format(k, scores['mrr@k'][k]))
 
         for k in scores['ndcg@k']:
-            logging.info("NDCG@{}: {:.4f}".format(k, scores['ndcg@k'][k]))
+            logger.info("NDCG@{}: {:.4f}".format(k, scores['ndcg@k'][k]))
 
         for k in scores['map@k']:
-            logging.info("MAP@{}: {:.4f}".format(k, scores['map@k'][k]))
+            logger.info("MAP@{}: {:.4f}".format(k, scores['map@k'][k]))
 
 
     @staticmethod

--- a/sentence_transformers/evaluation/LabelAccuracyEvaluator.py
+++ b/sentence_transformers/evaluation/LabelAccuracyEvaluator.py
@@ -7,6 +7,9 @@ from ..util import batch_to_device
 import os
 import csv
 
+
+logger = logging.getLogger(__name__)
+
 class LabelAccuracyEvaluator(SentenceEvaluator):
     """
     Evaluate a model based on its accuracy on a labeled dataset
@@ -46,7 +49,7 @@ class LabelAccuracyEvaluator(SentenceEvaluator):
         else:
             out_txt = ":"
 
-        logging.info("Evaluation on the "+self.name+" dataset"+out_txt)
+        logger.info("Evaluation on the "+self.name+" dataset"+out_txt)
         self.dataloader.collate_fn = model.smart_batching_collate
         for step, batch in enumerate(tqdm(self.dataloader, desc="Evaluating")):
             features, label_ids = batch_to_device(batch, model.device)
@@ -57,7 +60,7 @@ class LabelAccuracyEvaluator(SentenceEvaluator):
             correct += torch.argmax(prediction, dim=1).eq(label_ids).sum().item()
         accuracy = correct/total
 
-        logging.info("Accuracy: {:.4f} ({}/{})\n".format(accuracy, correct, total))
+        logger.info("Accuracy: {:.4f} ({}/{})\n".format(accuracy, correct, total))
 
         if output_path is not None:
             csv_path = os.path.join(output_path, self.csv_file)

--- a/sentence_transformers/evaluation/MSEEvaluator.py
+++ b/sentence_transformers/evaluation/MSEEvaluator.py
@@ -5,6 +5,9 @@ import os
 import csv
 from typing import List
 
+
+logger = logging.getLogger(__name__)
+
 class MSEEvaluator(SentenceEvaluator):
     """
     Computes the mean squared error (x100) between the computed sentence embedding
@@ -46,8 +49,8 @@ class MSEEvaluator(SentenceEvaluator):
         mse = ((self.source_embeddings - target_embeddings)**2).mean()
         mse *= 100
 
-        logging.info("MSE evaluation (lower = better) on "+self.name+" dataset"+out_txt)
-        logging.info("MSE (*100):\t{:4f}".format(mse))
+        logger.info("MSE evaluation (lower = better) on "+self.name+" dataset"+out_txt)
+        logger.info("MSE (*100):\t{:4f}".format(mse))
 
         if output_path is not None:
             csv_path = os.path.join(output_path, self.csv_file)

--- a/sentence_transformers/evaluation/MSEEvaluatorFromDataFrame.py
+++ b/sentence_transformers/evaluation/MSEEvaluatorFromDataFrame.py
@@ -9,6 +9,9 @@ import os
 import csv
 
 
+logger = logging.getLogger(__name__)
+
+
 class MSEEvaluatorFromDataFrame(SentenceEvaluator):
     """
     Computes the mean squared error (x100) between the computed sentence embedding
@@ -36,7 +39,7 @@ class MSEEvaluatorFromDataFrame(SentenceEvaluator):
         self.csv_headers = ["epoch", "steps"]
         self.data = {}
 
-        logging.info("Compute teacher embeddings")
+        logger.info("Compute teacher embeddings")
         all_source_sentences = set()
         for src_lang, trg_lang in self.combinations:
             src_sentences = []
@@ -69,8 +72,8 @@ class MSEEvaluatorFromDataFrame(SentenceEvaluator):
             mse *= 100
             mse_scores.append(mse)
 
-            logging.info("MSE evaluation on {} dataset - {}-{}:".format(self.name, src_lang, trg_lang))
-            logging.info("MSE (*100):\t{:4f}".format(mse))
+            logger.info("MSE evaluation on {} dataset - {}-{}:".format(self.name, src_lang, trg_lang))
+            logger.info("MSE (*100):\t{:4f}".format(mse))
 
         if output_path is not None:
             csv_path = os.path.join(output_path, self.csv_file)

--- a/sentence_transformers/evaluation/ParaphraseMiningEvaluator.py
+++ b/sentence_transformers/evaluation/ParaphraseMiningEvaluator.py
@@ -8,6 +8,9 @@ from typing import List, Tuple, Dict
 from collections import defaultdict
 
 
+logger = logging.getLogger(__name__)
+
+
 class ParaphraseMiningEvaluator(SentenceEvaluator):
     """
     Given a large set of sentences, this evaluator performs paraphrase (duplicate) mining and
@@ -78,13 +81,13 @@ class ParaphraseMiningEvaluator(SentenceEvaluator):
         else:
             out_txt = ":"
 
-        logging.info("Paraphrase Mining Evaluation on " + self.name + " dataset" + out_txt)
+        logger.info("Paraphrase Mining Evaluation on " + self.name + " dataset" + out_txt)
 
         #Compute embedding for the sentences
         pairs_list = paraphrase_mining(model, self.sentences, self.show_progress_bar, self.batch_size,  self.query_chunk_size,  self.corpus_chunk_size, self.max_pairs, self.top_k )
 
 
-        logging.info("Number of candidate pairs: " + str(len(pairs_list)))
+        logger.info("Number of candidate pairs: " + str(len(pairs_list)))
 
         #Compute F1 score and Average Precision
         n_extract = n_correct = 0
@@ -114,11 +117,11 @@ class ParaphraseMiningEvaluator(SentenceEvaluator):
 
         average_precision = average_precision / self.total_num_duplicates
 
-        logging.info("Average Precision: {:.2f}".format(average_precision * 100))
-        logging.info("Optimal threshold: {:.4f}".format(threshold))
-        logging.info("Precision: {:.2f}".format(best_precision * 100))
-        logging.info("Recall: {:.2f}".format(best_recall * 100))
-        logging.info("F1: {:.2f}\n".format(best_f1 * 100))
+        logger.info("Average Precision: {:.2f}".format(average_precision * 100))
+        logger.info("Optimal threshold: {:.4f}".format(threshold))
+        logger.info("Precision: {:.2f}".format(best_precision * 100))
+        logger.info("Recall: {:.2f}".format(best_recall * 100))
+        logger.info("F1: {:.2f}\n".format(best_f1 * 100))
 
         if output_path is not None:
             csv_path = os.path.join(output_path, self.csv_file)

--- a/sentence_transformers/evaluation/TranslationEvaluator.py
+++ b/sentence_transformers/evaluation/TranslationEvaluator.py
@@ -8,6 +8,9 @@ import scipy.spatial
 from typing import List
 import torch
 
+
+logger = logging.getLogger(__name__)
+
 class TranslationEvaluator(SentenceEvaluator):
     """
     Given two sets of sentences in different languages, e.g. (en_1, en_2, en_3...) and (fr_1, fr_2, fr_3, ...),
@@ -51,7 +54,7 @@ class TranslationEvaluator(SentenceEvaluator):
         else:
             out_txt = ":"
 
-        logging.info("Evaluating translation matching Accuracy on "+self.name+" dataset"+out_txt)
+        logger.info("Evaluating translation matching Accuracy on "+self.name+" dataset"+out_txt)
 
         embeddings1 = torch.stack(model.encode(self.source_sentences, show_progress_bar=self.show_progress_bar, batch_size=self.batch_size, convert_to_numpy=False))
         embeddings2 = torch.stack(model.encode(self.target_sentences, show_progress_bar=self.show_progress_bar, batch_size=self.batch_size, convert_to_numpy=False))
@@ -89,8 +92,8 @@ class TranslationEvaluator(SentenceEvaluator):
         acc_src2trg = correct_src2trg / len(cos_sims)
         acc_trg2src = correct_trg2src / len(cos_sims)
 
-        logging.info("Accuracy src2trg: {:.2f}".format(acc_src2trg*100))
-        logging.info("Accuracy trg2src: {:.2f}".format(acc_trg2src*100))
+        logger.info("Accuracy src2trg: {:.2f}".format(acc_src2trg*100))
+        logger.info("Accuracy trg2src: {:.2f}".format(acc_trg2src*100))
 
         if output_path is not None:
             csv_path = os.path.join(output_path, self.csv_file)

--- a/sentence_transformers/evaluation/TripletEvaluator.py
+++ b/sentence_transformers/evaluation/TripletEvaluator.py
@@ -7,6 +7,8 @@ from typing import List
 from ..readers import InputExample
 
 
+logger = logging.getLogger(__name__)
+
 class TripletEvaluator(SentenceEvaluator):
     """
     Evaluate a model based on a triplet: (sentence, positive_example, negative_example). Checks if distance(sentence,positive_example) < distance(sentence, negative_example).
@@ -60,7 +62,7 @@ class TripletEvaluator(SentenceEvaluator):
         else:
             out_txt = ":"
 
-        logging.info("TripletEvaluator: Evaluating the model on "+self.name+" dataset"+out_txt)
+        logger.info("TripletEvaluator: Evaluating the model on "+self.name+" dataset"+out_txt)
 
         num_triplets = 0
         num_correct_cos_triplets, num_correct_manhatten_triplets, num_correct_euclidean_triplets = 0, 0, 0
@@ -101,9 +103,9 @@ class TripletEvaluator(SentenceEvaluator):
         accuracy_manhatten = num_correct_manhatten_triplets / num_triplets
         accuracy_euclidean = num_correct_euclidean_triplets / num_triplets
 
-        logging.info("Accuracy Cosine Distance:   \t{:.2f}".format(accuracy_cos*100))
-        logging.info("Accuracy Manhatten Distance:\t{:.2f}".format(accuracy_manhatten*100))
-        logging.info("Accuracy Euclidean Distance:\t{:.2f}\n".format(accuracy_euclidean*100))
+        logger.info("Accuracy Cosine Distance:   \t{:.2f}".format(accuracy_cos*100))
+        logger.info("Accuracy Manhatten Distance:\t{:.2f}".format(accuracy_manhatten*100))
+        logger.info("Accuracy Euclidean Distance:\t{:.2f}\n".format(accuracy_euclidean*100))
 
         if output_path is not None:
             csv_path = os.path.join(output_path, self.csv_file)

--- a/sentence_transformers/losses/SoftmaxLoss.py
+++ b/sentence_transformers/losses/SoftmaxLoss.py
@@ -4,6 +4,9 @@ from typing import Union, Tuple, List, Iterable, Dict
 from ..SentenceTransformer import SentenceTransformer
 import logging
 
+
+logger = logging.getLogger(__name__)
+
 class SoftmaxLoss(nn.Module):
     """
     This loss was used in our SBERT publication (https://arxiv.org/abs/1908.10084) to train the SentenceTransformer
@@ -49,7 +52,7 @@ class SoftmaxLoss(nn.Module):
             num_vectors_concatenated += 1
         if concatenation_sent_multiplication:
             num_vectors_concatenated += 1
-        logging.info("Softmax loss: #Vectors concatenated: {}".format(num_vectors_concatenated))
+        logger.info("Softmax loss: #Vectors concatenated: {}".format(num_vectors_concatenated))
         self.classifier = nn.Linear(num_vectors_concatenated * sentence_embedding_dimension, num_labels)
 
     def forward(self, sentence_features: Iterable[Dict[str, Tensor]], labels: Tensor):

--- a/sentence_transformers/models/BoW.py
+++ b/sentence_transformers/models/BoW.py
@@ -8,6 +8,9 @@ import logging
 import numpy as np
 from .tokenizer import WhitespaceTokenizer
 
+
+logger = logging.getLogger(__name__)
+
 class BoW(nn.Module):
     """Implements a Bag-of-Words (BoW) model to derive sentence embeddings.
 
@@ -36,7 +39,7 @@ class BoW(nn.Module):
                 num_unknown_words += 1
             self.weights.append(weight)
 
-        logging.info("{} out of {} words without a weighting value. Set weight to {}".format(num_unknown_words, len(vocab), unknown_word_weight))
+        logger.info("{} out of {} words without a weighting value. Set weight to {}".format(num_unknown_words, len(vocab), unknown_word_weight))
 
         self.tokenizer = WhitespaceTokenizer(vocab, stop_words=set(), do_lower_case=False)
         self.sentence_embedding_dimension = len(vocab)

--- a/sentence_transformers/models/T5.py
+++ b/sentence_transformers/models/T5.py
@@ -6,6 +6,9 @@ import os
 import numpy as np
 import logging
 
+
+logger = logging.getLogger(__name__)
+
 class T5(nn.Module):
     """DEPRECATED: Please use models.Transformer instead.
 
@@ -19,7 +22,7 @@ class T5(nn.Module):
         self.do_lower_case = do_lower_case
 
         if max_seq_length > 512:
-            logging.warning("T5 only allows a max_seq_length of 512. Value will be set to 512")
+            logger.warning("T5 only allows a max_seq_length of 512. Value will be set to 512")
             max_seq_length = 512
         self.max_seq_length = max_seq_length
 

--- a/sentence_transformers/models/WordEmbeddings.py
+++ b/sentence_transformers/models/WordEmbeddings.py
@@ -11,6 +11,8 @@ from ..util import import_from_string, fullname, http_get
 from .tokenizer import WordTokenizer, WhitespaceTokenizer
 
 
+logger = logging.getLogger(__name__)
+
 class WordEmbeddings(nn.Module):
     def __init__(self, tokenizer: WordTokenizer, embedding_weights, update_embeddings: bool = False, max_seq_length: int = 1000000):
         nn.Module.__init__(self)
@@ -84,10 +86,10 @@ class WordEmbeddings(nn.Module):
 
     @staticmethod
     def from_text_file(embeddings_file_path: str, update_embeddings: bool = False, item_separator: str = " ", tokenizer=WhitespaceTokenizer(), max_vocab_size: int = None):
-        logging.info("Read in embeddings file {}".format(embeddings_file_path))
+        logger.info("Read in embeddings file {}".format(embeddings_file_path))
 
         if not os.path.exists(embeddings_file_path):
-            logging.info("{} does not exist, try to download from server".format(embeddings_file_path))
+            logger.info("{} does not exist, try to download from server".format(embeddings_file_path))
 
             if '/' in embeddings_file_path or '\\' in embeddings_file_path:
                 raise ValueError("Embeddings file not found: ".format(embeddings_file_path))
@@ -111,7 +113,7 @@ class WordEmbeddings(nn.Module):
                     embeddings.append(np.zeros(embeddings_dimension))
 
                 if (len(split) - 1) != embeddings_dimension:  # Assure that all lines in the embeddings file are of the same length
-                    logging.error("ERROR: A line in the embeddings file had more or less  dimensions than expected. Skip token.")
+                    logger.error("ERROR: A line in the embeddings file had more or less  dimensions than expected. Skip token.")
                     continue
 
                 vector = np.array([float(num) for num in split[1:]])

--- a/sentence_transformers/models/WordWeights.py
+++ b/sentence_transformers/models/WordWeights.py
@@ -6,6 +6,9 @@ import os
 import json
 import logging
 
+
+logger = logging.getLogger(__name__)
+
 class WordWeights(nn.Module):
     """This model can weight word embeddings, for example, with idf-values."""
 
@@ -36,8 +39,8 @@ class WordWeights(nn.Module):
             else:
                 num_unknown_words += 1
             weights.append(weight)
-        
-        logging.info("{} of {} words without a weighting value. Set weight to {}".format(num_unknown_words, len(vocab), unknown_word_weight))
+
+        logger.info("{} of {} words without a weighting value. Set weight to {}".format(num_unknown_words, len(vocab), unknown_word_weight))
 
         self.emb_layer = nn.Embedding(len(vocab), 1)
         self.emb_layer.load_state_dict({'weight': torch.FloatTensor(weights).unsqueeze(1)})

--- a/sentence_transformers/models/tokenizer/PhraseTokenizer.py
+++ b/sentence_transformers/models/tokenizer/PhraseTokenizer.py
@@ -7,6 +7,9 @@ import logging
 from .WordTokenizer import WordTokenizer, ENGLISH_STOP_WORDS
 import nltk
 
+
+logger = logging.getLogger(__name__)
+
 class PhraseTokenizer(WordTokenizer):
     """Tokenizes the text with respect to existent phrases in the vocab.
 
@@ -40,8 +43,8 @@ class PhraseTokenizer(WordTokenizer):
                     self.ngram_lengths.add(ngram_count)
 
         if len(vocab) > 0:
-            logging.info("PhraseTokenizer - Phrase ngram lengths: {}".format(self.ngram_lengths))
-            logging.info("PhraseTokenizer - Num phrases: {}".format(len(self.ngram_lookup)))
+            logger.info("PhraseTokenizer - Phrase ngram lengths: {}".format(self.ngram_lengths))
+            logger.info("PhraseTokenizer - Num phrases: {}".format(len(self.ngram_lookup)))
 
     def tokenize(self, text: str) -> List[int]:
         tokens = nltk.word_tokenize(text, preserve_line=True)

--- a/sentence_transformers/util.py
+++ b/sentence_transformers/util.py
@@ -8,6 +8,10 @@ import os
 import torch
 import numpy as np
 import queue
+import logging
+
+
+logger = logging.getLogger(__name__)
 
 
 def pytorch_cos_sim(a: Tensor, b: Tensor):
@@ -72,7 +76,7 @@ def paraphrase_mining(model,
         for query_start_idx in range(0, len(embeddings), query_chunk_size):
             query_end_idx = min(query_start_idx + query_chunk_size, len(embeddings))
 
-            #logging.info("Compute cosine similarities")
+            #logger.info("Compute cosine similarities")
             cos_scores = pytorch_cos_sim(embeddings[query_start_idx:query_end_idx],
                                          embeddings[corpus_start_idx:corpus_end_idx]).cpu()
 
@@ -81,7 +85,7 @@ def paraphrase_mining(model,
             cos_scores_top_k_values = cos_scores_top_k_values.tolist()
             cos_scores_top_k_idx = cos_scores_top_k_idx.tolist()
 
-            #logging.info("Find most similar pairs out of {} queries".format(len(cos_scores)))
+            #logger.info("Find most similar pairs out of {} queries".format(len(cos_scores)))
             for query_itr in range(len(cos_scores)):
                 for top_k_idx, corpus_itr in enumerate(cos_scores_top_k_idx[query_itr]):
                     i = query_start_idx + query_itr


### PR DESCRIPTION
This PR addresses [issue#514](https://github.com/UKPLab/sentence-transformers/issues/514)

**Main changes**:

- Added `install_logger` function in `LoggingHandler` to simplify the configuration of the library logger
- Added call to `install_logger` function in `__init__.py` to set the library logger properties (level, format, etc) and optionally from a env. variable `ST_LOG_LEVEL` to control the library logging level
- Removed the use of `logging.info` and similar calls for `logger.info`. Each file uses its logger inheriting from the library root logger. 

**Dependency additions**:

- Dependency addition:  `coloredlogs` to enable colored logging based on the logging level. 

This is actually optional, I consider it helpful when reading logs but totally optional and can be removed if prefered.

-----

> **NOTE**: I've run the tests as `pytest -s tests/` both in the `master` branch and the one for this PR. With some test failing. I am unsure if this tests should be run differently. 