### PR TITLE
[`fix`] Avoid sets and dicts in `BinaryClassificationEvaluator` when sentences are not hashable

### DIFF
--- a/sentence_transformers/evaluation/BinaryClassificationEvaluator.py
+++ b/sentence_transformers/evaluation/BinaryClassificationEvaluator.py
@@ -144,13 +144,22 @@ class BinaryClassificationEvaluator(SentenceEvaluator):
         return main_score
 
     def compute_metrices(self, model):
-        sentences = list(set(self.sentences1 + self.sentences2))
-        embeddings = model.encode(
-            sentences, batch_size=self.batch_size, show_progress_bar=self.show_progress_bar, convert_to_numpy=True
-        )
-        emb_dict = {sent: emb for sent, emb in zip(sentences, embeddings)}
-        embeddings1 = [emb_dict[sent] for sent in self.sentences1]
-        embeddings2 = [emb_dict[sent] for sent in self.sentences2]
+        try:
+            # If the sentences are hashable, then we can use a set to avoid embedding the same sentences multiple times
+            sentences = list(set(self.sentences1 + self.sentences2))
+            embeddings = model.encode(
+                sentences, batch_size=self.batch_size, show_progress_bar=self.show_progress_bar, convert_to_numpy=True
+            )
+            emb_dict = {sent: emb for sent, emb in zip(sentences, embeddings)}
+            embeddings1 = [emb_dict[sent] for sent in self.sentences1]
+            embeddings2 = [emb_dict[sent] for sent in self.sentences2]
+        except TypeError:
+            # Otherwise we just embed everything, e.g. if the sentences are images for evaluating a CLIP model
+            embeddings = model.encode(
+                self.sentences1 + self.sentences2, batch_size=self.batch_size, show_progress_bar=self.show_progress_bar, convert_to_numpy=True
+            )
+            embeddings1 = embeddings[:len(self.sentences1)]
+            embeddings2 = embeddings[len(self.sentences1):]
 
         cosine_scores = 1 - paired_cosine_distances(embeddings1, embeddings2)
         manhattan_distances = paired_manhattan_distances(embeddings1, embeddings2)

--- a/sentence_transformers/evaluation/BinaryClassificationEvaluator.py
+++ b/sentence_transformers/evaluation/BinaryClassificationEvaluator.py
@@ -156,10 +156,13 @@ class BinaryClassificationEvaluator(SentenceEvaluator):
         except TypeError:
             # Otherwise we just embed everything, e.g. if the sentences are images for evaluating a CLIP model
             embeddings = model.encode(
-                self.sentences1 + self.sentences2, batch_size=self.batch_size, show_progress_bar=self.show_progress_bar, convert_to_numpy=True
+                self.sentences1 + self.sentences2,
+                batch_size=self.batch_size,
+                show_progress_bar=self.show_progress_bar,
+                convert_to_numpy=True,
             )
-            embeddings1 = embeddings[:len(self.sentences1)]
-            embeddings2 = embeddings[len(self.sentences1):]
+            embeddings1 = embeddings[: len(self.sentences1)]
+            embeddings2 = embeddings[len(self.sentences1) :]
 
         cosine_scores = 1 - paired_cosine_distances(embeddings1, embeddings2)
         manhattan_distances = paired_manhattan_distances(embeddings1, embeddings2)


### PR DESCRIPTION
Resolves #2461

Hello!

## Pull Request overview
* If hashing fails in `BinaryClassificationEvaluator`, then retry without sets and dicts.

## Details
The BinaryClassificationEvaluator currently does not work for evaluating CLIP models, as can be seen in #2461. This is because the evaluator avoids embedding duplicate sentences through hashing, but this hashing is not possible for images.
This PR wraps the hashing in a try-except and otherwise retries without hashing.

- Tom Aarsen