### PR TITLE
change save latest model to save best model

### DIFF
--- a/examples/training/ms_marco/train_cross-encoder_scratch.py
+++ b/examples/training/ms_marco/train_cross-encoder_scratch.py
@@ -177,5 +177,5 @@ model.fit(train_dataloader=train_dataloader,
           output_path=model_save_path,
           use_amp=True)
 
-#Save latest model
-model.save(model_save_path+'-latest')
+#Save best model
+model.save(model_save_path+'-best')


### PR DESCRIPTION
According to sentence_transformers/cross_encoder/CrossEncoder.py  https://github.com/UKPLab/sentence-transformers/blob/e1157ce45811df59f8ae817c1a10e12ded7ff51d/sentence_transformers/cross_encoder/CrossEncoder.py#L116 the save_best_model: bool = True, is the default parameter in CrossEncoder.fit method. So the best model will be saved, not the last.