### PR TITLE
Display correct pooling mode in model card comment

### DIFF
--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -386,7 +386,7 @@ class SentenceTransformer(nn.Sequential):
                 pooling_mode = pooling_module.get_pooling_mode_str()
                 model_card = model_card.replace("{USAGE_TRANSFORMERS_SECTION}", ModelCardTemplate.__USAGE_TRANSFORMERS__)
                 pooling_fct_name, pooling_fct = ModelCardTemplate.model_card_get_pooling_function(pooling_mode)
-                model_card = model_card.replace("{POOLING_FUNCTION}", pooling_fct).replace("{POOLING_FUNCTION_NAME}", pooling_fct_name)
+                model_card = model_card.replace("{POOLING_FUNCTION}", pooling_fct).replace("{POOLING_FUNCTION_NAME}", pooling_fct_name).replace("{POOLING_MODE}", pooling_mode)
                 tags.append('transformers')
 
             # Print full model

--- a/sentence_transformers/model_card_templates.py
+++ b/sentence_transformers/model_card_templates.py
@@ -105,7 +105,7 @@ encoded_input = tokenizer(sentences, padding=True, truncation=True, return_tenso
 with torch.no_grad():
     model_output = model(**encoded_input)
 
-# Perform pooling. In this case, max pooling.
+# Perform pooling. In this case, {POOLING_MODE} pooling.
 sentence_embeddings = {POOLING_FUNCTION_NAME}(model_output, encoded_input['attention_mask'])
 
 print("Sentence embeddings:")


### PR DESCRIPTION
The model card creation would always include a comment saying `max pooling`, even if another pooling mode was used. This PR makes sure it is substituted along with the pooling function and pooling function name.