### PR TITLE
[`examples`] Replace _target_device with device in semantic search example

### DIFF
--- a/examples/applications/semantic-search/semantic_search_quora_pytorch.py
+++ b/examples/applications/semantic-search/semantic_search_quora_pytorch.py
@@ -69,7 +69,7 @@ else:
 print("Corpus loaded with {} sentences / embeddings".format(len(corpus_sentences)))
 
 # Move embeddings to the target device of the model
-corpus_embeddings = corpus_embeddings.to(model._target_device)
+corpus_embeddings = corpus_embeddings.to(model.device)
 
 while True:
     inp_question = input("Please enter a question: ")


### PR DESCRIPTION
Hello!

## Pull Request overview
* Replace `_target_device` with `device` in semantic search example

## Details
Nowadays, `device` works as expected, so we don't have to rely on `_target_device` for `SentenceTransformer` anymore.

- Tom Aarsen