### PR TITLE
Add support for MPS device (M1/M2/M3)

### DIFF
--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -5,11 +5,10 @@ import shutil
 import stat
 from collections import OrderedDict
 from typing import List, Dict, Tuple, Iterable, Type, Union, Callable, Optional, Literal
-import requests
 import numpy as np
 from numpy import ndarray
 import transformers
-from huggingface_hub import HfApi, HfFolder, Repository, hf_hub_url, cached_download
+from huggingface_hub import HfApi, HfFolder, Repository
 import torch
 from torch import nn, Tensor, device
 from torch.optim import Optimizer
@@ -24,7 +23,7 @@ from distutils.dir_util import copy_tree
 from . import __MODEL_HUB_ORGANIZATION__
 from .evaluation import SentenceEvaluator
 from .util import import_from_string, batch_to_device, fullname, snapshot_download
-from .models import Transformer, Pooling, Dense
+from .models import Transformer, Pooling
 from .model_card_templates import ModelCardTemplate
 from . import __version__
 


### PR DESCRIPTION
This PR extends automatic detection for PyTorch devices for MPS (Apple silicon laptops M-series, e.g. Macbook M1/M2/M3).

Test details (on Apple M1 Max)
TLDR: it's recommended to use the latest PyTorch version (as of now 2.1.0), but both >=2 successfully run 

<details>
<summary>tests: Python 3.9; torch 2.0.1; transformers 4.30.2</summary>
 (without model download)

Python 3.9
packages:
```text
torch 2.0.1
transformers 4.30.2
```

![CleanShot 2023-11-02 at 12 42 26](https://github.com/UKPLab/sentence-transformers/assets/12535180/a7c721b2-2c05-40de-af0e-aabcb832ec49)

All tests pass successfully but some errors appear for MPS (seems fallback works without explicitly setting `PYTORCH_ENABLE_MPS_FALLBACK`)

[Test Results - Python 3.9; torch 2.0.1; transformers 4.30.2.html.zip](https://github.com/UKPLab/sentence-transformers/files/13238869/Test.Results.-.Python.3.9.torch.2.0.1.transformers.4.30.2.html.zip)
(unable to attach html directly, this contains zipped version)


</details>

<details>
<summary>tests: Python 3.9; torch 2.1.0; transformers 4.34.1</summary>

![CleanShot 2023-11-02 at 12 14 14](https://github.com/UKPLab/sentence-transformers/assets/12535180/ec2a4c40-5196-40ad-ba38-c1f9666d25db)

All tests pass successfully (no warnings)

[Test Results - Python 3.9; torch 2.1.0; transformers 4.34.1.html.zip](https://github.com/UKPLab/sentence-transformers/files/13238870/Test.Results.-.Python.3.9.torch.2.1.0.transformers.4.34.1.html.zip)

</details>
