### PR TITLE
Correct Semantic Search Code Snippet

### DIFF
--- a/docs/pretrained_models.md
+++ b/docs/pretrained_models.md
@@ -28,7 +28,7 @@ The following models have been specifically trained for **Semantic Search**: Giv
 ```python
 from sentence_transformers import SentenceTransformer, util
 
-model = SentenceTransformer("multi-qa-MiniLM-L6-cos-v1")
+model = SentenceTransformer("multi-qa-MiniLM-L6-dot-v1")
 
 query_embedding = model.encode("How big is London")
 passage_embedding = model.encode([


### PR DESCRIPTION
Add the correct `model_name` for the example in the docs on **Semantic Search**. Align evaluation function (dot product) with model trained toward dot products for multi-QA task code block shown.