### PR TITLE
remove unneeded import that causes an error

### DIFF
--- a/sentence_transformers/util.py
+++ b/sentence_transformers/util.py
@@ -404,7 +404,6 @@ from typing import Dict, Optional, Union
 from pathlib import Path
 from huggingface_hub.constants import HUGGINGFACE_HUB_CACHE
 from huggingface_hub import HfApi, hf_hub_url, cached_download
-from huggingface_hub.snapshot_download import REPO_ID_SEPARATOR
 import fnmatch
 
 def snapshot_download(

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", mode="r", encoding="utf-8") as readme_file:
 
 setup(
     name="sentence-transformers",
-    version="2.2.0",
+    version="2.2.1",
     author="Nils Reimers",
     author_email="info@nils-reimers.de",
     description="Multilingual text embeddings",


### PR DESCRIPTION
[This line](https://github.com/UKPLab/sentence-transformers/blob/master/sentence_transformers/util.py#L407) is an unused import which causes an error with `huggingface-hub==0.8.0` (and presumably other future versions).

Removing it has no effect on any real functionality, since the import is unused. However, with the install requirement of `huggingface-hub` being unrestricted, an error can be caused by this line if `huggingface-hub==0.8.0` happens to be installed (and presumably other future versions).

Error:
```lang-py
>>> from sentence_transformers import SentenceTransformer
/working_dir/venv/lib/python3.8/site-packages/huggingface_hub/snapshot_download.py:6: FutureWarning: snapshot_download.py has been made private and will no longer be available from version 0.11. Please use `from huggingface_hub import snapshot_download` to import the only public function in this module. Other members of the file may be changed without a deprecation notice.
  warnings.warn(
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/working_dir/venv/lib/python3.8/site-packages/sentence_transformers/__init__.py", line 3, in <module>
    from .datasets import SentencesDataset, ParallelSentencesDataset
  File "/working_dir/venv/lib/python3.8/site-packages/sentence_transformers/datasets/__init__.py", line 3, in <module>
    from .ParallelSentencesDataset import ParallelSentencesDataset
  File "/working_dir/Downloads/venv/lib/python3.8/site-packages/sentence_transformers/datasets/ParallelSentencesDataset.py", line 4, in <module>
    from .. import SentenceTransformer
  File "/working_dir/venv/lib/python3.8/site-packages/sentence_transformers/SentenceTransformer.py", line 25, in <module>
    from .evaluation import SentenceEvaluator
  File "/working_dir/venv/lib/python3.8/site-packages/sentence_transformers/evaluation/__init__.py", line 5, in <module>
    from .InformationRetrievalEvaluator import InformationRetrievalEvaluator
  File "/working_dir/venv/lib/python3.8/site-packages/sentence_transformers/evaluation/InformationRetrievalEvaluator.py", line 6, in <module>
    from ..util import cos_sim, dot_score
  File "/working_dir/venv/lib/python3.8/site-packages/sentence_transformers/util.py", line 407, in <module>
    from huggingface_hub.snapshot_download import REPO_ID_SEPARATOR
ImportError: cannot import name 'REPO_ID_SEPARATOR' from 'huggingface_hub.snapshot_download' (/working_dir/venv/lib/python3.8/site-packages/huggingface_hub/snapshot_download.py)
```

Python:
```lang-none
$ python --version
Python 3.8.13
```

Packages:
```lang-none
$ pip freeze
certifi==2022.6.15
charset-normalizer==2.0.12
click==8.1.3
filelock==3.7.1
huggingface-hub==0.8.0
idna==3.3
joblib==1.1.0
nltk==3.7
numpy==1.22.4
packaging==21.3
Pillow==9.1.1
pyparsing==3.0.9
PyYAML==6.0
regex==2022.6.2
requests==2.28.0
scikit-learn==1.1.1
scipy==1.8.1
sentence-transformers==2.2.0
sentencepiece==0.1.96
threadpoolctl==3.1.0
tokenizers==0.12.1
torch==1.11.0
torchvision==0.12.0
tqdm==4.64.0
transformers==4.20.0
typing_extensions==4.2.0
urllib3==1.26.9
```