### PR TITLE
cos similarirty between embeddings instead of direct MSE

### DIFF
--- a/sentence_transformers/losses/COSLoss.py
+++ b/sentence_transformers/losses/COSLoss.py
@@ -1,0 +1,24 @@
+import torch
+from torch import nn, Tensor
+from typing import Union, Tuple, List, Iterable, Dict
+
+
+class COSLoss(nn.Module):
+    """
+    Computes the cosine similarity between the computed sentence embedding and a target sentence embedding. 
+    The final loss is then computed with MSE between the returned similarity and label of 1.0.
+    This loss should work similar to the MSELoss, but instead of MSE minimization between sentence embedding and target, 
+    cosinus similarity is used.
+    For an example, see the documentation on extending language models to new languages.
+    """
+    def __init__(self, model, loss_fct = nn.MSELoss()):
+        super(COSLoss, self).__init__()
+        self.model = model
+        self.loss_fct = loss_fct
+
+    def forward(self, sentence_features: Iterable[Dict[str, Tensor]], labels: Tensor):
+        rep = self.model(sentence_features[0])['sentence_embedding']
+        cos_sim = torch.cosine_similarity(rep, labels)
+        float_labs = torch.Tensor([1.0 for x in cos_sim]).cuda()
+
+        return self.loss_fct(cos_sim, float_labs)

--- a/sentence_transformers/losses/MSELoss.py
+++ b/sentence_transformers/losses/MSELoss.py
@@ -18,4 +18,11 @@ class MSELoss(nn.Module):
 
     def forward(self, sentence_features: Iterable[Dict[str, Tensor]], labels: Tensor):
         rep = self.model(sentence_features[0])['sentence_embedding']
-        return self.loss_fct(rep, labels)
+        """
+        Calculate cosine similarity between the vector embeddings and 
+        then the MSE between the it's similarity and label of 1.0
+        """
+        cos_sim = torch.cosine_similarity(rep, labels)
+        float_labs = torch.Tensor([1.0 for x in cos_sim]).cuda()
+
+        return self.loss_fct(cos_sim, float_labs)

--- a/sentence_transformers/losses/MSELoss.py
+++ b/sentence_transformers/losses/MSELoss.py
@@ -18,11 +18,4 @@ class MSELoss(nn.Module):
 
     def forward(self, sentence_features: Iterable[Dict[str, Tensor]], labels: Tensor):
         rep = self.model(sentence_features[0])['sentence_embedding']
-        """
-        Calculate cosine similarity between the vector embeddings and 
-        then the MSE between the it's similarity and label of 1.0
-        """
-        cos_sim = torch.cosine_similarity(rep, labels)
-        float_labs = torch.Tensor([1.0 for x in cos_sim]).cuda()
-
-        return self.loss_fct(cos_sim, float_labs)
+        return self.loss_fct(rep, labels)


### PR DESCRIPTION
Since our embeddings might never achieve very good similarity in terms of MSE (hyperdimensional space), we would much rather prefer the cosine similarity as this is the angular similarity measure.
1. Cosine similarity between the our embeddings and then MSE between the returned similarity measures and label of 1.0