### PR TITLE
[`chore`] Add "build" to gitignore, used by setup.py etc.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ nr_*/
 /docs/make.bat
 /docs/Makefile
 /examples/training/quora_duplicate_questions/quora-IR-dataset/
+build


### PR DESCRIPTION
Hello!

## Pull Request overview
* Add "build" to gitignore, used by setup.py etc.

## Details
We don't want anyone's `build` folder to be included in a commit, so let's prevent that.

- Tom Aarsen