### PR TITLE
[`deps`] Introduce Pillow as a dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ scipy
 nltk
 sentencepiece
 huggingface-hub
+Pillow

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,8 @@ setup(
         'scipy',
         'nltk',
         'sentencepiece',
-        'huggingface-hub>=0.4.0'
+        'huggingface-hub>=0.4.0',
+        'Pillow'
     ],
     classifiers=[
         "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
Related to #1881

Hello!

## Pull Request overview
*Introduce Pillow as a dependency

## Details
This is a necessary module, which was initially installed via torchvision. However, as #1881 removed `torchvision` as a dependency, it also stopped installing pillow.

- Tom Aarsen


