### PR TITLE
`[tests]` Be sure to stop the multi-processing pool after/during test

### DIFF
--- a/tests/test_multi_process.py
+++ b/tests/test_multi_process.py
@@ -19,6 +19,7 @@ class ComputeMultiProcessTest(unittest.TestCase):
 
         # Compute the embeddings using the multi-process pool
         emb = self.model.encode_multi_process(sentences, pool, chunk_size=50)
+        self.model.stop_multi_process_pool(pool)
         assert emb.shape == (len(sentences), 768)
 
         emb_normal = self.model.encode(sentences)


### PR DESCRIPTION
Hello!

## Pull Request overview
* In the `test_multi_gpu_encode` test, a MP pool is started, but never stopped.

## Details
During the `test_multi_gpu_encode` test (which is oddly named as it only tests with two "cpu" instances), the multi-processing pool was never stopped. This PR simply stops it after performing the encoding.

- Tom Aarsen