### PR TITLE
Add datasets section

### DIFF
--- a/docs/training/overview.md
+++ b/docs/training/overview.md
@@ -53,8 +53,14 @@ Here, we add on top of the pooling layer a fully connected dense layer with Tanh
 For all available building blocks see [» Models Package Reference](../package_reference/models.md)
 
 ## Training Data 
+
+To train a SentenceTransformer model, you need to inform it somehow that two sentences have a certain degree of similarity. Therefore, each example in the data requires a label or structure that allows the model to understand whether two sentences are similar or different.
+
+Unfortunately, there is no single way to prepare your data to train a Sentence Transformers model. It largely depends on your goals and the structure of your data. If you don't have an explicit label, which is the most likely scenario, you can derive it from the design of the documents where you obtained the sentences. For example, two sentences in the same report should be more comparable than two sentences in different reports. Neighboring sentences might be more comparable than non-neighboring sentences. 
+
+For more information on available datasets for training SentenceTransformers models see [» Datasets Reference](../examples/training/datasets/README.md).
  
- To represent our training data, we use the `InputExample` class to store training examples. As parameters, it accepts texts, which is a list of strings representing our pairs (or triplets). Further, we can also pass a label (either float or int). The following shows a simple example, where we pass text pairs to `InputExample` together with a label indicating the semantic similarity.
+To represent our training data, we use the `InputExample` class to store training examples. As parameters, it accepts texts, which is a list of strings representing our pairs (or triplets). Further, we can also pass a label (either float or int). The following shows a simple example, where we pass text pairs to `InputExample` together with a label indicating the semantic similarity.
  
  ```python
 from sentence_transformers import SentenceTransformer, InputExample

--- a/examples/training/datasets/README.md
+++ b/examples/training/datasets/README.md
@@ -1,0 +1,56 @@
+# Training Datasets
+
+Most dataset configurations will take one of four forms (below you will see examples of each case):
+
+- Case 1: The example is a pair of sentences and a label indicating how similar they are. The label can be either an integer or a float. This case applies to datasets originally prepared for Natural Language Inference (NLI), since they contain pairs of sentences with a label indicating whether they infer each other or not.
+- Case 2: The example is a pair of positive (similar) sentences **without** a label. For example, pairs of paraphrases, pairs of full texts and their summaries, pairs of duplicate questions, pairs of (`query`, `response`), or pairs of (`source_language`, `target_language`). Natural Language Inference datasets can also be formatted this way by pairing entailing sentences.
+- Case 3: The example is a sentence with an integer label. This data format is easily converted by loss functions into three sentences (triplets) where the first is an "anchor", the second a "positive" of the same class as the anchor, and the third a "negative" of a different class. Each sentence has an integer label indicating the class to which it belongs.
+- Case 4: The example is a triplet (anchor, positive, negative) without classes or labels for the sentences.
+
+Note that Sentence Transformers models can be trained with human labeling (cases 1 and 3) or with labels automatically deduced from text formatting (cases 2 and 4).
+
+You can get almost ready-to-train datasets from various sources. One of them is the Hugging Face Hub.
+
+## Datasets in the Hugging Face Hub
+
+The [Datasets library](https://huggingface.co/docs/datasets/index) (`pip install datasets`) allows you to load datasets from the Hugging Face Hub with the `load_dataset` function:
+
+```python
+from datasets import load_dataset
+
+# Indicate the repo id from the Hub
+dataset_id = "embedding-data/QQP_triplets"
+
+dataset = load_dataset(dataset_id)
+```
+
+For more information on how to manipulate your dataset see [» Datasets Documentation]([../examples/training/datasets/README.md](https://huggingface.co/docs/datasets/access)).
+
+These are popular datasets used to train and fine-tune SentenceTransformers models.
+
+| Dataset                                                                                                   |
+|-----------------------------------------------------------------------------------------------------------|
+| [altlex pairs](https://huggingface.co/datasets/embedding-data/altlex)                                     |
+| [sentence compression pairs](https://huggingface.co/datasets/embedding-data/sentence-compression)         |
+| [QQP triplets](https://huggingface.co/datasets/embedding-data/QQP_triplets)                               |
+| [PAQ pairs](https://huggingface.co/datasets/embedding-data/PAQ_pairs)                                     |
+| [SPECTER triplets](https://huggingface.co/datasets/embedding-data/SPECTER)                                |
+| [Amazon QA pairs](https://huggingface.co/datasets/embedding-data/Amazon-QA)                               |
+| [Simple Wiki pairs](https://huggingface.co/datasets/embedding-data/simple-wiki)                           |
+| [Wiki Answers equivalent sentences](https://huggingface.co/datasets/embedding-data/WikiAnswers)           |
+| [COCO Captions quintets](https://huggingface.co/datasets/embedding-data/coco_captions_quintets)           |
+| [Flickr30k Captions quintets](https://huggingface.co/datasets/embedding-data/flickr30k_captions_quintets) |
+| [albert-base-v2](https://huggingface.co/albert-base-v2)                                                   |
+| [MS Marco](https://huggingface.co/datasets/ms_marco)                                                      |
+| [GOOAQ](https://huggingface.co/datasets/gooaq)                                                            |
+| [MS Marco](https://huggingface.co/datasets/ms_marco)                                                      |
+| [Yahoo Answers topics](https://huggingface.co/datasets/yahoo_answers_topics)                              |
+| [Search QA](https://huggingface.co/datasets/search_qa)                                                    |
+| [Stack Exchange](https://huggingface.co/datasets/flax-sentence-embeddings/stackexchange_xml )             |
+| [ELI5](https://huggingface.co/datasets/eli5)                                                              |
+| [MultiNLI](https://huggingface.co/datasets/multi_nli)                                                     |
+| [SNLI](https://huggingface.co/datasets/snli)                                                              |
+| [S2ORC](https://huggingface.co/datasets/s2orc)                                                            |
+| [Trivia QA](https://huggingface.co/datasets/trivia_qa)                                                    |
+| [Code Search Net](https://huggingface.co/datasets/code_search_net)                                        |
+| [Natural Questions](https://huggingface.co/datasets/natural_questions)                                    |

--- a/examples/training/datasets/README.md
+++ b/examples/training/datasets/README.md
@@ -1,17 +1,21 @@
 # Training Datasets
 
-Most dataset configurations will take one of four forms (below you will see examples of each case):
+Most dataset configurations will take one of four forms:
 
-- Case 1: The example is a pair of sentences and a label indicating how similar they are. The label can be either an integer or a float. This case applies to datasets originally prepared for Natural Language Inference (NLI), since they contain pairs of sentences with a label indicating whether they infer each other or not.
-- Case 2: The example is a pair of positive (similar) sentences **without** a label. For example, pairs of paraphrases, pairs of full texts and their summaries, pairs of duplicate questions, pairs of (`query`, `response`), or pairs of (`source_language`, `target_language`). Natural Language Inference datasets can also be formatted this way by pairing entailing sentences.
-- Case 3: The example is a sentence with an integer label. This data format is easily converted by loss functions into three sentences (triplets) where the first is an "anchor", the second a "positive" of the same class as the anchor, and the third a "negative" of a different class. Each sentence has an integer label indicating the class to which it belongs.
-- Case 4: The example is a triplet (anchor, positive, negative) without classes or labels for the sentences.
+- **Case 1**: The example is a pair of sentences and a label indicating how similar they are. The label can be either an integer or a float. This case applies to datasets originally prepared for Natural Language Inference (NLI), since they contain pairs of sentences with a label indicating whether they infer each other or not.
+   **Case Example:** [SNLI](https://huggingface.co/datasets/snli).
+- **Case 2**: The example is a pair of positive (similar) sentences **without** a label. For example, pairs of paraphrases, pairs of full texts and their summaries, pairs of duplicate questions, pairs of (`query`, `response`), or pairs of (`source_language`, `target_language`). Natural Language Inference datasets can also be formatted this way by pairing entailing sentences.
+   **Case Examples:** [Sentence Compression](https://huggingface.co/datasets/embedding-data/sentence-compression), [COCO Captions](https://huggingface.co/datasets/embedding-data/coco_captions_quintets), [Flickr30k captions](https://huggingface.co/datasets/embedding-data/flickr30k_captions_quintets).
+- **Case 3**: The example is a sentence with an integer label indicating the class to which it belongs. This data format is easily converted by loss functions into three sentences (triplets) where the first is an "anchor", the second a "positive" of the same class as the anchor, and the third a "negative" of a different class.
+   **Case Examples:** [TREC](https://huggingface.co/datasets/trec), [Yahoo Answers Topics](https://huggingface.co/datasets/yahoo_answers_topics).
+- **Case 4**: The example is a triplet (anchor, positive, negative) without classes or labels for the sentences.
+   **Case Example:** [Quora Triplets](https://huggingface.co/datasets/embedding-data/QQP_triplets)
 
 Note that Sentence Transformers models can be trained with human labeling (cases 1 and 3) or with labels automatically deduced from text formatting (cases 2 and 4).
 
 You can get almost ready-to-train datasets from various sources. One of them is the Hugging Face Hub.
 
-## Datasets in the Hugging Face Hub
+## Datasets on the Hugging Face Hub
 
 The [Datasets library](https://huggingface.co/docs/datasets/index) (`pip install datasets`) allows you to load datasets from the Hugging Face Hub with the `load_dataset` function:
 
@@ -24,7 +28,7 @@ dataset_id = "embedding-data/QQP_triplets"
 dataset = load_dataset(dataset_id)
 ```
 
-For more information on how to manipulate your dataset see [» Datasets Documentation]([../examples/training/datasets/README.md](https://huggingface.co/docs/datasets/access)).
+For more information on how to manipulate your dataset see [» Datasets Documentation](https://huggingface.co/docs/datasets/access).
 
 These are popular datasets used to train and fine-tune SentenceTransformers models.
 
@@ -40,7 +44,6 @@ These are popular datasets used to train and fine-tune SentenceTransformers mode
 | [Wiki Answers equivalent sentences](https://huggingface.co/datasets/embedding-data/WikiAnswers)           |
 | [COCO Captions quintets](https://huggingface.co/datasets/embedding-data/coco_captions_quintets)           |
 | [Flickr30k Captions quintets](https://huggingface.co/datasets/embedding-data/flickr30k_captions_quintets) |
-| [albert-base-v2](https://huggingface.co/albert-base-v2)                                                   |
 | [MS Marco](https://huggingface.co/datasets/ms_marco)                                                      |
 | [GOOAQ](https://huggingface.co/datasets/gooaq)                                                            |
 | [MS Marco](https://huggingface.co/datasets/ms_marco)                                                      |

--- a/index.rst
+++ b/index.rst
@@ -158,6 +158,7 @@ If you use the code for `data augmentation <https://github.com/UKPLab/sentence-t
    examples/training/distillation/README
    examples/training/cross-encoder/README
    examples/training/data_augmentation/README
+   examples/training/datasets/README
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
## Description
Add (1) additional information on training data in `docs/training/overview.md`; and (2) add a section with links to available datasets for training.

FYI @NimaBoscarino @osanseviero 