### PR TITLE
remove unsupported arg output_path_ignore_not_empty from examples 

### DIFF
--- a/examples/training/data_augmentation/train_sts_qqp_crossdomain.py
+++ b/examples/training/data_augmentation/train_sts_qqp_crossdomain.py
@@ -207,8 +207,7 @@ bi_encoder.fit(train_objectives=[(train_dataloader, train_loss)],
           epochs=num_epochs,
           evaluation_steps=1000,
           warmup_steps=warmup_steps,
-          output_path=bi_encoder_path,
-          output_path_ignore_not_empty=True
+          output_path=bi_encoder_path
           )
 
 ###############################################################

--- a/examples/training/data_augmentation/train_sts_seed_optimization.py
+++ b/examples/training/data_augmentation/train_sts_seed_optimization.py
@@ -132,5 +132,4 @@ for seed in range(seed_count):
             steps_per_epoch=steps_per_epoch,
             evaluation_steps=1000,
             warmup_steps=warmup_steps,
-            output_path=model_save_path,
-            output_path_ignore_not_empty=True)
+            output_path=model_save_path)

--- a/examples/training/distillation/model_distillation.py
+++ b/examples/training/distillation/model_distillation.py
@@ -194,6 +194,5 @@ student_model.fit(train_objectives=[(train_dataloader, train_loss)],
                   output_path=output_path,
                   save_best_model=True,
                   optimizer_params={'lr': 1e-4, 'eps': 1e-6, 'correct_bias': False},
-                  use_amp=True,
-                  output_path_ignore_not_empty=True)
+                  use_amp=True)
 

--- a/examples/training/quora_duplicate_questions/README.md
+++ b/examples/training/quora_duplicate_questions/README.md
@@ -152,8 +152,7 @@ model.fit(train_objectives=[(train_dataloader_MultipleNegativesRankingLoss, trai
           evaluator=seq_evaluator,
           epochs=num_epochs,
           warmup_steps=1000,
-          output_path=model_save_path,
-          output_path_ignore_not_empty=True
+          output_path=model_save_path
           )
 ```
 

--- a/examples/training/quora_duplicate_questions/training_MultipleNegativesRankingLoss.py
+++ b/examples/training/quora_duplicate_questions/training_MultipleNegativesRankingLoss.py
@@ -187,6 +187,5 @@ model.fit(train_objectives=[(train_dataloader, train_loss)],
           evaluator=seq_evaluator,
           epochs=num_epochs,
           warmup_steps=1000,
-          output_path=model_save_path,
-          output_path_ignore_not_empty=True
+          output_path=model_save_path
           )

--- a/examples/training/quora_duplicate_questions/training_OnlineContrastiveLoss.py
+++ b/examples/training/quora_duplicate_questions/training_OnlineContrastiveLoss.py
@@ -186,6 +186,5 @@ model.fit(train_objectives=[(train_dataloader, train_loss)],
           evaluator=seq_evaluator,
           epochs=num_epochs,
           warmup_steps=1000,
-          output_path=model_save_path,
-          output_path_ignore_not_empty=True
+          output_path=model_save_path
           )

--- a/examples/training/quora_duplicate_questions/training_multi-task-learning.py
+++ b/examples/training/quora_duplicate_questions/training_multi-task-learning.py
@@ -204,6 +204,5 @@ model.fit(train_objectives=[(train_dataloader_MultipleNegativesRankingLoss, trai
           evaluator=seq_evaluator,
           epochs=num_epochs,
           warmup_steps=1000,
-          output_path=model_save_path,
-          output_path_ignore_not_empty=True
+          output_path=model_save_path
           )


### PR DESCRIPTION
The `fit` methods in these examples are still taking in `output_path_ignore_not_empty` as input. This argument of `fit` has been deprecated and removed previously. Hence, it's leading to errors when installed from source 

I removed this as an argument in the fit methods of the examples that were using them 

Issue #716