### PR TITLE
use cache even if module.json is not present in the cache. 

### DIFF
--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -82,7 +82,7 @@ class SentenceTransformer(nn.Sequential):
 
                 model_path = os.path.join(cache_folder, model_name_or_path.replace("/", "_"))
                 
-                if not os.path.exists(os.path.join(model_path, 'modules.json')):
+                if not os.path.exists(model_path):
                     # Download from hub with caching
                     snapshot_download(model_name_or_path,
                                         cache_dir=cache_folder,
@@ -90,6 +90,8 @@ class SentenceTransformer(nn.Sequential):
                                         library_version=__version__,
                                         ignore_files=['flax_model.msgpack', 'rust_model.ot', 'tf_model.h5'],
                                         use_auth_token=use_auth_token)
+                else:
+                    logger.info("Load from cache: {}".format(model_path))
 
             if os.path.exists(os.path.join(model_path, 'modules.json')):    #Load as SentenceTransformer model
                 modules = self._load_sbert_model(model_path)


### PR DESCRIPTION
Fix issus #1461. Pull #1565 checks whether module.json exist in the cache, which causes downloading from hub every time as there is no module.json from the hub.