### PR TITLE
util.community_detection : init_max_size should not exceed the dataset size

### DIFF
--- a/sentence_transformers/util.py
+++ b/sentence_transformers/util.py
@@ -340,6 +340,9 @@ def community_detection(embeddings, threshold=0.75, min_community_size=10, init_
     in decreasing order. The first element in each list is the central point in the community.
     """
 
+    # Maximum size for community
+    init_max_size = min(init_max_size, len(embeddings))
+
     # Compute cosine similarity scores
     cos_scores = cos_sim(embeddings, embeddings)
 


### PR DESCRIPTION
Added a fix for init_max_size argument when the size of the dataset is less than the default value 1000 for init_max_size.