### PR TITLE
[`enhancement`] Improve efficiency of community detection on GPU

### DIFF
--- a/sentence_transformers/util.py
+++ b/sentence_transformers/util.py
@@ -359,42 +359,36 @@ def community_detection(embeddings, threshold=0.75, min_community_size=10, batch
         embeddings = torch.tensor(embeddings)
 
     threshold = torch.tensor(threshold, device=embeddings.device)
+    embeddings = normalize_embeddings(embeddings)
 
     extracted_communities = []
 
     # Maximum size for community
     min_community_size = min(min_community_size, len(embeddings))
-    sort_max_size = min(max(2 * min_community_size, 50), len(embeddings))
 
     for start_idx in tqdm(range(0, len(embeddings), batch_size), desc="Finding clusters", disable=not show_progress_bar):
         # Compute cosine similarity scores
-        cos_scores = cos_sim(embeddings[start_idx:start_idx + batch_size], embeddings)
+        cos_scores = embeddings[start_idx:start_idx + batch_size] @ embeddings.T
 
-        # Minimum size for a community
-        top_k_values, _ = cos_scores.topk(k=min_community_size, largest=True)
+        # Threshold the cos scores and determine how many close embeddings exist per embedding
+        threshold_mask = cos_scores >= threshold
+        row_wise_count = threshold_mask.sum(1)
 
-        # Filter for rows >= min_threshold
-        for i in range(len(top_k_values)):
-            if top_k_values[i][-1] >= threshold:
-                new_cluster = []
+        # Only consider embeddings with enough close other embeddings
+        large_enough_mask = row_wise_count >= min_community_size
+        if not large_enough_mask.any():
+            continue
 
-                # Only check top k most similar entries
-                top_val_large, top_idx_large = cos_scores[i].topk(k=sort_max_size, largest=True)
+        row_wise_count = row_wise_count[large_enough_mask]
+        cos_scores = cos_scores[large_enough_mask]
 
-                # Check if we need to increase sort_max_size
-                while top_val_large[-1] > threshold and sort_max_size < len(embeddings):
-                    sort_max_size = min(2 * sort_max_size, len(embeddings))
-                    top_val_large, top_idx_large = cos_scores[i].topk(k=sort_max_size, largest=True)
+        # The max is the largest potential community, so we use that in topk
+        k = row_wise_count.max()
+        _, top_k_indices = cos_scores.topk(k=k, largest=True)
 
-                for idx, val in zip(top_idx_large.tolist(), top_val_large):
-                    if val < threshold:
-                        break
-
-                    new_cluster.append(idx)
-
-                extracted_communities.append(new_cluster)
-
-        del cos_scores
+        # Use the row-wise count to slice the indices
+        for count, indices in zip(row_wise_count, top_k_indices):
+            extracted_communities.append(indices[:count].tolist())
 
     # Largest cluster first
     extracted_communities = sorted(extracted_communities, key=lambda x: len(x), reverse=True)

--- a/sentence_transformers/util.py
+++ b/sentence_transformers/util.py
@@ -365,30 +365,49 @@ def community_detection(embeddings, threshold=0.75, min_community_size=10, batch
 
     # Maximum size for community
     min_community_size = min(min_community_size, len(embeddings))
+    sort_max_size = min(max(2 * min_community_size, 50), len(embeddings))
 
     for start_idx in tqdm(range(0, len(embeddings), batch_size), desc="Finding clusters", disable=not show_progress_bar):
         # Compute cosine similarity scores
         cos_scores = embeddings[start_idx:start_idx + batch_size] @ embeddings.T
 
-        # Threshold the cos scores and determine how many close embeddings exist per embedding
-        threshold_mask = cos_scores >= threshold
-        row_wise_count = threshold_mask.sum(1)
+        # Use a torch-heavy approach if the embeddings are on CUDA, otherwise a loop-heavy one
+        if embeddings.device.type == "cuda":
+            # Threshold the cos scores and determine how many close embeddings exist per embedding
+            threshold_mask = cos_scores >= threshold
+            row_wise_count = threshold_mask.sum(1)
 
-        # Only consider embeddings with enough close other embeddings
-        large_enough_mask = row_wise_count >= min_community_size
-        if not large_enough_mask.any():
-            continue
+            # Only consider embeddings with enough close other embeddings
+            large_enough_mask = row_wise_count >= min_community_size
+            if not large_enough_mask.any():
+                continue
 
-        row_wise_count = row_wise_count[large_enough_mask]
-        cos_scores = cos_scores[large_enough_mask]
+            row_wise_count = row_wise_count[large_enough_mask]
+            cos_scores = cos_scores[large_enough_mask]
 
-        # The max is the largest potential community, so we use that in topk
-        k = row_wise_count.max()
-        _, top_k_indices = cos_scores.topk(k=k, largest=True)
+            # The max is the largest potential community, so we use that in topk
+            k = row_wise_count.max()
+            _, top_k_indices = cos_scores.topk(k=k, largest=True)
 
-        # Use the row-wise count to slice the indices
-        for count, indices in zip(row_wise_count, top_k_indices):
-            extracted_communities.append(indices[:count].tolist())
+            # Use the row-wise count to slice the indices
+            for count, indices in zip(row_wise_count, top_k_indices):
+                extracted_communities.append(indices[:count].tolist())
+        else:
+            # Minimum size for a community
+            top_k_values, _ = cos_scores.topk(k=min_community_size, largest=True)
+
+            # Filter for rows >= min_threshold
+            for i in range(len(top_k_values)):
+                if top_k_values[i][-1] >= threshold:
+                    # Only check top k most similar entries
+                    top_val_large, top_idx_large = cos_scores[i].topk(k=sort_max_size, largest=True)
+
+                    # Check if we need to increase sort_max_size
+                    while top_val_large[-1] > threshold and sort_max_size < len(embeddings):
+                        sort_max_size = min(2 * sort_max_size, len(embeddings))
+                        top_val_large, top_idx_large = cos_scores[i].topk(k=sort_max_size, largest=True)
+
+                    extracted_communities.append(top_idx_large[top_val_large >= threshold].tolist())
 
     # Largest cluster first
     extracted_communities = sorted(extracted_communities, key=lambda x: len(x), reverse=True)


### PR DESCRIPTION
Supersedes #1857
Closes #1654, Closes #1840, Closes #1703

Hello!

## Pull Request overview
* Improve efficiency of community detection on GPU

## Details
I noticed that running `community_detection` on GPU was barely faster than on CPU. I chased this down, and it's due to the large amount of looping rather than taking good advantage of `torch` and the GPU's strengths. The new implementation uses torch operations much more, and will be notably faster when the embeddings are on GPU.

However, the implementation performs slightly worse than the `master` implementation for CPU. As a result, (a slight variation of) the original implementation is still used for CPU, with one exception: 
https://github.com/UKPLab/sentence-transformers/blob/3db309af5a138f5db69fac544e66663bf4da9c48/sentence_transformers/util.py#L389-L395
This loop has been replaced with:
```py
extracted_communities.append(top_idx_large[top_val_large >= threshold].tolist())
```
Which is slightly more performant.

## Benchmarks
![sentence_transformers_clustering](https://github.com/UKPLab/sentence-transformers/assets/37621491/d52142c4-ffc6-4ff2-8a8e-80502e414e76)

## Note
The computation time is still exponential! This is simply due to how all N embeddings must be compared with all N other embeddings. In short, this PR does not allow clustering on any amount of embeddings, but it does allow it on a much larger amount.

- Tom Aarsen