### PR TITLE
Msmarco train bi encoder mnrl fixes

### DIFF
--- a/examples/training/ms_marco/train_bi-encoder_mnrl.py
+++ b/examples/training/ms_marco/train_bi-encoder_mnrl.py
@@ -60,7 +60,7 @@ args = parser.parse_args()
 print(args)
 
 # The  model we want to fine-tune
-model_name = 'distilbert-base-uncased'
+model_name = args.model_name
 
 train_batch_size = args.train_batch_size           #Increasing the train batch size improves the model performance, but requires more GPU memory
 max_seq_length = args.max_seq_length            #Max length for passages. Increasing it, requires more GPU memory

--- a/examples/training/ms_marco/train_bi-encoder_mnrl.py
+++ b/examples/training/ms_marco/train_bi-encoder_mnrl.py
@@ -78,7 +78,9 @@ else:
     word_embedding_model = models.Transformer(model_name, max_seq_length=max_seq_length)
     pooling_model = models.Pooling(word_embedding_model.get_word_embedding_dimension(), args.pooling)
     model = SentenceTransformer(modules=[word_embedding_model, pooling_model])
-
+    
+# Resize model embeddings to match curr tokenizer in case of added tokens
+model._first_module().auto_model.resize_token_embeddings(len(model.tokenizer))
 model_save_path = 'output/train_bi-encoder-mnrl-{}-margin_{:.1f}-{}'.format(model_name.replace("/", "-"), ce_score_margin, datetime.now().strftime("%Y-%m-%d_%H-%M-%S"))
 
 


### PR DESCRIPTION
1. Fixed model_name variable to be assigned from cli argument
2. Adjusted token embedding size based on model tokenizer in case of new tokens