### PR TITLE
Add `classifier_dropout` param for CrossEncoder.

### DIFF
--- a/sentence_transformers/cross_encoder/CrossEncoder.py
+++ b/sentence_transformers/cross_encoder/CrossEncoder.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 
 class CrossEncoder():
     def __init__(self, model_name:str, num_labels:int = None, max_length:int = None, device:str = None, tokenizer_args:Dict = {},
-                  automodel_args:Dict = {}, default_activation_function = None):
+                  automodel_args:Dict = {}, default_activation_function = None, classifier_dropout:float = None):
         """
         A CrossEncoder takes exactly two sentences / texts as input and either predicts
         a score or label for this sentence pair. It can for example predict the similarity of the sentence pair
@@ -40,12 +40,16 @@ class CrossEncoder():
         :param default_activation_function: Callable (like nn.Sigmoid) about the default activation function that
             should be used on-top of model.predict(). If None. nn.Sigmoid() will be used if num_labels=1,
             else nn.Identity()
+        :param classifier_dropout: The dropout ratio for the classification head.
         """
 
         self.config = AutoConfig.from_pretrained(model_name)
         classifier_trained = True
         if self.config.architectures is not None:
             classifier_trained = any([arch.endswith('ForSequenceClassification') for arch in self.config.architectures])
+
+        if classifier_dropout is not None:
+            self.config.classifier_dropout = classifier_dropout
 
         if num_labels is None and not classifier_trained:
             num_labels = 1

--- a/tests/test_cross_encoder.py
+++ b/tests/test_cross_encoder.py
@@ -60,3 +60,15 @@ class CrossEncoderTest(unittest.TestCase):
                   epochs=1,
                   warmup_steps=int(len(train_dataloader)*0.1))
         self.evaluate_stsb_test(model, 50, num_test_samples=100)
+
+
+class CrossEncoderClassifierDropoutTest(unittest.TestCase):
+    def test_classifier_dropout_is_set(self):
+        model = CrossEncoder("cross-encoder/stsb-distilroberta-base", classifier_dropout=0.1234)
+        assert model.config.classifier_dropout == 0.1234
+        assert model.model.config.classifier_dropout == 0.1234
+
+    def test_classifier_dropout_default_value(self):
+        model = CrossEncoder("cross-encoder/stsb-distilroberta-base")
+        assert model.config.classifier_dropout is None
+        assert model.model.config.classifier_dropout is None

--- a/tests/test_sentence_transformer.py
+++ b/tests/test_sentence_transformer.py
@@ -83,12 +83,13 @@ def test_save_to_hub(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureF
             git_ref_info = GitRefInfo(name="main", ref="refs/heads/main", target_commit="123456")
         except TypeError:
             git_ref_info = GitRefInfo(dict(name="main", ref="refs/heads/main", targetCommit="123456"))
-        return GitRefs(
-            branches=[git_ref_info],
-            converts=[],
-            tags=[],
-            pull_requests=None,  # workaround for https://github.com/huggingface/huggingface_hub/issues/1956
-        )
+        # workaround for https://github.com/huggingface/huggingface_hub/issues/1956
+        git_ref_kwargs = {"branches": [git_ref_info], "converts": [], "tags": [], "pull_requests": None}
+        try:
+            return GitRefs(**git_ref_kwargs)
+        except TypeError:
+            git_ref_kwargs.pop("pull_requests")
+            return GitRefs(**git_ref_kwargs)
 
     monkeypatch.setattr(HfApi, "create_repo", mock_create_repo)
     monkeypatch.setattr(HfApi, "upload_folder", mock_upload_folder)

--- a/tests/test_sentence_transformer.py
+++ b/tests/test_sentence_transformer.py
@@ -83,7 +83,12 @@ def test_save_to_hub(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureF
             git_ref_info = GitRefInfo(name="main", ref="refs/heads/main", target_commit="123456")
         except TypeError:
             git_ref_info = GitRefInfo(dict(name="main", ref="refs/heads/main", targetCommit="123456"))
-        return GitRefs(branches=[git_ref_info], converts=[], tags=[])
+        return GitRefs(
+            branches=[git_ref_info],
+            converts=[],
+            tags=[],
+            pull_requests=None,  # workaround for https://github.com/huggingface/huggingface_hub/issues/1956
+        )
 
     monkeypatch.setattr(HfApi, "create_repo", mock_create_repo)
     monkeypatch.setattr(HfApi, "upload_folder", mock_upload_folder)


### PR DESCRIPTION
This PR adds the option to set / change the `classifier_dropout` value. This way it is possible to set the dropout value of the classification head. This can be a very important hyperparameter for classification tasks (and also regression).

**This is a non breaking change:** When the `classifier_dropout` is `None` (the default) then nothing happens.

For more background please also see:
- https://github.com/huggingface/transformers/pull/12794
- https://github.com/huggingface/transformers/issues/12781
- https://github.com/huggingface/transformers/issues/12792