### PR TITLE
[`feat`] Add revision to load a specific model version

### DIFF
--- a/sentence_transformers/util.py
+++ b/sentence_transformers/util.py
@@ -473,13 +473,20 @@ class disabled_tqdm(tqdm):
 
 
 def is_sentence_transformer_model(
-    model_name_or_path: str, token: Optional[Union[bool, str]] = None, cache_folder: Optional[str] = None
+    model_name_or_path: str,
+    token: Optional[Union[bool, str]] = None,
+    cache_folder: Optional[str] = None,
+    revision: Optional[str] = None,
 ) -> bool:
-    return bool(load_file_path(model_name_or_path, "modules.json", token, cache_folder))
+    return bool(load_file_path(model_name_or_path, "modules.json", token, cache_folder, revision=revision))
 
 
 def load_file_path(
-    model_name_or_path: str, filename: str, token: Optional[Union[bool, str]], cache_folder: Optional[str]
+    model_name_or_path: str,
+    filename: str,
+    token: Optional[Union[bool, str]],
+    cache_folder: Optional[str],
+    revision: Optional[str] = None,
 ) -> Optional[str]:
     # If file is local
     file_path = os.path.join(model_name_or_path, filename)
@@ -491,6 +498,7 @@ def load_file_path(
         return hf_hub_download(
             model_name_or_path,
             filename=filename,
+            revision=revision,
             library_name="sentence-transformers",
             token=token,
             cache_dir=cache_folder,
@@ -500,7 +508,11 @@ def load_file_path(
 
 
 def load_dir_path(
-    model_name_or_path: str, directory: str, token: Optional[Union[bool, str]], cache_folder: Optional[str]
+    model_name_or_path: str,
+    directory: str,
+    token: Optional[Union[bool, str]],
+    cache_folder: Optional[str],
+    revision: Optional[str] = None,
 ) -> Optional[str]:
     # If file is local
     dir_path = os.path.join(model_name_or_path, directory)
@@ -509,6 +521,7 @@ def load_dir_path(
 
     download_kwargs = {
         "repo_id": model_name_or_path,
+        "revision": revision,
         "allow_patterns": f"{directory}/**",
         "library_name": "sentence-transformers",
         "token": token,

--- a/tests/test_sentence_transformer.py
+++ b/tests/test_sentence_transformer.py
@@ -171,3 +171,18 @@ def test_save_to_hub(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureF
             caplog.record_tuples[0][2]
             == 'Providing an `organization` to `save_to_hub` is deprecated, please use `repo_id="sentence-transformers-testing/stsb-bert-tiny-safetensors"` instead.'
         )
+
+
+def test_load_with_revision() -> None:
+    main_model = SentenceTransformer("sentence-transformers-testing/stsb-bert-tiny-safetensors", revision="main")
+    latest_model = SentenceTransformer(
+        "sentence-transformers-testing/stsb-bert-tiny-safetensors", revision="f3cb857cba53019a20df283396bcca179cf051a4"
+    )
+    older_model = SentenceTransformer(
+        "sentence-transformers-testing/stsb-bert-tiny-safetensors", revision="ba33022fdf0b0fc2643263f0726f44d0a07d0e24"
+    )
+
+    test_sentence = ["Hello there!"]
+    main_embeddings = main_model.encode(test_sentence, convert_to_tensor=True)
+    assert torch.equal(main_embeddings, latest_model.encode(test_sentence, convert_to_tensor=True))
+    assert not torch.equal(main_embeddings, older_model.encode(test_sentence, convert_to_tensor=True))


### PR DESCRIPTION
Supersedes #1645, closes #1373

Hello!

## Pull Request overview
* Add revision to load a specific model version
* Plus some tests

## Details
This adds the `revision` keyword argument to `SentenceTransformers`, and propagates it down to all `huggingface_hub` and `transformer` functions that load from the Hub. The diff is fairly big, but the change is in essence really simple.

I also added some tests to show that different revisions can indeed be successfully loaded.

Thanks @plynch-chwy @yoko92 @amine-mf for your comments on #1645 to notify me of this missing feature.

- Tom Aarsen