### PR TITLE
Pass model and tokenizer arguments when instantiating `SentenceTransformer`

### DIFF
--- a/sentence_transformers/models/Transformer.py
+++ b/sentence_transformers/models/Transformer.py
@@ -18,12 +18,17 @@ class Transformer(nn.Module):
     :param tokenizer_name_or_path: Name or path of the tokenizer. When None, then model_name_or_path is used
     """
     def __init__(self, model_name_or_path: str, max_seq_length: Optional[int] = None,
-                 model_args: Dict = {}, cache_dir: Optional[str] = None,
-                 tokenizer_args: Dict = {}, do_lower_case: bool = False,
+                 model_args: Optional[Dict] = None, cache_dir: Optional[str] = None,
+                 tokenizer_args: Optional[Dict] = None, do_lower_case: bool = False,
                  tokenizer_name_or_path : str = None):
         super(Transformer, self).__init__()
         self.config_keys = ['max_seq_length', 'do_lower_case']
         self.do_lower_case = do_lower_case
+
+        if model_args is None:
+            model_args = {}
+        if tokenizer_args is None:
+            tokenizer_args = {}
 
         config = AutoConfig.from_pretrained(model_name_or_path, **model_args, cache_dir=cache_dir)
         self._load_model(model_name_or_path, config, cache_dir, **model_args)

--- a/sentence_transformers/models/Transformer.py
+++ b/sentence_transformers/models/Transformer.py
@@ -138,7 +138,7 @@ class Transformer(nn.Module):
             json.dump(self.get_config_dict(), fOut, indent=2)
 
     @staticmethod
-    def load(input_path: str):
+    def load(input_path: str, model_args: Optional[Dict] = None, tokenizer_args: Optional[Dict] = None):
         #Old classes used other config names than 'sentence_bert_config.json'
         for config_name in ['sentence_bert_config.json', 'sentence_roberta_config.json', 'sentence_distilbert_config.json', 'sentence_camembert_config.json', 'sentence_albert_config.json', 'sentence_xlm-roberta_config.json', 'sentence_xlnet_config.json']:
             sbert_config_path = os.path.join(input_path, config_name)
@@ -147,6 +147,11 @@ class Transformer(nn.Module):
 
         with open(sbert_config_path) as fIn:
             config = json.load(fIn)
+        # Override stored model and tokenizer arguments if specified
+        if model_args:
+            config["model_args"] = {**config.get("model_args", {}), **model_args}
+        if tokenizer_args:
+            config["tokenizer_args"] = {**config.get("tokenizer_args", {}), **tokenizer_args}
         return Transformer(model_name_or_path=input_path, **config)
 
 


### PR DESCRIPTION
Fixes #794.

The `Transformer` class already has `model_args` and `tokenizer_args` arguments in its constructor to allow overriding when instantiating models and tokenizers from the `transformers` library. However, there is no way to set these from the `SentenceTransformers` class, which is the one that many users would be instantiating instead. I have added arguments to the `SentenceTransformers` constructor to allow these to be more easily used.

My specific motivation in this case is to make disabling the fast tokenizer easier, but it should work for any arguments that users might want to override.