### PR TITLE
Adding auth_token to SentenceTransformers and args to CrossEncoders to allow the use of private models

### DIFF
--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -38,8 +38,14 @@ class SentenceTransformer(nn.Sequential):
     :param modules: This parameter can be used to create custom SentenceTransformer models from scratch.
     :param device: Device (like 'cuda' / 'cpu') that should be used for computation. If None, checks if a GPU can be used.
     :param cache_folder: Path to store models
+    :param use_auth_token: HuggingFace authentication token to download private models.
     """
-    def __init__(self, model_name_or_path: Optional[str] = None, modules: Optional[Iterable[nn.Module]] = None, device: Optional[str] = None, cache_folder: Optional[str] = None):
+    def __init__(self, model_name_or_path: Optional[str] = None,
+                 modules: Optional[Iterable[nn.Module]] = None,
+                 device: Optional[str] = None,
+                 cache_folder: Optional[str] = None,
+                 use_auth_token: Union[bool, str, None] = None
+                 ):
         self._model_card_vars = {}
         self._model_card_text = None
         self._model_config = {}
@@ -81,7 +87,8 @@ class SentenceTransformer(nn.Sequential):
                                     cache_dir=cache_folder,
                                     library_name='sentence-transformers',
                                     library_version=__version__,
-                                    ignore_files=['flax_model.msgpack', 'rust_model.ot', 'tf_model.h5'])
+                                    ignore_files=['flax_model.msgpack', 'rust_model.ot', 'tf_model.h5'],
+                                    use_auth_token=use_auth_token)
 
             if os.path.exists(os.path.join(model_path, 'modules.json')):    #Load as SentenceTransformer model
                 modules = self._load_sbert_model(model_path)

--- a/sentence_transformers/cross_encoder/CrossEncoder.py
+++ b/sentence_transformers/cross_encoder/CrossEncoder.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 
 class CrossEncoder():
     def __init__(self, model_name:str, num_labels:int = None, max_length:int = None, device:str = None, tokenizer_args:Dict = {},
-                 default_activation_function = None):
+                  automodel_args:Dict = {}, default_activation_function = None):
         """
         A CrossEncoder takes exactly two sentences / texts as input and either predicts
         a score or label for this sentence pair. It can for example predict the similarity of the sentence pair
@@ -32,6 +32,7 @@ class CrossEncoder():
         :param max_length: Max length for input sequences. Longer sequences will be truncated. If None, max length of the model will be used
         :param device: Device that should be used for the model. If None, it will use CUDA if available.
         :param tokenizer_args: Arguments passed to AutoTokenizer
+        :param automodel_args: Arguments passed to AutoModelForSequenceClassification
         :param default_activation_function: Callable (like nn.Sigmoid) about the default activation function that should be used on-top of model.predict(). If None. nn.Sigmoid() will be used if num_labels=1, else nn.Identity()
         """
 
@@ -46,7 +47,7 @@ class CrossEncoder():
         if num_labels is not None:
             self.config.num_labels = num_labels
 
-        self.model = AutoModelForSequenceClassification.from_pretrained(model_name, config=self.config)
+        self.model = AutoModelForSequenceClassification.from_pretrained(model_name, config=self.config, **automodel_args)
         self.tokenizer = AutoTokenizer.from_pretrained(model_name, **tokenizer_args)
         self.max_length = max_length
 

--- a/sentence_transformers/util.py
+++ b/sentence_transformers/util.py
@@ -414,7 +414,8 @@ def snapshot_download(
     library_name: Optional[str] = None,
     library_version: Optional[str] = None,
     user_agent: Union[Dict, str, None] = None,
-    ignore_files: Optional[List[str]] = None
+    ignore_files: Optional[List[str]] = None,
+    use_auth_token: Union[bool, str, None] = None
 ) -> str:
     """
     Method derived from huggingface_hub.
@@ -461,6 +462,7 @@ def snapshot_download(
             library_name=library_name,
             library_version=library_version,
             user_agent=user_agent,
+            use_auth_token=use_auth_token,
         )
 
         if os.path.exists(path + ".lock"):


### PR DESCRIPTION
To use private models from the HuggingFace HUB we need to provide your HuggingFace auth token to download models.

This PR adds the option to provide your private token to the SentenceTransformer and CrossEncoder class and so allows it to be used with private models from the HUB.