### PR TITLE
Fix save_to_hub for last huggingface_hub version

### DIFF
--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -464,9 +464,12 @@ class SentenceTransformer(nn.Sequential):
                 raise ValueError("You passed and invalid repository name: {}.".format(repo_name))
 
         endpoint = "https://huggingface.co"
+        repo_id = repo_name
+        if organization:
+          repo_id = f"{organization}/{repo_id}"
         repo_url = HfApi(endpoint=endpoint).create_repo(
-                token,
-                repo_name,
+                repo_id=repo_id,
+                token=token,
                 organization=organization,
                 private=private,
                 repo_type=None,


### PR DESCRIPTION
Fixes #1742 

This should work both with old and new `huggingface_hub` versions

`organization` and `name` parameters have been deprecated since some releases ago, and it was announced they were going to be deprecated in favour of `repo_id`. At the same time, positional parameters are no longer supported, which led to users not being able to push with the latest version of `huggingface_hub`