### PR TITLE
Update doc about installation

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -15,6 +15,7 @@ pip install -U sentence-transformers
 ```
 
 **Install with conda**
+
 Apple silicon Installation of *sentence-transformers*
 ```
 conda install -c conda-forge sentence-transformers

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -14,6 +14,12 @@ Install the *sentence-transformers* with `pip`:
 pip install -U sentence-transformers
 ```
 
+**Install with conda**
+Apple silicon Installation of *sentence-transformers*
+```
+conda install -c conda-forge sentence-transformers
+```
+
 **Install from sources**
 
 Alternatively, you can also clone the latest version from the [repository](https://github.com/UKPLab/sentence-transformers) and install it directly from the source code:


### PR DESCRIPTION
Apple silicon Installation of `sentence-transformers` failed using `pip`

Using conda-forge for apple silicon works for this.

Closes #1324 