### PR TITLE
Adding the possibility to pass arguments to the AutoConfig() in the Cross-Encoder

### DIFF
--- a/sentence_transformers/cross_encoder/CrossEncoder.py
+++ b/sentence_transformers/cross_encoder/CrossEncoder.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 
 class CrossEncoder():
     def __init__(self, model_name:str, num_labels:int = None, max_length:int = None, device:str = None, tokenizer_args:Dict = {},
-                  automodel_args:Dict = {}, default_activation_function = None):
+                  automodel_args:Dict = {}, autoconfig_args:Dict = {}, default_activation_function = None):
         """
         A CrossEncoder takes exactly two sentences / texts as input and either predicts
         a score or label for this sentence pair. It can for example predict the similarity of the sentence pair
@@ -33,10 +33,11 @@ class CrossEncoder():
         :param device: Device that should be used for the model. If None, it will use CUDA if available.
         :param tokenizer_args: Arguments passed to AutoTokenizer
         :param automodel_args: Arguments passed to AutoModelForSequenceClassification
+        :param autoconfig_args: Arguments passed to AutoConfig
         :param default_activation_function: Callable (like nn.Sigmoid) about the default activation function that should be used on-top of model.predict(). If None. nn.Sigmoid() will be used if num_labels=1, else nn.Identity()
         """
 
-        self.config = AutoConfig.from_pretrained(model_name)
+        self.config = AutoConfig.from_pretrained(model_name, **autoconfig_args)
         classifier_trained = True
         if self.config.architectures is not None:
             classifier_trained = any([arch.endswith('ForSequenceClassification') for arch in self.config.architectures])


### PR DESCRIPTION
This is to allow the specification of additional arguments for the `AutoConfig()`.

Apologies, I probably should have included this in https://github.com/UKPLab/sentence-transformers/pull/1406. 
As such, this could be considered as a bug-fix or a new feature. Depending on one's use-case.

If one wants to pull a private Cross-Encoder model with its config and tokenizer from the Hub, then this is bug-fix for that use-case, as that won't work without the `use_auth_token` being supplied to the `AutoConfig()` too.
If one wants to just add some random arguments to the `AutoConfig()`, then this is a new feature to allow that.