### PR TITLE
test: replace unittest with pytest

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,32 @@
 import pytest
 
-from sentence_transformers import SentenceTransformer
+from sentence_transformers import SentenceTransformer, CrossEncoder
+from sentence_transformers.models import Transformer, Pooling
 
 
 @pytest.fixture()
-def model() -> SentenceTransformer:
+def stsb_bert_tiny_model() -> SentenceTransformer:
     return SentenceTransformer("sentence-transformers-testing/stsb-bert-tiny-safetensors")
+
+
+@pytest.fixture()
+def paraphrase_distilroberta_base_v1_model() -> SentenceTransformer:
+    return SentenceTransformer("paraphrase-distilroberta-base-v1")
+
+
+@pytest.fixture()
+def distilroberta_base_ce_model() -> CrossEncoder:
+    return CrossEncoder("distilroberta-base", num_labels=1)
+
+
+@pytest.fixture()
+def clip_vit_b_32_model() -> SentenceTransformer:
+    return SentenceTransformer("clip-ViT-B-32")
+
+
+@pytest.fixture()
+def distilbert_base_uncased_model() -> SentenceTransformer:
+    word_embedding_model = Transformer("distilbert-base-uncased")
+    pooling_model = Pooling(word_embedding_model.get_word_embedding_dimension())
+    model = SentenceTransformer(modules=[word_embedding_model, pooling_model])
+    return model

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,4 @@ from sentence_transformers import SentenceTransformer
 
 @pytest.fixture()
 def model() -> SentenceTransformer:
-    return SentenceTransformer(
-        "sentence-transformers-testing/stsb-bert-tiny-safetensors"
-    )
+    return SentenceTransformer("sentence-transformers-testing/stsb-bert-tiny-safetensors")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,10 @@
-from sentence_transformers import SentenceTransformer
 import pytest
+
+from sentence_transformers import SentenceTransformer
 
 
 @pytest.fixture()
 def model() -> SentenceTransformer:
-    return SentenceTransformer("sentence-transformers-testing/stsb-bert-tiny-safetensors")
+    return SentenceTransformer(
+        "sentence-transformers-testing/stsb-bert-tiny-safetensors"
+    )

--- a/tests/test_compute_embeddings.py
+++ b/tests/test_compute_embeddings.py
@@ -11,7 +11,7 @@ from sentence_transformers import SentenceTransformer
 
 @pytest.fixture()
 def model():
-    return SentenceTransformer('paraphrase-distilroberta-base-v1')
+    return SentenceTransformer("paraphrase-distilroberta-base-v1")
 
 
 def test_encode_token_embeddings(model):
@@ -26,10 +26,10 @@ def test_encode_token_embeddings(model):
         "Sentences",
         "Sentence five five five five five five five",
     ]
-    emb = model.encode(sent, output_value='token_embeddings', batch_size=2)
+    emb = model.encode(sent, output_value="token_embeddings", batch_size=2)
     assert len(emb) == len(sent)
     for s, e in zip(sent, emb):
-        assert len(model.tokenize([s])['input_ids'][0]) == e.shape[0]
+        assert len(model.tokenize([s])["input_ids"][0]) == e.shape[0]
 
 
 def test_encode_single_sentences(model):

--- a/tests/test_compute_embeddings.py
+++ b/tests/test_compute_embeddings.py
@@ -3,70 +3,85 @@ Computes embeddings
 """
 
 
-import unittest
-from sentence_transformers import SentenceTransformer
 import numpy as np
+import pytest
+
+from sentence_transformers import SentenceTransformer
 
 
-class ComputeEmbeddingsTest(unittest.TestCase):
-    def setUp(self):
-        self.model = SentenceTransformer("paraphrase-distilroberta-base-v1")
+@pytest.fixture()
+def model():
+    return SentenceTransformer('paraphrase-distilroberta-base-v1')
 
-    def test_encode_token_embeddings(self):
-        """
-        Test that encode(output_value='token_embeddings') works
-        :return:
-        """
-        sent = [
+
+def test_encode_token_embeddings(model):
+    """
+    Test that encode(output_value='token_embeddings') works
+    :return:
+    """
+    sent = [
+        "Hello Word, a test sentence",
+        "Here comes another sentence",
+        "My final sentence",
+        "Sentences",
+        "Sentence five five five five five five five",
+    ]
+    emb = model.encode(sent, output_value='token_embeddings', batch_size=2)
+    assert len(emb) == len(sent)
+    for s, e in zip(sent, emb):
+        assert len(model.tokenize([s])['input_ids'][0]) == e.shape[0]
+
+
+def test_encode_single_sentences(model):
+    # Single sentence
+    emb = model.encode("Hello Word, a test sentence")
+    assert emb.shape == (768,)
+    assert abs(np.sum(emb) - 7.9811716) < 0.001
+
+    # Single sentence as list
+    emb = model.encode(["Hello Word, a test sentence"])
+    assert emb.shape == (1, 768)
+    assert abs(np.sum(emb) - 7.9811716) < 0.001
+
+    # Sentence list
+    emb = model.encode(
+        [
             "Hello Word, a test sentence",
             "Here comes another sentence",
             "My final sentence",
-            "Sentences",
-            "Sentence five five five five five five five",
         ]
-        emb = self.model.encode(sent, output_value="token_embeddings", batch_size=2)
-        assert len(emb) == len(sent)
-        for s, e in zip(sent, emb):
-            assert len(self.model.tokenize([s])["input_ids"][0]) == e.shape[0]
+    )
+    assert emb.shape == (3, 768)
+    assert abs(np.sum(emb) - 22.968266) < 0.001
 
-    def test_encode_single_sentences(self):
-        # Single sentence
-        emb = self.model.encode("Hello Word, a test sentence")
-        assert emb.shape == (768,)
-        assert abs(np.sum(emb) - 7.9811716) < 0.001
 
-        # Single sentence as list
-        emb = self.model.encode(["Hello Word, a test sentence"])
-        assert emb.shape == (1, 768)
-        assert abs(np.sum(emb) - 7.9811716) < 0.001
+def test_encode_normalize(model):
+    emb = model.encode(
+        [
+            "Hello Word, a test sentence",
+            "Here comes another sentence",
+            "My final sentence",
+        ],
+        normalize_embeddings=True,
+    )
+    assert emb.shape == (3, 768)
+    for norm in np.linalg.norm(emb, axis=1):
+        assert abs(norm - 1) < 0.001
 
-        # Sentence list
-        emb = self.model.encode(["Hello Word, a test sentence", "Here comes another sentence", "My final sentence"])
-        assert emb.shape == (3, 768)
-        assert abs(np.sum(emb) - 22.968266) < 0.001
 
-    def test_encode_normalize(self):
-        emb = self.model.encode(
-            ["Hello Word, a test sentence", "Here comes another sentence", "My final sentence"],
-            normalize_embeddings=True,
-        )
-        assert emb.shape == (3, 768)
-        for norm in np.linalg.norm(emb, axis=1):
-            assert abs(norm - 1) < 0.001
+def test_encode_tuple_sentences(model):
+    # Input a sentence tuple
+    emb = model.encode([("Hello Word, a test sentence", "Second input for model")])
+    assert emb.shape == (1, 768)
+    assert abs(np.sum(emb) - 9.503508) < 0.001
 
-    def test_encode_tuple_sentences(self):
-        # Input a sentence tuple
-        emb = self.model.encode([("Hello Word, a test sentence", "Second input for model")])
-        assert emb.shape == (1, 768)
-        assert abs(np.sum(emb) - 9.503508) < 0.001
-
-        # List of sentence tuples
-        emb = self.model.encode(
-            [
-                ("Hello Word, a test sentence", "Second input for model"),
-                ("My second tuple", "With two inputs"),
-                ("Final tuple", "final test"),
-            ]
-        )
-        assert emb.shape == (3, 768)
-        assert abs(np.sum(emb) - 32.14627) < 0.001
+    # List of sentence tuples
+    emb = model.encode(
+        [
+            ("Hello Word, a test sentence", "Second input for model"),
+            ("My second tuple", "With two inputs"),
+            ("Final tuple", "final test"),
+        ]
+    )
+    assert emb.shape == (3, 768)
+    assert abs(np.sum(emb) - 32.14627) < 0.001

--- a/tests/test_compute_embeddings.py
+++ b/tests/test_compute_embeddings.py
@@ -4,21 +4,16 @@ Computes embeddings
 
 
 import numpy as np
-import pytest
 
 from sentence_transformers import SentenceTransformer
 
 
-@pytest.fixture()
-def model():
-    return SentenceTransformer("paraphrase-distilroberta-base-v1")
-
-
-def test_encode_token_embeddings(model):
+def test_encode_token_embeddings(paraphrase_distilroberta_base_v1_model: SentenceTransformer) -> None:
     """
     Test that encode(output_value='token_embeddings') works
     :return:
     """
+    model = paraphrase_distilroberta_base_v1_model
     sent = [
         "Hello Word, a test sentence",
         "Here comes another sentence",
@@ -32,7 +27,8 @@ def test_encode_token_embeddings(model):
         assert len(model.tokenize([s])["input_ids"][0]) == e.shape[0]
 
 
-def test_encode_single_sentences(model):
+def test_encode_single_sentences(paraphrase_distilroberta_base_v1_model: SentenceTransformer) -> None:
+    model = paraphrase_distilroberta_base_v1_model
     # Single sentence
     emb = model.encode("Hello Word, a test sentence")
     assert emb.shape == (768,)
@@ -55,7 +51,8 @@ def test_encode_single_sentences(model):
     assert abs(np.sum(emb) - 22.968266) < 0.001
 
 
-def test_encode_normalize(model):
+def test_encode_normalize(paraphrase_distilroberta_base_v1_model: SentenceTransformer) -> None:
+    model = paraphrase_distilroberta_base_v1_model
     emb = model.encode(
         [
             "Hello Word, a test sentence",
@@ -69,7 +66,8 @@ def test_encode_normalize(model):
         assert abs(norm - 1) < 0.001
 
 
-def test_encode_tuple_sentences(model):
+def test_encode_tuple_sentences(paraphrase_distilroberta_base_v1_model: SentenceTransformer) -> None:
+    model = paraphrase_distilroberta_base_v1_model
     # Input a sentence tuple
     emb = model.encode([("Hello Word, a test sentence", "Second input for model")])
     assert emb.shape == (1, 768)

--- a/tests/test_cross_encoder.py
+++ b/tests/test_cross_encoder.py
@@ -15,38 +15,32 @@ from sentence_transformers.readers import InputExample
 
 @pytest.fixture()
 def sts_resource():
-    sts_dataset_path = 'datasets/stsbenchmark.tsv.gz'
+    sts_dataset_path = "datasets/stsbenchmark.tsv.gz"
     if not os.path.exists(sts_dataset_path):
-        util.http_get(
-            'https://sbert.net/datasets/stsbenchmark.tsv.gz', sts_dataset_path
-        )
+        util.http_get("https://sbert.net/datasets/stsbenchmark.tsv.gz", sts_dataset_path)
 
     stsb_train_samples = []
     stsb_test_samples = []
-    with gzip.open(sts_dataset_path, 'rt', encoding='utf8') as fIn:
-        reader = csv.DictReader(fIn, delimiter='\t', quoting=csv.QUOTE_NONE)
+    with gzip.open(sts_dataset_path, "rt", encoding="utf8") as fIn:
+        reader = csv.DictReader(fIn, delimiter="\t", quoting=csv.QUOTE_NONE)
         for row in reader:
-            score = float(row['score']) / 5.0  # Normalize score to range 0 ... 1
-            inp_example = InputExample(
-                texts=[row['sentence1'], row['sentence2']], label=score
-            )
+            score = float(row["score"]) / 5.0  # Normalize score to range 0 ... 1
+            inp_example = InputExample(texts=[row["sentence1"], row["sentence2"]], label=score)
 
-            if row['split'] == 'test':
+            if row["split"] == "test":
                 stsb_test_samples.append(inp_example)
-            elif row['split'] == 'train':
+            elif row["split"] == "train":
                 stsb_train_samples.append(inp_example)
         yield stsb_train_samples, stsb_test_samples
 
 
 @pytest.fixture()
 def model():
-    return CrossEncoder('distilroberta-base', num_labels=1)
+    return CrossEncoder("distilroberta-base", num_labels=1)
 
 
 def evaluate_stsb_test(model, expected_score, test_samples, num_test_samples: int = -1):
-    evaluator = CECorrelationEvaluator.from_input_examples(
-        test_samples[:num_test_samples], name='sts-test'
-    )
+    evaluator = CECorrelationEvaluator.from_input_examples(test_samples[:num_test_samples], name="sts-test")
     score = evaluator(model) * 100
     print("STS-Test Performance: {:.2f} vs. exp: {:.2f}".format(score, expected_score))
     assert score > expected_score or abs(score - expected_score) < 0.1

--- a/tests/test_cross_encoder.py
+++ b/tests/test_cross_encoder.py
@@ -4,66 +4,78 @@ Tests that the pretrained models produce the correct scores on the STSbenchmark 
 import csv
 import gzip
 import os
-import unittest
+
 import pytest
-
 from torch.utils.data import DataLoader
+
 from sentence_transformers import CrossEncoder, util
-from sentence_transformers.readers import InputExample
 from sentence_transformers.cross_encoder.evaluation import CECorrelationEvaluator
+from sentence_transformers.readers import InputExample
 
 
-class CrossEncoderTest(unittest.TestCase):
-    def setUp(self):
-        sts_dataset_path = "datasets/stsbenchmark.tsv.gz"
-        if not os.path.exists(sts_dataset_path):
-            util.http_get("https://sbert.net/datasets/stsbenchmark.tsv.gz", sts_dataset_path)
+@pytest.fixture()
+def sts_resource():
+    sts_dataset_path = 'datasets/stsbenchmark.tsv.gz'
+    if not os.path.exists(sts_dataset_path):
+        util.http_get(
+            'https://sbert.net/datasets/stsbenchmark.tsv.gz', sts_dataset_path
+        )
 
-        # Read STSB
-        self.stsb_train_samples = []
-        self.test_samples = []
-        with gzip.open(sts_dataset_path, "rt", encoding="utf8") as fIn:
-            reader = csv.DictReader(fIn, delimiter="\t", quoting=csv.QUOTE_NONE)
-            for row in reader:
-                score = float(row["score"]) / 5.0  # Normalize score to range 0 ... 1
-                inp_example = InputExample(texts=[row["sentence1"], row["sentence2"]], label=score)
+    stsb_train_samples = []
+    stsb_test_samples = []
+    with gzip.open(sts_dataset_path, 'rt', encoding='utf8') as fIn:
+        reader = csv.DictReader(fIn, delimiter='\t', quoting=csv.QUOTE_NONE)
+        for row in reader:
+            score = float(row['score']) / 5.0  # Normalize score to range 0 ... 1
+            inp_example = InputExample(
+                texts=[row['sentence1'], row['sentence2']], label=score
+            )
 
-                if row["split"] == "test":
-                    self.test_samples.append(inp_example)
-                elif row["split"] == "train":
-                    self.stsb_train_samples.append(inp_example)
-
-    def evaluate_stsb_test(self, model, expected_score, num_test_samples: int = -1):
-        evaluator = CECorrelationEvaluator.from_input_examples(self.test_samples[:num_test_samples], name="sts-test")
-        score = evaluator(model) * 100
-        print("STS-Test Performance: {:.2f} vs. exp: {:.2f}".format(score, expected_score))
-        assert score > expected_score or abs(score - expected_score) < 0.1
-
-    def test_pretrained_stsb(self):
-        model = CrossEncoder("cross-encoder/stsb-distilroberta-base")
-        self.evaluate_stsb_test(model, 87.92)
-
-    @pytest.mark.slow
-    def test_train_stsb_slow(self):
-        model = CrossEncoder("distilroberta-base", num_labels=1)
-        train_dataloader = DataLoader(self.stsb_train_samples, shuffle=True, batch_size=16)
-        model.fit(train_dataloader=train_dataloader, epochs=1, warmup_steps=int(len(train_dataloader) * 0.1))
-        self.evaluate_stsb_test(model, 75)
-
-    def test_train_stsb(self):
-        model = CrossEncoder("distilroberta-base", num_labels=1)
-        train_dataloader = DataLoader(self.stsb_train_samples[:500], shuffle=True, batch_size=16)
-        model.fit(train_dataloader=train_dataloader, epochs=1, warmup_steps=int(len(train_dataloader) * 0.1))
-        self.evaluate_stsb_test(model, 50, num_test_samples=100)
+            if row['split'] == 'test':
+                stsb_test_samples.append(inp_example)
+            elif row['split'] == 'train':
+                stsb_train_samples.append(inp_example)
+        yield stsb_train_samples, stsb_test_samples
 
 
-class CrossEncoderClassifierDropoutTest(unittest.TestCase):
-    def test_classifier_dropout_is_set(self):
-        model = CrossEncoder("cross-encoder/stsb-distilroberta-base", classifier_dropout=0.1234)
-        assert model.config.classifier_dropout == 0.1234
-        assert model.model.config.classifier_dropout == 0.1234
+@pytest.fixture()
+def model():
+    return CrossEncoder('distilroberta-base', num_labels=1)
 
-    def test_classifier_dropout_default_value(self):
-        model = CrossEncoder("cross-encoder/stsb-distilroberta-base")
-        assert model.config.classifier_dropout is None
-        assert model.model.config.classifier_dropout is None
+
+def evaluate_stsb_test(model, expected_score, test_samples, num_test_samples: int = -1):
+    evaluator = CECorrelationEvaluator.from_input_examples(
+        test_samples[:num_test_samples], name='sts-test'
+    )
+    score = evaluator(model) * 100
+    print("STS-Test Performance: {:.2f} vs. exp: {:.2f}".format(score, expected_score))
+    assert score > expected_score or abs(score - expected_score) < 0.1
+
+
+def test_pretrained_stsb(sts_resource):
+    _, sts_test_samples = sts_resource
+    model = CrossEncoder("cross-encoder/stsb-distilroberta-base")
+    evaluate_stsb_test(model, 87.92, sts_test_samples)
+
+
+@pytest.mark.slow
+def test_train_stsb_slow(model, sts_resource):
+    sts_train_samples, sts_test_samples = sts_resource
+    train_dataloader = DataLoader(sts_train_samples, shuffle=True, batch_size=16)
+    model.fit(
+        train_dataloader=train_dataloader,
+        epochs=1,
+        warmup_steps=int(len(train_dataloader) * 0.1),
+    )
+    evaluate_stsb_test(model, 75, sts_test_samples)
+
+
+def test_train_stsb(model, sts_resource):
+    sts_train_samples, sts_test_samples = sts_resource
+    train_dataloader = DataLoader(sts_train_samples[:500], shuffle=True, batch_size=16)
+    model.fit(
+        train_dataloader=train_dataloader,
+        epochs=1,
+        warmup_steps=int(len(train_dataloader) * 0.1),
+    )
+    evaluate_stsb_test(model, 50, sts_test_samples, num_test_samples=100)

--- a/tests/test_cross_encoder.py
+++ b/tests/test_cross_encoder.py
@@ -73,3 +73,15 @@ def test_train_stsb(model, sts_resource):
         warmup_steps=int(len(train_dataloader) * 0.1),
     )
     evaluate_stsb_test(model, 50, sts_test_samples, num_test_samples=100)
+
+
+def test_classifier_dropout_is_set() -> None:
+    model = CrossEncoder("cross-encoder/stsb-distilroberta-base", classifier_dropout=0.1234)
+    assert model.config.classifier_dropout == 0.1234
+    assert model.model.config.classifier_dropout == 0.1234
+
+
+def test_classifier_dropout_default_value() -> None:
+    model = CrossEncoder("cross-encoder/stsb-distilroberta-base")
+    assert model.config.classifier_dropout is None
+    assert model.model.config.classifier_dropout is None

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -6,7 +6,6 @@ import gzip
 import os
 
 import numpy as np
-import pytest
 from sklearn.metrics import accuracy_score, f1_score
 from torch.utils.data import DataLoader
 
@@ -19,12 +18,7 @@ from sentence_transformers import (
 )
 
 
-@pytest.fixture()
-def model():
-    return SentenceTransformer("paraphrase-distilroberta-base-v1")
-
-
-def test_BinaryClassificationEvaluator_find_best_f1_and_threshold():
+def test_BinaryClassificationEvaluator_find_best_f1_and_threshold() -> None:
     """Tests that the F1 score for the computed threshold is correct"""
     y_true = np.random.randint(0, 2, 1000)
     y_pred_cosine = np.random.randn(1000)
@@ -41,7 +35,7 @@ def test_BinaryClassificationEvaluator_find_best_f1_and_threshold():
     assert np.abs(best_f1 - sklearn_f1score) < 1e-6
 
 
-def test_BinaryClassificationEvaluator_find_best_accuracy_and_threshold():
+def test_BinaryClassificationEvaluator_find_best_accuracy_and_threshold() -> None:
     """Tests that the Acc score for the computed threshold is correct"""
     y_true = np.random.randint(0, 2, 1000)
     y_pred_cosine = np.random.randn(1000)
@@ -56,8 +50,9 @@ def test_BinaryClassificationEvaluator_find_best_accuracy_and_threshold():
     assert np.abs(max_acc - sklearn_acc) < 1e-6
 
 
-def test_LabelAccuracyEvaluator(model):
+def test_LabelAccuracyEvaluator(paraphrase_distilroberta_base_v1_model: SentenceTransformer) -> None:
     """Tests that the LabelAccuracyEvaluator can be loaded correctly"""
+    model = paraphrase_distilroberta_base_v1_model
     nli_dataset_path = "datasets/AllNLI.tsv.gz"
     if not os.path.exists(nli_dataset_path):
         util.http_get("https://sbert.net/datasets/AllNLI.tsv.gz", nli_dataset_path)
@@ -85,8 +80,9 @@ def test_LabelAccuracyEvaluator(model):
     assert acc > 0.2
 
 
-def test_ParaphraseMiningEvaluator(model):
+def test_ParaphraseMiningEvaluator(paraphrase_distilroberta_base_v1_model: SentenceTransformer) -> None:
     """Tests that the ParaphraseMiningEvaluator can be loaded"""
+    model = paraphrase_distilroberta_base_v1_model
     sentences = {
         0: "Hello World",
         1: "Hello World!",

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -21,7 +21,7 @@ from sentence_transformers import (
 
 @pytest.fixture()
 def model():
-    return SentenceTransformer('paraphrase-distilroberta-base-v1')
+    return SentenceTransformer("paraphrase-distilroberta-base-v1")
 
 
 def test_BinaryClassificationEvaluator_find_best_f1_and_threshold():
@@ -58,22 +58,18 @@ def test_BinaryClassificationEvaluator_find_best_accuracy_and_threshold():
 
 def test_LabelAccuracyEvaluator(model):
     """Tests that the LabelAccuracyEvaluator can be loaded correctly"""
-    nli_dataset_path = 'datasets/AllNLI.tsv.gz'
+    nli_dataset_path = "datasets/AllNLI.tsv.gz"
     if not os.path.exists(nli_dataset_path):
-        util.http_get('https://sbert.net/datasets/AllNLI.tsv.gz', nli_dataset_path)
+        util.http_get("https://sbert.net/datasets/AllNLI.tsv.gz", nli_dataset_path)
 
     label2int = {"contradiction": 0, "entailment": 1, "neutral": 2}
     dev_samples = []
-    with gzip.open(nli_dataset_path, 'rt', encoding='utf8') as fIn:
-        reader = csv.DictReader(fIn, delimiter='\t', quoting=csv.QUOTE_NONE)
+    with gzip.open(nli_dataset_path, "rt", encoding="utf8") as fIn:
+        reader = csv.DictReader(fIn, delimiter="\t", quoting=csv.QUOTE_NONE)
         for row in reader:
-            if row['split'] == 'train':
-                label_id = label2int[row['label']]
-                dev_samples.append(
-                    InputExample(
-                        texts=[row['sentence1'], row['sentence2']], label=label_id
-                    )
-                )
+            if row["split"] == "train":
+                label_id = label2int[row["label"]]
+                dev_samples.append(InputExample(texts=[row["sentence1"], row["sentence2"]], label=label_id))
                 if len(dev_samples) >= 100:
                     break
 
@@ -84,9 +80,7 @@ def test_LabelAccuracyEvaluator(model):
     )
 
     dev_dataloader = DataLoader(dev_samples, shuffle=False, batch_size=16)
-    evaluator = evaluation.LabelAccuracyEvaluator(
-        dev_dataloader, softmax_model=train_loss
-    )
+    evaluator = evaluation.LabelAccuracyEvaluator(dev_dataloader, softmax_model=train_loss)
     acc = evaluator(model)
     assert acc > 0.2
 

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -1,79 +1,104 @@
 """
 Tests the correct computation of evaluation scores from BinaryClassificationEvaluator
 """
-from sentence_transformers import SentenceTransformer, evaluation, util, losses
-import unittest
-from sklearn.metrics import f1_score, accuracy_score
-import numpy as np
-import gzip
 import csv
-from sentence_transformers import InputExample
-from torch.utils.data import DataLoader
+import gzip
 import os
 
+import numpy as np
+import pytest
+from sklearn.metrics import accuracy_score, f1_score
+from torch.utils.data import DataLoader
 
-class EvaluatorTest(unittest.TestCase):
-    def test_BinaryClassificationEvaluator_find_best_f1_and_threshold(self):
-        """Tests that the F1 score for the computed threshold is correct"""
-        y_true = np.random.randint(0, 2, 1000)
-        y_pred_cosine = np.random.randn(1000)
-        (
-            best_f1,
-            best_precision,
-            best_recall,
-            threshold,
-        ) = evaluation.BinaryClassificationEvaluator.find_best_f1_and_threshold(
-            y_pred_cosine, y_true, high_score_more_similar=True
-        )
-        y_pred_labels = [1 if pred >= threshold else 0 for pred in y_pred_cosine]
-        sklearn_f1score = f1_score(y_true, y_pred_labels)
-        assert np.abs(best_f1 - sklearn_f1score) < 1e-6
+from sentence_transformers import (
+    InputExample,
+    SentenceTransformer,
+    evaluation,
+    losses,
+    util,
+)
 
-    def test_BinaryClassificationEvaluator_find_best_accuracy_and_threshold(self):
-        """Tests that the Acc score for the computed threshold is correct"""
-        y_true = np.random.randint(0, 2, 1000)
-        y_pred_cosine = np.random.randn(1000)
-        max_acc, threshold = evaluation.BinaryClassificationEvaluator.find_best_acc_and_threshold(
-            y_pred_cosine, y_true, high_score_more_similar=True
-        )
-        y_pred_labels = [1 if pred >= threshold else 0 for pred in y_pred_cosine]
-        sklearn_acc = accuracy_score(y_true, y_pred_labels)
-        assert np.abs(max_acc - sklearn_acc) < 1e-6
 
-    def test_LabelAccuracyEvaluator(self):
-        """Tests that the LabelAccuracyEvaluator can be loaded correctly"""
-        model = SentenceTransformer("paraphrase-distilroberta-base-v1")
+@pytest.fixture()
+def model():
+    return SentenceTransformer('paraphrase-distilroberta-base-v1')
 
-        nli_dataset_path = "datasets/AllNLI.tsv.gz"
-        if not os.path.exists(nli_dataset_path):
-            util.http_get("https://sbert.net/datasets/AllNLI.tsv.gz", nli_dataset_path)
 
-        label2int = {"contradiction": 0, "entailment": 1, "neutral": 2}
-        dev_samples = []
-        with gzip.open(nli_dataset_path, "rt", encoding="utf8") as fIn:
-            reader = csv.DictReader(fIn, delimiter="\t", quoting=csv.QUOTE_NONE)
-            for row in reader:
-                if row["split"] == "train":
-                    label_id = label2int[row["label"]]
-                    dev_samples.append(InputExample(texts=[row["sentence1"], row["sentence2"]], label=label_id))
-                    if len(dev_samples) >= 100:
-                        break
+def test_BinaryClassificationEvaluator_find_best_f1_and_threshold():
+    """Tests that the F1 score for the computed threshold is correct"""
+    y_true = np.random.randint(0, 2, 1000)
+    y_pred_cosine = np.random.randn(1000)
+    (
+        best_f1,
+        best_precision,
+        best_recall,
+        threshold,
+    ) = evaluation.BinaryClassificationEvaluator.find_best_f1_and_threshold(
+        y_pred_cosine, y_true, high_score_more_similar=True
+    )
+    y_pred_labels = [1 if pred >= threshold else 0 for pred in y_pred_cosine]
+    sklearn_f1score = f1_score(y_true, y_pred_labels)
+    assert np.abs(best_f1 - sklearn_f1score) < 1e-6
 
-        train_loss = losses.SoftmaxLoss(
-            model=model,
-            sentence_embedding_dimension=model.get_sentence_embedding_dimension(),
-            num_labels=len(label2int),
-        )
 
-        dev_dataloader = DataLoader(dev_samples, shuffle=False, batch_size=16)
-        evaluator = evaluation.LabelAccuracyEvaluator(dev_dataloader, softmax_model=train_loss)
-        acc = evaluator(model)
-        assert acc > 0.2
+def test_BinaryClassificationEvaluator_find_best_accuracy_and_threshold():
+    """Tests that the Acc score for the computed threshold is correct"""
+    y_true = np.random.randint(0, 2, 1000)
+    y_pred_cosine = np.random.randn(1000)
+    (
+        max_acc,
+        threshold,
+    ) = evaluation.BinaryClassificationEvaluator.find_best_acc_and_threshold(
+        y_pred_cosine, y_true, high_score_more_similar=True
+    )
+    y_pred_labels = [1 if pred >= threshold else 0 for pred in y_pred_cosine]
+    sklearn_acc = accuracy_score(y_true, y_pred_labels)
+    assert np.abs(max_acc - sklearn_acc) < 1e-6
 
-    def test_ParaphraseMiningEvaluator(self):
-        """Tests that the ParaphraseMiningEvaluator can be loaded"""
-        model = SentenceTransformer("paraphrase-distilroberta-base-v1")
-        sentences = {0: "Hello World", 1: "Hello World!", 2: "The cat is on the table", 3: "On the table the cat is"}
-        data_eval = evaluation.ParaphraseMiningEvaluator(sentences, [(0, 1), (2, 3)])
-        score = data_eval(model)
-        assert score > 0.99
+
+def test_LabelAccuracyEvaluator(model):
+    """Tests that the LabelAccuracyEvaluator can be loaded correctly"""
+    nli_dataset_path = 'datasets/AllNLI.tsv.gz'
+    if not os.path.exists(nli_dataset_path):
+        util.http_get('https://sbert.net/datasets/AllNLI.tsv.gz', nli_dataset_path)
+
+    label2int = {"contradiction": 0, "entailment": 1, "neutral": 2}
+    dev_samples = []
+    with gzip.open(nli_dataset_path, 'rt', encoding='utf8') as fIn:
+        reader = csv.DictReader(fIn, delimiter='\t', quoting=csv.QUOTE_NONE)
+        for row in reader:
+            if row['split'] == 'train':
+                label_id = label2int[row['label']]
+                dev_samples.append(
+                    InputExample(
+                        texts=[row['sentence1'], row['sentence2']], label=label_id
+                    )
+                )
+                if len(dev_samples) >= 100:
+                    break
+
+    train_loss = losses.SoftmaxLoss(
+        model=model,
+        sentence_embedding_dimension=model.get_sentence_embedding_dimension(),
+        num_labels=len(label2int),
+    )
+
+    dev_dataloader = DataLoader(dev_samples, shuffle=False, batch_size=16)
+    evaluator = evaluation.LabelAccuracyEvaluator(
+        dev_dataloader, softmax_model=train_loss
+    )
+    acc = evaluator(model)
+    assert acc > 0.2
+
+
+def test_ParaphraseMiningEvaluator(model):
+    """Tests that the ParaphraseMiningEvaluator can be loaded"""
+    sentences = {
+        0: "Hello World",
+        1: "Hello World!",
+        2: "The cat is on the table",
+        3: "On the table the cat is",
+    }
+    data_eval = evaluation.ParaphraseMiningEvaluator(sentences, [(0, 1), (2, 3)])
+    score = data_eval(model)
+    assert score > 0.99

--- a/tests/test_image_embeddings.py
+++ b/tests/test_image_embeddings.py
@@ -2,29 +2,34 @@
 Compute image embeddings
 """
 
-import unittest
-from sentence_transformers import SentenceTransformer, util
-from PIL import Image
 import os
 
+import pytest
+from PIL import Image
 
-class ComputeEmbeddingsTest(unittest.TestCase):
-    def setUp(self):
-        self.model = SentenceTransformer("clip-ViT-B-32")
+from sentence_transformers import SentenceTransformer, util
 
-    def test_simple_encode(self):
-        # Encode an image:
-        image_filepath = os.path.join(
-            os.path.dirname(os.path.realpath(__file__)), "../examples/applications/image-search/two_dogs_in_snow.jpg"
-        )
-        print(image_filepath)
-        img_emb = self.model.encode(Image.open(image_filepath))
 
-        # Encode text descriptions
-        text_emb = self.model.encode(["Two dogs in the snow", "A cat on a table", "A picture of London at night"])
+@pytest.fixture()
+def model():
+    return SentenceTransformer('clip-ViT-B-32')
 
-        # Compute cosine similarities
-        cos_scores = util.cos_sim(img_emb, text_emb)[0]
-        assert abs(cos_scores[0] - 0.3069) < 0.01
-        assert abs(cos_scores[1] - 0.1010) < 0.01
-        assert abs(cos_scores[2] - 0.1086) < 0.01
+
+def test_simple_encode(model):
+    # Encode an image:
+    image_filepath = os.path.join(
+        os.path.dirname(os.path.realpath(__file__)),
+        "../examples/applications/image-search/two_dogs_in_snow.jpg",
+    )
+    img_emb = model.encode(Image.open(image_filepath))
+
+    # Encode text descriptions
+    text_emb = model.encode(
+        ['Two dogs in the snow', 'A cat on a table', 'A picture of London at night']
+    )
+
+    # Compute cosine similarities
+    cos_scores = util.cos_sim(img_emb, text_emb)[0]
+    assert abs(cos_scores[0] - 0.3069) < 0.01
+    assert abs(cos_scores[1] - 0.1010) < 0.01
+    assert abs(cos_scores[2] - 0.1086) < 0.01

--- a/tests/test_image_embeddings.py
+++ b/tests/test_image_embeddings.py
@@ -12,7 +12,7 @@ from sentence_transformers import SentenceTransformer, util
 
 @pytest.fixture()
 def model():
-    return SentenceTransformer('clip-ViT-B-32')
+    return SentenceTransformer("clip-ViT-B-32")
 
 
 def test_simple_encode(model):
@@ -24,9 +24,7 @@ def test_simple_encode(model):
     img_emb = model.encode(Image.open(image_filepath))
 
     # Encode text descriptions
-    text_emb = model.encode(
-        ['Two dogs in the snow', 'A cat on a table', 'A picture of London at night']
-    )
+    text_emb = model.encode(["Two dogs in the snow", "A cat on a table", "A picture of London at night"])
 
     # Compute cosine similarities
     cos_scores = util.cos_sim(img_emb, text_emb)[0]

--- a/tests/test_image_embeddings.py
+++ b/tests/test_image_embeddings.py
@@ -4,18 +4,13 @@ Compute image embeddings
 
 import os
 
-import pytest
 from PIL import Image
 
-from sentence_transformers import SentenceTransformer, util
+from sentence_transformers import util, SentenceTransformer
 
 
-@pytest.fixture()
-def model():
-    return SentenceTransformer("clip-ViT-B-32")
-
-
-def test_simple_encode(model):
+def test_simple_encode(clip_vit_b_32_model: SentenceTransformer) -> None:
+    model = clip_vit_b_32_model
     # Encode an image:
     image_filepath = os.path.join(
         os.path.dirname(os.path.realpath(__file__)),

--- a/tests/test_multi_process.py
+++ b/tests/test_multi_process.py
@@ -10,16 +10,12 @@ from sentence_transformers import SentenceTransformer
 
 
 @pytest.mark.parametrize("normalize_embeddings", (False, True))
-def test_encode_multi_process(
-    model: SentenceTransformer, normalize_embeddings: bool
-) -> None:
+def test_encode_multi_process(model: SentenceTransformer, normalize_embeddings: bool) -> None:
     sentences = ["This is sentence {}".format(i) for i in range(40)]
 
     # Start the multi-process pool on e.g. two CPU devices & compute the embeddings using the pool
-    pool = model.start_multi_process_pool(['cpu', 'cpu'])
-    emb = model.encode_multi_process(
-        sentences, pool, chunk_size=10, normalize_embeddings=normalize_embeddings
-    )
+    pool = model.start_multi_process_pool(["cpu", "cpu"])
+    emb = model.encode_multi_process(sentences, pool, chunk_size=10, normalize_embeddings=normalize_embeddings)
     model.stop_multi_process_pool(pool)
     assert emb.shape == (len(sentences), 128)
 

--- a/tests/test_multi_process.py
+++ b/tests/test_multi_process.py
@@ -10,7 +10,8 @@ from sentence_transformers import SentenceTransformer
 
 
 @pytest.mark.parametrize("normalize_embeddings", (False, True))
-def test_encode_multi_process(model: SentenceTransformer, normalize_embeddings: bool) -> None:
+def test_encode_multi_process(stsb_bert_tiny_model: SentenceTransformer, normalize_embeddings: bool) -> None:
+    model = stsb_bert_tiny_model
     sentences = ["This is sentence {}".format(i) for i in range(40)]
 
     # Start the multi-process pool on e.g. two CPU devices & compute the embeddings using the pool

--- a/tests/test_multi_process.py
+++ b/tests/test_multi_process.py
@@ -3,18 +3,23 @@ Computes embeddings
 """
 
 
-from sentence_transformers import SentenceTransformer
 import numpy as np
 import pytest
 
+from sentence_transformers import SentenceTransformer
+
 
 @pytest.mark.parametrize("normalize_embeddings", (False, True))
-def test_encode_multi_process(model: SentenceTransformer, normalize_embeddings: bool) -> None:
+def test_encode_multi_process(
+    model: SentenceTransformer, normalize_embeddings: bool
+) -> None:
     sentences = ["This is sentence {}".format(i) for i in range(40)]
 
     # Start the multi-process pool on e.g. two CPU devices & compute the embeddings using the pool
-    pool = model.start_multi_process_pool(["cpu", "cpu"])
-    emb = model.encode_multi_process(sentences, pool, chunk_size=10, normalize_embeddings=normalize_embeddings)
+    pool = model.start_multi_process_pool(['cpu', 'cpu'])
+    emb = model.encode_multi_process(
+        sentences, pool, chunk_size=10, normalize_embeddings=normalize_embeddings
+    )
     model.stop_multi_process_pool(pool)
     assert emb.shape == (len(sentences), 128)
 

--- a/tests/test_pretrained_stsb.py
+++ b/tests/test_pretrained_stsb.py
@@ -1,127 +1,157 @@
 """
 Tests that the pretrained models produce the correct scores on the STSbenchmark dataset
 """
-from functools import partial
-from sentence_transformers import SentenceTransformer, InputExample, util
-from sentence_transformers.evaluation import EmbeddingSimilarityEvaluator
-import os
-import gzip
 import csv
+import gzip
+import os
+from functools import partial
+
 import pytest
+
+from sentence_transformers import InputExample, SentenceTransformer, util
+from sentence_transformers.evaluation import EmbeddingSimilarityEvaluator
 
 
 def pretrained_model_score(model_name, expected_score, max_test_samples: int = 100):
     model = SentenceTransformer(model_name)
-    sts_dataset_path = "datasets/stsbenchmark.tsv.gz"
+    sts_dataset_path = 'datasets/stsbenchmark.tsv.gz'
 
     if not os.path.exists(sts_dataset_path):
-        util.http_get("https://sbert.net/datasets/stsbenchmark.tsv.gz", sts_dataset_path)
+        util.http_get(
+            'https://sbert.net/datasets/stsbenchmark.tsv.gz', sts_dataset_path
+        )
 
     test_samples = []
-    with gzip.open(sts_dataset_path, "rt", encoding="utf8") as fIn:
-        reader = csv.DictReader(fIn, delimiter="\t", quoting=csv.QUOTE_NONE)
+    with gzip.open(sts_dataset_path, 'rt', encoding='utf8') as fIn:
+        reader = csv.DictReader(fIn, delimiter='\t', quoting=csv.QUOTE_NONE)
         for row in reader:
-            score = float(row["score"]) / 5.0  # Normalize score to range 0 ... 1
-            inp_example = InputExample(texts=[row["sentence1"], row["sentence2"]], label=score)
+            score = float(row['score']) / 5.0  # Normalize score to range 0 ... 1
+            inp_example = InputExample(
+                texts=[row['sentence1'], row['sentence2']], label=score
+            )
 
-            if row["split"] == "test":
+            if row['split'] == 'test':
                 test_samples.append(inp_example)
             if max_test_samples != -1 and len(test_samples) >= max_test_samples:
                 break
 
-    evaluator = EmbeddingSimilarityEvaluator.from_input_examples(test_samples, name="sts-test")
+    evaluator = EmbeddingSimilarityEvaluator.from_input_examples(
+        test_samples, name='sts-test'
+    )
 
     score = model.evaluate(evaluator) * 100
     print(model_name, "{:.2f} vs. exp: {:.2f}".format(score, expected_score))
     assert score > expected_score or abs(score - expected_score) < 0.1
 
 
+pretrained_model_score = partial(pretrained_model_score, max_test_samples=100)
+pretrained_model_score_slow = partial(pretrained_model_score, max_test_samples=-1)
+
+
 @pytest.mark.slow
-class TestPretrainedSTSbSlow:
-    pretrained_model_score = partial(pretrained_model_score, max_test_samples=-1)
-
-    def test_bert_base(self):
-        self.pretrained_model_score("bert-base-nli-mean-tokens", 77.12)
-        self.pretrained_model_score("bert-base-nli-max-tokens", 77.21)
-        self.pretrained_model_score("bert-base-nli-cls-token", 76.30)
-        self.pretrained_model_score("bert-base-nli-stsb-mean-tokens", 85.14)
-
-    def test_bert_large(self):
-        self.pretrained_model_score("bert-large-nli-mean-tokens", 79.19)
-        self.pretrained_model_score("bert-large-nli-max-tokens", 78.41)
-        self.pretrained_model_score("bert-large-nli-cls-token", 78.29)
-        self.pretrained_model_score("bert-large-nli-stsb-mean-tokens", 85.29)
-
-    def test_roberta(self):
-        self.pretrained_model_score("roberta-base-nli-mean-tokens", 77.49)
-        self.pretrained_model_score("roberta-large-nli-mean-tokens", 78.69)
-        self.pretrained_model_score("roberta-base-nli-stsb-mean-tokens", 85.30)
-        self.pretrained_model_score("roberta-large-nli-stsb-mean-tokens", 86.39)
-
-    def test_distilbert(self):
-        self.pretrained_model_score("distilbert-base-nli-mean-tokens", 78.69)
-        self.pretrained_model_score("distilbert-base-nli-stsb-mean-tokens", 85.16)
-        self.pretrained_model_score("paraphrase-distilroberta-base-v1", 81.81)
-
-    def test_multiling(self):
-        self.pretrained_model_score("distiluse-base-multilingual-cased", 80.75)
-        self.pretrained_model_score("paraphrase-xlm-r-multilingual-v1", 83.50)
-        self.pretrained_model_score("paraphrase-multilingual-MiniLM-L12-v2", 84.42)
-
-    def test_mpnet(self):
-        self.pretrained_model_score("paraphrase-mpnet-base-v2", 86.99)
-
-    def test_other_models(self):
-        self.pretrained_model_score("average_word_embeddings_komninos", 61.56)
-
-    def test_msmarco(self):
-        self.pretrained_model_score("msmarco-roberta-base-ance-firstp", 77.0)
-        self.pretrained_model_score("msmarco-distilbert-base-v3", 78.85)
-
-    def test_sentence_t5(self):
-        self.pretrained_model_score("sentence-t5-base", 85.52)
+def test_bert_base_slow():
+    pretrained_model_score_slow('bert-base-nli-mean-tokens', 77.12)
+    pretrained_model_score_slow('bert-base-nli-max-tokens', 77.21)
+    pretrained_model_score_slow('bert-base-nli-cls-token', 76.30)
+    pretrained_model_score_slow('bert-base-nli-stsb-mean-tokens', 85.14)
 
 
-class TestPretrainedSTSbFast:
-    pretrained_model_score = partial(pretrained_model_score, max_test_samples=100)
+@pytest.mark.slow
+def test_bert_large_slow():
+    pretrained_model_score_slow('bert-large-nli-mean-tokens', 79.19)
+    pretrained_model_score_slow('bert-large-nli-max-tokens', 78.41)
+    pretrained_model_score_slow('bert-large-nli-cls-token', 78.29)
+    pretrained_model_score_slow('bert-large-nli-stsb-mean-tokens', 85.29)
 
-    def test_bert_base(self):
-        self.pretrained_model_score("bert-base-nli-mean-tokens", 86.53)
-        self.pretrained_model_score("bert-base-nli-max-tokens", 87.00)
-        self.pretrained_model_score("bert-base-nli-cls-token", 85.93)
-        self.pretrained_model_score("bert-base-nli-stsb-mean-tokens", 89.26)
 
-    def test_bert_large(self):
-        self.pretrained_model_score("bert-large-nli-mean-tokens", 90.06)
-        self.pretrained_model_score("bert-large-nli-max-tokens", 90.15)
-        self.pretrained_model_score("bert-large-nli-cls-token", 89.51)
-        self.pretrained_model_score("bert-large-nli-stsb-mean-tokens", 92.27)
+@pytest.mark.slow
+def test_roberta_slow():
+    pretrained_model_score_slow('roberta-base-nli-mean-tokens', 77.49)
+    pretrained_model_score_slow('roberta-large-nli-mean-tokens', 78.69)
+    pretrained_model_score_slow('roberta-base-nli-stsb-mean-tokens', 85.30)
+    pretrained_model_score_slow('roberta-large-nli-stsb-mean-tokens', 86.39)
 
-    def test_roberta(self):
-        self.pretrained_model_score("roberta-base-nli-mean-tokens", 87.91)
-        self.pretrained_model_score("roberta-large-nli-mean-tokens", 89.41)
-        self.pretrained_model_score("roberta-base-nli-stsb-mean-tokens", 93.39)
-        self.pretrained_model_score("roberta-large-nli-stsb-mean-tokens", 91.26)
 
-    def test_distilbert(self):
-        self.pretrained_model_score("distilbert-base-nli-mean-tokens", 88.83)
-        self.pretrained_model_score("distilbert-base-nli-stsb-mean-tokens", 91.01)
-        self.pretrained_model_score("paraphrase-distilroberta-base-v1", 90.89)
+@pytest.mark.slow
+def test_distilbert_slow():
+    pretrained_model_score_slow('distilbert-base-nli-mean-tokens', 78.69)
+    pretrained_model_score_slow('distilbert-base-nli-stsb-mean-tokens', 85.16)
+    pretrained_model_score_slow('paraphrase-distilroberta-base-v1', 81.81)
 
-    def test_multiling(self):
-        self.pretrained_model_score("distiluse-base-multilingual-cased", 88.79)
-        self.pretrained_model_score("paraphrase-xlm-r-multilingual-v1", 92.76)
-        self.pretrained_model_score("paraphrase-multilingual-MiniLM-L12-v2", 92.64)
 
-    def test_mpnet(self):
-        self.pretrained_model_score("paraphrase-mpnet-base-v2", 92.83)
+@pytest.mark.slow
+def test_multiling_slow():
+    pretrained_model_score_slow('distiluse-base-multilingual-cased', 80.75)
+    pretrained_model_score_slow('paraphrase-xlm-r-multilingual-v1', 83.50)
+    pretrained_model_score_slow('paraphrase-multilingual-MiniLM-L12-v2', 84.42)
 
-    def test_other_models(self):
-        self.pretrained_model_score("average_word_embeddings_komninos", 68.97)
 
-    def test_msmarco(self):
-        self.pretrained_model_score("msmarco-roberta-base-ance-firstp", 83.61)
-        self.pretrained_model_score("msmarco-distilbert-base-v3", 87.96)
+# @pytest.mark.slow
+def test_mpnet_slow():
+    pretrained_model_score_slow('paraphrase-mpnet-base-v2', 86.99)
 
-    def test_sentence_t5(self):
-        self.pretrained_model_score("sentence-t5-base", 92.75)
+
+@pytest.mark.slow
+def test_other_models_slow():
+    pretrained_model_score_slow('average_word_embeddings_komninos', 61.56)
+
+
+@pytest.mark.slow
+def test_msmarco_slow():
+    pretrained_model_score_slow('msmarco-roberta-base-ance-firstp', 77.0)
+    pretrained_model_score_slow('msmarco-distilbert-base-v3', 78.85)
+
+
+@pytest.mark.slow
+def test_sentence_t5_slow():
+    pretrained_model_score_slow('sentence-t5-base', 85.52)
+
+
+def test_bert_base():
+    pretrained_model_score('bert-base-nli-mean-tokens', 86.53)
+    pretrained_model_score('bert-base-nli-max-tokens', 87.00)
+    pretrained_model_score('bert-base-nli-cls-token', 85.93)
+    pretrained_model_score('bert-base-nli-stsb-mean-tokens', 89.26)
+
+
+def test_bert_large():
+    pretrained_model_score('bert-large-nli-mean-tokens', 90.06)
+    pretrained_model_score('bert-large-nli-max-tokens', 90.15)
+    pretrained_model_score('bert-large-nli-cls-token', 89.51)
+    pretrained_model_score('bert-large-nli-stsb-mean-tokens', 92.27)
+
+
+def test_roberta():
+    pretrained_model_score('roberta-base-nli-mean-tokens', 87.91)
+    pretrained_model_score('roberta-large-nli-mean-tokens', 89.41)
+    pretrained_model_score('roberta-base-nli-stsb-mean-tokens', 93.39)
+    pretrained_model_score('roberta-large-nli-stsb-mean-tokens', 91.26)
+
+
+def test_distilbert():
+    pretrained_model_score('distilbert-base-nli-mean-tokens', 88.83)
+    pretrained_model_score('distilbert-base-nli-stsb-mean-tokens', 91.01)
+    pretrained_model_score('paraphrase-distilroberta-base-v1', 90.89)
+
+
+def test_multiling():
+    pretrained_model_score('distiluse-base-multilingual-cased', 88.79)
+    pretrained_model_score('paraphrase-xlm-r-multilingual-v1', 92.76)
+    pretrained_model_score('paraphrase-multilingual-MiniLM-L12-v2', 92.64)
+
+
+def test_mpnet():
+    pretrained_model_score('paraphrase-mpnet-base-v2', 92.83)
+
+
+def test_other_models():
+    pretrained_model_score('average_word_embeddings_komninos', 68.97)
+
+
+def test_msmarco():
+    pretrained_model_score('msmarco-roberta-base-ance-firstp', 83.61)
+    pretrained_model_score('msmarco-distilbert-base-v3', 87.96)
+
+
+def test_sentence_t5():
+    pretrained_model_score('sentence-t5-base', 92.75)

--- a/tests/test_pretrained_stsb.py
+++ b/tests/test_pretrained_stsb.py
@@ -80,7 +80,7 @@ def test_multiling_slow():
     pretrained_model_score_slow("paraphrase-multilingual-MiniLM-L12-v2", 84.42)
 
 
-# @pytest.mark.slow
+@pytest.mark.slow
 def test_mpnet_slow():
     pretrained_model_score_slow("paraphrase-mpnet-base-v2", 86.99)
 

--- a/tests/test_pretrained_stsb.py
+++ b/tests/test_pretrained_stsb.py
@@ -12,7 +12,7 @@ from sentence_transformers import InputExample, SentenceTransformer, util
 from sentence_transformers.evaluation import EmbeddingSimilarityEvaluator
 
 
-def pretrained_model_score(model_name, expected_score, max_test_samples: int = 100):
+def pretrained_model_score(model_name, expected_score: float, max_test_samples: int = 100) -> None:
     model = SentenceTransformer(model_name)
     sts_dataset_path = "datasets/stsbenchmark.tsv.gz"
 
@@ -43,7 +43,7 @@ pretrained_model_score_slow = partial(pretrained_model_score, max_test_samples=-
 
 
 @pytest.mark.slow
-def test_bert_base_slow():
+def test_bert_base_slow() -> None:
     pretrained_model_score_slow("bert-base-nli-mean-tokens", 77.12)
     pretrained_model_score_slow("bert-base-nli-max-tokens", 77.21)
     pretrained_model_score_slow("bert-base-nli-cls-token", 76.30)
@@ -51,7 +51,7 @@ def test_bert_base_slow():
 
 
 @pytest.mark.slow
-def test_bert_large_slow():
+def test_bert_large_slow() -> None:
     pretrained_model_score_slow("bert-large-nli-mean-tokens", 79.19)
     pretrained_model_score_slow("bert-large-nli-max-tokens", 78.41)
     pretrained_model_score_slow("bert-large-nli-cls-token", 78.29)
@@ -59,7 +59,7 @@ def test_bert_large_slow():
 
 
 @pytest.mark.slow
-def test_roberta_slow():
+def test_roberta_slow() -> None:
     pretrained_model_score_slow("roberta-base-nli-mean-tokens", 77.49)
     pretrained_model_score_slow("roberta-large-nli-mean-tokens", 78.69)
     pretrained_model_score_slow("roberta-base-nli-stsb-mean-tokens", 85.30)
@@ -67,85 +67,85 @@ def test_roberta_slow():
 
 
 @pytest.mark.slow
-def test_distilbert_slow():
+def test_distilbert_slow() -> None:
     pretrained_model_score_slow("distilbert-base-nli-mean-tokens", 78.69)
     pretrained_model_score_slow("distilbert-base-nli-stsb-mean-tokens", 85.16)
     pretrained_model_score_slow("paraphrase-distilroberta-base-v1", 81.81)
 
 
 @pytest.mark.slow
-def test_multiling_slow():
+def test_multiling_slow() -> None:
     pretrained_model_score_slow("distiluse-base-multilingual-cased", 80.75)
     pretrained_model_score_slow("paraphrase-xlm-r-multilingual-v1", 83.50)
     pretrained_model_score_slow("paraphrase-multilingual-MiniLM-L12-v2", 84.42)
 
 
 @pytest.mark.slow
-def test_mpnet_slow():
+def test_mpnet_slow() -> None:
     pretrained_model_score_slow("paraphrase-mpnet-base-v2", 86.99)
 
 
 @pytest.mark.slow
-def test_other_models_slow():
+def test_other_models_slow() -> None:
     pretrained_model_score_slow("average_word_embeddings_komninos", 61.56)
 
 
 @pytest.mark.slow
-def test_msmarco_slow():
+def test_msmarco_slow() -> None:
     pretrained_model_score_slow("msmarco-roberta-base-ance-firstp", 77.0)
     pretrained_model_score_slow("msmarco-distilbert-base-v3", 78.85)
 
 
 @pytest.mark.slow
-def test_sentence_t5_slow():
+def test_sentence_t5_slow() -> None:
     pretrained_model_score_slow("sentence-t5-base", 85.52)
 
 
-def test_bert_base():
+def test_bert_base() -> None:
     pretrained_model_score("bert-base-nli-mean-tokens", 86.53)
     pretrained_model_score("bert-base-nli-max-tokens", 87.00)
     pretrained_model_score("bert-base-nli-cls-token", 85.93)
     pretrained_model_score("bert-base-nli-stsb-mean-tokens", 89.26)
 
 
-def test_bert_large():
+def test_bert_large() -> None:
     pretrained_model_score("bert-large-nli-mean-tokens", 90.06)
     pretrained_model_score("bert-large-nli-max-tokens", 90.15)
     pretrained_model_score("bert-large-nli-cls-token", 89.51)
     pretrained_model_score("bert-large-nli-stsb-mean-tokens", 92.27)
 
 
-def test_roberta():
+def test_roberta() -> None:
     pretrained_model_score("roberta-base-nli-mean-tokens", 87.91)
     pretrained_model_score("roberta-large-nli-mean-tokens", 89.41)
     pretrained_model_score("roberta-base-nli-stsb-mean-tokens", 93.39)
     pretrained_model_score("roberta-large-nli-stsb-mean-tokens", 91.26)
 
 
-def test_distilbert():
+def test_distilbert() -> None:
     pretrained_model_score("distilbert-base-nli-mean-tokens", 88.83)
     pretrained_model_score("distilbert-base-nli-stsb-mean-tokens", 91.01)
     pretrained_model_score("paraphrase-distilroberta-base-v1", 90.89)
 
 
-def test_multiling():
+def test_multiling() -> None:
     pretrained_model_score("distiluse-base-multilingual-cased", 88.79)
     pretrained_model_score("paraphrase-xlm-r-multilingual-v1", 92.76)
     pretrained_model_score("paraphrase-multilingual-MiniLM-L12-v2", 92.64)
 
 
-def test_mpnet():
+def test_mpnet() -> None:
     pretrained_model_score("paraphrase-mpnet-base-v2", 92.83)
 
 
-def test_other_models():
+def test_other_models() -> None:
     pretrained_model_score("average_word_embeddings_komninos", 68.97)
 
 
-def test_msmarco():
+def test_msmarco() -> None:
     pretrained_model_score("msmarco-roberta-base-ance-firstp", 83.61)
     pretrained_model_score("msmarco-distilbert-base-v3", 87.96)
 
 
-def test_sentence_t5():
+def test_sentence_t5() -> None:
     pretrained_model_score("sentence-t5-base", 92.75)

--- a/tests/test_pretrained_stsb.py
+++ b/tests/test_pretrained_stsb.py
@@ -14,30 +14,24 @@ from sentence_transformers.evaluation import EmbeddingSimilarityEvaluator
 
 def pretrained_model_score(model_name, expected_score, max_test_samples: int = 100):
     model = SentenceTransformer(model_name)
-    sts_dataset_path = 'datasets/stsbenchmark.tsv.gz'
+    sts_dataset_path = "datasets/stsbenchmark.tsv.gz"
 
     if not os.path.exists(sts_dataset_path):
-        util.http_get(
-            'https://sbert.net/datasets/stsbenchmark.tsv.gz', sts_dataset_path
-        )
+        util.http_get("https://sbert.net/datasets/stsbenchmark.tsv.gz", sts_dataset_path)
 
     test_samples = []
-    with gzip.open(sts_dataset_path, 'rt', encoding='utf8') as fIn:
-        reader = csv.DictReader(fIn, delimiter='\t', quoting=csv.QUOTE_NONE)
+    with gzip.open(sts_dataset_path, "rt", encoding="utf8") as fIn:
+        reader = csv.DictReader(fIn, delimiter="\t", quoting=csv.QUOTE_NONE)
         for row in reader:
-            score = float(row['score']) / 5.0  # Normalize score to range 0 ... 1
-            inp_example = InputExample(
-                texts=[row['sentence1'], row['sentence2']], label=score
-            )
+            score = float(row["score"]) / 5.0  # Normalize score to range 0 ... 1
+            inp_example = InputExample(texts=[row["sentence1"], row["sentence2"]], label=score)
 
-            if row['split'] == 'test':
+            if row["split"] == "test":
                 test_samples.append(inp_example)
             if max_test_samples != -1 and len(test_samples) >= max_test_samples:
                 break
 
-    evaluator = EmbeddingSimilarityEvaluator.from_input_examples(
-        test_samples, name='sts-test'
-    )
+    evaluator = EmbeddingSimilarityEvaluator.from_input_examples(test_samples, name="sts-test")
 
     score = model.evaluate(evaluator) * 100
     print(model_name, "{:.2f} vs. exp: {:.2f}".format(score, expected_score))
@@ -50,108 +44,108 @@ pretrained_model_score_slow = partial(pretrained_model_score, max_test_samples=-
 
 @pytest.mark.slow
 def test_bert_base_slow():
-    pretrained_model_score_slow('bert-base-nli-mean-tokens', 77.12)
-    pretrained_model_score_slow('bert-base-nli-max-tokens', 77.21)
-    pretrained_model_score_slow('bert-base-nli-cls-token', 76.30)
-    pretrained_model_score_slow('bert-base-nli-stsb-mean-tokens', 85.14)
+    pretrained_model_score_slow("bert-base-nli-mean-tokens", 77.12)
+    pretrained_model_score_slow("bert-base-nli-max-tokens", 77.21)
+    pretrained_model_score_slow("bert-base-nli-cls-token", 76.30)
+    pretrained_model_score_slow("bert-base-nli-stsb-mean-tokens", 85.14)
 
 
 @pytest.mark.slow
 def test_bert_large_slow():
-    pretrained_model_score_slow('bert-large-nli-mean-tokens', 79.19)
-    pretrained_model_score_slow('bert-large-nli-max-tokens', 78.41)
-    pretrained_model_score_slow('bert-large-nli-cls-token', 78.29)
-    pretrained_model_score_slow('bert-large-nli-stsb-mean-tokens', 85.29)
+    pretrained_model_score_slow("bert-large-nli-mean-tokens", 79.19)
+    pretrained_model_score_slow("bert-large-nli-max-tokens", 78.41)
+    pretrained_model_score_slow("bert-large-nli-cls-token", 78.29)
+    pretrained_model_score_slow("bert-large-nli-stsb-mean-tokens", 85.29)
 
 
 @pytest.mark.slow
 def test_roberta_slow():
-    pretrained_model_score_slow('roberta-base-nli-mean-tokens', 77.49)
-    pretrained_model_score_slow('roberta-large-nli-mean-tokens', 78.69)
-    pretrained_model_score_slow('roberta-base-nli-stsb-mean-tokens', 85.30)
-    pretrained_model_score_slow('roberta-large-nli-stsb-mean-tokens', 86.39)
+    pretrained_model_score_slow("roberta-base-nli-mean-tokens", 77.49)
+    pretrained_model_score_slow("roberta-large-nli-mean-tokens", 78.69)
+    pretrained_model_score_slow("roberta-base-nli-stsb-mean-tokens", 85.30)
+    pretrained_model_score_slow("roberta-large-nli-stsb-mean-tokens", 86.39)
 
 
 @pytest.mark.slow
 def test_distilbert_slow():
-    pretrained_model_score_slow('distilbert-base-nli-mean-tokens', 78.69)
-    pretrained_model_score_slow('distilbert-base-nli-stsb-mean-tokens', 85.16)
-    pretrained_model_score_slow('paraphrase-distilroberta-base-v1', 81.81)
+    pretrained_model_score_slow("distilbert-base-nli-mean-tokens", 78.69)
+    pretrained_model_score_slow("distilbert-base-nli-stsb-mean-tokens", 85.16)
+    pretrained_model_score_slow("paraphrase-distilroberta-base-v1", 81.81)
 
 
 @pytest.mark.slow
 def test_multiling_slow():
-    pretrained_model_score_slow('distiluse-base-multilingual-cased', 80.75)
-    pretrained_model_score_slow('paraphrase-xlm-r-multilingual-v1', 83.50)
-    pretrained_model_score_slow('paraphrase-multilingual-MiniLM-L12-v2', 84.42)
+    pretrained_model_score_slow("distiluse-base-multilingual-cased", 80.75)
+    pretrained_model_score_slow("paraphrase-xlm-r-multilingual-v1", 83.50)
+    pretrained_model_score_slow("paraphrase-multilingual-MiniLM-L12-v2", 84.42)
 
 
 # @pytest.mark.slow
 def test_mpnet_slow():
-    pretrained_model_score_slow('paraphrase-mpnet-base-v2', 86.99)
+    pretrained_model_score_slow("paraphrase-mpnet-base-v2", 86.99)
 
 
 @pytest.mark.slow
 def test_other_models_slow():
-    pretrained_model_score_slow('average_word_embeddings_komninos', 61.56)
+    pretrained_model_score_slow("average_word_embeddings_komninos", 61.56)
 
 
 @pytest.mark.slow
 def test_msmarco_slow():
-    pretrained_model_score_slow('msmarco-roberta-base-ance-firstp', 77.0)
-    pretrained_model_score_slow('msmarco-distilbert-base-v3', 78.85)
+    pretrained_model_score_slow("msmarco-roberta-base-ance-firstp", 77.0)
+    pretrained_model_score_slow("msmarco-distilbert-base-v3", 78.85)
 
 
 @pytest.mark.slow
 def test_sentence_t5_slow():
-    pretrained_model_score_slow('sentence-t5-base', 85.52)
+    pretrained_model_score_slow("sentence-t5-base", 85.52)
 
 
 def test_bert_base():
-    pretrained_model_score('bert-base-nli-mean-tokens', 86.53)
-    pretrained_model_score('bert-base-nli-max-tokens', 87.00)
-    pretrained_model_score('bert-base-nli-cls-token', 85.93)
-    pretrained_model_score('bert-base-nli-stsb-mean-tokens', 89.26)
+    pretrained_model_score("bert-base-nli-mean-tokens", 86.53)
+    pretrained_model_score("bert-base-nli-max-tokens", 87.00)
+    pretrained_model_score("bert-base-nli-cls-token", 85.93)
+    pretrained_model_score("bert-base-nli-stsb-mean-tokens", 89.26)
 
 
 def test_bert_large():
-    pretrained_model_score('bert-large-nli-mean-tokens', 90.06)
-    pretrained_model_score('bert-large-nli-max-tokens', 90.15)
-    pretrained_model_score('bert-large-nli-cls-token', 89.51)
-    pretrained_model_score('bert-large-nli-stsb-mean-tokens', 92.27)
+    pretrained_model_score("bert-large-nli-mean-tokens", 90.06)
+    pretrained_model_score("bert-large-nli-max-tokens", 90.15)
+    pretrained_model_score("bert-large-nli-cls-token", 89.51)
+    pretrained_model_score("bert-large-nli-stsb-mean-tokens", 92.27)
 
 
 def test_roberta():
-    pretrained_model_score('roberta-base-nli-mean-tokens', 87.91)
-    pretrained_model_score('roberta-large-nli-mean-tokens', 89.41)
-    pretrained_model_score('roberta-base-nli-stsb-mean-tokens', 93.39)
-    pretrained_model_score('roberta-large-nli-stsb-mean-tokens', 91.26)
+    pretrained_model_score("roberta-base-nli-mean-tokens", 87.91)
+    pretrained_model_score("roberta-large-nli-mean-tokens", 89.41)
+    pretrained_model_score("roberta-base-nli-stsb-mean-tokens", 93.39)
+    pretrained_model_score("roberta-large-nli-stsb-mean-tokens", 91.26)
 
 
 def test_distilbert():
-    pretrained_model_score('distilbert-base-nli-mean-tokens', 88.83)
-    pretrained_model_score('distilbert-base-nli-stsb-mean-tokens', 91.01)
-    pretrained_model_score('paraphrase-distilroberta-base-v1', 90.89)
+    pretrained_model_score("distilbert-base-nli-mean-tokens", 88.83)
+    pretrained_model_score("distilbert-base-nli-stsb-mean-tokens", 91.01)
+    pretrained_model_score("paraphrase-distilroberta-base-v1", 90.89)
 
 
 def test_multiling():
-    pretrained_model_score('distiluse-base-multilingual-cased', 88.79)
-    pretrained_model_score('paraphrase-xlm-r-multilingual-v1', 92.76)
-    pretrained_model_score('paraphrase-multilingual-MiniLM-L12-v2', 92.64)
+    pretrained_model_score("distiluse-base-multilingual-cased", 88.79)
+    pretrained_model_score("paraphrase-xlm-r-multilingual-v1", 92.76)
+    pretrained_model_score("paraphrase-multilingual-MiniLM-L12-v2", 92.64)
 
 
 def test_mpnet():
-    pretrained_model_score('paraphrase-mpnet-base-v2', 92.83)
+    pretrained_model_score("paraphrase-mpnet-base-v2", 92.83)
 
 
 def test_other_models():
-    pretrained_model_score('average_word_embeddings_komninos', 68.97)
+    pretrained_model_score("average_word_embeddings_komninos", 68.97)
 
 
 def test_msmarco():
-    pretrained_model_score('msmarco-roberta-base-ance-firstp', 83.61)
-    pretrained_model_score('msmarco-distilbert-base-v3', 87.96)
+    pretrained_model_score("msmarco-roberta-base-ance-firstp", 83.61)
+    pretrained_model_score("msmarco-distilbert-base-v3", 87.96)
 
 
 def test_sentence_t5():
-    pretrained_model_score('sentence-t5-base', 92.75)
+    pretrained_model_score("sentence-t5-base", 92.75)

--- a/tests/test_sentence_transformer.py
+++ b/tests/test_sentence_transformer.py
@@ -83,6 +83,13 @@ def test_save_to_hub(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureF
             git_ref_info = GitRefInfo(name="main", ref="refs/heads/main", target_commit="123456")
         except TypeError:
             git_ref_info = GitRefInfo(dict(name="main", ref="refs/heads/main", targetCommit="123456"))
+        # workaround for https://github.com/huggingface/huggingface_hub/issues/1956
+        git_ref_kwargs = {"branches": [git_ref_info], "converts": [], "tags": [], "pull_requests": None}
+        try:
+            return GitRefs(**git_ref_kwargs)
+        except TypeError:
+            git_ref_kwargs.pop("pull_requests")
+            return GitRefs(**git_ref_kwargs)
         return GitRefs(branches=[git_ref_info], converts=[], tags=[])
 
     monkeypatch.setattr(HfApi, "create_repo", mock_create_repo)

--- a/tests/test_sentence_transformer.py
+++ b/tests/test_sentence_transformer.py
@@ -83,13 +83,7 @@ def test_save_to_hub(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureF
             git_ref_info = GitRefInfo(name="main", ref="refs/heads/main", target_commit="123456")
         except TypeError:
             git_ref_info = GitRefInfo(dict(name="main", ref="refs/heads/main", targetCommit="123456"))
-        # workaround for https://github.com/huggingface/huggingface_hub/issues/1956
-        git_ref_kwargs = {"branches": [git_ref_info], "converts": [], "tags": [], "pull_requests": None}
-        try:
-            return GitRefs(**git_ref_kwargs)
-        except TypeError:
-            git_ref_kwargs.pop("pull_requests")
-            return GitRefs(**git_ref_kwargs)
+        return GitRefs(branches=[git_ref_info], converts=[], tags=[])
 
     monkeypatch.setattr(HfApi, "create_repo", mock_create_repo)
     monkeypatch.setattr(HfApi, "upload_folder", mock_upload_folder)
@@ -157,10 +151,10 @@ def test_save_to_hub(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureF
     caplog.clear()
     with caplog.at_level(logging.WARNING):
         url = model.save_to_hub(
-            "stsb-bert-tiny-safetensors",  # repo_name
-            "sentence-transformers-testing",  # organization
-            True,  # private
-            "Adding new awesome Model!",  # commit message
+            "stsb-bert-tiny-safetensors", # repo_name
+            "sentence-transformers-testing", # organization
+            True, # private
+            "Adding new awesome Model!", # commit message
             exist_ok=True,
         )
         assert mock_upload_folder_kwargs["repo_id"] == "sentence-transformers-testing/stsb-bert-tiny-safetensors"

--- a/tests/test_sentence_transformer.py
+++ b/tests/test_sentence_transformer.py
@@ -158,10 +158,10 @@ def test_save_to_hub(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureF
     caplog.clear()
     with caplog.at_level(logging.WARNING):
         url = model.save_to_hub(
-            "stsb-bert-tiny-safetensors", # repo_name
-            "sentence-transformers-testing", # organization
-            True, # private
-            "Adding new awesome Model!", # commit message
+            "stsb-bert-tiny-safetensors",  # repo_name
+            "sentence-transformers-testing",  # organization
+            True,  # private
+            "Adding new awesome Model!",  # commit message
             exist_ok=True,
         )
         assert mock_upload_folder_kwargs["repo_id"] == "sentence-transformers-testing/stsb-bert-tiny-safetensors"

--- a/tests/test_sentence_transformer.py
+++ b/tests/test_sentence_transformer.py
@@ -90,7 +90,6 @@ def test_save_to_hub(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureF
         except TypeError:
             git_ref_kwargs.pop("pull_requests")
             return GitRefs(**git_ref_kwargs)
-        return GitRefs(branches=[git_ref_info], converts=[], tags=[])
 
     monkeypatch.setattr(HfApi, "create_repo", mock_create_repo)
     monkeypatch.setattr(HfApi, "upload_folder", mock_upload_folder)

--- a/tests/test_train_stsb.py
+++ b/tests/test_train_stsb.py
@@ -4,133 +4,158 @@ Tests that the pretrained models produce the correct scores on the STSbenchmark 
 import csv
 import gzip
 import os
-import unittest
-import pytest
 
+import pytest
 from torch.utils.data import DataLoader
 
-from sentence_transformers import SentenceTransformer, SentencesDataset, losses, models, util
+from sentence_transformers import (
+    SentencesDataset,
+    SentenceTransformer,
+    losses,
+    models,
+    util,
+)
 from sentence_transformers.evaluation import EmbeddingSimilarityEvaluator
 from sentence_transformers.readers import InputExample
 
 
-class PretrainedSTSbTest(unittest.TestCase):
-    def setUp(self):
-        sts_dataset_path = "datasets/stsbenchmark.tsv.gz"
-        if not os.path.exists(sts_dataset_path):
-            util.http_get("https://sbert.net/datasets/stsbenchmark.tsv.gz", sts_dataset_path)
+@pytest.fixture()
+def sts_resource():
+    sts_dataset_path = 'datasets/stsbenchmark.tsv.gz'
+    if not os.path.exists(sts_dataset_path):
+        util.http_get(
+            'https://sbert.net/datasets/stsbenchmark.tsv.gz', sts_dataset_path
+        )
 
-        nli_dataset_path = "datasets/AllNLI.tsv.gz"
-        if not os.path.exists(nli_dataset_path):
-            util.http_get("https://sbert.net/datasets/AllNLI.tsv.gz", nli_dataset_path)
+    stsb_train_samples = []
+    stsb_test_samples = []
+    with gzip.open(sts_dataset_path, 'rt', encoding='utf8') as f:
+        reader = csv.DictReader(f, delimiter='\t', quoting=csv.QUOTE_NONE)
+        for row in reader:
+            score = float(row['score']) / 5.0  # Normalize score to range 0 ... 1
+            inp_example = InputExample(
+                texts=[row['sentence1'], row['sentence2']], label=score
+            )
 
-        # Read NLI
-        label2int = {"contradiction": 0, "entailment": 1, "neutral": 2}
-        self.nli_train_samples = []
-        max_train_samples = 10000
-        with gzip.open(nli_dataset_path, "rt", encoding="utf8") as fIn:
-            reader = csv.DictReader(fIn, delimiter="\t", quoting=csv.QUOTE_NONE)
-            for row in reader:
-                if row["split"] == "train":
-                    label_id = label2int[row["label"]]
-                    self.nli_train_samples.append(
-                        InputExample(texts=[row["sentence1"], row["sentence2"]], label=label_id)
+            if row['split'] == 'test':
+                stsb_test_samples.append(inp_example)
+            elif row['split'] == 'train':
+                stsb_train_samples.append(inp_example)
+        yield stsb_train_samples, stsb_test_samples
+
+
+@pytest.fixture()
+def nli_resource():
+    nli_dataset_path = 'datasets/AllNLI.tsv.gz'
+    if not os.path.exists(nli_dataset_path):
+        util.http_get('https://sbert.net/datasets/AllNLI.tsv.gz', nli_dataset_path)
+
+    label2int = {"contradiction": 0, "entailment": 1, "neutral": 2}
+    nli_train_samples = []
+    max_train_samples = 10000
+    with gzip.open(nli_dataset_path, 'rt', encoding='utf8') as f:
+        reader = csv.DictReader(f, delimiter='\t', quoting=csv.QUOTE_NONE)
+        for row in reader:
+            if row['split'] == 'train':
+                label_id = label2int[row['label']]
+                nli_train_samples.append(
+                    InputExample(
+                        texts=[row['sentence1'], row['sentence2']], label=label_id
                     )
-                    if len(self.nli_train_samples) >= max_train_samples:
-                        break
+                )
+                if len(nli_train_samples) >= max_train_samples:
+                    break
+        yield nli_train_samples
 
-        # Read STSB
-        self.stsb_train_samples = []
-        self.test_samples = []
-        with gzip.open(sts_dataset_path, "rt", encoding="utf8") as fIn:
-            reader = csv.DictReader(fIn, delimiter="\t", quoting=csv.QUOTE_NONE)
-            for row in reader:
-                score = float(row["score"]) / 5.0  # Normalize score to range 0 ... 1
-                inp_example = InputExample(texts=[row["sentence1"], row["sentence2"]], label=score)
 
-                if row["split"] == "test":
-                    self.test_samples.append(inp_example)
-                elif row["split"] == "train":
-                    self.stsb_train_samples.append(inp_example)
+@pytest.fixture()
+def model():
+    word_embedding_model = models.Transformer('distilbert-base-uncased')
+    pooling_model = models.Pooling(word_embedding_model.get_word_embedding_dimension())
+    model = SentenceTransformer(modules=[word_embedding_model, pooling_model])
+    return model
 
-    def evaluate_stsb_test(self, model, expected_score):
-        evaluator = EmbeddingSimilarityEvaluator.from_input_examples(self.test_samples, name="sts-test")
-        score = model.evaluate(evaluator) * 100
-        print("STS-Test Performance: {:.2f} vs. exp: {:.2f}".format(score, expected_score))
-        assert score > expected_score or abs(score - expected_score) < 0.1
 
-    @pytest.mark.slow
-    def test_train_stsb_slow(self):
-        word_embedding_model = models.Transformer("distilbert-base-uncased")
-        pooling_model = models.Pooling(word_embedding_model.get_word_embedding_dimension())
-        model = SentenceTransformer(modules=[word_embedding_model, pooling_model])
-        train_dataset = SentencesDataset(self.stsb_train_samples, model)
-        train_dataloader = DataLoader(train_dataset, shuffle=True, batch_size=16)
-        train_loss = losses.CosineSimilarityLoss(model=model)
-        model.fit(
-            train_objectives=[(train_dataloader, train_loss)],
-            evaluator=None,
-            epochs=1,
-            evaluation_steps=1000,
-            warmup_steps=int(len(train_dataloader) * 0.1),
-            use_amp=True,
-        )
+def evaluate_stsb_test(model, expected_score, test_samples):
+    evaluator = EmbeddingSimilarityEvaluator.from_input_examples(
+        test_samples, name='sts-test'
+    )
+    score = model.evaluate(evaluator) * 100
+    print("STS-Test Performance: {:.2f} vs. exp: {:.2f}".format(score, expected_score))
+    assert score > expected_score or abs(score - expected_score) < 0.1
 
-        self.evaluate_stsb_test(model, 80.0)
 
-    def test_train_stsb(self):
-        word_embedding_model = models.Transformer("distilbert-base-uncased")
-        pooling_model = models.Pooling(word_embedding_model.get_word_embedding_dimension())
-        model = SentenceTransformer(modules=[word_embedding_model, pooling_model])
-        train_dataset = SentencesDataset(self.stsb_train_samples[:100], model)
-        train_dataloader = DataLoader(train_dataset, shuffle=True, batch_size=16)
-        train_loss = losses.CosineSimilarityLoss(model=model)
-        model.fit(
-            train_objectives=[(train_dataloader, train_loss)],
-            evaluator=None,
-            epochs=1,
-            evaluation_steps=1000,
-            warmup_steps=int(len(train_dataloader) * 0.1),
-            use_amp=True,
-        )
+@pytest.mark.slow
+def test_train_stsb_slow(sts_resource, model):
+    sts_train_samples, sts_test_samples = sts_resource
+    train_dataset = SentencesDataset(sts_train_samples, model)
+    train_dataloader = DataLoader(train_dataset, shuffle=True, batch_size=16)
+    train_loss = losses.CosineSimilarityLoss(model=model)
+    model.fit(
+        train_objectives=[(train_dataloader, train_loss)],
+        evaluator=None,
+        epochs=1,
+        evaluation_steps=1000,
+        warmup_steps=int(len(train_dataloader) * 0.1),
+        use_amp=True,
+    )
 
-        self.evaluate_stsb_test(model, 60.0)
+    evaluate_stsb_test(model, 80.0, sts_test_samples)
 
-    @pytest.mark.slow
-    def test_train_nli_slow(self):
-        word_embedding_model = models.Transformer("distilbert-base-uncased")
-        pooling_model = models.Pooling(word_embedding_model.get_word_embedding_dimension())
-        model = SentenceTransformer(modules=[word_embedding_model, pooling_model])
-        train_dataset = SentencesDataset(self.nli_train_samples, model=model)
-        train_dataloader = DataLoader(train_dataset, shuffle=True, batch_size=16)
-        train_loss = losses.SoftmaxLoss(
-            model=model, sentence_embedding_dimension=model.get_sentence_embedding_dimension(), num_labels=3
-        )
-        model.fit(
-            train_objectives=[(train_dataloader, train_loss)],
-            evaluator=None,
-            epochs=1,
-            warmup_steps=int(len(train_dataloader) * 0.1),
-            use_amp=True,
-        )
 
-        self.evaluate_stsb_test(model, 50.0)
+def test_train_stsb(model, sts_resource):
+    sts_train_samples, sts_test_samples = sts_resource
+    train_dataset = SentencesDataset(sts_train_samples[:100], model)
+    train_dataloader = DataLoader(train_dataset, shuffle=True, batch_size=16)
+    train_loss = losses.CosineSimilarityLoss(model=model)
+    model.fit(
+        train_objectives=[(train_dataloader, train_loss)],
+        evaluator=None,
+        epochs=1,
+        evaluation_steps=1000,
+        warmup_steps=int(len(train_dataloader) * 0.1),
+        use_amp=True,
+    )
 
-    def test_train_nli(self):
-        word_embedding_model = models.Transformer("distilbert-base-uncased")
-        pooling_model = models.Pooling(word_embedding_model.get_word_embedding_dimension())
-        model = SentenceTransformer(modules=[word_embedding_model, pooling_model])
-        train_dataset = SentencesDataset(self.nli_train_samples[:100], model=model)
-        train_dataloader = DataLoader(train_dataset, shuffle=True, batch_size=16)
-        train_loss = losses.SoftmaxLoss(
-            model=model, sentence_embedding_dimension=model.get_sentence_embedding_dimension(), num_labels=3
-        )
-        model.fit(
-            train_objectives=[(train_dataloader, train_loss)],
-            evaluator=None,
-            epochs=1,
-            warmup_steps=int(len(train_dataloader) * 0.1),
-            use_amp=True,
-        )
+    evaluate_stsb_test(model, 60.0, sts_test_samples)
 
-        self.evaluate_stsb_test(model, 50.0)
+
+@pytest.mark.slow
+def test_train_nli_slow(model, nli_resource, sts_resource):
+    _, sts_test_samples = sts_resource
+    train_dataset = SentencesDataset(nli_resource, model=model)
+    train_dataloader = DataLoader(train_dataset, shuffle=True, batch_size=16)
+    train_loss = losses.SoftmaxLoss(
+        model=model,
+        sentence_embedding_dimension=model.get_sentence_embedding_dimension(),
+        num_labels=3,
+    )
+    model.fit(
+        train_objectives=[(train_dataloader, train_loss)],
+        evaluator=None,
+        epochs=1,
+        warmup_steps=int(len(train_dataloader) * 0.1),
+        use_amp=True,
+    )
+
+    evaluate_stsb_test(model, 50.0, sts_test_samples)
+
+
+def test_train_nli(model, nli_resource, sts_resource):
+    _, sts_test_samples = sts_resource
+    train_dataset = SentencesDataset(nli_resource[:100], model=model)
+    train_dataloader = DataLoader(train_dataset, shuffle=True, batch_size=16)
+    train_loss = losses.SoftmaxLoss(
+        model=model,
+        sentence_embedding_dimension=model.get_sentence_embedding_dimension(),
+        num_labels=3,
+    )
+    model.fit(
+        train_objectives=[(train_dataloader, train_loss)],
+        evaluator=None,
+        epochs=1,
+        warmup_steps=int(len(train_dataloader) * 0.1),
+        use_amp=True,
+    )
+
+    evaluate_stsb_test(model, 50.0, sts_test_samples)

--- a/tests/test_train_stsb.py
+++ b/tests/test_train_stsb.py
@@ -21,48 +21,40 @@ from sentence_transformers.readers import InputExample
 
 @pytest.fixture()
 def sts_resource():
-    sts_dataset_path = 'datasets/stsbenchmark.tsv.gz'
+    sts_dataset_path = "datasets/stsbenchmark.tsv.gz"
     if not os.path.exists(sts_dataset_path):
-        util.http_get(
-            'https://sbert.net/datasets/stsbenchmark.tsv.gz', sts_dataset_path
-        )
+        util.http_get("https://sbert.net/datasets/stsbenchmark.tsv.gz", sts_dataset_path)
 
     stsb_train_samples = []
     stsb_test_samples = []
-    with gzip.open(sts_dataset_path, 'rt', encoding='utf8') as f:
-        reader = csv.DictReader(f, delimiter='\t', quoting=csv.QUOTE_NONE)
+    with gzip.open(sts_dataset_path, "rt", encoding="utf8") as f:
+        reader = csv.DictReader(f, delimiter="\t", quoting=csv.QUOTE_NONE)
         for row in reader:
-            score = float(row['score']) / 5.0  # Normalize score to range 0 ... 1
-            inp_example = InputExample(
-                texts=[row['sentence1'], row['sentence2']], label=score
-            )
+            score = float(row["score"]) / 5.0  # Normalize score to range 0 ... 1
+            inp_example = InputExample(texts=[row["sentence1"], row["sentence2"]], label=score)
 
-            if row['split'] == 'test':
+            if row["split"] == "test":
                 stsb_test_samples.append(inp_example)
-            elif row['split'] == 'train':
+            elif row["split"] == "train":
                 stsb_train_samples.append(inp_example)
         yield stsb_train_samples, stsb_test_samples
 
 
 @pytest.fixture()
 def nli_resource():
-    nli_dataset_path = 'datasets/AllNLI.tsv.gz'
+    nli_dataset_path = "datasets/AllNLI.tsv.gz"
     if not os.path.exists(nli_dataset_path):
-        util.http_get('https://sbert.net/datasets/AllNLI.tsv.gz', nli_dataset_path)
+        util.http_get("https://sbert.net/datasets/AllNLI.tsv.gz", nli_dataset_path)
 
     label2int = {"contradiction": 0, "entailment": 1, "neutral": 2}
     nli_train_samples = []
     max_train_samples = 10000
-    with gzip.open(nli_dataset_path, 'rt', encoding='utf8') as f:
-        reader = csv.DictReader(f, delimiter='\t', quoting=csv.QUOTE_NONE)
+    with gzip.open(nli_dataset_path, "rt", encoding="utf8") as f:
+        reader = csv.DictReader(f, delimiter="\t", quoting=csv.QUOTE_NONE)
         for row in reader:
-            if row['split'] == 'train':
-                label_id = label2int[row['label']]
-                nli_train_samples.append(
-                    InputExample(
-                        texts=[row['sentence1'], row['sentence2']], label=label_id
-                    )
-                )
+            if row["split"] == "train":
+                label_id = label2int[row["label"]]
+                nli_train_samples.append(InputExample(texts=[row["sentence1"], row["sentence2"]], label=label_id))
                 if len(nli_train_samples) >= max_train_samples:
                     break
         yield nli_train_samples
@@ -70,16 +62,14 @@ def nli_resource():
 
 @pytest.fixture()
 def model():
-    word_embedding_model = models.Transformer('distilbert-base-uncased')
+    word_embedding_model = models.Transformer("distilbert-base-uncased")
     pooling_model = models.Pooling(word_embedding_model.get_word_embedding_dimension())
     model = SentenceTransformer(modules=[word_embedding_model, pooling_model])
     return model
 
 
 def evaluate_stsb_test(model, expected_score, test_samples):
-    evaluator = EmbeddingSimilarityEvaluator.from_input_examples(
-        test_samples, name='sts-test'
-    )
+    evaluator = EmbeddingSimilarityEvaluator.from_input_examples(test_samples, name="sts-test")
     score = model.evaluate(evaluator) * 100
     print("STS-Test Performance: {:.2f} vs. exp: {:.2f}".format(score, expected_score))
     assert score > expected_score or abs(score - expected_score) < 0.1

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -5,7 +5,7 @@ import torch
 from sentence_transformers import SentenceTransformer, util
 
 
-def test_normalize_embeddings():
+def test_normalize_embeddings() -> None:
     """Tests the correct computation of util.normalize_embeddings"""
     embedding_size = 100
     a = torch.tensor(np.random.randn(50, embedding_size))
@@ -17,7 +17,7 @@ def test_normalize_embeddings():
         assert abs(emb_norm.item() - 1) < 0.0001
 
 
-def test_pytorch_cos_sim():
+def test_pytorch_cos_sim() -> None:
     """Tests the correct computation of util.pytorch_cos_scores"""
     a = np.random.randn(50, 100)
     b = np.random.randn(50, 100)
@@ -29,7 +29,7 @@ def test_pytorch_cos_sim():
             assert abs(sklearn_pairwise[i][j] - pytorch_cos_scores[i][j]) < 0.001
 
 
-def test_semantic_search():
+def test_semantic_search() -> None:
     """Tests util.semantic_search function"""
     num_queries = 20
     num_k = 10
@@ -52,7 +52,7 @@ def test_semantic_search():
             assert np.abs(hits[qid][hit_num]["score"] - cos_scores_values[qid][hit_num]) < 0.001
 
 
-def test_paraphrase_mining():
+def test_paraphrase_mining() -> None:
     model = SentenceTransformer("all-MiniLM-L6-v2")
     sentences = [
         "This is a test",
@@ -71,7 +71,7 @@ def test_paraphrase_mining():
             assert (a, b) in [(0, 1), (2, 3), (2, 4), (3, 4), (5, 6), (5, 7), (6, 7)]
 
 
-def test_pairwise_scores():
+def test_pairwise_scores() -> None:
     a = np.random.randn(50, 100)
     b = np.random.randn(50, 100)
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -36,9 +36,7 @@ def test_semantic_search():
 
     doc_emb = torch.tensor(np.random.randn(1000, 100))
     q_emb = torch.tensor(np.random.randn(num_queries, 100))
-    hits = util.semantic_search(
-        q_emb, doc_emb, top_k=num_k, query_chunk_size=5, corpus_chunk_size=17
-    )
+    hits = util.semantic_search(q_emb, doc_emb, top_k=num_k, query_chunk_size=5, corpus_chunk_size=17)
     assert len(hits) == num_queries
     assert len(hits[0]) == num_k
 
@@ -50,15 +48,12 @@ def test_semantic_search():
 
     for qid in range(num_queries):
         for hit_num in range(num_k):
-            assert hits[qid][hit_num]['corpus_id'] == cos_scores_idx[qid][hit_num]
-            assert (
-                np.abs(hits[qid][hit_num]['score'] - cos_scores_values[qid][hit_num])
-                < 0.001
-            )
+            assert hits[qid][hit_num]["corpus_id"] == cos_scores_idx[qid][hit_num]
+            assert np.abs(hits[qid][hit_num]["score"] - cos_scores_values[qid][hit_num]) < 0.001
 
 
 def test_paraphrase_mining():
-    model = SentenceTransformer('all-MiniLM-L6-v2')
+    model = SentenceTransformer("all-MiniLM-L6-v2")
     sentences = [
         "This is a test",
         "This is a test!",

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,82 +1,86 @@
-from sentence_transformers import util, SentenceTransformer
-import unittest
 import numpy as np
 import sklearn
 import torch
 
-
-class UtilTest(unittest.TestCase):
-    def test_normalize_embeddings(self):
-        """Tests the correct computation of util.normalize_embeddings"""
-        embedding_size = 100
-        a = torch.tensor(np.random.randn(50, embedding_size))
-        a_norm = util.normalize_embeddings(a)
-
-        for embedding in a_norm:
-            assert len(embedding) == embedding_size
-            emb_norm = torch.norm(embedding)
-            assert abs(emb_norm.item() - 1) < 0.0001
-
-    def test_pytorch_cos_sim(self):
-        """Tests the correct computation of util.pytorch_cos_scores"""
-        a = np.random.randn(50, 100)
-        b = np.random.randn(50, 100)
-
-        sklearn_pairwise = sklearn.metrics.pairwise.cosine_similarity(a, b)
-        pytorch_cos_scores = util.pytorch_cos_sim(a, b).numpy()
-        for i in range(len(sklearn_pairwise)):
-            for j in range(len(sklearn_pairwise[i])):
-                assert abs(sklearn_pairwise[i][j] - pytorch_cos_scores[i][j]) < 0.001
-
-    def test_semantic_search(self):
-        """Tests util.semantic_search function"""
-        num_queries = 20
-        num_k = 10
-
-        doc_emb = torch.tensor(np.random.randn(1000, 100))
-        q_emb = torch.tensor(np.random.randn(num_queries, 100))
-        hits = util.semantic_search(q_emb, doc_emb, top_k=num_k, query_chunk_size=5, corpus_chunk_size=17)
-        assert len(hits) == num_queries
-        assert len(hits[0]) == num_k
-
-        # Sanity Check of the results
-        cos_scores = util.pytorch_cos_sim(q_emb, doc_emb)
-        cos_scores_values, cos_scores_idx = cos_scores.topk(num_k)
-        cos_scores_values = cos_scores_values.cpu().tolist()
-        cos_scores_idx = cos_scores_idx.cpu().tolist()
-
-        for qid in range(num_queries):
-            for hit_num in range(num_k):
-                assert hits[qid][hit_num]["corpus_id"] == cos_scores_idx[qid][hit_num]
-                assert np.abs(hits[qid][hit_num]["score"] - cos_scores_values[qid][hit_num]) < 0.001
-
-    def test_paraphrase_mining(self):
-        model = SentenceTransformer("paraphrase-distilroberta-base-v1")
-        sentences = [
-            "This is a test",
-            "This is a test!",
-            "The cat sits on mat",
-            "The cat sits on the mat",
-            "On the mat a cat sits",
-            "A man eats pasta",
-            "A woman eats pasta",
-            "A man eats spaghetti",
-        ]
-        duplicates = util.paraphrase_mining(model, sentences)
-
-        for score, a, b in duplicates:
-            if score > 0.5:
-                assert (a, b) in [(0, 1), (2, 3), (2, 4), (3, 4), (5, 6), (5, 7), (6, 7)]
-
-    def test_pairwise_scores(self):
-        a = np.random.randn(50, 100)
-        b = np.random.randn(50, 100)
-
-        # Pairwise cos
-        sklearn_pairwise = 1 - sklearn.metrics.pairwise.paired_cosine_distances(a, b)
-        pytorch_cos_scores = util.pairwise_cos_sim(a, b).numpy()
-        assert np.allclose(sklearn_pairwise, pytorch_cos_scores)
+from sentence_transformers import SentenceTransformer, util
 
 
-if "__main__" == __name__:
-    unittest.main()
+def test_normalize_embeddings():
+    """Tests the correct computation of util.normalize_embeddings"""
+    embedding_size = 100
+    a = torch.tensor(np.random.randn(50, embedding_size))
+    a_norm = util.normalize_embeddings(a)
+
+    for embedding in a_norm:
+        assert len(embedding) == embedding_size
+        emb_norm = torch.norm(embedding)
+        assert abs(emb_norm.item() - 1) < 0.0001
+
+
+def test_pytorch_cos_sim():
+    """Tests the correct computation of util.pytorch_cos_scores"""
+    a = np.random.randn(50, 100)
+    b = np.random.randn(50, 100)
+
+    sklearn_pairwise = sklearn.metrics.pairwise.cosine_similarity(a, b)
+    pytorch_cos_scores = util.pytorch_cos_sim(a, b).numpy()
+    for i in range(len(sklearn_pairwise)):
+        for j in range(len(sklearn_pairwise[i])):
+            assert abs(sklearn_pairwise[i][j] - pytorch_cos_scores[i][j]) < 0.001
+
+
+def test_semantic_search():
+    """Tests util.semantic_search function"""
+    num_queries = 20
+    num_k = 10
+
+    doc_emb = torch.tensor(np.random.randn(1000, 100))
+    q_emb = torch.tensor(np.random.randn(num_queries, 100))
+    hits = util.semantic_search(
+        q_emb, doc_emb, top_k=num_k, query_chunk_size=5, corpus_chunk_size=17
+    )
+    assert len(hits) == num_queries
+    assert len(hits[0]) == num_k
+
+    # Sanity Check of the results
+    cos_scores = util.pytorch_cos_sim(q_emb, doc_emb)
+    cos_scores_values, cos_scores_idx = cos_scores.topk(num_k)
+    cos_scores_values = cos_scores_values.cpu().tolist()
+    cos_scores_idx = cos_scores_idx.cpu().tolist()
+
+    for qid in range(num_queries):
+        for hit_num in range(num_k):
+            assert hits[qid][hit_num]['corpus_id'] == cos_scores_idx[qid][hit_num]
+            assert (
+                np.abs(hits[qid][hit_num]['score'] - cos_scores_values[qid][hit_num])
+                < 0.001
+            )
+
+
+def test_paraphrase_mining():
+    model = SentenceTransformer('all-MiniLM-L6-v2')
+    sentences = [
+        "This is a test",
+        "This is a test!",
+        "The cat sits on mat",
+        "The cat sits on the mat",
+        "On the mat a cat sits",
+        "A man eats pasta",
+        "A woman eats pasta",
+        "A man eats spaghetti",
+    ]
+    duplicates = util.paraphrase_mining(model, sentences)
+
+    for score, a, b in duplicates:
+        if score > 0.5:
+            assert (a, b) in [(0, 1), (2, 3), (2, 4), (3, 4), (5, 6), (5, 7), (6, 7)]
+
+
+def test_pairwise_scores():
+    a = np.random.randn(50, 100)
+    b = np.random.randn(50, 100)
+
+    # Pairwise cos
+    sklearn_pairwise = 1 - sklearn.metrics.pairwise.paired_cosine_distances(a, b)
+    pytorch_cos_scores = util.pairwise_cos_sim(a, b).numpy()
+    assert np.allclose(sklearn_pairwise, pytorch_cos_scores)


### PR DESCRIPTION
What has been changed:

I refactored all tests dependent on `unittest`, replaced with `pytest`. Note: no testing behaviour was changed.

Some general things should be further improved:

1. figure out a better way to perform integration tests, especially validate training behaviour.
2. testing model inference involves a lot of model downloading, maybe test from HF inference endpoint?
3. convert tests into real "unittest" and mock responses.


Fast tests all passed (`pytest -s -v tests`):

```
============================== 32 passed, 1 skipped, 11 deselected, 4 warnings in 402.78s (0:06:42) ==============================
```

slow tests all passed (`pytest -s -v -m slow tests`):

```
=================================== 11 passed, 33 deselected, 4 warnings in 3311.94s (0:55:11) ===================================
```