### PR TITLE
Update __init__.py

### DIFF
--- a/sentence_transformers/__init__.py
+++ b/sentence_transformers/__init__.py
@@ -1,8 +1,11 @@
 __version__ = "2.1.1"
 __MODEL_HUB_ORGANIZATION__ = 'sentence-transformers'
-from .datasets import SentencesDataset, ParallelSentencesDataset
-from .LoggingHandler import LoggingHandler
-from .SentenceTransformer import SentenceTransformer
-from .readers import InputExample
-from .cross_encoder.CrossEncoder import CrossEncoder
+from .datasets import (
+  SentencesDataset as SentencesDataset,
+  ParallelSentencesDataset as ParallelSentencesDataset,
+)
+from .LoggingHandler import LoggingHandler as LoggingHandler
+from .SentenceTransformer import SentenceTransformer as SentenceTransformer
+from .readers import InputExample as InputExample
+from .cross_encoder.CrossEncoder import CrossEncoder as CrossEncoder
 


### PR DESCRIPTION
Explicitly reexport the imported symbols in the top-level `__init__.py` file.

This would fix #1368.