### PR TITLE
Fix: typo (manhatten -> manhattan)

### DIFF
--- a/sentence_transformers/evaluation/BinaryClassificationEvaluator.py
+++ b/sentence_transformers/evaluation/BinaryClassificationEvaluator.py
@@ -51,7 +51,7 @@ class BinaryClassificationEvaluator(SentenceEvaluator):
         self.csv_file = "binary_classification_evaluation" + ("_"+name if name else '') + "_results.csv"
         self.csv_headers = ["epoch", "steps",
                             "cossim_accuracy", "cossim_accuracy_threshold", "cossim_f1", "cossim_precision", "cossim_recall", "cossim_f1_threshold", "cossim_ap",
-                            "manhatten_accuracy", "manhatten_accuracy_threshold", "manhatten_f1", "manhatten_precision", "manhatten_recall", "manhatten_f1_threshold", "manhatten_ap",
+                            "manhattan_accuracy", "manhattan_accuracy_threshold", "manhattan_f1", "manhattan_precision", "manhattan_recall", "manhattan_f1_threshold", "manhattan_ap",
                             "euclidean_accuracy", "euclidean_accuracy_threshold", "euclidean_f1", "euclidean_precision", "euclidean_recall", "euclidean_f1_threshold", "euclidean_ap",
                             "dot_accuracy", "dot_accuracy_threshold", "dot_f1", "dot_precision", "dot_recall", "dot_f1_threshold", "dot_ap"]
 
@@ -126,7 +126,7 @@ class BinaryClassificationEvaluator(SentenceEvaluator):
 
         labels = np.asarray(self.labels)
         output_scores = {}
-        for short_name, name, scores, reverse in [['cossim', 'Cosine-Similarity', cosine_scores, True], ['manhatten', 'Manhatten-Distance', manhattan_distances, False], ['euclidean', 'Euclidean-Distance', euclidean_distances, False], ['dot', 'Dot-Product', dot_scores, True]]:
+        for short_name, name, scores, reverse in [['cossim', 'Cosine-Similarity', cosine_scores, True], ['manhattan', 'Manhattan-Distance', manhattan_distances, False], ['euclidean', 'Euclidean-Distance', euclidean_distances, False], ['dot', 'Dot-Product', dot_scores, True]]:
             acc, acc_threshold = self.find_best_acc_and_threshold(scores, labels, reverse)
             f1, precision, recall, f1_threshold = self.find_best_f1_and_threshold(scores, labels, reverse)
             ap = average_precision_score(labels, scores * (1 if reverse else -1))

--- a/sentence_transformers/evaluation/TripletEvaluator.py
+++ b/sentence_transformers/evaluation/TripletEvaluator.py
@@ -55,7 +55,7 @@ class TripletEvaluator(SentenceEvaluator):
         self.show_progress_bar = show_progress_bar
 
         self.csv_file: str = "triplet_evaluation" + ("_" + name if name else "") + "_results.csv"
-        self.csv_headers = ["epoch", "steps", "accuracy_cosinus", "accuracy_manhatten", "accuracy_euclidean"]
+        self.csv_headers = ["epoch", "steps", "accuracy_cosinus", "accuracy_manhattan", "accuracy_euclidean"]
         self.write_csv = write_csv
 
     @classmethod
@@ -82,7 +82,7 @@ class TripletEvaluator(SentenceEvaluator):
         logger.info("TripletEvaluator: Evaluating the model on " + self.name + " dataset" + out_txt)
 
         num_triplets = 0
-        num_correct_cos_triplets, num_correct_manhatten_triplets, num_correct_euclidean_triplets = 0, 0, 0
+        num_correct_cos_triplets, num_correct_manhattan_triplets, num_correct_euclidean_triplets = 0, 0, 0
 
         embeddings_anchors = model.encode(
             self.anchors, batch_size=self.batch_size, show_progress_bar=self.show_progress_bar, convert_to_numpy=True
@@ -113,13 +113,13 @@ class TripletEvaluator(SentenceEvaluator):
                 num_correct_cos_triplets += 1
 
             if pos_manhattan_distance[idx] < neg_manhattan_distances[idx]:
-                num_correct_manhatten_triplets += 1
+                num_correct_manhattan_triplets += 1
 
             if pos_euclidean_distance[idx] < neg_euclidean_distances[idx]:
                 num_correct_euclidean_triplets += 1
 
         accuracy_cos = num_correct_cos_triplets / num_triplets
-        accuracy_manhattan = num_correct_manhatten_triplets / num_triplets
+        accuracy_manhattan = num_correct_manhattan_triplets / num_triplets
         accuracy_euclidean = num_correct_euclidean_triplets / num_triplets
 
         logger.info("Accuracy Cosine Distance:   \t{:.2f}".format(accuracy_cos * 100))


### PR DESCRIPTION
Changes the spelling of the Manhattan distance in various places from "manhatten" to "manhattan".