### PR TITLE
[Fix typo] `ElasticSearch` -> `Elasticsearch`

### DIFF
--- a/examples/applications/semantic-search/README.md
+++ b/examples/applications/semantic-search/README.md
@@ -70,10 +70,10 @@ hits = util.semantic_search(query_embeddings, corpus_embeddings, score_function=
 
 
 
-## ElasticSearch
-Starting with version 7.3, [ElasticSearch](https://www.elastic.co/elasticsearch/) introduced the possibility to index dense vectors and to use to for document scoring. Hence, we can use ElasticSearch to index embeddings along the documents and we can use the query embeddings to retrieve relevant entries.
+## Elasticsearch
+Starting with version 7.3, [Elasticsearch](https://www.elastic.co/elasticsearch/) introduced the possibility to index dense vectors and to use to for document scoring. Hence, we can use Elasticsearch to index embeddings along the documents and we can use the query embeddings to retrieve relevant entries.
 
-An advantage of ElasticSearch is that it is easy to add new documents to an index and that we can store also other data along with our vectors. A disadvantage is the slow performance, as it compares the query embeddings with all stored embeddings. This has a linear run-time and might be too slow for large (>100k) corpora.
+An advantage of Elasticsearch is that it is easy to add new documents to an index and that we can store also other data along with our vectors. A disadvantage is the slow performance, as it compares the query embeddings with all stored embeddings. This has a linear run-time and might be too slow for large (>100k) corpora.
 
 For further details, see [semantic_search_quora_elasticsearch.py](semantic_search_quora_elasticsearch.py).
 


### PR DESCRIPTION
Just a case of using the wrong case. 😄 