### PR TITLE
Preserve `sentence_transformer` version in model config file

### DIFF
--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -794,13 +794,19 @@ class SentenceTransformer(nn.Sequential):
         Loads a full sentence-transformers model
         """
         # Check if the config_sentence_transformers.json file exists (exists since v2 of the framework)
+        # Before v2, models were saved with the sentence_transformers version in config.json
         config_sentence_transformers_json_path = os.path.join(model_path, 'config_sentence_transformers.json')
+        config_json_path = os.path.join(model_path, 'config.json')
         if os.path.exists(config_sentence_transformers_json_path):
             with open(config_sentence_transformers_json_path) as fIn:
                 self._model_config = json.load(fIn)
+        elif os.path.exists(config_json_path):
+            with open(config_json_path) as fIn:
+                old_config = json.load(fIn)
+            self._model_config = {"__version__": {"sentence_transformers": old_config["__version__"]}}
 
-            if '__version__' in self._model_config and 'sentence_transformers' in self._model_config['__version__'] and self._model_config['__version__']['sentence_transformers'] > __version__:
-                logger.warning("You try to use a model that was created with version {}, however, your version is {}. This might cause unexpected behavior or errors. In that case, try to update to the latest version.\n\n\n".format(self._model_config['__version__']['sentence_transformers'], __version__))
+        if '__version__' in self._model_config and 'sentence_transformers' in self._model_config['__version__'] and self._model_config['__version__']['sentence_transformers'] > __version__:
+            logger.warning("You try to use a model that was created with version {}, however, your version is {}. This might cause unexpected behavior or errors. In that case, try to update to the latest version.\n\n\n".format(self._model_config['__version__']['sentence_transformers'], __version__))
 
         # Check if a readme exists
         model_card_path = os.path.join(model_path, 'README.md')


### PR DESCRIPTION
Currently, when loading and saving a `SentenceTransformer` model created with v2, the saved `sentence_transformers`, `transformers`, and `pytorch` versions will be retained. For example, if I run `SentenceTransformer('stsb-roberta-base-v2').save('temp')`, the resulting `config_sentence_transformers.json` file will contain `"transformers": "4.7.0"`, even though I have `transformers==4.9.2` installed locally.

Unfortunately, this behavior does not apply to models originally saved with `sentence_transformers<2`. As can be seen at [lines 378-379 of`SentenceTransformer.py` from v1.2.1](https://github.com/UKPLab/sentence-transformers/blob/v1.2.1/sentence_transformers/SentenceTransformer.py#L378-L379), the `sentence_transformers` version was also being saved in the model. This was introduced in v0.2.0, so this should work for models produced by all releases except for the first release. The [release notes for v0.2.0](https://github.com/UKPLab/sentence-transformers/releases/tag/v0.2.0) note that there were many breaking changes from v0.1.0 anyway, so I don't think it's worth worrying about.

This PR ensures that older models have the same output behavior as newer ones. If this isn't desired, then it might make sense to modify `SentenceTransformer.save()` to not preserve the original versions that were used in model generation.