### PR TITLE
added rnn.pack_padded_sequence argument cpu conversion

### DIFF
--- a/sentence_transformers/models/LSTM.py
+++ b/sentence_transformers/models/LSTM.py
@@ -29,7 +29,7 @@ class LSTM(nn.Module):
         token_embeddings = features['token_embeddings']
         sentence_lengths = torch.clamp(features['sentence_lengths'], min=1)
 
-        packed = nn.utils.rnn.pack_padded_sequence(token_embeddings, sentence_lengths, batch_first=True, enforce_sorted=False)
+        packed = nn.utils.rnn.pack_padded_sequence(token_embeddings, sentence_lengths.cpu(), batch_first=True, enforce_sorted=False)
         packed = self.encoder(packed)
         unpack = nn.utils.rnn.pad_packed_sequence(packed[0], batch_first=True)[0]
         features.update({'token_embeddings': unpack})


### PR DESCRIPTION
Fixes #1251 

The problem is that in newer torch versions arguments of rnn.pack_padded_sequence do not get converted to CPU, and the function assumes arguments to be on CPU.