### PR TITLE
[`hotfix`] Don't require loading files for Normalize

### DIFF
--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -30,7 +30,7 @@ from .util import (
     load_file_path,
     save_to_hub_args_decorator,
 )
-from .models import Transformer, Pooling
+from .models import Transformer, Pooling, Normalize
 from .model_card_templates import ModelCardTemplate
 from . import __version__
 
@@ -1059,13 +1059,17 @@ class SentenceTransformer(nn.Sequential):
                     kwargs["tokenizer_args"] = hub_kwargs
                 module = Transformer(model_name_or_path, cache_dir=cache_folder, **kwargs)
             else:
-                module_path = load_dir_path(
-                    model_name_or_path,
-                    module_config["path"],
-                    token=token,
-                    cache_folder=cache_folder,
-                    revision=revision,
-                )
+                # Normalize does not require any files to be loaded
+                if module_class == Normalize:
+                    module_path = None
+                else:
+                    module_path = load_dir_path(
+                        model_name_or_path,
+                        module_config["path"],
+                        token=token,
+                        cache_folder=cache_folder,
+                        revision=revision,
+                    )
                 module = module_class.load(module_path)
             modules[module_config["name"]] = module
 


### PR DESCRIPTION
Resolves #2458, Resolves #2459 (I suspect)

Hello!

## Pull Request overview
* No longer require a Normalize folder to exist.

## Details
Normally, upon saving a model, every module except for the first one (if it is `Transformer`) will result in a new directory being created. However, for Normalize, that often means that an empty directory is created, such as a `2_Normalize` directory. Normally this isn't an issue, except `git` does not like empty directories. In practice, this means that the repository will not have that folder. E.g. https://huggingface.co/intfloat/multilingual-e5-large/tree/main despite `2_Normalize` existing in https://huggingface.co/intfloat/multilingual-e5-large/blob/main/modules.json.

This appears to not be an issue on the Hub, as the `snapshot_download` still seems to happily return a path on which the folder should exist (but doesn't, as it didn't download anything), and then the Normalize initializer ignores that path. No problems there.

However, for local models where the `2_Normalize` does not exist, an error does occur. See #2458 and #2459 for details.

This PR should solve the problem by completely avoiding downloading/verifying the existence of any Normalize folders/files.

You can install this for the time being with:
```
pip install git+https://github.com/tomaarsen/sentence-transformers@hotfix/dont_require_normalize_files
```

cc: @mariokostelac @CloudRobot @2uu @wjdunlop

- Tom Aarsen