### PR TITLE
Resolve warning about deprecation

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-description-file = README.md
+description_file = README.md


### PR DESCRIPTION
This is the requested change for a setuptools deprecation notice about `description-file` printed during installation.

```
Usage of dash-separated 'description-file' will not be supported in future versions. Please use the underscore name 'description_file' instead.

This deprecation is overdue, please update your project and remove deprecated calls to avoid build errors in the future.

See https://setuptools.pypa.io/en/latest/userguide/declarative_config.html for details.
```