### PR TITLE
[`model cards`] Use the library_name metadata in the model card

### DIFF
--- a/sentence_transformers/model_card_templates.py
+++ b/sentence_transformers/model_card_templates.py
@@ -15,6 +15,7 @@ class ModelCardTemplate:
 
     __MODEL_CARD__ = """
 ---
+library_name: sentence-transformers
 pipeline_tag: {PIPELINE_TAG}
 tags:
 {TAGS}


### PR DESCRIPTION
Hello!

## Pull Request overview
* Use the library_name metadata in the model card

## Details
This PR sets the `library_name`, which is otherwise inferred from the tags. It is preferable to include it directly as "library_name".

- Tom Aarsen