### PR TITLE
Replace broken relative links with sbert.net links

### DIFF
--- a/docs/training/overview.md
+++ b/docs/training/overview.md
@@ -50,7 +50,7 @@ model = SentenceTransformer(modules=[word_embedding_model, pooling_model, dense_
 
 Here, we add on top of the pooling layer a fully connected dense layer with Tanh activation, which performs a down-project to 256 dimensions. Hence, embeddings by this model will only have 256 instead of 768 dimensions.
 
-For all available building blocks see [» Models Package Reference](../package_reference/models.md)
+For all available building blocks see [» Models Package Reference](https://www.sbert.net/docs/package_reference/models.html)
 
 ## Training Data 
  
@@ -119,7 +119,7 @@ The `fit` method accepts the following parameter:
 
 ## Evaluators
 
-During training, we usually want to measure the performance to see if the performance improves. For this, the *[sentence_transformers.evaluation](../package_reference/evaluation)* package exists. It contains various evaluators which we can pass to the `fit`-method. These evaluators are run periodically during training. Further, they return a score and only the model with the highest score will be stored on disc.
+During training, we usually want to measure the performance to see if the performance improves. For this, the *[sentence_transformers.evaluation](https://www.sbert.net/docs/package_reference/evaluation.html)* package exists. It contains various evaluators which we can pass to the `fit`-method. These evaluators are run periodically during training. Further, they return a score and only the model with the highest score will be stored on disc.
 
 The usage is simple:
 ```python

--- a/examples/training/nli/README.md
+++ b/examples/training/nli/README.md
@@ -22,7 +22,7 @@ In our experiments we combine [SNLI](https://arxiv.org/abs/1508.05326) and [Mult
 
 
 ## SoftmaxLoss
-[Conneau et al.](https://arxiv.org/abs/1705.02364) described how a softmax classifier on top of a siamese network can be used to learn meaningful sentence representation. We can achieve this by using the  [losses.SoftmaxLoss](../../../docs/package_reference/losses.html#softmaxloss) package.
+[Conneau et al.](https://arxiv.org/abs/1705.02364) described how a softmax classifier on top of a siamese network can be used to learn meaningful sentence representation. We can achieve this by using the  [losses.SoftmaxLoss](https://www.sbert.net/docs/package_reference/losses.html#softmaxloss) package.
 
 
 The softmax loss looks like this:

--- a/examples/training/sts/README.md
+++ b/examples/training/sts/README.md
@@ -21,7 +21,7 @@ train_dataset = SentencesDataset(train_examples, model)
 ```
 
 ## Loss Function
-As loss function we use [CosineSimilarityLoss](../../../docs/package_reference/losses.html#cosinesimilarityloss).
+As loss function we use [CosineSimilarityLoss](https://www.sbert.net/docs/package_reference/losses.html#cosinesimilarityloss).
 
 
 *CosineSimilarityLoss* trains the network with a siamese network strucuture (for details see: [Sentence-BERT: Sentence Embeddings using Siamese BERT-Networks](https://arxiv.org/abs/1908.10084))


### PR DESCRIPTION
Currently some docs (e.g. [https://github.com/UKPLab/sentence-transformers/tree/master/examples/training/sts](https://github.com/UKPLab/sentence-transformers/tree/master/examples/training/sts)) have broken links (e.g. [CosineSimilarityLoss](https://github.com/UKPLab/sentence-transformers/blob/master/docs/package_reference/losses.html#cosinesimilarityloss)) or links to not very informative github pages (e.g. [models overview](https://github.com/UKPLab/sentence-transformers/blob/master/docs/package_reference/models.md)).

Replaced them with corresponding links to sbert.net as in most other docs. 