### PR TITLE
`[ci]` Simplify tests, add CI, patch `paraphrase_mining_embeddings`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,6 +39,7 @@ jobs:
       - name: Install external dependencies on cache miss
         run: |
           python -m pip install --no-cache-dir --upgrade pip
+          python -m pip install --no-cache-dir -r requirements.txt
           python -m pip install --no-cache-dir pytest
         if: steps.restore-cache.outputs.cache-hit != 'true'
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,29 +46,7 @@ jobs:
       - name: Install the checked-out sentence-transformers
         run: python -m pip install .
 
-      - name: Restore HF models from cache
-        uses: actions/cache/restore@v3
-        with:
-          path: |
-            ~/.cache/huggingface/hub
-            ~/.cache/torch
-          key: hf-models-${{ matrix.os }}-${{ env.NEW_HF_CACHE_HASH }}
-          restore-keys: |
-            hf-models-${{ matrix.os }}-
-
       - name: Run unit tests
         shell: bash
         run: |
-          echo "OLD_HF_CACHE_HASH=$(find ~/.cache/huggingface/hub ~/.cache/torch -type f -exec sha256sum {} + | LC_ALL=C sort | sha256sum | cut -d ' ' -f 1)" >> $GITHUB_ENV
           pytest -sv tests/
-          echo "NEW_HF_CACHE_HASH=$(find ~/.cache/huggingface/hub ~/.cache/torch -type f -exec sha256sum {} + | LC_ALL=C sort | sha256sum | cut -d ' ' -f 1)" >> $GITHUB_ENV
-
-      - name: Save new HF models to cache
-        uses: actions/cache/save@v3
-        with:
-          path: |
-            ~/.cache/huggingface/hub
-            ~/.cache/torch
-          key: hf-models-${{ matrix.os }}-${{ env.NEW_HF_CACHE_HASH }}
-        # Only save cache if the hash has changed
-        if: env.NEW_HF_CACHE_HASH != env.OLD_HF_CACHE_HASH

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,73 @@
+name: Unit tests
+
+on:
+  push:
+    branches:
+      - master
+      - v*-release
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch:
+
+jobs:
+
+  test_sampling:
+    name: Run unit tests
+    strategy:
+      matrix:
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
+        os: [ubuntu-latest, windows-latest]
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Setup Python environment
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Try to load cached dependencies
+        uses: actions/cache@v3
+        id: restore-cache
+        with:
+          path: ${{ env.pythonLocation }}
+          key: python-dependencies-${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('setup.py') }}-${{ hashFiles('requirements.txt') }}-${{ env.pythonLocation }}
+
+      - name: Install external dependencies on cache miss
+        run: |
+          python -m pip install --no-cache-dir --upgrade pip
+          python -m pip install --no-cache-dir .
+        if: steps.restore-cache.outputs.cache-hit != 'true'
+
+      - name: Install the checked-out setfit
+        run: python -m pip install .
+
+      - name: Restore HF models from cache
+        uses: actions/cache/restore@v3
+        with:
+          path: |
+            ~/.cache/huggingface/hub
+            ~/.cache/torch
+          key: hf-models-${{ matrix.os }}-${{ env.NEW_HF_CACHE_HASH }}
+          restore-keys: |
+            hf-models-${{ matrix.os }}-
+
+      - name: Run unit tests
+        shell: bash
+        run: |
+          echo "OLD_HF_CACHE_HASH=$(find ~/.cache/huggingface/hub ~/.cache/torch -type f -exec sha256sum {} + | LC_ALL=C sort | sha256sum | cut -d ' ' -f 1)" >> $GITHUB_ENV
+          pytest -sv tests/
+          echo "NEW_HF_CACHE_HASH=$(find ~/.cache/huggingface/hub ~/.cache/torch -type f -exec sha256sum {} + | LC_ALL=C sort | sha256sum | cut -d ' ' -f 1)" >> $GITHUB_ENV
+
+      - name: Save new HF models to cache
+        uses: actions/cache/save@v3
+        with:
+          path: |
+            ~/.cache/huggingface/hub
+            ~/.cache/torch
+          key: hf-models-${{ matrix.os }}-${{ env.NEW_HF_CACHE_HASH }}
+        # Only save cache if the hash has changed
+        if: env.NEW_HF_CACHE_HASH != env.OLD_HF_CACHE_HASH

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
     name: Run unit tests
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
         os: [ubuntu-latest, windows-latest]
       fail-fast: false
     runs-on: ${{ matrix.os }}
@@ -43,7 +43,7 @@ jobs:
           python -m pip install --no-cache-dir pytest
         if: steps.restore-cache.outputs.cache-hit != 'true'
 
-      - name: Install the checked-out setfit
+      - name: Install the checked-out sentence-transformers
         run: python -m pip install .
 
       - name: Restore HF models from cache

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,6 +40,7 @@ jobs:
         run: |
           python -m pip install --no-cache-dir --upgrade pip
           python -m pip install --no-cache-dir .
+          python -m pip install --no-cache-dir pytest
         if: steps.restore-cache.outputs.cache-hit != 'true'
 
       - name: Install the checked-out setfit

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
     name: Run unit tests
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
         os: [ubuntu-latest, windows-latest]
       fail-fast: false
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,7 +39,6 @@ jobs:
       - name: Install external dependencies on cache miss
         run: |
           python -m pip install --no-cache-dir --upgrade pip
-          python -m pip install --no-cache-dir .
           python -m pip install --no-cache-dir pytest
         if: steps.restore-cache.outputs.cache-hit != 'true'
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,6 @@
+[pytest]
+testpaths =
+    tests
+addopts = --strict-markers -m "not slow"
+markers =
+    slow: marks tests as slow

--- a/sentence_transformers/util.py
+++ b/sentence_transformers/util.py
@@ -189,7 +189,7 @@ def paraphrase_mining_embeddings(embeddings: Tensor,
 
         if sorted_i != sorted_j and (sorted_i, sorted_j) not in added_pairs:
             added_pairs.add((sorted_i, sorted_j))
-            pairs_list.append([score, i, j])
+            pairs_list.append([score, sorted_i, sorted_j])
 
     # Highest scores first
     pairs_list = sorted(pairs_list, key=lambda x: x[0], reverse=True)

--- a/tests/test_cross_encoder.py
+++ b/tests/test_cross_encoder.py
@@ -21,8 +21,9 @@ class CrossEncoderTest(unittest.TestCase):
             util.http_get('https://sbert.net/datasets/stsbenchmark.tsv.gz', sts_dataset_path)
 
         #Read STSB
+        max_test_samples = 100
+        max_train_samples = 500
         self.stsb_train_samples = []
-        self.dev_samples = []
         self.test_samples = []
         with gzip.open(sts_dataset_path, 'rt', encoding='utf8') as fIn:
             reader = csv.DictReader(fIn, delimiter='\t', quoting=csv.QUOTE_NONE)
@@ -30,11 +31,9 @@ class CrossEncoderTest(unittest.TestCase):
                 score = float(row['score']) / 5.0  # Normalize score to range 0 ... 1
                 inp_example = InputExample(texts=[row['sentence1'], row['sentence2']], label=score)
 
-                if row['split'] == 'dev':
-                    self.dev_samples.append(inp_example)
-                elif row['split'] == 'test':
+                if row['split'] == 'test' and len(self.test_samples) < max_test_samples:
                     self.test_samples.append(inp_example)
-                else:
+                elif row['split'] == 'train' and len(self.stsb_train_samples) < max_train_samples:
                     self.stsb_train_samples.append(inp_example)
 
     def evaluate_stsb_test(self, model, expected_score):
@@ -53,7 +52,7 @@ class CrossEncoderTest(unittest.TestCase):
         model.fit(train_dataloader=train_dataloader,
                   epochs=1,
                   warmup_steps=int(len(train_dataloader)*0.1))
-        self.evaluate_stsb_test(model, 75)
+        self.evaluate_stsb_test(model, 50)
 
 
 

--- a/tests/test_pretrained_stsb.py
+++ b/tests/test_pretrained_stsb.py
@@ -36,46 +36,46 @@ class PretrainedSTSbTest(unittest.TestCase):
         assert score > expected_score or abs(score-expected_score) < 0.1
 
     def test_bert_base(self):
-        self.pretrained_model_score('bert-base-nli-mean-tokens', 77.12)
-        self.pretrained_model_score('bert-base-nli-max-tokens', 77.21)
-        self.pretrained_model_score('bert-base-nli-cls-token', 76.30)
-        self.pretrained_model_score('bert-base-nli-stsb-mean-tokens', 85.14)
+        self.pretrained_model_score('bert-base-nli-mean-tokens', 86.53)
+        self.pretrained_model_score('bert-base-nli-max-tokens', 87.00)
+        self.pretrained_model_score('bert-base-nli-cls-token', 85.93)
+        self.pretrained_model_score('bert-base-nli-stsb-mean-tokens', 89.26)
 
 
     def test_bert_large(self):
-        self.pretrained_model_score('bert-large-nli-mean-tokens', 79.19)
-        self.pretrained_model_score('bert-large-nli-max-tokens', 78.41)
-        self.pretrained_model_score('bert-large-nli-cls-token', 78.29)
-        self.pretrained_model_score('bert-large-nli-stsb-mean-tokens', 85.29)
+        self.pretrained_model_score('bert-large-nli-mean-tokens', 90.06)
+        self.pretrained_model_score('bert-large-nli-max-tokens', 90.15)
+        self.pretrained_model_score('bert-large-nli-cls-token', 89.51)
+        self.pretrained_model_score('bert-large-nli-stsb-mean-tokens', 92.27)
 
     def test_roberta(self):
-        self.pretrained_model_score('roberta-base-nli-mean-tokens', 77.49)
-        self.pretrained_model_score('roberta-large-nli-mean-tokens', 78.69)
-        self.pretrained_model_score('roberta-base-nli-stsb-mean-tokens', 85.30)
-        self.pretrained_model_score('roberta-large-nli-stsb-mean-tokens', 86.39)
+        self.pretrained_model_score('roberta-base-nli-mean-tokens', 87.91)
+        self.pretrained_model_score('roberta-large-nli-mean-tokens', 89.41)
+        self.pretrained_model_score('roberta-base-nli-stsb-mean-tokens', 93.39)
+        self.pretrained_model_score('roberta-large-nli-stsb-mean-tokens', 91.26)
 
     def test_distilbert(self):
-        self.pretrained_model_score('distilbert-base-nli-mean-tokens', 78.69)
-        self.pretrained_model_score('distilbert-base-nli-stsb-mean-tokens', 85.16)
-        self.pretrained_model_score('paraphrase-distilroberta-base-v1', 81.81)
+        self.pretrained_model_score('distilbert-base-nli-mean-tokens', 88.83)
+        self.pretrained_model_score('distilbert-base-nli-stsb-mean-tokens', 91.01)
+        self.pretrained_model_score('paraphrase-distilroberta-base-v1', 90.89)
 
     def test_multiling(self):
-        self.pretrained_model_score('distiluse-base-multilingual-cased', 80.75)
-        self.pretrained_model_score('paraphrase-xlm-r-multilingual-v1', 83.50)
-        self.pretrained_model_score('paraphrase-multilingual-MiniLM-L12-v2', 84.42)
+        self.pretrained_model_score('distiluse-base-multilingual-cased', 88.79)
+        self.pretrained_model_score('paraphrase-xlm-r-multilingual-v1', 92.76)
+        self.pretrained_model_score('paraphrase-multilingual-MiniLM-L12-v2', 92.64)
 
     def test_mpnet(self):
-        self.pretrained_model_score('paraphrase-mpnet-base-v2', 86.99)
+        self.pretrained_model_score('paraphrase-mpnet-base-v2', 92.83)
 
     def test_other_models(self):
-        self.pretrained_model_score('average_word_embeddings_komninos', 61.56)
+        self.pretrained_model_score('average_word_embeddings_komninos', 68.97)
 
     def test_msmarco(self):
-        self.pretrained_model_score('msmarco-roberta-base-ance-firstp', 77.0)
-        self.pretrained_model_score('msmarco-distilbert-base-v3', 78.85)
+        self.pretrained_model_score('msmarco-roberta-base-ance-firstp', 83.61)
+        self.pretrained_model_score('msmarco-distilbert-base-v3', 87.96)
 
     def test_sentence_t5(self):
-        self.pretrained_model_score('sentence-t5-base', 85.52)
+        self.pretrained_model_score('sentence-t5-base', 92.75)
 
 if "__main__" == __name__:
     unittest.main()

--- a/tests/test_pretrained_stsb.py
+++ b/tests/test_pretrained_stsb.py
@@ -1,46 +1,93 @@
 """
 Tests that the pretrained models produce the correct scores on the STSbenchmark dataset
 """
+from functools import partial
 from sentence_transformers import SentenceTransformer,  InputExample, util
 from sentence_transformers.evaluation import EmbeddingSimilarityEvaluator
-import unittest
 import os
 import gzip
 import csv
+import pytest
 
-class PretrainedSTSbTest(unittest.TestCase):
+def pretrained_model_score(model_name, expected_score, max_test_samples: int = 100):
+    model = SentenceTransformer(model_name)
+    sts_dataset_path = 'datasets/stsbenchmark.tsv.gz'
 
-    def pretrained_model_score(self, model_name, expected_score, max_test_samples: int = 100):
-        model = SentenceTransformer(model_name)
-        sts_dataset_path = 'datasets/stsbenchmark.tsv.gz'
+    if not os.path.exists(sts_dataset_path):
+        util.http_get('https://sbert.net/datasets/stsbenchmark.tsv.gz', sts_dataset_path)
 
-        if not os.path.exists(sts_dataset_path):
-            util.http_get('https://sbert.net/datasets/stsbenchmark.tsv.gz', sts_dataset_path)
+    test_samples = []
+    with gzip.open(sts_dataset_path, 'rt', encoding='utf8') as fIn:
+        reader = csv.DictReader(fIn, delimiter='\t', quoting=csv.QUOTE_NONE)
+        for row in reader:
+            score = float(row['score']) / 5.0  # Normalize score to range 0 ... 1
+            inp_example = InputExample(texts=[row['sentence1'], row['sentence2']], label=score)
 
-        test_samples = []
-        with gzip.open(sts_dataset_path, 'rt', encoding='utf8') as fIn:
-            reader = csv.DictReader(fIn, delimiter='\t', quoting=csv.QUOTE_NONE)
-            for row in reader:
-                score = float(row['score']) / 5.0  # Normalize score to range 0 ... 1
-                inp_example = InputExample(texts=[row['sentence1'], row['sentence2']], label=score)
+            if row['split'] == 'test':
+                test_samples.append(inp_example)
+            if max_test_samples != -1 and len(test_samples) >= max_test_samples:
+                break
 
-                if row['split'] == 'test':
-                    test_samples.append(inp_example)
-                if len(test_samples) >= max_test_samples:
-                    break
+    evaluator = EmbeddingSimilarityEvaluator.from_input_examples(test_samples, name='sts-test')
 
-        evaluator = EmbeddingSimilarityEvaluator.from_input_examples(test_samples, name='sts-test')
+    score = model.evaluate(evaluator)*100
+    print(model_name, "{:.2f} vs. exp: {:.2f}".format(score, expected_score))
+    assert score > expected_score or abs(score-expected_score) < 0.1
 
-        score = model.evaluate(evaluator)*100
-        print(model_name, "{:.2f} vs. exp: {:.2f}".format(score, expected_score))
-        assert score > expected_score or abs(score-expected_score) < 0.1
+@pytest.mark.slow
+class TestPretrainedSTSbSlow:
+    pretrained_model_score = partial(pretrained_model_score, max_test_samples=-1)
+
+    def test_bert_base(self):
+        self.pretrained_model_score('bert-base-nli-mean-tokens', 77.12)
+        self.pretrained_model_score('bert-base-nli-max-tokens', 77.21)
+        self.pretrained_model_score('bert-base-nli-cls-token', 76.30)
+        self.pretrained_model_score('bert-base-nli-stsb-mean-tokens', 85.14)
+
+    def test_bert_large(self):
+        self.pretrained_model_score('bert-large-nli-mean-tokens', 79.19)
+        self.pretrained_model_score('bert-large-nli-max-tokens', 78.41)
+        self.pretrained_model_score('bert-large-nli-cls-token', 78.29)
+        self.pretrained_model_score('bert-large-nli-stsb-mean-tokens', 85.29)
+
+    def test_roberta(self):
+        self.pretrained_model_score('roberta-base-nli-mean-tokens', 77.49)
+        self.pretrained_model_score('roberta-large-nli-mean-tokens', 78.69)
+        self.pretrained_model_score('roberta-base-nli-stsb-mean-tokens', 85.30)
+        self.pretrained_model_score('roberta-large-nli-stsb-mean-tokens', 86.39)
+
+    def test_distilbert(self):
+        self.pretrained_model_score('distilbert-base-nli-mean-tokens', 78.69)
+        self.pretrained_model_score('distilbert-base-nli-stsb-mean-tokens', 85.16)
+        self.pretrained_model_score('paraphrase-distilroberta-base-v1', 81.81)
+
+    def test_multiling(self):
+        self.pretrained_model_score('distiluse-base-multilingual-cased', 80.75)
+        self.pretrained_model_score('paraphrase-xlm-r-multilingual-v1', 83.50)
+        self.pretrained_model_score('paraphrase-multilingual-MiniLM-L12-v2', 84.42)
+
+    def test_mpnet(self):
+        self.pretrained_model_score('paraphrase-mpnet-base-v2', 86.99)
+
+    def test_other_models(self):
+        self.pretrained_model_score('average_word_embeddings_komninos', 61.56)
+
+    def test_msmarco(self):
+        self.pretrained_model_score('msmarco-roberta-base-ance-firstp', 77.0)
+        self.pretrained_model_score('msmarco-distilbert-base-v3', 78.85)
+
+    def test_sentence_t5(self):
+        self.pretrained_model_score('sentence-t5-base', 85.52)
+
+
+class TestPretrainedSTSbFast:
+    pretrained_model_score = partial(pretrained_model_score, max_test_samples=100)
 
     def test_bert_base(self):
         self.pretrained_model_score('bert-base-nli-mean-tokens', 86.53)
         self.pretrained_model_score('bert-base-nli-max-tokens', 87.00)
         self.pretrained_model_score('bert-base-nli-cls-token', 85.93)
         self.pretrained_model_score('bert-base-nli-stsb-mean-tokens', 89.26)
-
 
     def test_bert_large(self):
         self.pretrained_model_score('bert-large-nli-mean-tokens', 90.06)
@@ -76,6 +123,3 @@ class PretrainedSTSbTest(unittest.TestCase):
 
     def test_sentence_t5(self):
         self.pretrained_model_score('sentence-t5-base', 92.75)
-
-if "__main__" == __name__:
-    unittest.main()

--- a/tests/test_train_stsb.py
+++ b/tests/test_train_stsb.py
@@ -26,7 +26,7 @@ class PretrainedSTSbTest(unittest.TestCase):
         #Read NLI
         label2int = {"contradiction": 0, "entailment": 1, "neutral": 2}
         self.nli_train_samples = []
-        max_train_samples = 10000
+        max_train_samples = 100
         with gzip.open(nli_dataset_path, 'rt', encoding='utf8') as fIn:
             reader = csv.DictReader(fIn, delimiter='\t', quoting=csv.QUOTE_NONE)
             for row in reader:
@@ -38,19 +38,17 @@ class PretrainedSTSbTest(unittest.TestCase):
 
         #Read STSB
         self.stsb_train_samples = []
-        self.dev_samples = []
         self.test_samples = []
+        max_train_samples = 100
         with gzip.open(sts_dataset_path, 'rt', encoding='utf8') as fIn:
             reader = csv.DictReader(fIn, delimiter='\t', quoting=csv.QUOTE_NONE)
             for row in reader:
                 score = float(row['score']) / 5.0  # Normalize score to range 0 ... 1
                 inp_example = InputExample(texts=[row['sentence1'], row['sentence2']], label=score)
 
-                if row['split'] == 'dev':
-                    self.dev_samples.append(inp_example)
-                elif row['split'] == 'test':
+                if row['split'] == 'test':
                     self.test_samples.append(inp_example)
-                else:
+                elif row['split'] == 'train' and len(self.stsb_train_samples) < max_train_samples:
                     self.stsb_train_samples.append(inp_example)
 
     def evaluate_stsb_test(self, model, expected_score):
@@ -73,7 +71,7 @@ class PretrainedSTSbTest(unittest.TestCase):
                   warmup_steps=int(len(train_dataloader)*0.1),
                   use_amp=True)
 
-        self.evaluate_stsb_test(model, 80.0)
+        self.evaluate_stsb_test(model, 65.0)
 
     def test_train_nli(self):
         word_embedding_model = models.Transformer('distilbert-base-uncased')

--- a/tests/test_train_stsb.py
+++ b/tests/test_train_stsb.py
@@ -71,7 +71,7 @@ class PretrainedSTSbTest(unittest.TestCase):
                   warmup_steps=int(len(train_dataloader)*0.1),
                   use_amp=True)
 
-        self.evaluate_stsb_test(model, 65.0)
+        self.evaluate_stsb_test(model, 60.0)
 
     def test_train_nli(self):
         word_embedding_model = models.Transformer('distilbert-base-uncased')


### PR DESCRIPTION
Hello!

## Pull Request overview
* Simplify tests: only train with 100-500 samples, only test with 100 samples.
* Add CI, automated tests for:
  * os: Linux, Windows
  * Python version: 3.7, 3.8, 3.9, 3.10, 3.11
* Patch `paraphrase_mining_embeddings` such that `i < j` is always true with `i` and `j` as paraphrase indices.

## Details
### Tests
Before CI can be applied, we need to simplify the tests. In essence, this involved first verifying that the there is no regression on `master` by running the current (large) tests. Then, I decreased the number of testing samples to 100 across all tests, and the number of training samples down to 100-500, depending on the test setup.

I then updated the expected scores across all pretrained models. Ideally, I think it would be best to test less of the pretrained models, as it allows us to actually cache the downloaded models, but alas, I think this should be fine too: the GitHub CI environment can usually download at ~250MB/s.

In a later PR I intend to improve the test suite in various ways. For example:
1. No longer load the STSB/NLI files in numerous locations, but only once.
2. Heavily improve the test coverage. Currently SentenceTransformers has a dreadful 46% test coverage, whereas 95% is commonly the target for large OS projects.

Test time seems to be between 6 and 15 minutes. The test time might improve further when #2345 is merged, in case we currently download unnecessary model files (e.g. `model.safetensors` *and* `pytorch_model.bin`).

### CI
I've added a simple continuous integration setup. CI is extremely important for large OS projects, and it should help simplify PRs etc. a ton. The CI caches Python dependencies, but not HF models. The reason is that the test suite simply uses too many large models that they cannot all be cached across all OS-es.

After v2.3.0 I intend to deprecate Python 3.6 and 3.7. I would have added Python 3.6 to the CI, but it did not work: The Ubuntu 22.04 GitHub CI image doesn't have Python 3.6 anymore, and for Windows it isn't possible to install a recent enough `tokenizers` version from scratch.
Although 3.12 has been out for quite some time, the `torch` support is still lacking, so that's why it was not included in the CI.

### Patch `paraphrase_mining_embeddings`
When running the CI, I learned that for Python 3.10 and 3.11, on Linux only, the `paraphrase_mining_embeddings` function could return `(score, i, j)` triples where `i > j`. This does not occur in other versions. I applied a simple patch to ensure that `i < j` always holds, allowing the matching test to pass.

---

Run the (fast) tests with `pytest`, and the slow tests with `pytest -m slow`.

- Tom Aarsen