### PR TITLE
[`fix`] Set the Linear device equal to the main model device in SoftmaxLoss

### DIFF
--- a/sentence_transformers/losses/SoftmaxLoss.py
+++ b/sentence_transformers/losses/SoftmaxLoss.py
@@ -55,7 +55,7 @@ class SoftmaxLoss(nn.Module):
         if concatenation_sent_multiplication:
             num_vectors_concatenated += 1
         logger.info("Softmax loss: #Vectors concatenated: {}".format(num_vectors_concatenated))
-        self.classifier = nn.Linear(num_vectors_concatenated * sentence_embedding_dimension, num_labels)
+        self.classifier = nn.Linear(num_vectors_concatenated * sentence_embedding_dimension, num_labels, device=model.device)
         self.loss_fct = loss_fct
 
     def forward(self, sentence_features: Iterable[Dict[str, Tensor]], labels: Tensor):


### PR DESCRIPTION
Hello!

## Pull Request overview
* Set the Linear device equal to the main model device in SoftmaxLoss.
* Prevents crashes if torch is compiled with CUDA.

## Details
Since #2351, a model loaded when CUDA is available is immediately placed on CUDA. However, when a SoftmaxLoss instance is initialized, the Linear layer is not moved to a particular device. This results in a mismatch in devices when CUDA is available in the tests.
The CI missed it, as it only has CPU.

- Tom Aarsen