### PR TITLE
Created CoSENTLoss.py

### DIFF
--- a/docs/package_reference/losses.md
+++ b/docs/package_reference/losses.md
@@ -35,6 +35,12 @@ Sadly there is no "one size fits all" loss function. Which loss function is suit
 .. autoclass:: sentence_transformers.losses.ContrastiveTensionLoss
 ```
 
+## CoSENTLoss
+
+```eval_rst
+.. autoclass:: sentence_transformers.losses.CoSENTLoss
+```
+
 ## CosineSimilarityLoss
 
 ![SBERT Siamese Network Architecture](../img/SBERT_Siamese_Network.png "SBERT Siamese Architecture")

--- a/sentence_transformers/losses/CoSENTLoss.py
+++ b/sentence_transformers/losses/CoSENTLoss.py
@@ -7,14 +7,14 @@ from .. import util
 class CoSENTLoss(nn.Module):
     """
     This class implements CoSENT (Consistent Sentence Embedding via Similarity Ranking) loss.
-    It expects that the InputExample consists of a pair of texts and a float valued label, representing
+    It expects that each of the InputExamples consists of a pair of texts and a float valued label, representing
     the expected similarity score between the pair.
     
     
     It computes the following loss function:
 
-    loss = logsum(1+exp(s(k,l)-s(i,j))+exp...), where (i,j) and (k,l) are any of the input pairs such that the expected 
-    similarity of (i,j) is greater than (k,l). The summation is over all possible pairs of input pairs that match this condition.
+    loss = logsum(1+exp(s(k,l)-s(i,j))+exp...), where (i,j) and (k,l) are any of the input pairs in the batch such that the expected 
+    similarity of (i,j) is greater than (k,l). The summation is over all possible pairs of input pairs in the batch that match this condition.
 
     For further details, see: https://kexue.fm/archives/8847
 

--- a/sentence_transformers/losses/CoSENTLoss.py
+++ b/sentence_transformers/losses/CoSENTLoss.py
@@ -18,8 +18,8 @@ class CoSENTLoss(nn.Module):
     pairs of input pairs in the batch that match this condition.
 
     Anecdotal experiments show that this loss function produces a more powerful training signal than :class:`CosineSimilarityLoss`,
-    resulting in faster convergence and a final model with superior Spearman correlation coefficients. Consequently,
-    CoSENTLoss may be used as a drop-in replacement for :class:`CosineSimilarityLoss` in any training script.
+    resulting in faster convergence and a final model with superior performance. Consequently, CoSENTLoss may be used
+    as a drop-in replacement for :class:`CosineSimilarityLoss` in any training script.
 
     For further details, see: https://kexue.fm/archives/8847
 

--- a/sentence_transformers/losses/CoSENTLoss.py
+++ b/sentence_transformers/losses/CoSENTLoss.py
@@ -4,16 +4,17 @@ from typing import Iterable, Dict
 from ..SentenceTransformer import SentenceTransformer
 from .. import util
 
+
 class CoSENTLoss(nn.Module):
     """
     This class implements CoSENT (Consistent Sentence Embedding via Similarity Ranking) loss.
     It expects that each of the InputExamples consists of a pair of texts and a float valued label, representing
     the expected similarity score between the pair.
-    
-    
+
+
     It computes the following loss function:
 
-    loss = logsum(1+exp(s(k,l)-s(i,j))+exp...), where (i,j) and (k,l) are any of the input pairs in the batch such that the expected 
+    loss = logsum(1+exp(s(k,l)-s(i,j))+exp...), where (i,j) and (k,l) are any of the input pairs in the batch such that the expected
     similarity of (i,j) is greater than (k,l). The summation is over all possible pairs of input pairs in the batch that match this condition.
 
     For further details, see: https://kexue.fm/archives/8847
@@ -34,8 +35,8 @@ class CoSENTLoss(nn.Module):
     +================================+========================+
     | (sentence_A, sentence_B) pairs | float similarity score |
     +--------------------------------+------------------------+
-    
-    
+
+
     Example::
 
         from sentence_transformers import SentenceTransformer, losses
@@ -44,23 +45,22 @@ class CoSENTLoss(nn.Module):
         model = SentenceTransformer('bert-base-uncased')
         train_examples = [InputExample(texts=['My first sentence', 'My second sentence'], label=1.0),
                 InputExample(texts=['My third sentence', 'Unrelated sentence'], label=0.3)]
-                
+
         train_dataloader = DataLoader(train_examples, shuffle=True, batch_size=train_batch_size)
         train_loss = losses.CoSENTLoss(model=model)
     """
 
-    def __init__(self, model: SentenceTransformer, scale: float = 20.0, similarity_fct = util.pairwise_cos_sim):        
+    def __init__(self, model: SentenceTransformer, scale: float = 20.0, similarity_fct=util.pairwise_cos_sim):
         super(CoSENTLoss, self).__init__()
         self.model = model
         self.similarity_fct = similarity_fct
         self.scale = scale
 
-
     def forward(self, sentence_features: Iterable[Dict[str, Tensor]], labels: Tensor):
-        embeddings = [self.model(sentence_feature)['sentence_embedding'] for sentence_feature in sentence_features]
+        embeddings = [self.model(sentence_feature)["sentence_embedding"] for sentence_feature in sentence_features]
 
         scores = self.similarity_fct(embeddings[0], embeddings[1])
-        scores = scores*self.scale
+        scores = scores * self.scale
         scores = scores[:, None] - scores[None, :]
 
         # label matrix indicating which pairs are relevant
@@ -76,6 +76,5 @@ class CoSENTLoss(nn.Module):
 
         return loss
 
-    
     def get_config_dict(self):
         return {"scale": self.scale, "similarity_fct": self.similarity_fct.__name__}

--- a/sentence_transformers/losses/CoSENTLoss.py
+++ b/sentence_transformers/losses/CoSENTLoss.py
@@ -13,8 +13,9 @@ class CoSENTLoss(nn.Module):
 
     It computes the following loss function:
 
-    loss = logsum(1+exp(s(k,l)-s(i,j))+exp...), where (i,j) and (k,l) are any of the input pairs in the batch such that the expected
-    similarity of (i,j) is greater than (k,l). The summation is over all possible pairs of input pairs in the batch that match this condition.
+    ``loss = logsum(1+exp(s(k,l)-s(i,j))+exp...)``, where ``(i,j)`` and ``(k,l)`` are any of the input pairs in the
+    batch such that the expected similarity of ``(i,j)`` is greater than ``(k,l)``. The summation is over all possible
+    pairs of input pairs in the batch that match this condition.
 
     Anecdotal experiments show that this loss function produces a more powerful training signal than :class:`CosineSimilarityLoss`,
     resulting in faster convergence and a final model with superior Spearman correlation coefficients. Consequently,
@@ -22,35 +23,32 @@ class CoSENTLoss(nn.Module):
 
     For further details, see: https://kexue.fm/archives/8847
 
-
     :param model: SentenceTransformerModel
-    :param similarity_fct: Function to compute the PAIRWISE similarity between embeddings. Default is util.pairwise_cos_sim.
+    :param similarity_fct: Function to compute the PAIRWISE similarity between embeddings. Default is ``util.pairwise_cos_sim``.
     :param scale: Output of similarity function is multiplied by scale value. Represents the inverse temperature.
-
 
     Requirements:
         - Sentence pairs with corresponding similarity scores in range of the similarity function. Default is [-1,1].
 
-
     Inputs:
-    +--------------------------------+------------------------+
-    | Texts                          | Labels                 |
-    +================================+========================+
-    | (sentence_A, sentence_B) pairs | float similarity score |
-    +--------------------------------+------------------------+
+        +--------------------------------+------------------------+
+        | Texts                          | Labels                 |
+        +================================+========================+
+        | (sentence_A, sentence_B) pairs | float similarity score |
+        +--------------------------------+------------------------+
 
+    Example:
+        ::
 
-    Example::
+            from sentence_transformers import SentenceTransformer, losses
+            from sentence_transformers.readers import InputExample
 
-        from sentence_transformers import SentenceTransformer, losses
-        from sentence_transformers.readers import InputExample
+            model = SentenceTransformer('bert-base-uncased')
+            train_examples = [InputExample(texts=['My first sentence', 'My second sentence'], label=1.0),
+                    InputExample(texts=['My third sentence', 'Unrelated sentence'], label=0.3)]
 
-        model = SentenceTransformer('bert-base-uncased')
-        train_examples = [InputExample(texts=['My first sentence', 'My second sentence'], label=1.0),
-                InputExample(texts=['My third sentence', 'Unrelated sentence'], label=0.3)]
-
-        train_dataloader = DataLoader(train_examples, shuffle=True, batch_size=train_batch_size)
-        train_loss = losses.CoSENTLoss(model=model)
+            train_dataloader = DataLoader(train_examples, shuffle=True, batch_size=train_batch_size)
+            train_loss = losses.CoSENTLoss(model=model)
     """
 
     def __init__(self, model: SentenceTransformer, scale: float = 20.0, similarity_fct=util.pairwise_cos_sim):

--- a/sentence_transformers/losses/CoSENTLoss.py
+++ b/sentence_transformers/losses/CoSENTLoss.py
@@ -1,0 +1,81 @@
+import torch
+from torch import nn, Tensor
+from typing import Iterable, Dict
+from ..SentenceTransformer import SentenceTransformer
+from .. import util
+
+class CoSENTLoss(nn.Module):
+    """
+    This class implements CoSENT (Consistent Sentence Embedding via Similarity Ranking) loss.
+    It expects that the InputExample consists of a pair of texts and a float valued label, representing
+    the expected similarity score between the pair.
+    
+    
+    It computes the following loss function:
+
+    loss = logsum(1+exp(s(k,l)-s(i,j))+exp...), where (i,j) and (k,l) are any of the input pairs such that the expected 
+    similarity of (i,j) is greater than (k,l). The summation is over all possible pairs of input pairs that match this condition.
+
+    For further details, see: https://kexue.fm/archives/8847
+
+
+    :param model: SentenceTransformerModel
+    :param similarity_fct: Function to compute the PAIRWISE similarity between embeddings. Default is util.pairwise_cos_sim.
+    :param scale: Output of similarity function is multiplied by scale value. Represents the inverse temperature.
+
+
+    Requirements:
+        - Sentence pairs with corresponding similarity scores in range of the similarity function. Default is [-1,1].
+
+
+    Inputs:
+    +--------------------------------+------------------------+
+    | Texts                          | Labels                 |
+    +================================+========================+
+    | (sentence_A, sentence_B) pairs | float similarity score |
+    +--------------------------------+------------------------+
+    
+    
+    Example::
+
+        from sentence_transformers import SentenceTransformer, losses
+        from sentence_transformers.readers import InputExample
+
+        model = SentenceTransformer('bert-base-uncased')
+        train_examples = [InputExample(texts=['My first sentence', 'My second sentence'], label=1.0),
+                InputExample(texts=['My third sentence', 'Unrelated sentence'], label=0.3)]
+                
+        train_dataloader = DataLoader(train_examples, shuffle=True, batch_size=train_batch_size)
+        train_loss = losses.CoSENTLoss(model=model)
+    """
+
+    def __init__(self, model: SentenceTransformer, scale: float = 20.0, similarity_fct = util.pairwise_cos_sim):        
+        super(CoSENTLoss, self).__init__()
+        self.model = model
+        self.similarity_fct = similarity_fct
+        self.scale = scale
+
+
+    def forward(self, sentence_features: Iterable[Dict[str, Tensor]], labels: Tensor):
+        embeddings = [self.model(sentence_feature)['sentence_embedding'] for sentence_feature in sentence_features]
+
+        scores = self.similarity_fct(embeddings[0], embeddings[1])
+        scores = scores*self.scale
+        scores = scores[:, None] - scores[None, :]
+
+        # label matrix indicating which pairs are relevant
+        labels = labels[:, None] < labels[None, :]
+        labels = labels.float()
+
+        # mask out irrelevant pairs so they are negligible after exp()
+        scores = scores - (1 - labels) * 1e12
+
+        # append a zero as e^0 = 1
+        scores = torch.cat((torch.zeros(1).to(scores.device), scores.view(-1)), dim=0)
+        loss = torch.logsumexp(scores, dim=0)
+
+        return loss
+
+    
+    def get_config_dict(self):
+        return {"scale": self.scale, "similarity_fct": self.similarity_fct.__name__}

--- a/sentence_transformers/losses/CoSENTLoss.py
+++ b/sentence_transformers/losses/CoSENTLoss.py
@@ -11,11 +11,14 @@ class CoSENTLoss(nn.Module):
     It expects that each of the InputExamples consists of a pair of texts and a float valued label, representing
     the expected similarity score between the pair.
 
-
     It computes the following loss function:
 
     loss = logsum(1+exp(s(k,l)-s(i,j))+exp...), where (i,j) and (k,l) are any of the input pairs in the batch such that the expected
     similarity of (i,j) is greater than (k,l). The summation is over all possible pairs of input pairs in the batch that match this condition.
+
+    Anecdotal experiments show that this loss function produces a more powerful training signal than :class:`CosineSimilarityLoss`,
+    resulting in faster convergence and a final model with superior Spearman correlation coefficients. Consequently,
+    CoSENTLoss may be used as a drop-in replacement for :class:`CosineSimilarityLoss` in any training script.
 
     For further details, see: https://kexue.fm/archives/8847
 

--- a/sentence_transformers/losses/__init__.py
+++ b/sentence_transformers/losses/__init__.py
@@ -12,6 +12,7 @@ from .ContrastiveTensionLoss import (
     ContrastiveTensionLossInBatchNegatives,
     ContrastiveTensionDataLoader,
 )
+from .CoSENTLoss import CoSENTLoss
 from .OnlineContrastiveLoss import OnlineContrastiveLoss
 from .MegaBatchMarginLoss import MegaBatchMarginLoss
 from .DenoisingAutoEncoderLoss import DenoisingAutoEncoderLoss
@@ -37,6 +38,7 @@ __all__ = [
     "ContrastiveTensionLoss",
     "ContrastiveTensionLossInBatchNegatives",
     "ContrastiveTensionDataLoader",
+    "CoSENTLoss",
     "OnlineContrastiveLoss",
     "MegaBatchMarginLoss",
     "DenoisingAutoEncoderLoss",


### PR DESCRIPTION
# PR Overview

- Resolve #2438

# Details

- Implemented CoSENT loss as described in this [blogpost](https://kexue.fm/archives/8847) and the [AnglE repo](https://github.com/SeanLee97/AnglE/blob/ce6d402c794fe3ddd1c1c08a756124cd04f6bb65/angle_emb/angle.py#L67-L77).
- This loss follows the same input format as CosineSimilarityLoss, requiring each input to contain a pair of sentences and a floating point label, allowing for applications beyond two-category data. To use this loss with MNRLoss, like done [here in the AnglE repo,](https://github.com/SeanLee97/AnglE/blob/ce6d402c794fe3ddd1c1c08a756124cd04f6bb65/angle_emb/angle.py#L489-505) an [internal method](https://github.com/SeanLee97/AnglE/blob/ce6d402c794fe3ddd1c1c08a756124cd04f6bb65/angle_emb/angle.py#L120-133) must be used. I can't think of a way to use a different input format without assumptions about the labels, which would limit the applications beyond two-category data. If anyone has any ideas, take a look at the code and leave a comment!
- Subtraction by 1e^12 is how irrelevant values in the scores matrix become negligible in the logsumexp. I believe this is the constant used by the original implementation, and no other implementations have seen a need to change it. I agree, and for consistency have also used 1e^12. 
- The example in the doc string uses InputExamples, not a Dataset/DatasetDict, which will need to change in the future.