### PR TITLE
Use git-aware cache file layout

### DIFF
--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -79,7 +79,7 @@ class SentenceTransformer(nn.Sequential):
 
                 if not os.path.exists(os.path.join(model_name_or_path, 'modules.json')):
                     # Download from hub with caching
-                    snapshot_download(model_name_or_path,
+                    model_name_or_path = snapshot_download(model_name_or_path,
                                         cache_dir=cache_folder,
                                         library_name='sentence-transformers',
                                         library_version=__version__,

--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -68,11 +68,8 @@ class SentenceTransformer(nn.Sequential):
             #Old models that don't belong to any organization
             basic_transformer_models = ['albert-base-v1', 'albert-base-v2', 'albert-large-v1', 'albert-large-v2', 'albert-xlarge-v1', 'albert-xlarge-v2', 'albert-xxlarge-v1', 'albert-xxlarge-v2', 'bert-base-cased-finetuned-mrpc', 'bert-base-cased', 'bert-base-chinese', 'bert-base-german-cased', 'bert-base-german-dbmdz-cased', 'bert-base-german-dbmdz-uncased', 'bert-base-multilingual-cased', 'bert-base-multilingual-uncased', 'bert-base-uncased', 'bert-large-cased-whole-word-masking-finetuned-squad', 'bert-large-cased-whole-word-masking', 'bert-large-cased', 'bert-large-uncased-whole-word-masking-finetuned-squad', 'bert-large-uncased-whole-word-masking', 'bert-large-uncased', 'camembert-base', 'ctrl', 'distilbert-base-cased-distilled-squad', 'distilbert-base-cased', 'distilbert-base-german-cased', 'distilbert-base-multilingual-cased', 'distilbert-base-uncased-distilled-squad', 'distilbert-base-uncased-finetuned-sst-2-english', 'distilbert-base-uncased', 'distilgpt2', 'distilroberta-base', 'gpt2-large', 'gpt2-medium', 'gpt2-xl', 'gpt2', 'openai-gpt', 'roberta-base-openai-detector', 'roberta-base', 'roberta-large-mnli', 'roberta-large-openai-detector', 'roberta-large', 't5-11b', 't5-3b', 't5-base', 't5-large', 't5-small', 'transfo-xl-wt103', 'xlm-clm-ende-1024', 'xlm-clm-enfr-1024', 'xlm-mlm-100-1280', 'xlm-mlm-17-1280', 'xlm-mlm-en-2048', 'xlm-mlm-ende-1024', 'xlm-mlm-enfr-1024', 'xlm-mlm-enro-1024', 'xlm-mlm-tlm-xnli15-1024', 'xlm-mlm-xnli15-1024', 'xlm-roberta-base', 'xlm-roberta-large-finetuned-conll02-dutch', 'xlm-roberta-large-finetuned-conll02-spanish', 'xlm-roberta-large-finetuned-conll03-english', 'xlm-roberta-large-finetuned-conll03-german', 'xlm-roberta-large', 'xlnet-base-cased', 'xlnet-large-cased']
 
-            if os.path.exists(model_name_or_path):
-                #Load from path
-                model_path = model_name_or_path
-            else:
-                #Not a path, load from hub
+            if not os.path.exists(model_name_or_path):
+                # Not a path, load from hub
                 if '\\' in model_name_or_path or model_name_or_path.count('/') > 1:
                     raise ValueError("Path {} not found".format(model_name_or_path))
 
@@ -80,9 +77,7 @@ class SentenceTransformer(nn.Sequential):
                     # A model from sentence-transformers
                     model_name_or_path = __MODEL_HUB_ORGANIZATION__ + "/" + model_name_or_path
 
-                model_path = os.path.join(cache_folder, model_name_or_path.replace("/", "_"))
-                
-                if not os.path.exists(os.path.join(model_path, 'modules.json')):
+                if not os.path.exists(os.path.join(model_name_or_path, 'modules.json')):
                     # Download from hub with caching
                     snapshot_download(model_name_or_path,
                                         cache_dir=cache_folder,
@@ -91,10 +86,10 @@ class SentenceTransformer(nn.Sequential):
                                         ignore_files=['flax_model.msgpack', 'rust_model.ot', 'tf_model.h5'],
                                         use_auth_token=use_auth_token)
 
-            if os.path.exists(os.path.join(model_path, 'modules.json')):    #Load as SentenceTransformer model
-                modules = self._load_sbert_model(model_path)
+            if os.path.exists(os.path.join(model_name_or_path, 'modules.json')):    #Load as SentenceTransformer model
+                modules = self._load_sbert_model(model_name_or_path)
             else:   #Load with AutoModel
-                modules = self._load_auto_model(model_path)
+                modules = self._load_auto_model(model_name_or_path)
 
         if modules is not None and not isinstance(modules, OrderedDict):
             modules = OrderedDict([(str(idx), module) for idx, module in enumerate(modules)])

--- a/sentence_transformers/util.py
+++ b/sentence_transformers/util.py
@@ -14,7 +14,7 @@ from pathlib import Path
 
 import huggingface_hub
 from huggingface_hub.constants import HUGGINGFACE_HUB_CACHE
-from huggingface_hub import HfApi, hf_hub_url, cached_download, HfFolder
+from huggingface_hub import HfApi, hf_hub_url, hf_hub_download, HfFolder
 import fnmatch
 from packaging import version
 import heapq
@@ -483,20 +483,17 @@ def snapshot_download(
         )
         os.makedirs(nested_dirname, exist_ok=True)
 
-        cached_download_args = {'url': url,
+        cached_download_args = {
+            'repo_id': repo_id,
+            'filename': model_file.rfilename,
+            'revision': model_info.sha,
             'cache_dir': storage_folder,
-            'force_filename': relative_filepath,
             'library_name': library_name,
             'library_version': library_version,
             'user_agent': user_agent,
-            'use_auth_token': use_auth_token}
+            'token': use_auth_token}
 
-        if version.parse(huggingface_hub.__version__) >= version.parse("0.8.1"):
-            # huggingface_hub v0.8.1 introduces a new cache layout. We sill use a manual layout
-            # And need to pass legacy_cache_layout=True to avoid that a warning will be printed
-            cached_download_args['legacy_cache_layout'] = True
-
-        path = cached_download(**cached_download_args)
+        path = hf_hub_download(**cached_download_args)
 
         if os.path.exists(path + ".lock"):
             os.remove(path + ".lock")

--- a/sentence_transformers/util.py
+++ b/sentence_transformers/util.py
@@ -461,6 +461,8 @@ def snapshot_download(
             all_files.append(repofile)
             break
 
+    model_storage_folder = None
+
     for model_file in all_files:
         if ignore_files is not None:
             skip_download = False
@@ -472,9 +474,6 @@ def snapshot_download(
             if skip_download:
                 continue
 
-        url = hf_hub_url(
-            repo_id, filename=model_file.rfilename, revision=model_info.sha
-        )
         relative_filepath = os.path.join(*model_file.rfilename.split("/"))
 
         # Create potential nested dir
@@ -495,7 +494,11 @@ def snapshot_download(
 
         path = hf_hub_download(**cached_download_args)
 
+        # model path is the directory where the modules.json file is stored
+        if model_file.rfilename == "modules.json":
+            model_storage_folder = os.path.dirname(path)
+
         if os.path.exists(path + ".lock"):
             os.remove(path + ".lock")
 
-    return storage_folder
+    return model_storage_folder

--- a/sentence_transformers/util.py
+++ b/sentence_transformers/util.py
@@ -449,10 +449,6 @@ def snapshot_download(
         
     model_info = _api.model_info(repo_id=repo_id, revision=revision, token=token)
 
-    storage_folder = os.path.join(
-        cache_dir, repo_id.replace("/", "_")
-    )
-
     all_files = model_info.siblings
     #Download modules.json as the last file
     for idx, repofile in enumerate(all_files):
@@ -474,19 +470,11 @@ def snapshot_download(
             if skip_download:
                 continue
 
-        relative_filepath = os.path.join(*model_file.rfilename.split("/"))
-
-        # Create potential nested dir
-        nested_dirname = os.path.dirname(
-            os.path.join(storage_folder, relative_filepath)
-        )
-        os.makedirs(nested_dirname, exist_ok=True)
-
         cached_download_args = {
             'repo_id': repo_id,
             'filename': model_file.rfilename,
             'revision': model_info.sha,
-            'cache_dir': storage_folder,
+            'cache_dir': cache_dir,
             'library_name': library_name,
             'library_version': library_version,
             'user_agent': user_agent,


### PR DESCRIPTION
`cached_download` is deprecated. Use `hf_hub_download` instead to take advantage of the new cache.

The new cache is introduced in https://github.com/huggingface/huggingface_hub/releases/tag/v0.8.1
