### PR TITLE
Generic Log Framework for SentenceTransformer and CrossEncoder

### DIFF
--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -576,6 +576,8 @@ class SentenceTransformer(nn.Sequential):
             save_best_model: bool = True,
             max_grad_norm: float = 1,
             use_amp: bool = False,
+            log_steps: int=0,
+            log_callback = Callable[[int, int, float, float], None]=None,
             callback: Callable[[float, int, int], None] = None,
             show_progress_bar: bool = True,
             checkpoint_path: str = None,
@@ -602,6 +604,10 @@ class SentenceTransformer(nn.Sequential):
         :param save_best_model: If true, the best model (according to evaluator) is stored at output_path
         :param max_grad_norm: Used for gradient normalization.
         :param use_amp: Use Automatic Mixed Precision (AMP). Only for Pytorch >= 1.6.0
+        :param log_steps: Log every `log_steps` steps. Should be greater than 0 for logging to kick in.
+        :param log_callback: Callback function that is invoked to log during training:
+                It must accept the following parameters in this order:
+                `training idx`, `training_steps`, `current lr`, `loss value` (Sends loss value and current lr during `training_steps` for loss objective #`training_idx`)
         :param callback: Callback function that is invoked after each evaluation.
                 It must accept the following three parameters in this order:
                 `score`, `epoch`, `steps`
@@ -718,6 +724,12 @@ class SentenceTransformer(nn.Sequential):
 
                     if not skip_scheduler:
                         scheduler.step()
+
+                    if log_steps>0 and training_steps%log_steps==log_steps-1 and log_callable is not None:
+                        try:
+                            log_callable(train_idx, training_steps, scheduler.get_last_lr(), loss_value.item())
+                        except Exception as e:
+                            logger.warning("Logging error encountered. Ignoring..")
 
                 training_steps += 1
                 global_step += 1

--- a/sentence_transformers/cross_encoder/CrossEncoder.py
+++ b/sentence_transformers/cross_encoder/CrossEncoder.py
@@ -226,7 +226,7 @@ class CrossEncoder():
                     try:
                         logger_callback(training_steps, scheduler.get_last_lr(), loss_value.item())
                     except Exception as e:
-                        logger.warning(("Logging error encountered. Ignoring..")
+                        logger.warning("Logging error encountered. Ignoring..")
                 if evaluator is not None and evaluation_steps > 0 and training_steps % evaluation_steps == 0:
                     self._eval_during_training(evaluator, output_path, save_best_model, epoch, training_steps, callback)
 

--- a/sentence_transformers/cross_encoder/CrossEncoder.py
+++ b/sentence_transformers/cross_encoder/CrossEncoder.py
@@ -223,7 +223,10 @@ class CrossEncoder():
 
                 training_steps += 1
                 if logger_callback is not None and log_steps > 0 and training_steps%log_steps==0:
-                    logger_callback(training_steps, scheduler.get_last_lr(), loss_value.item())
+                    try:
+                        logger_callback(training_steps, scheduler.get_last_lr(), loss_value.item())
+                    except Exception as e:
+                        logger.warning(("Logging error encountered. Ignoring..")
                 if evaluator is not None and evaluation_steps > 0 and training_steps % evaluation_steps == 0:
                     self._eval_during_training(evaluator, output_path, save_best_model, epoch, training_steps, callback)
 


### PR DESCRIPTION
Added a generic logging framework for SentenceTransformer and Cross Encoder compatible with sbert 2.2. There's an existing pull request that's specific to Tensorboard logs (#1532). This is a generic log framework, that gives control to MLDevs who want more fine-grained logging. 

Sample usage for SentenceTransformer (with wandb):
```python
loss_names = ["contrastive_loss", "custom_loss"]
def log_callback_st(train_ix, training_steps, current_lr, loss_value):
    wandb.log({f"train/{loss_names[train_ix]}_loss": loss_value,
             f"train/{loss_names[train_ix]}_lr": current_lr,
            "train/steps": training_steps})
                          
model = SentenceTransformer(...)
train_dl =DataLoader(...)
n_epochs = 3
losses = [losses.ContrastiveLoss(model=model), MyCoolLossFn(model=model)]
model.fit(..., log_steps=len(train_dl)*n_epochs//1000, log_callable=log_callback_st)
```
Sample usage for CrossEncoder(with wandb):

```python
def log_callback_ce(training_steps, current_lr, loss_value): #NOTE: There are no joint loss training for CrossEncoders. 
    wandb.log({f"train/loss": loss_value,
             "train/learning_rate": current_lr,
             "train/steps": training_steps})
                          
model = CrossEncoder(...)
train_dl =DataLoader(...)
n_epochs = 3
model.fit(...., log_steps=len(train_dl)*n_epochs//1000, log_callable=log_callback_ce)
```