### PR TITLE
Allow `batch` to be a tuple in `batch_to_device`

### DIFF
--- a/sentence_transformers/util.py
+++ b/sentence_transformers/util.py
@@ -241,10 +241,19 @@ def batch_to_device(batch, target_device: device):
     """
     send a pytorch batch to a device (CPU/GPU)
     """
-    for key in batch:
-        if isinstance(batch[key], Tensor):
-            batch[key] = batch[key].to(target_device)
-    return batch
+    if isinstance(batch, dict):
+        for key in batch:
+            if isinstance(batch[key], Tensor):
+                batch[key] = batch[key].to(target_device)
+        return batch
+    elif isinstance(batch, tuple):
+        return tuple(map(lambda item: batch_to_device(item, target_device), batch))
+    elif isinstance(batch, list):
+        return list(map(lambda item: batch_to_device(item, target_device), batch))
+    elif isinstance(batch, Tensor):
+        return batch.to(target_device)
+    else:
+        raise ValueError("batch should be a dictionary, tuple, or list of tensors")
 
 
 


### PR DESCRIPTION
While evaluating using the `LabelAccuracyEvaluator`, the batch are not dictionaries, but rather a tuple containing a dictionary as first value, and a tensor as second value. This causes `batch_to_device(...)` to fail with error `TypeError: tuple indices must be integers or slices, not list`.

I fixed `batch_to_device` to be more tolerating in what types it accepts. Possibly `LabelAccuracyEvaluator` could use a refactor to avoid this scheme, but I think the solution I propose has the advantage of always outputting a clear error message.