### PR TITLE
[`chore`] Fix typo in training overview docs: decection -> detection

### DIFF
--- a/docs/training/overview.md
+++ b/docs/training/overview.md
@@ -262,7 +262,7 @@ In the above example, the two new tokens `[DOC]` and `[QRY]` are added to the mo
 ## Best Transformer Model
 The quality of your text embedding model depends on which transformer model you choose. Sadly we cannot infer from a better performance on e.g. the GLUE or SuperGLUE benchmark that this model will also yield better representations.
 
-To test the suitability of transformer models, I use the [training_nli_v2.py](https://github.com/UKPLab/sentence-transformers/blob/master/examples/training/nli/training_nli_v2.py) script and train on 560k (anchor, positive, negative)-triplets for 1 epoch with batch size 64. I then evaluate on 14 diverse text similarity tasks (clustering, semantic search, duplicate decection etc.) from various domains.
+To test the suitability of transformer models, I use the [training_nli_v2.py](https://github.com/UKPLab/sentence-transformers/blob/master/examples/training/nli/training_nli_v2.py) script and train on 560k (anchor, positive, negative)-triplets for 1 epoch with batch size 64. I then evaluate on 14 diverse text similarity tasks (clustering, semantic search, duplicate detection etc.) from various domains.
 
 In the following table you find the performance for different models and their performance on this benchmark:
 


### PR DESCRIPTION
Hello!

## Pull Request overview
* Fix typo in training overview docs: decection -> detection

## Details
This should speak for itself.

- Tom Aarsen