### PR TITLE
Fix a bug in the util.community_detection algorithm 

### DIFF
--- a/sentence_transformers/util.py
+++ b/sentence_transformers/util.py
@@ -399,7 +399,6 @@ def community_detection(embeddings, threshold=0.75, min_community_size=10, batch
     extracted_ids = set()
 
     for cluster_id, community in enumerate(extracted_communities):
-        community = sorted(community)
         non_overlapped_community = []
         for idx in community:
             if idx not in extracted_ids:


### PR DESCRIPTION
One line change to fix a bug in the  community_detection algorithm.

The bug is that currently each community is sorted by the indexes. However, the first item in each community should be the centroid (as per the documentation). 

 