### PR TITLE
Fix downloading models from Hub

### DIFF
--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -76,15 +76,12 @@ class SentenceTransformer(nn.Sequential):
 
                 model_path = os.path.join(cache_folder, model_name_or_path.replace("/", "_"))
 
-                if not os.path.exists(model_path):
-                    # Download from hub
-                    model_path_tmp = snapshot_download(model_name_or_path,
-                                                       cache_dir=cache_folder,
-                                                       library_name='sentence-transformers',
-                                                       library_version=__version__,
-                                                       ignore_files=['flax_model.msgpack', 'rust_model.ot', 'tf_model.h5'])
-
-                    os.rename(model_path_tmp, model_path)
+                # Download from hub with caching
+                snapshot_download(model_name_or_path,
+                                    cache_dir=cache_folder,
+                                    library_name='sentence-transformers',
+                                    library_version=__version__,
+                                    ignore_files=['flax_model.msgpack', 'rust_model.ot', 'tf_model.h5'])
 
             if os.path.exists(os.path.join(model_path, 'modules.json')):    #Load as SentenceTransformer model
                 modules = self._load_sbert_model(model_path)

--- a/sentence_transformers/util.py
+++ b/sentence_transformers/util.py
@@ -444,6 +444,7 @@ def snapshot_download(
             repo_id, filename=model_file.rfilename, revision=model_info.sha
         )
         relative_filepath = os.path.join(*model_file.rfilename.split("/"))
+
         # Create potential nested dir
         nested_dirname = os.path.dirname(
             os.path.join(storage_folder, relative_filepath)

--- a/sentence_transformers/util.py
+++ b/sentence_transformers/util.py
@@ -426,7 +426,7 @@ def snapshot_download(
     model_info = _api.model_info(repo_id=repo_id, revision=revision)
 
     storage_folder = os.path.join(
-        cache_dir, repo_id.replace("/", REPO_ID_SEPARATOR) + "." + model_info.sha
+        cache_dir, repo_id.replace("/", "_")
     )
 
     for model_file in model_info.siblings:
@@ -444,7 +444,6 @@ def snapshot_download(
             repo_id, filename=model_file.rfilename, revision=model_info.sha
         )
         relative_filepath = os.path.join(*model_file.rfilename.split("/"))
-
         # Create potential nested dir
         nested_dirname = os.path.dirname(
             os.path.join(storage_folder, relative_filepath)


### PR DESCRIPTION
The current approach has some issues when downloading repos from the Hub. The current approach skips downloading if a local directory is already present. This means that local files can easily get outdated if there are changes in the repo in the Hub. Users only get the latest model if they delete the directory from the cache. Additionally, if one file is missing (such as `modules.json`, it doesn't get automatically downloaded).

With this new approach, we always call `snapshot_download` and directly save in the expected directory instead of renaming the directory afterwards. It has this behavior:
 * If the file already exists in the cache, it won't get re-downloaded. 
 * If a file is missing locally, it gets downloaded.
 * If a file is updated in the Hub, it also gets downloaded.

This ensures that the local files are updated but maintaining the benefits of client-side caching.