### PR TITLE
Add path for tokenizer if its name is different than model name

### DIFF
--- a/sentence_transformers/models/Transformer.py
+++ b/sentence_transformers/models/Transformer.py
@@ -18,15 +18,17 @@ class Transformer(nn.Module):
     """
     def __init__(self, model_name_or_path: str, max_seq_length: Optional[int] = None,
                  model_args: Dict = {}, cache_dir: Optional[str] = None,
-                 tokenizer_args: Dict = {}, do_lower_case: bool = False):
+                 tokenizer_args: Dict = {}, do_lower_case: bool = False, tokenizer_name_or_path=None):
         super(Transformer, self).__init__()
+        if not tokenizer_name_or_path:
+            tokenizer_name_or_path = model_name_or_path
         self.config_keys = ['max_seq_length', 'do_lower_case']
         self.max_seq_length = max_seq_length
         self.do_lower_case = do_lower_case
 
         config = AutoConfig.from_pretrained(model_name_or_path, **model_args, cache_dir=cache_dir)
         self.auto_model = AutoModel.from_pretrained(model_name_or_path, config=config, cache_dir=cache_dir)
-        self.tokenizer = AutoTokenizer.from_pretrained(model_name_or_path, cache_dir=cache_dir, **tokenizer_args)
+        self.tokenizer = AutoTokenizer.from_pretrained(tokenizer_name_or_path, cache_dir=cache_dir, **tokenizer_args)
 
 
     def forward(self, features):

--- a/sentence_transformers/models/Transformer.py
+++ b/sentence_transformers/models/Transformer.py
@@ -15,10 +15,11 @@ class Transformer(nn.Module):
     :param cache_dir: Cache dir for Huggingface Transformers to store/load models
     :param tokenizer_args: Arguments (key, value pairs) passed to the Huggingface Tokenizer model
     :param do_lower_case: If true, lowercases the input (independet if the model is cased or not)
+    :param tokenizer_name_or_path: Huggingface tokenizer name. If None than derived from model name
     """
     def __init__(self, model_name_or_path: str, max_seq_length: Optional[int] = None,
                  model_args: Dict = {}, cache_dir: Optional[str] = None,
-                 tokenizer_args: Dict = {}, do_lower_case: bool = False, tokenizer_name_or_path=None):
+                 tokenizer_args: Dict = {}, do_lower_case: bool = False, tokenizer_name_or_path: str = None):
         super(Transformer, self).__init__()
         if not tokenizer_name_or_path:
             tokenizer_name_or_path = model_name_or_path


### PR DESCRIPTION
I have tried to use SBERT with herBERT. It's required to load tokenizer which has different name than model. I added an option for that