### PR TITLE
Add datasets info to model card when pushing to the Hub

### DIFF
--- a/sentence_transformers/model_card_templates.py
+++ b/sentence_transformers/model_card_templates.py
@@ -18,6 +18,8 @@ class ModelCardTemplate:
 pipeline_tag: {PIPELINE_TAG}
 tags:
 {TAGS}
+datasets:
+{DATASETS}
 ---
 
 # {MODEL_NAME}


### PR DESCRIPTION
## Description

Specify the datasets used in the training of the `SentenceTransformer` model so they appear in the Hub’s model card (image below).

<img width="602" alt="image" src="https://user-images.githubusercontent.com/4755430/172036407-0a1d61a0-a899-4d5e-a47e-4a92041cfb87.png">


## Why?

Hub’s users would have additional information regarding how to train/use Sentence Transformers models. This would add to transparency and reproducibility.


## Test
[This notebook](https://colab.research.google.com/gist/omarespejel/4af645eaa157437e296c04a05c84bd7c/training-sbeto.ipynb) trains a Sentence Transformer from scratch and shares it to the Hub with information on Datasets.

[Here](https://huggingface.co/espejelomar/sentece-embeddings-BETO) you can find the resulting model card.

## Possible next steps

- Update [sbert documentation](https://www.sbert.net/docs/package_reference/SentenceTransformer.html?highlight=hub#sentence_transformers.SentenceTransformer.save_to_hub).