### PR TITLE
word embeddings from word2vec fails to load correctly

### DIFF
--- a/sentence_transformers/models/WordEmbeddings.py
+++ b/sentence_transformers/models/WordEmbeddings.py
@@ -106,11 +106,11 @@ class WordEmbeddings(nn.Module):
                 word = split[0]
 
                 if len(split) == 2:
-                    embedding_dimension = int(split[1])
+                    embeddings_dimension = int(split[1])
+                    WordEmbeddings._add_padding_token(vocab, embeddings, embeddings_dimension)
                 elif embeddings_dimension == None:
                     embeddings_dimension = len(split) - 1
-                    vocab.append("PADDING_TOKEN")
-                    embeddings.append(np.zeros(embeddings_dimension))
+                    WordEmbeddings._add_padding_token(vocab, embeddings, embeddings_dimension)
 
                 if (len(split) - 1) != embeddings_dimension:  # Assure that all lines in the embeddings file are of the same length
                     logger.error("ERROR: A line in the embeddings file had more or less  dimensions than expected. Skip token.")
@@ -128,3 +128,7 @@ class WordEmbeddings(nn.Module):
             tokenizer.set_vocab(vocab)
             return WordEmbeddings(tokenizer=tokenizer, embedding_weights=embeddings, update_embeddings=update_embeddings)
 
+    @staticmethod
+    def _add_padding_token(vocab, embeddings, embeddings_dimension):
+        vocab.append("PADDING_TOKEN")
+        embeddings.append(np.zeros(embeddings_dimension))

--- a/sentence_transformers/models/WordEmbeddings.py
+++ b/sentence_transformers/models/WordEmbeddings.py
@@ -105,7 +105,9 @@ class WordEmbeddings(nn.Module):
                 split = line.rstrip().split(item_separator)
                 word = split[0]
 
-                if embeddings_dimension == None:
+                if len(split) == 2:
+                    embedding_dimension = int(split[1])
+                elif embeddings_dimension == None:
                     embeddings_dimension = len(split) - 1
                     vocab.append("PADDING_TOKEN")
                     embeddings.append(np.zeros(embeddings_dimension))


### PR DESCRIPTION
Loading from word2vec format fails if txt file contains first line with number of words and dimensionality.

For example gensim exports to .txt file with the first line like this:
```
10000 50
```

In the current version loading will set dimensionality to 1 and fail to load vectors.

I fixed this by checking whether first line contains exactly two tokens, and treating the second one as dimensionality.