### PR TITLE
Fix issue of storing too many docs during IR-eval.: Maintain topk with heaps

### DIFF
--- a/sentence_transformers/evaluation/InformationRetrievalEvaluator.py
+++ b/sentence_transformers/evaluation/InformationRetrievalEvaluator.py
@@ -174,7 +174,7 @@ class InformationRetrievalEvaluator(SentenceEvaluator):
                         if len(queries_result_list[name][query_itr]) < max_k:
                             heapq.heappush(queries_result_list[name][query_itr], (score, corpus_id))  # heaqp tracks the quantity of the first element in the tuple
                         else:
-                            heapq.heapreplace(queries_result_list[name][query_itr], (score, corpus_id))
+                            heapq.heappushpop(queries_result_list[name][query_itr], (score, corpus_id))
 
         for name in queries_result_list:
             for query_itr in range(len(queries_result_list[name])):

--- a/sentence_transformers/evaluation/InformationRetrievalEvaluator.py
+++ b/sentence_transformers/evaluation/InformationRetrievalEvaluator.py
@@ -7,6 +7,7 @@ from ..util import cos_sim, dot_score
 import os
 import numpy as np
 from typing import List, Tuple, Dict, Set, Callable
+import heapq
 
 
 
@@ -170,7 +171,14 @@ class InformationRetrievalEvaluator(SentenceEvaluator):
                 for query_itr in range(len(query_embeddings)):
                     for sub_corpus_id, score in zip(pair_scores_top_k_idx[query_itr], pair_scores_top_k_values[query_itr]):
                         corpus_id = self.corpus_ids[corpus_start_idx+sub_corpus_id]
-                        queries_result_list[name][query_itr].append({'corpus_id': corpus_id, 'score': score})
+                        if len(queries_result_list[name][query_itr]) < max_k:
+                            heapq.heappush(queries_result_list[name][query_itr], (score, {'corpus_id': corpus_id, 'score': score}))
+                        else:
+                            heapq.heapreplace(queries_result_list[name][query_itr], (score, {'corpus_id': corpus_id, 'score': score}))
+
+        for name in queries_result_list:
+            for query_itr in range(len(queries_result_list)):
+                queries_result_list[query_itr] = queries_result_list[query_itr][-1]  # keep only {'corpus_id': corpus_id, 'score': score}
 
         logger.info("Queries: {}".format(len(self.queries)))
         logger.info("Corpus: {}\n".format(len(self.corpus)))

--- a/sentence_transformers/evaluation/InformationRetrievalEvaluator.py
+++ b/sentence_transformers/evaluation/InformationRetrievalEvaluator.py
@@ -172,13 +172,15 @@ class InformationRetrievalEvaluator(SentenceEvaluator):
                     for sub_corpus_id, score in zip(pair_scores_top_k_idx[query_itr], pair_scores_top_k_values[query_itr]):
                         corpus_id = self.corpus_ids[corpus_start_idx+sub_corpus_id]
                         if len(queries_result_list[name][query_itr]) < max_k:
-                            heapq.heappush(queries_result_list[name][query_itr], (score, {'corpus_id': corpus_id, 'score': score}))
+                            heapq.heappush(queries_result_list[name][query_itr], (score, corpus_id))  # heaqp tracks the quantity of the first element in the tuple
                         else:
-                            heapq.heapreplace(queries_result_list[name][query_itr], (score, {'corpus_id': corpus_id, 'score': score}))
+                            heapq.heapreplace(queries_result_list[name][query_itr], (score, corpus_id))
 
         for name in queries_result_list:
-            for query_itr in range(len(queries_result_list)):
-                queries_result_list[query_itr] = queries_result_list[query_itr][-1]  # keep only {'corpus_id': corpus_id, 'score': score}
+            for query_itr in range(len(queries_result_list[name])):
+                for doc_itr in range(len(queries_result_list[name][query_itr])):
+                    score, corpus_id = queries_result_list[name][query_itr][doc_itr]
+                    queries_result_list[name][query_itr][doc_itr] = {'corpus_id': corpus_id, 'score': score}
 
         logger.info("Queries: {}".format(len(self.queries)))
         logger.info("Corpus: {}\n".format(len(self.corpus)))

--- a/sentence_transformers/util.py
+++ b/sentence_transformers/util.py
@@ -258,7 +258,7 @@ def semantic_search(query_embeddings: Tensor,
                     if len(queries_result_list[query_id]) < top_k:
                         heapq.heappush(queries_result_list[query_id], (score, corpus_id))  # heaqp tracks the quantity of the first element in the tuple
                     else:
-                        heapq.heapreplace(queries_result_list[query_id], (score, corpus_id))
+                        heapq.heappushpop(queries_result_list[query_id], (score, corpus_id))
 
     #change the data format and sort
     for query_id in range(len(queries_result_list)):

--- a/sentence_transformers/util.py
+++ b/sentence_transformers/util.py
@@ -17,6 +17,7 @@ from huggingface_hub.constants import HUGGINGFACE_HUB_CACHE
 from huggingface_hub import HfApi, hf_hub_url, cached_download, HfFolder
 import fnmatch
 from packaging import version
+import heapq
 
 logger = logging.getLogger(__name__)
 
@@ -254,12 +255,16 @@ def semantic_search(query_embeddings: Tensor,
                 for sub_corpus_id, score in zip(cos_scores_top_k_idx[query_itr], cos_scores_top_k_values[query_itr]):
                     corpus_id = corpus_start_idx + sub_corpus_id
                     query_id = query_start_idx + query_itr
-                    queries_result_list[query_id].append({'corpus_id': corpus_id, 'score': score})
+                    if len(queries_result_list[query_id]) < top_k:
+                        heapq.heappush(queries_result_list[query_id], (score, corpus_id))  # heaqp tracks the quantity of the first element in the tuple
+                    else:
+                        heapq.heapreplace(queries_result_list[query_id], (score, corpus_id))
 
-    #Sort and strip to top_k results
-    for idx in range(len(queries_result_list)):
-        queries_result_list[idx] = sorted(queries_result_list[idx], key=lambda x: x['score'], reverse=True)
-        queries_result_list[idx] = queries_result_list[idx][0:top_k]
+    #change the data format
+    for query_id in range(len(queries_result_list)):
+        for doc_itr in range(len(queries_result_list[query_id])):
+            score, corpus_id = queries_result_list[query_id][doc_itr]
+            queries_result_list[query_id][doc_itr] = {'corpus_id': corpus_id, 'score': score}
 
     return queries_result_list
 

--- a/sentence_transformers/util.py
+++ b/sentence_transformers/util.py
@@ -260,11 +260,12 @@ def semantic_search(query_embeddings: Tensor,
                     else:
                         heapq.heapreplace(queries_result_list[query_id], (score, corpus_id))
 
-    #change the data format
+    #change the data format and sort
     for query_id in range(len(queries_result_list)):
         for doc_itr in range(len(queries_result_list[query_id])):
             score, corpus_id = queries_result_list[query_id][doc_itr]
             queries_result_list[query_id][doc_itr] = {'corpus_id': corpus_id, 'score': score}
+        queries_result_list[query_id] = sorted(queries_result_list[query_id], key=lambda x: x['score'], reverse=True)
 
     return queries_result_list
 


### PR DESCRIPTION
In the current version, the `InformationRetrievalEvaluator` and the `util.semantic_search` accumulates all the docs in each top-k retrieved chunk in the query results:
https://github.com/UKPLab/sentence-transformers/blob/a8cebb235066cacf533d073b8c8250e5e7b04c3d/sentence_transformers/evaluation/InformationRetrievalEvaluator.py#L162-L173

https://github.com/UKPLab/sentence-transformers/blob/a36e6f126cf0e333e1b00eb7cfcef2863f8919ad/sentence_transformers/util.py#L218-L222

In other words, the `queries_result_list` will hold #trunks * top-K docs for each query instead of just top-K. This will result in a very **severe memory burden for a large corpus, e.g. 60GB+ when evaluating on MS MARCO**. One could do some simulation about how large RAM it could use:

```python
import random
import psutil

def entry():
	return {'corpus_id': random.randint(0, 100000), 'score': random.random()}

msmarco_docs = 8800000
corpus_chunk_size = 50000
top_k = 1000
queries = 100
# queries = 7000

print("Available RAM (GB), before:", psutil.virtual_memory().available / 1024 / 1024 / 1024)

query_results = [entry() for _ in range(msmarco_docs // corpus_chunk_size * top_k * queries)]

print("Available RAM (GB), after:", psutil.virtual_memory().available / 1024 / 1024 / 1024)

# Available RAM (GB), before: 16.977794647216797
# Available RAM (GB), after: 11.836997985839844
```

This PR fixes the issue by maintaining exactly top-K docs with heaps efficiently during the whole retrieval process. A test has been made to make sure the new code yields the same final results / scores:
https://colab.research.google.com/drive/1ibA6hjfXKsl97L1wA_FlT1HnVFhnRw0L?usp=sharing