### PR TITLE
Add support for bfloat16 automatic mixed precision

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ nr_*/
 /docs/make.bat
 /docs/Makefile
 /examples/training/quora_duplicate_questions/quora-IR-dataset/
+.venv


### PR DESCRIPTION
BF16 mixed precision can provide slightly better performance in some cases, especially with models previously trained with BF16 mixed precision (i.e. T5) due to the lack of requirement for gradient scaling. This PR adds a bf16_amp parameter to SentenceTransformer and CrossEncoder which allows users with Ampere+ GPUs to use BF16 for autocasting.