### PR TITLE
Add truncation argument

### DIFF
--- a/sentence_transformers/cross_encoder/CrossEncoder.py
+++ b/sentence_transformers/cross_encoder/CrossEncoder.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 
 
 class CrossEncoder():
-    def __init__(self, model_name:str, num_labels:int = None, max_length:int = None, device:str = None, tokenizer_args:Dict = {},
+    def __init__(self, model_name:str, num_labels:int = None, max_length:int = None, truncation: str = 'longest_first', device:str = None, tokenizer_args:Dict = {},
                   automodel_args:Dict = {}, default_activation_function = None):
         """
         A CrossEncoder takes exactly two sentences / texts as input and either predicts
@@ -30,6 +30,7 @@ class CrossEncoder():
         :param model_name: Any model name from Huggingface Models Repository that can be loaded with AutoModel. We provide several pre-trained CrossEncoder models that can be used for common tasks
         :param num_labels: Number of labels of the classifier. If 1, the CrossEncoder is a regression model that outputs a continous score 0...1. If > 1, it output several scores that can be soft-maxed to get probability scores for the different classes.
         :param max_length: Max length for input sequences. Longer sequences will be truncated. If None, max length of the model will be used
+        :param truncation: Truncation way for input sequences
         :param device: Device that should be used for the model. If None, it will use CUDA if available.
         :param tokenizer_args: Arguments passed to AutoTokenizer
         :param automodel_args: Arguments passed to AutoModelForSequenceClassification
@@ -50,6 +51,7 @@ class CrossEncoder():
         self.model = AutoModelForSequenceClassification.from_pretrained(model_name, config=self.config, **automodel_args)
         self.tokenizer = AutoTokenizer.from_pretrained(model_name, **tokenizer_args)
         self.max_length = max_length
+        self.truncation = truncation
 
         if device is None:
             device = "cuda" if torch.cuda.is_available() else "cpu"
@@ -78,7 +80,7 @@ class CrossEncoder():
 
             labels.append(example.label)
 
-        tokenized = self.tokenizer(*texts, padding=True, truncation='longest_first', return_tensors="pt", max_length=self.max_length)
+        tokenized = self.tokenizer(*texts, padding=True, truncation=self.truncation, return_tensors="pt", max_length=self.max_length)
         labels = torch.tensor(labels, dtype=torch.float if self.config.num_labels == 1 else torch.long).to(self._target_device)
 
         for name in tokenized:
@@ -93,7 +95,7 @@ class CrossEncoder():
             for idx, text in enumerate(example):
                 texts[idx].append(text.strip())
 
-        tokenized = self.tokenizer(*texts, padding=True, truncation='longest_first', return_tensors="pt", max_length=self.max_length)
+        tokenized = self.tokenizer(*texts, padding=True, truncation=self.self.truncation, return_tensors="pt", max_length=self.max_length)
 
         for name in tokenized:
             tokenized[name] = tokenized[name].to(self._target_device)

--- a/sentence_transformers/models/Transformer.py
+++ b/sentence_transformers/models/Transformer.py
@@ -11,6 +11,7 @@ class Transformer(nn.Module):
 
     :param model_name_or_path: Huggingface models name (https://huggingface.co/models)
     :param max_seq_length: Truncate any inputs longer than max_seq_length
+    :param truncation: Truncation way for input sequences
     :param model_args: Arguments (key, value pairs) passed to the Huggingface Transformers model
     :param cache_dir: Cache dir for Huggingface Transformers to store/load models
     :param tokenizer_args: Arguments (key, value pairs) passed to the Huggingface Tokenizer model
@@ -18,12 +19,14 @@ class Transformer(nn.Module):
     :param tokenizer_name_or_path: Name or path of the tokenizer. When None, then model_name_or_path is used
     """
     def __init__(self, model_name_or_path: str, max_seq_length: Optional[int] = None,
+                 truncation: str = 'longest_first',
                  model_args: Dict = {}, cache_dir: Optional[str] = None,
                  tokenizer_args: Dict = {}, do_lower_case: bool = False,
                  tokenizer_name_or_path : str = None):
         super(Transformer, self).__init__()
-        self.config_keys = ['max_seq_length', 'do_lower_case']
+        self.config_keys = ['max_seq_length', 'do_lower_case', 'truncation']
         self.do_lower_case = do_lower_case
+        self.truncation = truncation
 
         config = AutoConfig.from_pretrained(model_name_or_path, **model_args, cache_dir=cache_dir)
         self._load_model(model_name_or_path, config, cache_dir, **model_args)
@@ -118,7 +121,7 @@ class Transformer(nn.Module):
         if self.do_lower_case:
             to_tokenize = [[s.lower() for s in col] for col in to_tokenize]
 
-        output.update(self.tokenizer(*to_tokenize, padding=True, truncation='longest_first', return_tensors="pt", max_length=self.max_seq_length))
+        output.update(self.tokenizer(*to_tokenize, padding=True, truncation=self.truncation, return_tensors="pt", max_length=self.max_seq_length))
         return output
 
 


### PR DESCRIPTION
Currently truncation method is fixed to `longest_first`.
This PR enables use of other methods like `only_first`.

- Reference: https://huggingface.co/docs/transformers/pad_truncation


## Context

Tokenized sequences for the same text will vary depending on other inputs if `batch_size > 1`.
This is because the embeddings generated for the same text are not always the same.
I would like to fix it in an app.

### Example

```python
model = SentenceTransformer('model_name')
texts = [
               "short text",
               "short text",
               "long long long long long long text",
               "short text",
]
model.encode(texts, batch_size=2)
```

The embeddings for `short text` are not the same.