### PR TITLE
Use all the CPU's instead of just 4 CPU's

### DIFF
--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -239,8 +239,9 @@ class SentenceTransformer(nn.Sequential):
             if torch.cuda.is_available():
                 target_devices = ['cuda:{}'.format(i) for i in range(torch.cuda.device_count())]
             else:
-                logger.info("CUDA is not available. Starting 4 CPU workers")
-                target_devices = ['cpu']*4
+                num_cpus = os.cpu_count()
+                logger.info("CUDA is not available. Starting " +  str(num_cpus) + " CPU worker")
+                target_devices = ['cpu']*num_cpus
 
         logger.info("Start multi-process pool on devices: {}".format(', '.join(map(str, target_devices))))
 


### PR DESCRIPTION
Currently CPU are hardcoded to use only 4 which means even if we have 64 cores it used only 4 cores which is not efficient. Use all the cores based on the number of available cores.