### PR TITLE
Remove unused torchvision dependency

### DIFF
--- a/examples/applications/image-search/README.md
+++ b/examples/applications/image-search/README.md
@@ -6,7 +6,7 @@ SentenceTransformers provides models that allow to embed images and text into th
 
 
 ## Installation
-Ensure that you have [torchvision](https://pypi.org/project/torchvision/) installed to use the image-text-models and use a recent PyTorch version (tested with PyTorch 1.7.0). Image-Text-Models have been added with SentenceTransformers version 1.0.0. Image-Text-Models are still in an experimental phase. 
+Ensure that you have [transformers](https://pypi.org/project/transformers/) installed to use the image-text-models and use a recent PyTorch version (tested with PyTorch 1.7.0). Image-Text-Models have been added with SentenceTransformers version 1.0.0. Image-Text-Models are still in an experimental phase. 
 
 ## Usage
 SentenceTransformers provides a wrapper for the [OpenAI CLIP Model](https://github.com/openai/CLIP), which was trained on a variety of (image, text)-pairs.

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ transformers>=4.6.0,<5.0.0
 tokenizers>=0.10.3
 tqdm
 torch>=1.6.0
-torchvision
 numpy
 scikit-learn
 scipy

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,6 @@ setup(
         'transformers>=4.6.0,<5.0.0',
         'tqdm',
         'torch>=1.6.0',
-        'torchvision',
         'numpy',
         'scikit-learn',
         'scipy',


### PR DESCRIPTION
Torchvision is no longer used in the ST codebase, but it's still listed as a dependency. My guess is that whatever was using `torchvision` has since been replaced by `transformers` but the dependency was never  removed.

This has also been pointed out by #1644