### PR TITLE
Add support for Ascend NPU

### DIFF
--- a/examples/applications/semantic-search/semantic_search_wikipedia_qa.py
+++ b/examples/applications/semantic-search/semantic_search_wikipedia_qa.py
@@ -52,8 +52,8 @@ if model_name == "nq-distilbert-base-v1":
 
     corpus_embeddings = torch.load(embeddings_filepath)
     corpus_embeddings = corpus_embeddings.float()  # Convert embedding file to float
-    if torch.cuda.is_available():
-        corpus_embeddings = corpus_embeddings.to("cuda")
+    device = util.get_device_name()
+    corpus_embeddings = corpus_embeddings.to(device)
 else:  # Here, we compute the corpus_embeddings from scratch (which can take a while depending on the GPU)
     corpus_embeddings = bi_encoder.encode(passages, convert_to_tensor=True, show_progress_bar=True)
 


### PR DESCRIPTION
This PR integrates Ascend NPU hardware capabilities into the sentence-transformers, and enables users to leverage the NPUs for training and inference of embedding models.

Ascend NPU is an AI processor that support AI frameworks like [PyTorch](https://pytorch.org/blog/huawei-joins-pytorch/), TensorFlow, which has already integrated by transformers/accelerate/deepspeed and others popular deepspeed related software and tools.

cc @tomaarsen