### PR TITLE
Refactor save_to_hub, and add option to push training checkpoints to Hub

### DIFF
--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -5,6 +5,7 @@ import shutil
 import stat
 from collections import OrderedDict
 from typing import List, Dict, Tuple, Iterable, Type, Union, Callable, Optional
+from dataclasses import asdict, dataclass, field
 import requests
 import numpy as np
 from numpy import ndarray
@@ -31,24 +32,27 @@ from . import __version__
 logger = logging.getLogger(__name__)
 
 
+@dataclass
 class HubTrainingArguments:
-    def __init__(self, repo_name: str,
-                 organization: Optional[str] = None,
-                 private: Optional[bool] = None,
-                 local_model_path: Optional[str] = None,
-                 replace_model_card: Optional[bool] = True,
-                 train_datasets: Optional[List[str]] = None,
-                 local_repo_path: Optional[str] = None,
-                 ):
-        self.parameters = {
-            "repo_name": repo_name,
-            "organization": organization,
-            "private": private,
-            "local_model_path": local_model_path,
-            "replace_model_card": replace_model_card,
-            "train_datasets": train_datasets,
-            "local_repo_path": local_repo_path,
-            "exist_ok": True
+    repo_name: str = field()
+    organization: Optional[str] = field(default=None)
+    private: Optional[bool] = field(default=None, metadata={"help": "Specifies the model repo's visibility"})
+    local_model_path: Optional[str] = field(default=None, metadata={"help": "Local path to a model checkpoint"})
+    replace_model_card: Optional[bool] = field(default=None, metadata={"help": "Controls whether the existing model card is replaced with a new one"})
+    train_datasets: Optional[List[str]] = field(default=None, metadata={"help": "List of datasets used for training, included in the model card"})
+    local_repo_path: Optional[str] = field(default=None, metadata={"help": "Local path to use to initialize a repo"})
+
+    @property
+    def parameters(self):
+        return {
+            "repo_name": self.repo_name,
+            "organization": self.organization,
+            "private": self.private,
+            "local_model_path": self.local_model_path,
+            "replace_model_card": self.replace_model_card,
+            "train_datasets": self.train_datasets,
+            "local_repo_path": self.local_repo_path,
+            "exist_ok": True,
         }
 
 

--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -36,7 +36,7 @@ class HubParameters:
                  organization: Optional[str] = None,
                  private: Optional[bool] = None,
                  local_model_path: Optional[str] = None,
-                 replace_model_card: bool = False,
+                 replace_model_card: Optional[bool] = True,
                  train_datasets: Optional[List[str]] = None,
                  local_repo_path: Optional[str] = None,
                  ):
@@ -131,6 +131,8 @@ class SentenceTransformer(nn.Sequential):
 
         self._target_device = torch.device(device)
 
+
+
     def encode(self, sentences: Union[str, List[str]],
                batch_size: int = 32,
                show_progress_bar: bool = None,
@@ -224,6 +226,8 @@ class SentenceTransformer(nn.Sequential):
 
         return all_embeddings
 
+
+
     def start_multi_process_pool(self, target_devices: List[str] = None):
         """
         Starts multi process to process the encoding with several, independent processes.
@@ -253,6 +257,7 @@ class SentenceTransformer(nn.Sequential):
             processes.append(p)
 
         return {'input': input_queue, 'output': output_queue, 'processes': processes}
+
 
     @staticmethod
     def stop_multi_process_pool(pool):
@@ -320,6 +325,8 @@ class SentenceTransformer(nn.Sequential):
                 results_queue.put([id, embeddings])
             except queue.Empty:
                 break
+
+
 
     def get_max_seq_length(self):
         """
@@ -428,6 +435,7 @@ class SentenceTransformer(nn.Sequential):
             if train_datasets is not None:
                 datasets_str = "datasets:\n"+"\n".join(["- " + d for d in train_datasets])
             model_card = model_card.replace("{DATASETS}", datasets_str)
+
 
             # Add dim info
             self._model_card_vars["{NUM_DIMENSIONS}"] = self.get_sentence_embedding_dimension()
@@ -570,6 +578,7 @@ class SentenceTransformer(nn.Sequential):
 
         return sentence_features, labels
 
+
     def _text_length(self, text: Union[List[int], List[List[int]]]):
         """
         Help function to get the length for the input text. Text can be either
@@ -697,6 +706,7 @@ class SentenceTransformer(nn.Sequential):
 
             optimizers.append(optimizer)
             schedulers.append(scheduler_obj)
+
 
         global_step = 0
         data_iterators = [iter(dataloader) for dataloader in dataloaders]

--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -464,7 +464,7 @@ class SentenceTransformer(nn.Sequential):
                     exist_ok: bool = False,
                     replace_model_card: bool = False,
                     train_datasets: Optional[List[str]] = None,
-                    local_repo_path: Optional[str] = None):
+                    local_repo_path: Optional[str] = "./hub"):
         """
         Uploads all elements of this Sentence Transformer to a new HuggingFace Hub repository.
 
@@ -476,7 +476,7 @@ class SentenceTransformer(nn.Sequential):
         :param exist_ok: If true, saving to an existing repository is OK. If false, saving only to a new repository is possible
         :param replace_model_card: If true, replace an existing model card in the hub with the automatically created model card
         :param train_datasets: Datasets used to train the model. If set, the datasets will be added to the model card in the Hub.
-        :param local_repo_path: Local path where the model repo will be stored. If not provided, a temporary directory will be created.
+        :param local_repo_path: Local path where the model repo will be stored, "./hub" by default. Can be set to None to use a temporary directory.
         :return: The url of the commit of your model in the given repository.
         """
         token = HfFolder.get_token()

--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -66,7 +66,6 @@ class SentenceTransformer(nn.Sequential):
     :param cache_folder: Path to store models. Can be also set by SENTENCE_TRANSFORMERS_HOME enviroment variable.
     :param use_auth_token: HuggingFace authentication token to download private models.
     """
-
     def __init__(self, model_name_or_path: Optional[str] = None,
                  modules: Optional[Iterable[nn.Module]] = None,
                  device: Optional[str] = None,


### PR DESCRIPTION
This PR contributes two things:

1. The `save_to_hub` method has been refactored and simplified to use [one of the new utility functions](https://huggingface.co/docs/huggingface_hub/how-to-upstream#managing-files-in-a-repo-without-git-with-the-createcommit-api) from the Hugging Face Hub client library, which uses the `create_commit` API.
2. A feature has been added to allow `.fit()` to push checkpoints to the Hub.

Pushing the checkpoints halts training (and there are no progress bars for the upload), which might not be ideal UX. Would it be better if the upload happened in the background while training continued?