### PR TITLE
Enable encoding with mixed embeddings

### DIFF
--- a/sentence_transformers/models/Asym.py
+++ b/sentence_transformers/models/Asym.py
@@ -72,7 +72,7 @@ class Asym(nn.Sequential):
         return batch
 
     def get_sentence_embedding_dimension(self) -> int:
-        raise NotImplementedError()
+        return {m: m.get_sentence_embedding_dimension() for m in self.sub_modules}
 
     def save(self, output_path):
         model_lookup = {}

--- a/sentence_transformers/util.py
+++ b/sentence_transformers/util.py
@@ -489,19 +489,15 @@ def batch_collator(features: List[Dict[str, Any]]) -> Dict[str, Any]:
     first = features[0]
     batch = {}
 
-    # special casing: input embeddings are superseded by sentence embeddings
-    if 'sentence_embedding' in first.keys():
-        batch['sentence_embedding'] = torch.stack([f['sentence_embedding'] for f in features])
-    else:
-        # We will use the first element to figure out which key/values are not None for this model.
-        for k, v in first.items():
-            if v is not None and not isinstance(v, str):
-                if isinstance(v, torch.Tensor):
-                    batch[k] = torch.stack([f[k] for f in features])
+    # We will use the first element to figure out which key/values are not None for this model.
+    for k, v in first.items():
+        if v is not None and not isinstance(v, str):
+            if isinstance(v, torch.Tensor):
+                batch[k] = torch.stack([f[k] for f in features])
+            else:
+                if isinstance(v, (list, tuple)) and isinstance(v[0],str):
+                    batch[k] = [f[k] for f in features]
                 else:
-                    if isinstance(v, (list, tuple)) and isinstance(v[0],str):
-                        batch[k] = [f[k] for f in features]
-                    else:
-                        batch[k] = torch.tensor([f[k] for f in features])
+                    batch[k] = torch.tensor([f[k] for f in features])
 
     return batch


### PR DESCRIPTION
This change set generalizes the encoding of mixed batches, i.e. where different sentences in a batch may be in different languages and are encoded by different models.

Usage example for two languages:

```
from sentence_transformers.models import Transformer, Pooling, Asym
transformer_english = Transformer('bert-base-uncased')
transformer_german = Transformer('bert-base-german-cased')

combined = Asym({
    'english': [transformer_english, Pooling(transformer_english.get_word_embedding_dimension(),pooling_mode='cls')],
    'german': [transformer_german, Pooling(transformer_german.get_word_embedding_dimension(),pooling_mode='cls')],
})
transformer = SentenceTransformer(modules=[combined])
```

When there are multiple encodings per batch element, the sentence embeddings are concatenated.

```
>>> transformer_english.get_word_embedding_dimension() 
768
```

```
>>> transformer_german.get_word_embedding_dimension()
768
```

and 

```
>>> transformer.encode([{'english': ['Howdy'], 'german': ['Halloechen']}]).shape
(1, 1, 1536)
```

Of course, in the above example the combined model has to be fine-tuned first before reasonable results can be expected. I did not test fine-tuning of these models through `sentence-transformers`, my use case is that I have a protein and a ligand representation and I would like to get the combined embeddings of both for affinity prediction in an inference situation.

The combined embeddings can be passed through `Dense`, e.g., as an example for a classification head.