### PR TITLE
bump the minimum supported `torch` version to 1.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The following publications are integrated in this framework:
 
 ## Installation
 
-We recommend **Python 3.8** or higher, **[PyTorch 1.6.0](https://pytorch.org/get-started/locally/)** or higher and **[transformers v4.23.0](https://github.com/huggingface/transformers)** or higher. The code does **not** work with Python 2.7.
+We recommend **Python 3.8** or higher, **[PyTorch 1.11.0](https://pytorch.org/get-started/locally/)** or higher and **[transformers v4.32.0](https://github.com/huggingface/transformers)** or higher. The code does **not** work with Python 2.7.
 
 **Install with pip**
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,6 +1,6 @@
 # Installation
 
-We recommend **Python 3.8** or higher, **[PyTorch 1.6.0](https://pytorch.org/get-started/locally/)** or higher and **[transformers v4.6.0](https://github.com/huggingface/transformers)** or higher. The code does **not** work with Python 2.7. 
+We recommend **Python 3.8** or higher, **[PyTorch 1.11.0](https://pytorch.org/get-started/locally/)** or higher and **[transformers v4.32.0](https://github.com/huggingface/transformers)** or higher. The code does **not** work with Python 2.7. 
 
 
 

--- a/index.rst
+++ b/index.rst
@@ -18,7 +18,7 @@ You can install it using pip:
    pip install -U sentence-transformers
 
 
-We recommend **Python 3.8** or higher, and at least **PyTorch 1.6.0**. See `installation <docs/installation.html>`_ for further installation options, especially if you want to use a GPU.
+We recommend **Python 3.8** or higher, and at least **PyTorch 1.11.0**. See `installation <docs/installation.html>`_ for further installation options, especially if you want to use a GPU.
 
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 transformers>=4.32.0,<5.0.0
 tqdm
-torch>=1.6.0
+torch>=1.11.0
 numpy
 scikit-learn
 scipy

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     install_requires=[
         "transformers>=4.32.0,<5.0.0",
         "tqdm",
-        "torch>=1.6.0",
+        "torch>=1.11.0",
         "numpy",
         "scikit-learn",
         "scipy",


### PR DESCRIPTION
This PR updates the minimum supported version of `torch` to 1.11 as requested by `transformers`
https://github.com/huggingface/transformers/blob/83f9196cc44a612ef2bd5a0f721d08cb24885c1f/setup.py#L178
