### PR TITLE
Restrict version range of tokenizers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     packages=find_packages(),
     install_requires=[
         'transformers>=4.6.0,<5.0.0',
-        'tokenizers>=0.10.3',
+        'tokenizers>=0.10.3,<0.11',
         'tqdm',
         'torch>=1.6.0',
         'torchvision',


### PR DESCRIPTION
This is needed to avoid the error
transformers==4.15.0 requires tokenizers<0.11,>=0.10.1 but tokenizers 0.11.1 was resolved
when installing sentence-transformers