### PR TITLE
Acccept word2vec formats too.

### DIFF
--- a/sentence_transformers/models/WordEmbeddings.py
+++ b/sentence_transformers/models/WordEmbeddings.py
@@ -103,6 +103,10 @@ class WordEmbeddings(nn.Module):
             iterator = tqdm(fIn, desc="Load Word Embeddings", unit="Embeddings")
             for line in iterator:
                 split = line.rstrip().split(item_separator)
+                
+                if not vocab and len(split) == 2: # Handle Word2vec format
+                    continue
+
                 word = split[0]
 
                 if embeddings_dimension == None:

--- a/sentence_transformers/models/WordEmbeddings.py
+++ b/sentence_transformers/models/WordEmbeddings.py
@@ -103,7 +103,7 @@ class WordEmbeddings(nn.Module):
             iterator = tqdm(fIn, desc="Load Word Embeddings", unit="Embeddings")
             for line in iterator:
                 split = line.rstrip().split(item_separator)
-                
+
                 if not vocab and len(split) == 2: # Handle Word2vec format
                     continue
 


### PR DESCRIPTION
The difference between word2vec and glove embeddings (in text format) is just that in word2vec the first line indicates the size of the vocabulary and the embeddings dimensions. With this commit, the line is ignored and WordEmbeddings class is now able to read embeddings in both formats.