### PR TITLE
Fix typos in docs

### DIFF
--- a/docs/training/overview.md
+++ b/docs/training/overview.md
@@ -172,7 +172,7 @@ Loading trained models is easy. You can specify a path:
 ```python
 model = SentenceTransformer('./my/path/to/model/')
 ```
-Note: It is important that a / or \ is the path, otherwise, it is not recognized as a path.
+Note: It is important that a / or \ is present in the path, otherwise, it is not recognized as a path.
 
 You can also host the training output on a server and download it:
  ```python
@@ -188,7 +188,7 @@ This code allows multi-task learning with training data from different datasets 
 
 ## Adding Special Tokens
 
-Depending on the task, you might want to special tokens to the tokenizer and the Transformer model. You can use the following code-snippet to achieve this:
+Depending on the task, you might want to add special tokens to the tokenizer and the Transformer model. You can use the following code-snippet to achieve this:
 ```python
 from sentence_transformers import SentenceTransformer, models
 word_embedding_model = models.Transformer('bert-base-uncased')

--- a/sentence_transformers/losses/OnlineContrastiveLoss.py
+++ b/sentence_transformers/losses/OnlineContrastiveLoss.py
@@ -8,8 +8,8 @@ from sentence_transformers.SentenceTransformer import SentenceTransformer
 class OnlineContrastiveLoss(nn.Module):
     """
     Online Contrastive loss. Similar to ConstrativeLoss, but it selects hard positive (positives that are far apart)
-     and hard negative pairs (negatives that are close) and computes the loss only for these pairs. Often yields
-     better performances than  ConstrativeLoss.
+    and hard negative pairs (negatives that are close) and computes the loss only for these pairs. Often yields
+    better performances than  ConstrativeLoss.
 
     :param model: SentenceTransformer model
     :param distance_metric: Function that returns a distance between two emeddings. The class SiameseDistanceMetric contains pre-defined metrices that can be used


### PR DESCRIPTION
Hello! I've found a couple of typos in documentation. 
I've also fixed them to be correct in my understanding of corresponding phrases meaning (please correct my edits if they are wrong).