### PR TITLE
Fetch score_function for semantic_search from model config if available

### DIFF
--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -106,7 +106,9 @@ class SentenceTransformer(nn.Sequential):
 
         self._target_device = torch.device(device)
 
-
+    @property
+    def score_function(self):
+        return self._model_config.get("score_function", "cos_sim")
 
     def encode(self, sentences: Union[str, List[str]],
                batch_size: int = 32,


### PR DESCRIPTION
For issue: #1643 
This PR loads the score_function from the model config JSON file, only if the model is passed to the `semantic_search` function. I tested this by using a local model with an edited `config_sentence_transformers.json` file.

The other places where I think this could be relevant are:
* InformationRetrievalEvaluator
* SequentialEvaluator
* util.paraphrase_mining

If you think this looks okay, I can make sure this is tested in `test_util`, and then I can also implement it for those other ones that I listed above!