### PR TITLE
[`deprecate`] Remove Python 3.7 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
     name: Run unit tests
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
         os: [ubuntu-latest, windows-latest]
       fail-fast: false
     runs-on: ${{ matrix.os }}

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The following publications are integrated in this framework:
 
 ## Installation
 
-We recommend **Python 3.6** or higher, **[PyTorch 1.6.0](https://pytorch.org/get-started/locally/)** or higher and **[transformers v4.6.0](https://github.com/huggingface/transformers)** or higher. The code does **not** work with Python 2.7.
+We recommend **Python 3.8** or higher, **[PyTorch 1.6.0](https://pytorch.org/get-started/locally/)** or higher and **[transformers v4.23.0](https://github.com/huggingface/transformers)** or higher. The code does **not** work with Python 2.7.
 
 **Install with pip**
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,6 +1,6 @@
 # Installation
 
-We recommend **Python 3.6** or higher, **[PyTorch 1.6.0](https://pytorch.org/get-started/locally/)** or higher and **[transformers v4.6.0](https://github.com/huggingface/transformers)** or higher. The code does **not** work with Python 2.7. 
+We recommend **Python 3.8** or higher, **[PyTorch 1.6.0](https://pytorch.org/get-started/locally/)** or higher and **[transformers v4.6.0](https://github.com/huggingface/transformers)** or higher. The code does **not** work with Python 2.7. 
 
 
 

--- a/index.rst
+++ b/index.rst
@@ -18,7 +18,7 @@ You can install it using pip:
    pip install -U sentence-transformers
 
 
-We recommend **Python 3.6** or higher, and at least **PyTorch 1.6.0**. See `installation <docs/installation.html>`_ for further installation options, especially if you want to use a GPU.
+We recommend **Python 3.8** or higher, and at least **PyTorch 1.6.0**. See `installation <docs/installation.html>`_ for further installation options, especially if you want to use a GPU.
 
 
 

--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -4,11 +4,7 @@ import os
 import shutil
 import stat
 from collections import OrderedDict
-from typing import List, Dict, Tuple, Iterable, Type, Union, Callable, Optional
-try:
-    from typing import Literal
-except ImportError:
-    from typing_extensions import Literal
+from typing import List, Dict, Tuple, Iterable, Type, Union, Callable, Optional, Literal
 import numpy as np
 from numpy import ndarray
 import transformers

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     url="https://www.SBERT.net",
     download_url="https://github.com/UKPLab/sentence-transformers/",
     packages=find_packages(),
-    python_requires=">=3.6.0",
+    python_requires=">=3.8.0",
     install_requires=[
         'transformers>=4.6.0,<5.0.0',
         'tqdm',
@@ -33,7 +33,7 @@ setup(
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Science/Research",
         "License :: OSI Approved :: Apache Software License",
-        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.8",
         "Topic :: Scientific/Engineering :: Artificial Intelligence"
     ],
     keywords="Transformer Networks BERT XLNet sentence embedding PyTorch NLP deep learning"


### PR DESCRIPTION
Hello!

## Pull Request overview
* Remove Python 3.7 support

## Details
Python 3.7 has reached [end of life](https://endoflife.date/python), and so we should stop making releases for it. This will also help with compatibility issues due to breaking changes in third parties. For example, `token` is supported in `transformers` from 4.31.0 onwards, but Python 3.7 can't use that version.

- Tom Aarsen