### PR TITLE
Add Support for Multi-GPU Training with PyTorch Lightning

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,10 +112,28 @@ This framework allows you to fine-tune your own sentence embedding methods, so t
 See [Training Overview](https://www.sbert.net/docs/training/overview.html) for an introduction how to train your own embedding models. We provide [various examples](https://github.com/UKPLab/sentence-transformers/tree/master/examples/training) how to train models on various datasets.
 
 Some highlights are:
+- Support of multi-GPU training
 - Support of various transformer networks including BERT, RoBERTa, XLM-R, DistilBERT, Electra, BART, ...
 - Multi-Lingual and multi-task learning
 - Evaluation during training to find optimal model
 - [10+ loss-functions](https://www.sbert.net/docs/package_reference/losses.html) allowing to tune models specifically for semantic search, paraphrase mining, semantic similarity comparison, clustering, triplet loss, contrastive loss.
+
+### Multi-GPU Training
+The following snippet of code wraps SentenceTransformer to enable multi-GPU training using Pytorch Lightning:
+```
+from SentenceTransformer_MultiGPU import SentenceTransformerMultiGPU
+from sentence_transformers import losses
+import lightning.pytorch as pl
+
+model = SentenceTransformerMultiGPU("author/any_huggingface_model", losses.CosineSimilarityLoss)
+trainer = pl.Trainer(max_epochs = 2,
+                     accelerator = 'gpu',
+                     devices = 3,
+                     strategy = 'ddp_find_unused_parameters_true',
+                     log_every_n_steps = 50)
+trainer.fit(model = model, train_dataloader = train_dataloader, val_dataloader = val_dataloader)
+```
+Please note that the dataloader expects an InputExample object out of the dataset class. For more details, take a look at the main module `SentenceTransformer_MultiGPU.py` and the example `examples/multigpi_training.py`.
 
 ## Performance
 

--- a/examples/multigpu_training.py
+++ b/examples/multigpu_training.py
@@ -1,0 +1,35 @@
+import lightning.pytorch as pl
+from sentence_transformers import losses
+from sentence_transformers import InputExample
+from torch.utils.data import Dataset, DataLoader
+from sentence_transformers import SentenceTransformerMultiGPU
+
+st_model = SentenceTransformerMultiGPU("prajjwal1/bert-small", losses.CosineSimilarityLoss, "cpu")
+
+class DatasetClass(Dataset):
+    def __init__(self):
+        self.text1_list = ["hi", "bye", "I love you"]
+        self.text2_list = ["hello", "bye bye", "I hate you"]
+        self.score_list = [0.7, 0.9, 0.0]
+
+    def __len__(self):
+        return len(self.text1_list)
+
+    def __getitem__(self, idx):
+        text1 = self.text1_list[idx]
+        text2 = self.text2_list[idx]
+        score = self.score_list[idx]
+        return InputExample(texts=[text1, text2], label=score)
+
+def collate(batch):
+    return batch
+
+train_dataset = DatasetClass()
+train_dataloader = DataLoader(train_dataset, batch_size=1, shuffle=True, collate_fn=st_model.model.smart_batching_collate)
+val_dataloader = DataLoader(train_dataset, batch_size=1, shuffle=True, collate_fn=st_model.model.smart_batching_collate)
+
+trainer = pl.Trainer(max_epochs = 4,
+                     accelerator = 'cpu',
+                     devices = 1,
+                     log_every_n_steps = 50)
+trainer.fit(st_model, train_dataloader, val_dataloader)

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ scipy
 nltk
 sentencepiece
 huggingface-hub
+lightning

--- a/sentence_transformers/SentenceTransformerMultiGPU.py
+++ b/sentence_transformers/SentenceTransformerMultiGPU.py
@@ -1,0 +1,36 @@
+import torch
+from torch import optim
+import lightning.pytorch as pl
+from sentence_transformers.evaluation import EmbeddingSimilarityEvaluator
+from sentence_transformers import SentenceTransformer, models
+
+class SentenceTransformerMultiGPU(pl.LightningModule):
+    ''' Train a SentenceTransformer model using Pytorch Lightning '''
+    
+    def __init__(self, model, loss, model_device):
+        super().__init__()
+        self.model_device = model_device
+        # Load the transformer model you want to train as a sentence transformer
+        embedding_model = models.Transformer(model)
+        # Add the pooling layer
+        pooling = models.Pooling(embedding_model.get_word_embedding_dimension())
+        # Construct the sentence transformer
+        self.model = SentenceTransformer(modules=[embedding_model, pooling])
+        # Get the base model
+        self.base_model = self.model._first_module().auto_model
+        # Initialize the loss
+        self.loss = loss(self.model)
+
+    def training_step(self, batch, batch_idx):
+        ''' The training function used by Pytorch Lightning '''
+        features, labels = batch
+        loss_value = self.loss(features, labels)
+
+        self.log("train_loss", loss_value, batch_size=len(batch), sync_dist=True, prog_bar=True)
+        return loss_value
+    
+    def configure_optimizers(self):
+        ''' Optimizer configuration '''
+        optimizer = optim.AdamW([p for p in self.parameters() if p.requires_grad], lr=2e-8)
+        return optimizer
+

--- a/sentence_transformers/__init__.py
+++ b/sentence_transformers/__init__.py
@@ -5,4 +5,5 @@ from .LoggingHandler import LoggingHandler
 from .SentenceTransformer import SentenceTransformer
 from .readers import InputExample
 from .cross_encoder.CrossEncoder import CrossEncoder
+from .SentenceTransformerMultiGPU import SentenceTransformerMultiGPU
 

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,8 @@ setup(
         'scipy',
         'nltk',
         'sentencepiece',
-        'huggingface-hub>=0.4.0'
+        'huggingface-hub>=0.4.0',
+        'lightning'
     ],
     classifiers=[
         "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
This pull request introduces support for **multi-GPU training** in the Sentence Transformers library using PyTorch Lightning. 

The following changes have been made:
- Updated README.md to include instructions on how to perform multi-GPU training.
- Added a new module, SentenceTransformerMultiGPU.py, to enable multi-GPU training.
- Included PyTorch Lightning in the requirements.txt file to ensure compatibility.

This enhancement will allow users to leverage the power of multiple GPUs for faster and more efficient training with Sentence Transformers.

Closes the following issues:
- #311
- #556
- #59
- #1898
- #1340
- #1429