### PR TITLE
Image_Duplicates.ipynb example: Fix folder name

### DIFF
--- a/examples/applications/image-search/Image_Duplicates.ipynb
+++ b/examples/applications/image-search/Image_Duplicates.ipynb
@@ -94,7 +94,7 @@
     "        img_names, img_emb = pickle.load(fIn)  \n",
     "    print(\"Images:\", len(img_names))\n",
     "else:\n",
-    "    img_names = list(glob.glob('unsplash/photos/*.jpg'))\n",
+    "    img_names = list(glob.glob('photos/*.jpg'))\n",
     "    print(\"Images:\", len(img_names))\n",
     "    img_emb = model.encode([Image.open(filepath) for filepath in img_names], batch_size=128, convert_to_tensor=True, show_progress_bar=True)\n"
    ]


### PR DESCRIPTION
Fixes a bug in the `Image_Duplicates.ipynb` example notebook: images are downloaded from unsplash in the `photos/` folder, not in the `unsplash/photos/` folder