### PR TITLE
Edit transformers requirement to be <4.35.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The following publications are integrated in this framework:
 
 ## Installation
 
-We recommend **Python 3.6** or higher, **[PyTorch 1.6.0](https://pytorch.org/get-started/locally/)** or higher and **[transformers v4.6.0](https://github.com/huggingface/transformers)** or higher. The code does **not** work with Python 2.7.
+We recommend **Python 3.6** or higher, **[PyTorch 1.6.0](https://pytorch.org/get-started/locally/)** or higher and **[transformers v4.34.1](https://github.com/huggingface/transformers)** or lower. The code does **not** work with Python 2.7.
 
 **Install with pip**
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-transformers>=4.6.0,<5.0.0
+transformers<4.35.0 
 tokenizers>=0.10.3
 tqdm
 torch>=1.6.0

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     packages=find_packages(),
     python_requires=">=3.6.0",
     install_requires=[
-        'transformers>=4.6.0,<5.0.0',
+        'transformers<4.35.0',
         'tqdm',
         'torch>=1.6.0',
         'torchvision',


### PR DESCRIPTION
With safetensors serialization being the default in [`transformers v4.35.0`](https://github.com/huggingface/transformers/releases), `transformers v4.35.0` is currently not compatible with the `sentence-transformers` library as is. `sentence-transformers` cannot load safetensor models as of now, only pytorch_model.bin (pickle)