### PR TITLE
[Draft] Hugging Face model hub integration

### DIFF
--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -330,7 +330,7 @@ class SentenceTransformer(nn.Sequential):
 
         for idx, name in enumerate(self._modules):
             module = self._modules[name]
-            model_path = os.path.join(path, str(idx)+"_"+type(module).__name__)
+            model_path = path if idx == 0 else os.path.join(path, str(idx)+"_"+type(module).__name__)
             os.makedirs(model_path, exist_ok=True)
             module.save(model_path)
             contained_modules.append({'idx': idx, 'name': name, 'path': os.path.basename(model_path), 'type': type(module).__module__})

--- a/sentence_transformers/__init__.py
+++ b/sentence_transformers/__init__.py
@@ -1,5 +1,5 @@
 __version__ = "1.1.0"
-__DOWNLOAD_SERVER__ = 'http://sbert.net/models/'
+__MODEL_HUB_ORGANIZATION__ = 'sentence-transformers'
 from .datasets import SentencesDataset, ParallelSentencesDataset
 from .LoggingHandler import LoggingHandler
 from .SentenceTransformer import SentenceTransformer


### PR DESCRIPTION
This integration allows easily using models from the Hugging Face hub.

**Current State**
Today, users can either use local models or use models from the server. If both fail, a model is built using `Transformer`. 

**Proposal**
The models will now be hosted in the Hugging Face hub, which comes with many benefits such as all HugginFace users being able to use the models, free storage, versioning, etc. 

There are two directory structures supported thanks 

- New: Base model files are in the main directory. Pooling and additional layers will be in sub-directories. This allows `Transformers` users to use `from_pretrained` easily and add their custom pooling afterwards, which is the current custom use.
- Old: Base model files are in `0_Transformer` directory. This ensures everything still work if users have the old directories.

The new structure requires changing the path of the base in `modules.json` to `"path": ""`,

**Tested**
(Note, osanseviero should be changed to `sentence-transformers` once the models are ready in the organization)
```
# Sentence Transformer Model from organization with modules.json
model = SentenceTransformer('osanseviero/full-sentence-distillroberta2')

# Sentence Transformer Model adding pooling layer to global model
model = SentenceTransformer('bert-base-cased')

# Transformer Model which can also use the uploaded model
model = AutoModel.from_pretrained('osanseviero/full-sentence-distillroberta2')
```
