### PR TITLE
Add support for pytorch model quantization, add quantization example

### DIFF
--- a/examples/evaluation/evaluation_stsbenchmark_quantization.py
+++ b/examples/evaluation/evaluation_stsbenchmark_quantization.py
@@ -1,6 +1,6 @@
 """
 This examples loads a pre-trained model, and creates two instances of it.
-One model's weights are untouched and the others are quantized. Both are then evaluated on the STSbenchmark dataset
+One model's weights are untouched and the others are quantized. Both are then evaluated on the STSBenchmark dataset
 
 For more on quantization see https://pytorch.org/docs/stable/quantization.html
 Usage:
@@ -37,7 +37,7 @@ model_name = sys.argv[1] if len(sys.argv) > 1 else 'paraphrase-distilroberta-bas
 # Load a named sentence model (based on BERT). This will download the model from our server.
 # Alternatively, you can also pass a filepath to SentenceTransformer()
 model = SentenceTransformer(model_name)
-q_model = SentenceTransformer(model_name,quantize_model=True)
+q_model = SentenceTransformer(model_name, quantize_model=True)
 
 sts_reader = STSBenchmarkDataReader(os.path.join(script_folder_path, '../datasets/stsbenchmark'))
 evaluator = EmbeddingSimilarityEvaluator.from_input_examples(sts_reader.get_examples("sts-test.csv"), name='sts-test')
@@ -46,7 +46,7 @@ logging.info("Starting regular model evaluation")
 model.evaluate(evaluator)
 
 
-logging.info("Starting quantized nodel evaluation")
+logging.info("Starting quantized model evaluation")
 q_model.evaluate(evaluator)
 
 

--- a/examples/evaluation/evaluation_stsbenchmark_quantization.py
+++ b/examples/evaluation/evaluation_stsbenchmark_quantization.py
@@ -1,0 +1,62 @@
+"""
+This examples loads a pre-trained model, and creates two instances of it.
+One model's weights are untouched and the others are quantized. Both are then evaluated on the STSbenchmark dataset
+
+For more on quantization see https://pytorch.org/docs/stable/quantization.html
+Usage:
+python evaluation_stsbenchmark.py
+OR
+python evaluation_stsbenchmark.py model_name
+"""
+import logging
+import os
+import sys
+
+import torch
+# pyinfer not in base environment - pip install pyinfer
+from pyinfer import MultiInferenceReport
+from sentence_transformers import LoggingHandler, SentenceTransformer
+from sentence_transformers.evaluation import EmbeddingSimilarityEvaluator
+from sentence_transformers.readers import STSBenchmarkDataReader
+from torch.utils.data import DataLoader
+
+
+script_folder_path = os.path.dirname(os.path.realpath(__file__))
+
+#Limit torch to 4 threads
+torch.set_num_threads(4)
+
+#### Just some code to print debug information to stdout
+logging.basicConfig(format='%(asctime)s - %(message)s',
+                    datefmt='%Y-%m-%d %H:%M:%S',
+                    level=logging.INFO)
+### /print debug information to stdout
+
+model_name = sys.argv[1] if len(sys.argv) > 1 else 'paraphrase-distilroberta-base-v1'
+
+# Load a named sentence model (based on BERT). This will download the model from our server.
+# Alternatively, you can also pass a filepath to SentenceTransformer()
+model = SentenceTransformer(model_name)
+q_model = SentenceTransformer(model_name,quantize_model=True)
+
+sts_reader = STSBenchmarkDataReader(os.path.join(script_folder_path, '../datasets/stsbenchmark'))
+evaluator = EmbeddingSimilarityEvaluator.from_input_examples(sts_reader.get_examples("sts-test.csv"), name='sts-test')
+
+logging.info("Starting regular model evaluation")
+model.evaluate(evaluator)
+
+
+logging.info("Starting quantized nodel evaluation")
+q_model.evaluate(evaluator)
+
+
+logging.info("Evaluating inference speed statistics")
+
+
+sentences = ['This framework generates embeddings for each input sentence',
+            'Sentences are passed as a list of string.', 
+            'The quick brown fox jumps over the lazy dog.']
+
+logging.getLogger().setLevel(5)
+report = MultiInferenceReport([model.encode, q_model.encode], sentences, n_iterations=500, model_names=["distilroberta","q_distilroberta"])
+report.run()

--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -35,7 +35,7 @@ class SentenceTransformer(nn.Sequential):
     :param model_name_or_path: If it is a filepath on disc, it loads the model from that path. If it is not a path, it first tries to download a pre-trained SentenceTransformer model. If that fails, tries to construct a model from Huggingface models repository with that name.
     :param modules: This parameter can be used to create custom SentenceTransformer models from scratch.
     :param device: Device (like 'cuda' / 'cpu') that should be used for computation. If None, checks if a GPU can be used.
-    :param quantize_model: This parameter controls whether a model's modules are dynamically quantized see https://pytorch.org/docs/stable/quantization.html for more details.
+    :param quantize_model: This bool parameter controls whether a model's modules are dynamically quantized see https://pytorch.org/docs/stable/quantization.html for more details.
     Quantization can deliver significant improvements in inference speed for models by storing tensors at lower bitwidths than floating point precision.
     Quantization is currently only supported by pytorch on cpu.
     """


### PR DESCRIPTION
Hi,

I recently had the need to squeeze out as much performance at inference from a sentence transformers model as possible so I had a look at integrating Pytorch's very neat quantization tools into the package.

It turned out to be a very simple change to make and I thought I would propose it as a PR to the base `SentenceTransformer` class as I had noticed there had been a mention of it recently #627. This implementation uses dynamic quantization from [Pytorch's quantization API](https://pytorch.org/docs/1.7.1/quantization.html). It specifically quantizes all `Linear` and `Embedding` modules in the Transformer model, if GPT2 like model architectures were ever added to the package we could also add `Conv1D` modules to this quantization as GPT2 uses these layers also. 

Additionally, I've added a script in the `examples/evaluation` directory to allow easy comparision of quantized versus non-quantized models, the script runs the STSBenchmark on both models (`paraphrase-distilroberta-base-v1` by default) and then runs an inference speed benchmark. I've copied the results from my machine below, as you can see the quantized model still performs fairly well on most metrics often dropping less than 1% on scores. The most notable drop occur in `Dot-Product-Similarity`. 

I think this could be a nice overall addition to the package and there are definitely some great benefits in terms of inference speed for production situations like my own. 

**STS Benchmark Results**
```
2021-02-24 21:53:38 - Use pytorch device: cpu
2021-02-24 21:53:39 - Starting regular model evaluation
2021-02-24 21:53:39 - EmbeddingSimilarityEvaluator: Evaluating the model on sts-test dataset:
2021-02-24 21:54:25 - Cosine-Similarity :       Pearson: 0.8236 Spearman: 0.8179
2021-02-24 21:54:25 - Manhattan-Distance:       Pearson: 0.7481 Spearman: 0.7478
2021-02-24 21:54:25 - Euclidean-Distance:       Pearson: 0.7518 Spearman: 0.7519
2021-02-24 21:54:25 - Dot-Product-Similarity:   Pearson: 0.7443 Spearman: 0.7356
2021-02-24 21:54:25 - Starting quantized model evaluation
2021-02-24 21:54:25 - EmbeddingSimilarityEvaluator: Evaluating the model on sts-test dataset:
2021-02-24 21:54:38 - Cosine-Similarity :       Pearson: 0.8112 Spearman: 0.8106
2021-02-24 21:54:38 - Manhattan-Distance:       Pearson: 0.7339 Spearman: 0.7315
2021-02-24 21:54:38 - Euclidean-Distance:       Pearson: 0.7392 Spearman: 0.7369
2021-02-24 21:54:38 - Dot-Product-Similarity:   Pearson: 0.7042 Spearman: 0.6861
```
**Inference Speed Report** 
Each model is run for 500 inferences on a batch of 3 short sentences. These results show ~3x improvement on inference time for this particular model. `distilroberta` is as normal while `q_distilroberta` has it's Linear and Embedding layers quantized. 
```
╒═════════════════╤═══════════╤════════╤═════════╤════════════════╤══════════════╤══════════════╤═══════════╤════════════╤══════════════╤═══════════╤════════════╤════════════╕
│ Model           │   Success │   Fail │    Took │   Infer(p/sec) │   MaxRun(ms) │   MinRun(ms) │   Std(ms) │   Mean(ms) │   Median(ms) │   IQR(ms) │   Cores(L) │   Cores(P) │
╞═════════════════╪═══════════╪════════╪═════════╪════════════════╪══════════════╪══════════════╪═══════════╪════════════╪══════════════╪═══════════╪════════════╪════════════╡
│ distilroberta   │       500 │      0 │ 17.1329 │          29.18 │         42.9 │         29.6 │    2.3832 │     34.266 │           34 │       2.9 │         16 │          8 │
├─────────────────┼───────────┼────────┼─────────┼────────────────┼──────────────┼──────────────┼───────────┼────────────┼──────────────┼───────────┼────────────┼────────────┤
│ q_distilroberta │       500 │      0 │ 5.70767 │           87.6 │         16.6 │          7.8 │   1.77495 │    11.4148 │         11.1 │       2.6 │         16 │          8 │
╘═════════════════╧═══════════╧════════╧═════════╧════════════════╧══════════════╧══════════════╧═══════════╧════════════╧══════════════╧═══════════╧════════════╧════════════╛

```