### PR TITLE
Change instance check to image instead of imagefile

### DIFF
--- a/sentence_transformers/models/CLIPModel.py
+++ b/sentence_transformers/models/CLIPModel.py
@@ -1,7 +1,7 @@
 from torch import nn
 import transformers
 import torch
-from PIL import ImageFile
+from PIL import Image
 
 
 class CLIPModel(nn.Module):
@@ -56,7 +56,7 @@ class CLIPModel(nn.Module):
         image_text_info = []
 
         for idx, data in enumerate(texts):
-            if isinstance(data, ImageFile.ImageFile):  # An Image
+            if isinstance(data, Image.Image):  # An Image
                 images.append(data)
                 image_text_info.append(0)
             else:  # A text


### PR DESCRIPTION
I was running into issues attempting to embed images that I created from a numpy array since the CLIP tokenizer checks if the data is an instance of class "ImageFile" rather than the base "Image" type:

```python
from sentence_transformers import SentenceTransformer, util
from PIL import Image

#Load CLIP model
model = SentenceTransformer('clip-ViT-B-32')

#Encode an image:
url = "http://images.cocodataset.org/val2017/000000039769.jpg"
img = Image.fromarray(np.array(Image.open(requests.get(url, stream=True).raw))).convert('RGB')
img_emb = model.encode(img)

#Encode text descriptions
text_emb = model.encode(['Two dogs in the snow', 'A cat on a table', 'A picture of London at night'])

#Compute cosine similarities 
cos_scores = util.cos_sim(img_emb, text_emb)
print(cos_scores)
```

produces the following error:
```
ValueError: text input must of type `str` (single example), `List[str]` (batch or single pretokenized example) or `List[List[str]]` (batch of pretokenized examples).
```

Checking for the base "Image" class gives people a bit more leeway on how they want to generate their image embeddings from (i.e., not having to have the image be from a file such as in my case where I went directly from a video to a sequence of numpy arrays).

P.S. Awesome library! I'm having a blast using it for both personal and research projects!