### PR TITLE
[`feat`] Add prompt templates

### DIFF
--- a/docs/pretrained_models.md
+++ b/docs/pretrained_models.md
@@ -132,6 +132,59 @@ We further provide this multilingual text-image model:
 
 ## Other Models
 
+### INSTRUCTOR models
+As of Sentence Transformers 2.4.0, some INSTRUCTOR models such as [hkunlp/instructor-large](https://huggingface.co/hkunlp/instructor-large) are natively supported in Sentence Transformers. These models are special, as they are trained with instructions in mind. Notably, the primary difference between normal Sentence Transformer models and Instructor models is that the latter do not include the instructions themselves in the pooling step.
+
+The following models work out of the box:
+* [hkunlp/instructor-base](https://huggingface.co/hkunlp/instructor-base)
+* [hkunlp/instructor-large](https://huggingface.co/hkunlp/instructor-large)
+* [hkunlp/instructor-xl](https://huggingface.co/hkunlp/instructor-xl)
+
+You can use these models like so:
+
+```python
+from sentence_transformers import SentenceTransformer
+
+model = SentenceTransformer("hkunlp/instructor-large")
+embeddings = model.encode(
+    [
+        "Dynamical Scalar Degree of Freedom in Horava-Lifshitz Gravity",
+        "Comparison of Atmospheric Neutrino Flux Calculations at Low Energies",
+        "Fermion Bags in the Massive Gross-Neveu Model",
+        "QCD corrections to Associated t-tbar-H production at the Tevatron",
+    ],
+    prompt="Represent the Medicine sentence for clustering: ",
+)
+print(embeddings.shape)
+# => (4, 768)
+```
+
+For example, for information retrieval:
+```python
+from sentence_transformers import SentenceTransformer
+from sentence_transformers.util import cos_sim
+
+model = SentenceTransformer("hkunlp/instructor-large")
+query = "where is the food stored in a yam plant"
+query_instruction = (
+    "Represent the Wikipedia question for retrieving supporting documents: "
+)
+corpus = [
+    'Yams are perennial herbaceous vines native to Africa, Asia, and the Americas and cultivated for the consumption of their starchy tubers in many temperate and tropical regions. The tubers themselves, also called "yams", come in a variety of forms owing to numerous cultivars and related species.',
+    "The disparate impact theory is especially controversial under the Fair Housing Act because the Act regulates many activities relating to housing, insurance, and mortgage loansâ€”and some scholars have argued that the theory's use under the Fair Housing Act, combined with extensions of the Community Reinvestment Act, contributed to rise of sub-prime lending and the crash of the U.S. housing market and ensuing global economic recession",
+    "Disparate impact in United States labor law refers to practices in employment, housing, and other areas that adversely affect one group of people of a protected characteristic more than another, even though rules applied by employers or landlords are formally neutral. Although the protected classes vary by statute, most federal civil rights laws protect based on race, color, religion, national origin, and sex as protected traits, and some laws include disability status and other traits as well.",
+]
+corpus_instruction = "Represent the Wikipedia document for retrieval: "
+
+query_embedding = model.encode(query, prompt=query_instruction)
+corpus_embeddings = model.encode(corpus, prompt=corpus_instruction)
+similarities = cos_sim(query_embedding, corpus_embeddings)
+print(similarities)
+# => tensor([[0.8835, 0.7037, 0.6970]])
+```
+
+All other Instructor models either 1) will not load as they refer to `InstructorEmbedding` in their `modules.json` or 2) require calling `model.set_pooling_include_prompt(include_prompt=False)`.
+
 ### Scientific Publications
 [SPECTER](https://arxiv.org/abs/2004.07180) is a model trained on scientific citations and can be used to estimate the similarity of two publications. We can use it to find similar papers.
 
@@ -169,7 +222,7 @@ You can index the passages as shown [here](../examples/applications/semantic-sea
 
 
 
-**DPR-Models**
+### DPR-Models
 
 In [Dense Passage Retrieval  for Open-Domain Question Answering](https://arxiv.org/abs/2004.04906)  Karpukhin et al. trained models based on [Google's Natural Questions dataset](https://ai.google.com/research/NaturalQuestions):
 - **facebook-dpr-ctx_encoder-single-nq-base** 

--- a/examples/applications/computing-embeddings/README.md
+++ b/examples/applications/computing-embeddings/README.md
@@ -55,21 +55,21 @@ The relevant method to encode a set of sentences / texts is `model.encode()`. In
 Some models require using specific text *prompts* to achieve optimal performance. For example, with [intfloat/multilingual-e5-large](https://huggingface.co/intfloat/multilingual-e5-large) you should prefix all queries with `query: ` and all passages with `passage: `. Another example is [BAAI/bge-large-en-v1.5](https://huggingface.co/BAAI/bge-large-en-v1.5), which performs best for retrieval when the input texts are prefixed with `Represent this sentence for searching relevant passages: `. 
 
 Sentence Transformer models can be initialized with `prompts` and `default_prompt_name` parameters:
-* `prompts` is an optional argument that accepts a dictionary of prompts with prompt names to prompt format-strings. The `{}` will be replaced with the input text during inference. For example,
+* `prompts` is an optional argument that accepts a dictionary of prompts with prompt names to prompt texts. The prompt will be prepended to the input text during inference. For example,
     ```python
     model = SentenceTransformer(
         "intfloat/multilingual-e5-large",
         prompts={
-            "classification": "Classify the following text: {}",
-            "retrieval": "Retrieve semantically similar text: {}",
-            "clustering": "Identify the topic or theme based on the text: {}",
+            "classification": "Classify the following text: ",
+            "retrieval": "Retrieve semantically similar text: ",
+            "clustering": "Identify the topic or theme based on the text: ",
         },
     )
     # or
     model.prompts = {
-        "classification": "Classify the following text: {}",
-        "retrieval": "Retrieve semantically similar text: {}",
-        "clustering": "Identify the topic or theme based on the text: {}",
+        "classification": "Classify the following text: ",
+        "retrieval": "Retrieve semantically similar text: ",
+        "clustering": "Identify the topic or theme based on the text: ",
     }
     ```
 * `default_prompt_name` is an optional argument that determines the default prompt to be used. It has to correspond with a prompt name from `prompts`. If `None`, then no prompt is used by default. For example,
@@ -77,9 +77,9 @@ Sentence Transformer models can be initialized with `prompts` and `default_promp
     model = SentenceTransformer(
         "intfloat/multilingual-e5-large",
         prompts={
-            "classification": "Classify the following text: {}",
-            "retrieval": "Retrieve semantically similar text: {}",
-            "clustering": "Identify the topic or theme based on the text: {}",
+            "classification": "Classify the following text: ",
+            "retrieval": "Retrieve semantically similar text: ",
+            "clustering": "Identify the topic or theme based on the text: ",
         },
         default_prompt_name="retrieval",
     )
@@ -89,10 +89,10 @@ Sentence Transformer models can be initialized with `prompts` and `default_promp
 Both of these parameters can also be specified in the `config_sentence_transformers.json` file of a saved model. That way, you won't have to specify these options manually when loading. When you save a Sentence Transformer model, these options will be automatically saved as well.
 
 
-During inference, prompts can be applied in a few different ways:
+During inference, prompts can be applied in a few different ways. All of these scenarios result in identical texts being embedded:
 1. Explicitly using the `prompt` option in `SentenceTransformer.encode`:
     ```python
-    embeddings = model.encode("How to bake a strawberry cake", prompt="Retrieve semantically similar text: {}")
+    embeddings = model.encode("How to bake a strawberry cake", prompt="Retrieve semantically similar text: ")
     ```
 2. Explicitly using the `prompt_name` option in `SentenceTransformer.encode` by relying on the prompts loaded from a) initialization or b) the model config.
     ```python

--- a/examples/applications/computing-embeddings/README.md
+++ b/examples/applications/computing-embeddings/README.md
@@ -51,6 +51,59 @@ The relevant method to encode a set of sentences / texts is `model.encode()`. In
     :members: encode
 ```
 
+## Prompt Templates
+Some models require using specific text *prompts* to achieve optimal performance. For example, with [intfloat/multilingual-e5-large](https://huggingface.co/intfloat/multilingual-e5-large) you should prefix all queries with `query: ` and all passages with `passage: `. Another example is [BAAI/bge-large-en-v1.5](https://huggingface.co/BAAI/bge-large-en-v1.5), which performs best for retrieval when the input texts are prefixed with `Represent this sentence for searching relevant passages: `. 
+
+Sentence Transformer models can be initialized with `prompts` and `default_prompt_name` parameters:
+* `prompts` is an optional argument that accepts a dictionary of prompts with prompt names to prompt format-strings. The `{}` will be replaced with the input text during inference. For example,
+    ```python
+    model = SentenceTransformer(
+        "intfloat/multilingual-e5-large",
+        prompts={
+            "classification": "Classify the following text: {}",
+            "retrieval": "Retrieve semantically similar text: {}",
+            "clustering": "Identify the topic or theme based on the text: {}",
+        },
+    )
+    # or
+    model.prompts = {
+        "classification": "Classify the following text: {}",
+        "retrieval": "Retrieve semantically similar text: {}",
+        "clustering": "Identify the topic or theme based on the text: {}",
+    }
+    ```
+* `default_prompt_name` is an optional argument that determines the default prompt to be used. It has to correspond with a prompt name from `prompts`. If `None`, then no prompt is used by default. For example,
+    ```python
+    model = SentenceTransformer(
+        "intfloat/multilingual-e5-large",
+        prompts={
+            "classification": "Classify the following text: {}",
+            "retrieval": "Retrieve semantically similar text: {}",
+            "clustering": "Identify the topic or theme based on the text: {}",
+        },
+        default_prompt_name="retrieval",
+    )
+    # or
+    model.default_prompt_name="retrieval"
+    ```
+Both of these parameters can also be specified in the `config_sentence_transformers.json` file of a saved model. That way, you won't have to specify these options manually when loading. When you save a Sentence Transformer model, these options will be automatically saved as well.
+
+
+During inference, prompts can be applied in a few different ways:
+1. Explicitly using the `prompt` option in `SentenceTransformer.encode`:
+    ```python
+    embeddings = model.encode("How to bake a strawberry cake", prompt="Retrieve semantically similar text: {}")
+    ```
+2. Explicitly using the `prompt_name` option in `SentenceTransformer.encode` by relying on the prompts loaded from a) initialization or b) the model config.
+    ```python
+    embeddings = model.encode("How to bake a strawberry cake", prompt_name="retrieval")
+    ```
+3. If `prompt` nor `prompt_name` are specified in `SentenceTransformer.encode`, then the prompt specified by `default_prompt_name` will be applied. If it is `None`, then no prompt will be applied.
+    ```python
+    embeddings = model.encode("How to bake a strawberry cake")
+    ```
+
+
 ## Input Sequence Length
 Transformer models like BERT / RoBERTa / DistilBERT etc. the runtime and the memory requirement grows quadratic with the input length. This limits transformers to inputs of certain lengths. A common value for BERT & Co. are 512 word pieces, which corresponds to about 300-400 words (for English). Longer texts than this are truncated to the first x word pieces.
 

--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -1072,12 +1072,6 @@ class SentenceTransformer(nn.Sequential):
             if not self.prompts:
                 self.prompts = self._model_config.get("prompts", {})
             if not self.default_prompt_name:
-                # if default_prompt_name is not None and default_prompt_name not in self.prompts:
-                #     logger.warning(
-                #         f"Configured `default_prompt_name` of {default_prompt_name!r} not found in the prompts with keys {list(self.prompts.keys())!r}. "
-                #         "Setting `default_prompt_name` to `None` to disable automatic prompt use."
-                #     )
-
                 self.default_prompt_name = self._model_config.get("default_prompt_name", None)
 
         # Check if a readme exists

--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -215,7 +215,17 @@ class SentenceTransformer(nn.Sequential):
 
         if self.default_prompt_name is not None and self.default_prompt_name not in self.prompts:
             raise ValueError(
-                f"Default prompt name '{self.default_prompt_name}' not found in the configured prompts dictionary with keys {list(self.prompts.keys())!r}."
+                f"Default prompt name '{self.default_prompt_name}' not found in the configured prompts "
+                f"dictionary with keys {list(self.prompts.keys())!r}."
+            )
+
+        if self.prompts:
+            logger.info(f"{len(self.prompts)} prompts are loaded, with the keys: {list(self.prompts.keys())}")
+        if self.default_prompt_name:
+            logger.warning(
+                f"Default prompt name is set to '{self.default_prompt_name}'. "
+                "This prompt will be applied to all `encode()` calls, except if `encode()` "
+                "is called with `prompt` or `prompt_name` parameters."
             )
 
     def encode(

--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -228,9 +228,10 @@ class SentenceTransformer(nn.Sequential):
                 "is called with `prompt` or `prompt_name` parameters."
             )
 
-        # Hardcode INSTRUCTOR support by setting `include_prompt=False`.
-        # Ideally, INSTRUCTOR models should support `include_prompt` in their pooling configuration, but
+        # Ideally, INSTRUCTOR models should set `include_prompt=False` in their pooling configuration, but
         # that would be a breaking change for users currently using the InstructorEmbedding project.
+        # So, instead we hardcode setting it for the main INSTRUCTOR models, and otherwise give a warning if we
+        # suspect the user is using an INSTRUCTOR model.
         if model_name_or_path in ("hkunlp/instructor-base", "hkunlp/instructor-large", "hkunlp/instructor-xl"):
             self.set_pooling_include_prompt(include_prompt=False)
         elif (

--- a/sentence_transformers/models/Pooling.py
+++ b/sentence_transformers/models/Pooling.py
@@ -32,7 +32,8 @@ class Pooling(nn.Module):
         pooling_mode_mean_sqrt_len_tokens: bool = False,
         pooling_mode_weightedmean_tokens: bool = False,
         pooling_mode_lasttoken: bool = False,
-    ):
+        include_prompt=True,
+    ) -> None:
         super(Pooling, self).__init__()
 
         self.config_keys = [
@@ -43,6 +44,7 @@ class Pooling(nn.Module):
             "pooling_mode_mean_sqrt_len_tokens",
             "pooling_mode_weightedmean_tokens",
             "pooling_mode_lasttoken",
+            "include_prompt",
         ]
 
         if pooling_mode is not None:  # Set pooling mode by string
@@ -61,6 +63,8 @@ class Pooling(nn.Module):
         self.pooling_mode_mean_sqrt_len_tokens = pooling_mode_mean_sqrt_len_tokens
         self.pooling_mode_weightedmean_tokens = pooling_mode_weightedmean_tokens
         self.pooling_mode_lasttoken = pooling_mode_lasttoken
+
+        self.include_prompt = include_prompt
 
         pooling_mode_multiplier = sum(
             [
@@ -100,6 +104,24 @@ class Pooling(nn.Module):
     def forward(self, features: Dict[str, Tensor]):
         token_embeddings = features["token_embeddings"]
         attention_mask = features["attention_mask"]
+        if not self.include_prompt:
+            if "postfix_length" in features:
+                bs, seq_len = attention_mask.shape
+                # attention_mask shape: (bs, seq_len)
+                # Gather the indices of the 1) first 0 in the attention mask, 2) the last 1 in the attention mask
+                values, indices = torch.min(attention_mask, 1, keepdim=False)
+                gather_indices = torch.where(values == 0, indices, seq_len)
+
+                # Get indices of the last `postfix_length` tokens
+                arange = torch.arange(-features["postfix_length"] - 1, 0, device=attention_mask.device).repeat(bs, 1)
+                gather_indices = gather_indices.unsqueeze(-1) + arange
+                # Clamp indices to 0
+                gather_indices = torch.clamp(gather_indices, min=0)
+
+                # Set the attention mask to 0 for the last `postfix_length` tokens
+                attention_mask[torch.arange(bs).unsqueeze(1), gather_indices] = 0
+            if "prefix_length" in features:
+                attention_mask[:, : features["prefix_length"]] = 0
 
         ## Pooling strategy
         output_vectors = []
@@ -155,13 +177,10 @@ class Pooling(nn.Module):
             bs, seq_len, hidden_dim = token_embeddings.shape
             # attention_mask shape: (bs, seq_len)
             # Get shape [bs] indices of the last token (i.e. the last token for each batch item)
-            # argmin gives us the index of the first 0 in the attention mask; We get the last 1 index by subtracting 1
-            # Any sequence where min == 1, we use the entire sequence length since argmin = 0
-            values, indices = torch.min(attention_mask, 1, keepdim=False)
-            gather_indices = torch.where(values == 0, indices, seq_len) - 1  # Shape [bs]
-
-            # There are empty sequences, where the index would become -1 which will crash
-            gather_indices = torch.clamp(gather_indices, min=0)
+            # Use flip and max() to get the last index of 1 in the attention mask
+            values, indices = attention_mask.flip(1).max(1)
+            indices = torch.where(values == 0, seq_len - 1, indices)
+            gather_indices = seq_len - indices - 1
 
             # Turn indices from shape [bs] --> [bs, 1, hidden_dim]
             gather_indices = gather_indices.unsqueeze(-1).repeat(1, hidden_dim)

--- a/tests/test_multi_process.py
+++ b/tests/test_multi_process.py
@@ -5,18 +5,25 @@ Computes embeddings
 
 import numpy as np
 import pytest
+from typing import Optional
 
 from sentence_transformers import SentenceTransformer
 
 
 @pytest.mark.parametrize("normalize_embeddings", (False, True))
-def test_encode_multi_process(stsb_bert_tiny_model: SentenceTransformer, normalize_embeddings: bool) -> None:
+@pytest.mark.parametrize("prompt_name", (None, "retrieval"))
+def test_encode_multi_process(
+    stsb_bert_tiny_model: SentenceTransformer, normalize_embeddings: bool, prompt_name: Optional[str]
+) -> None:
     model = stsb_bert_tiny_model
+    model.prompts = {"retrieval": "Represent this sentence for searching relevant passages: {}"}
     sentences = ["This is sentence {}".format(i) for i in range(40)]
 
     # Start the multi-process pool on e.g. two CPU devices & compute the embeddings using the pool
     pool = model.start_multi_process_pool(["cpu", "cpu"])
-    emb = model.encode_multi_process(sentences, pool, chunk_size=10, normalize_embeddings=normalize_embeddings)
+    emb = model.encode_multi_process(
+        sentences, pool, chunk_size=10, normalize_embeddings=normalize_embeddings, prompt_name=prompt_name
+    )
     model.stop_multi_process_pool(pool)
     assert emb.shape == (len(sentences), 128)
 
@@ -24,7 +31,7 @@ def test_encode_multi_process(stsb_bert_tiny_model: SentenceTransformer, normali
     assert emb.sum() != 0.0
 
     # Compare against normal embeddings
-    emb_normal = model.encode(sentences, normalize_embeddings=normalize_embeddings)
+    emb_normal = model.encode(sentences, normalize_embeddings=normalize_embeddings, prompt_name=prompt_name)
     diff = np.max(np.abs(emb - emb_normal))
     assert diff < 0.001
 

--- a/tests/test_multi_process.py
+++ b/tests/test_multi_process.py
@@ -16,7 +16,7 @@ def test_encode_multi_process(
     stsb_bert_tiny_model: SentenceTransformer, normalize_embeddings: bool, prompt_name: Optional[str]
 ) -> None:
     model = stsb_bert_tiny_model
-    model.prompts = {"retrieval": "Represent this sentence for searching relevant passages: {}"}
+    model.prompts = {"retrieval": "Represent this sentence for searching relevant passages: "}
     sentences = ["This is sentence {}".format(i) for i in range(40)]
 
     # Start the multi-process pool on e.g. two CPU devices & compute the embeddings using the pool

--- a/tests/test_sentence_transformer.py
+++ b/tests/test_sentence_transformer.py
@@ -3,10 +3,13 @@ Tests general behaviour of the SentenceTransformer class
 """
 
 
+import json
 import logging
 import os
 from pathlib import Path
+import re
 import tempfile
+import numpy as np
 import pytest
 
 from huggingface_hub import HfApi, RepoUrl, GitRefs, GitRefInfo
@@ -203,3 +206,77 @@ def test_load_local_without_normalize_directory() -> None:
         # This fails in v2.3.0
         fresh_tiny_model = SentenceTransformer(str(model_path))
         assert isinstance(fresh_tiny_model, SentenceTransformer)
+
+
+def test_prompts(caplog: pytest.LogCaptureFixture) -> None:
+    model = SentenceTransformer("sentence-transformers-testing/stsb-bert-tiny-safetensors")
+    assert model.prompts == {}
+    assert model.default_prompt_name is None
+    texts = ["How to bake a chocolate cake", "Symptoms of the flu"]
+    no_prompt_embedding = model.encode(texts)
+    prompt_embedding = model.encode([f"query: {text}" for text in texts])
+    assert not np.array_equal(no_prompt_embedding, prompt_embedding)
+
+    for query in ["query: {}", "query:", "query:   "]:
+        # Test prompt="... {}"
+        model.prompts = {}
+        assert np.array_equal(model.encode(texts, prompt=query), prompt_embedding)
+
+        # Test prompt_name="..."
+        model.prompts = {"query": query}
+        assert np.array_equal(model.encode(texts, prompt_name="query"), prompt_embedding)
+
+        caplog.clear()
+        # Test prompt_name="..." & prompt="..."
+        with caplog.at_level(logging.WARNING):
+            assert np.array_equal(model.encode(texts, prompt=query, prompt_name="query"), prompt_embedding)
+            assert len(caplog.record_tuples) == 1
+            assert (
+                caplog.record_tuples[0][2]
+                == "Encode with either a `prompt`, a `prompt_name`, or neither, but not both. "
+                "Ignoring the `prompt_name` in favor of `prompt`."
+            )
+
+        with pytest.raises(
+            ValueError,
+            match=re.escape(
+                "Prompt name 'invalid_prompt_name' not found in the configured prompts dictionary with keys ['query']."
+            ),
+        ):
+            model.encode(texts, prompt_name="invalid_prompt_name")
+
+
+def test_save_load_prompts() -> None:
+    with pytest.raises(
+        ValueError,
+        match=re.escape(
+            "Default prompt name 'invalid_prompt_name' not found in the configured prompts dictionary with keys ['query']."
+        ),
+    ):
+        model = SentenceTransformer(
+            "sentence-transformers-testing/stsb-bert-tiny-safetensors",
+            prompts={"query": "query: {}"},
+            default_prompt_name="invalid_prompt_name",
+        )
+
+    model = SentenceTransformer(
+        "sentence-transformers-testing/stsb-bert-tiny-safetensors",
+        prompts={"query": "query: {}"},
+        default_prompt_name="query",
+    )
+    assert model.prompts == {"query": "query: {}"}
+    assert model.default_prompt_name == "query"
+
+    with tempfile.TemporaryDirectory() as tmp_folder:
+        model_path = Path(tmp_folder) / "tiny_model_local"
+        model.save(str(model_path))
+        config_path = model_path / "config_sentence_transformers.json"
+        assert config_path.exists()
+        with open(config_path, "r", encoding="utf8") as f:
+            saved_config = json.load(f)
+        assert saved_config["prompts"] == {"query": "query: {}"}
+        assert saved_config["default_prompt_name"] == "query"
+
+        fresh_model = SentenceTransformer(str(model_path))
+        assert fresh_model.prompts == {"query": "query: {}"}
+        assert fresh_model.default_prompt_name == "query"

--- a/tests/test_sentence_transformer.py
+++ b/tests/test_sentence_transformer.py
@@ -217,7 +217,7 @@ def test_prompts(caplog: pytest.LogCaptureFixture) -> None:
     prompt_embedding = model.encode([f"query: {text}" for text in texts])
     assert not np.array_equal(no_prompt_embedding, prompt_embedding)
 
-    for query in ["query: {}", "query:", "query:   "]:
+    for query in ["query: ", "query:", "query:   "]:
         # Test prompt="... {}"
         model.prompts = {}
         assert np.array_equal(model.encode(texts, prompt=query), prompt_embedding)
@@ -255,16 +255,16 @@ def test_save_load_prompts() -> None:
     ):
         model = SentenceTransformer(
             "sentence-transformers-testing/stsb-bert-tiny-safetensors",
-            prompts={"query": "query: {}"},
+            prompts={"query": "query: "},
             default_prompt_name="invalid_prompt_name",
         )
 
     model = SentenceTransformer(
         "sentence-transformers-testing/stsb-bert-tiny-safetensors",
-        prompts={"query": "query: {}"},
+        prompts={"query": "query: "},
         default_prompt_name="query",
     )
-    assert model.prompts == {"query": "query: {}"}
+    assert model.prompts == {"query": "query: "}
     assert model.default_prompt_name == "query"
 
     with tempfile.TemporaryDirectory() as tmp_folder:
@@ -274,9 +274,9 @@ def test_save_load_prompts() -> None:
         assert config_path.exists()
         with open(config_path, "r", encoding="utf8") as f:
             saved_config = json.load(f)
-        assert saved_config["prompts"] == {"query": "query: {}"}
+        assert saved_config["prompts"] == {"query": "query: "}
         assert saved_config["default_prompt_name"] == "query"
 
         fresh_model = SentenceTransformer(str(model_path))
-        assert fresh_model.prompts == {"query": "query: {}"}
+        assert fresh_model.prompts == {"query": "query: "}
         assert fresh_model.default_prompt_name == "query"


### PR DESCRIPTION
Closes #2439

Hello!

## Pull Request overview
* Add prompt templates

## Details
This PR adds prompt templates to SentenceTransformer models and their configuration.

### Initialization
```python
from sentence_transformers import SentenceTransformer

model = SentenceTransformer(
    "intfloat/multilingual-e5-large",
    prompts={
        "classification": "Classify the following text: {}",
        "retrieval": "Retrieve semantically similar text: {}",
        "clustering": "Identify the topic or theme based on the text: {}",
    },
    default_prompt_name="retrieval",
)
```
* `prompts` is a new (optional) argument that accepts a dictionary of prompts with prompt names to prompt format-strings.
* `default_prompt_name` is a new (optional) argument that determines the default prompt to be used. If None, then no prompt is used by default.

## Inference
1. Explicit `prompt` in `model.encode`:
   ```python
   embeddings = model.encode("How to bake a strawberry cake", prompt="Retrieve semantically similar text: {}")
   ```
2. Explicit `prompt_name` in `model.encode` by relying on the `prompts` loaded from a) initialization or b) the model config:
   ```python
   embeddings = model.encode("How to bake a strawberry cake", prompt_name="retrieval")
   ```
3. Via `model.default_prompt_name`, that prompt will be applied by default already:
   ```python
   embeddings = model.encode("How to bake a strawberry cake")
   ```

## Saved models
Upon saving a model (`model.save`), the `config_sentence_transformers.json` will now contain the `prompts` & `default_prompt_name`:
```python
{
  "__version__": {
    "sentence_transformers": "2.0.0",
    "transformers": "4.6.1",
    "pytorch": "1.8.1"
  },
  "prompts": {
    "classification": "Classify the following text: {}",
    "retrieval": "Retrieve semantically similar text: {}",
    "clustering": "Identify the topic or theme based on the text: {}"
  },
  "default_prompt_name": "retrieval"
}
```

## Loading models
If a model with the above configuration is loaded, then the prompts and `default_prompt_name` will be loaded directly into the model. This means that model authors can set the configuration & their users will automatically be able to use the prompts designed by the model authors.

## Todos
- [x] Documentation
- [x] Flag to exclude prompt tokens from pooling
- [x] INSTRUCTOR support

---

- Tom Aarsen