### PR TITLE
[`deps`] Remove the sentencepiece & nltk dependencies

### DIFF
--- a/examples/applications/retrieve_rerank/in_document_search_crossencoder.py
+++ b/examples/applications/retrieve_rerank/in_document_search_crossencoder.py
@@ -13,6 +13,8 @@ Note: As we score the [query, passage]-pair for every new query, this search met
 becomes at some point in-efficient if the document gets too large.
 
 Usage: python in_document_search_crossencoder.py
+
+Note: Requires NLTK: `pip install nltk`
 """
 
 from sentence_transformers import CrossEncoder

--- a/examples/applications/text-summarization/text-summarization.py
+++ b/examples/applications/text-summarization/text-summarization.py
@@ -14,6 +14,8 @@ New York City (NYC), often called simply New York, is the most populous city in 
 Anchored by Wall Street in the Financial District of Lower Manhattan, New York City has been called both the world's leading financial center and the most financially powerful city in the world, and is home to the world's two largest stock exchanges by total market capitalization, the New York Stock Exchange and NASDAQ.
 New York City has been described as the cultural, financial, and media capital of the world, significantly influencing commerce, entertainment, research, technology, education, politics, tourism, art, fashion, and sports.
 If the New York metropolitan area were a sovereign state, it would have the eighth-largest economy in the world.
+
+Note: Requires NLTK: `pip install nltk`
 """
 import nltk
 from sentence_transformers import SentenceTransformer, util

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,5 @@ torch>=1.11.0
 numpy
 scikit-learn
 scipy
-nltk
 huggingface-hub>=0.15.1
 Pillow

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,5 @@ numpy
 scikit-learn
 scipy
 nltk
-sentencepiece
 huggingface-hub>=0.15.1
 Pillow

--- a/sentence_transformers/datasets/DenoisingAutoEncoderDataset.py
+++ b/sentence_transformers/datasets/DenoisingAutoEncoderDataset.py
@@ -2,8 +2,7 @@ from torch.utils.data import Dataset
 from typing import List
 from ..readers.InputExample import InputExample
 import numpy as np
-import nltk
-from nltk.tokenize.treebank import TreebankWordDetokenizer
+from transformers.utils.import_utils import is_nltk_available, NLTK_IMPORT_ERROR
 
 
 class DenoisingAutoEncoderDataset(Dataset):
@@ -17,6 +16,9 @@ class DenoisingAutoEncoderDataset(Dataset):
     """
 
     def __init__(self, sentences: List[str], noise_fn=lambda s: DenoisingAutoEncoderDataset.delete(s)):
+        if not is_nltk_available():
+            raise ImportError(NLTK_IMPORT_ERROR.format(self.__class__.__name__))
+
         self.sentences = sentences
         self.noise_fn = noise_fn
 
@@ -30,7 +32,9 @@ class DenoisingAutoEncoderDataset(Dataset):
     # Deletion noise.
     @staticmethod
     def delete(text, del_ratio=0.6):
-        words = nltk.word_tokenize(text)
+        from nltk import word_tokenize, TreebankWordDetokenizer
+
+        words = word_tokenize(text)
         n = len(words)
         if n == 0:
             return text

--- a/sentence_transformers/models/tokenizer/PhraseTokenizer.py
+++ b/sentence_transformers/models/tokenizer/PhraseTokenizer.py
@@ -5,7 +5,7 @@ import os
 import json
 import logging
 from .WordTokenizer import WordTokenizer, ENGLISH_STOP_WORDS
-import nltk
+from transformers.utils.import_utils import is_nltk_available, NLTK_IMPORT_ERROR
 
 
 logger = logging.getLogger(__name__)
@@ -26,6 +26,9 @@ class PhraseTokenizer(WordTokenizer):
         ngram_separator: str = "_",
         max_ngram_length: int = 5,
     ):
+        if not is_nltk_available():
+            raise ImportError(NLTK_IMPORT_ERROR.format(self.__class__.__name__))
+
         self.stop_words = set(stop_words)
         self.do_lower_case = do_lower_case
         self.ngram_separator = ngram_separator
@@ -55,7 +58,9 @@ class PhraseTokenizer(WordTokenizer):
             logger.info("PhraseTokenizer - Num phrases: {}".format(len(self.ngram_lookup)))
 
     def tokenize(self, text: str) -> List[int]:
-        tokens = nltk.word_tokenize(text, preserve_line=True)
+        from nltk import word_tokenize
+
+        tokens = word_tokenize(text, preserve_line=True)
 
         # phrase detection
         for ngram_len in sorted(self.ngram_lengths, reverse=True):

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,6 @@ setup(
         "numpy",
         "scikit-learn",
         "scipy",
-        "nltk",
         "huggingface-hub>=0.15.1",
         "Pillow",
     ],

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,6 @@ setup(
         "scikit-learn",
         "scipy",
         "nltk",
-        "sentencepiece",
         "huggingface-hub>=0.15.1",
         "Pillow",
     ],


### PR DESCRIPTION
Hello!

## Pull Request overview
* Remove the sentencepiece dependency
* Remove the NLTK dependency

## Details
### sentencepiece
The `sentencepiece` dependency has become a problempoint for some users (especially on Python 3.12), and it should be optional now that `transformers` has moved to `tokenizers` for most (but not all!) models.

Now, if a user wants to load a model that requires a `sentencepiece` tokenizer (e.g. [Mahmoud8/ernie-m-base_pytorch](https://huggingface.co/Mahmoud8/ernie-m-base_pytorch)), they will be greeted with an error such as this one:
```
ImportError:
ErnieMTokenizer requires the SentencePiece library but it was not found in your environment. Checkout the instructions on the
installation page of its repo: https://github.com/google/sentencepiece#installation and follow the ones
that match your environment. Please note that you may need to restart your runtime after installation.
```

The only models for which this is relevant are ones from here: https://github.com/huggingface/transformers/blob/main/src/transformers/models/auto/tokenization_auto.py#L170
Which have a tokenizer in the first entry of the tuple with `if is_sentencepiece_available() else None`, and `None` as the second entry. The second entry normally has the fast `tokenizers`-based tokenizer.

### NLTK
NLTK was only being used in 2 (rarely used) files & 2 examples. I've imported functionality from `transformers` to deal with a smooth error if PhraseTokenizer or DenoisingAutoEncoderDataset are used without NLTK being installed.

- Tom Aarsen