### PR TITLE
[`feat`] Add `trust_remote_code` parameter to SentenceTransformer init

### DIFF
--- a/sentence_transformers/models/Transformer.py
+++ b/sentence_transformers/models/Transformer.py
@@ -142,6 +142,9 @@ class Transformer(nn.Module):
 
         with open(sbert_config_path) as fIn:
             config = json.load(fIn)
+        # Don't allow configs to set trust_remote_code
+        if "model_args" in config:
+            config["model_args"].pop("trust_remote_code")
         return Transformer(model_name_or_path=input_path, **config)
 
 


### PR DESCRIPTION
Hello!

## Pull Request overview
* Add `trust_remote_code` parameter to SentenceTransformer
* Disallow models from setting `trust_remote_code` via configuration

## Details
Any HF Hub model that requires `trust_remote_code` could not be reasonably loaded, except if the `sentence_bert_config.json` contains `"model_args": {"trust_remote_code": true}`. That said, you could argue that this isn't particularly reasonable either: we don't want models to specify this parameter.

Hence, I make 2 changes:
1. Add `trust_remote_code`. We'll want this parameter as a keyword argument in `SentenceTransformer` even after a potential refactor, so I'm good with already adding it.
2. Remove`trust_remote_code` from the loaded configuration options.

E.g.:
```py
from sentence_transformers import SentenceTransformer
from sentence_transformers.util import cos_sim

model = SentenceTransformer("jinaai/jina-embeddings-v2-base-en", trust_remote_code=True)
embeddings = model.encode(['How is the weather today?', 'What is the current weather like today?'])

print(cos_sim(*embeddings))
# => tensor([[0.9341]])
```

cc: @bwanglzu

- Tom Aarsen