### PR TITLE
[`ci`] On Ubuntu CI runner, use temporary directories as cache folders for some models

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,19 +21,6 @@ jobs:
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@master
-        with:
-          root-reserve-mb: 8192
-          remove-android: 'true'
-          remove-dotnet: 'true'
-        if: matrix.os == 'ubuntu-latest'
-
-      - name: check storage
-        run: |
-          sudo df -h
-        if: matrix.os == 'ubuntu-latest'
-
       - name: Checkout code
         uses: actions/checkout@v3
 
@@ -63,3 +50,5 @@ jobs:
         shell: bash
         run: |
           pytest --durations 20 -sv tests/
+        env:
+          SENTENCE_TRANSFORMERS_HOME: "/mnt/.cache/huggingface"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,5 +50,3 @@ jobs:
         shell: bash
         run: |
           pytest --durations 20 -sv tests/
-        env:
-          SENTENCE_TRANSFORMERS_HOME: "/.cache/huggingface"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,6 +24,7 @@ jobs:
       - name: Maximize build space
         uses: easimon/maximize-build-space@master
         with:
+          root-reserve-mb: 4096
           remove-android: 'true'
           remove-dotnet: 'true'
         if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,6 +21,18 @@ jobs:
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
+      - name: Maximize build space
+        uses: easimon/maximize-build-space@master
+        with:
+          remove-android: 'true'
+          remove-dotnet: 'true'
+        if: matrix.os == 'ubuntu-latest'
+
+      - name: check storage
+        run: |
+          sudo df -h
+        if: matrix.os == 'ubuntu-latest'
+
       - name: Checkout code
         uses: actions/checkout@v3
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,4 +51,4 @@ jobs:
         run: |
           pytest --durations 20 -sv tests/
         env:
-          SENTENCE_TRANSFORMERS_HOME: "/mnt/.cache/huggingface"
+          SENTENCE_TRANSFORMERS_HOME: "/.cache/huggingface"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Maximize build space
         uses: easimon/maximize-build-space@master
         with:
-          root-reserve-mb: 4096
+          root-reserve-mb: 8192
           remove-android: 'true'
           remove-dotnet: 'true'
         if: matrix.os == 'ubuntu-latest'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,6 @@
+import os
+import platform
+import tempfile
 import pytest
 
 from sentence_transformers import SentenceTransformer, CrossEncoder
@@ -30,3 +33,18 @@ def distilbert_base_uncased_model() -> SentenceTransformer:
     pooling_model = Pooling(word_embedding_model.get_word_embedding_dimension())
     model = SentenceTransformer(modules=[word_embedding_model, pooling_model])
     return model
+
+
+@pytest.fixture()
+def cache_dir():
+    """
+    In the CI environment, we use a temporary directory as `cache_dir`
+    to avoid keeping the downloaded models on disk after the test.
+
+    This is only required for Ubuntu, as we otherwise have disk space issues there.
+    """
+    if os.environ.get("CI", None) and platform.system() == "Linux":
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            yield tmp_dir
+    else:
+        yield None

--- a/tests/test_pretrained_stsb.py
+++ b/tests/test_pretrained_stsb.py
@@ -5,6 +5,7 @@ import csv
 import gzip
 import os
 from functools import partial
+from typing import Optional
 
 import pytest
 
@@ -12,8 +13,10 @@ from sentence_transformers import InputExample, SentenceTransformer, util
 from sentence_transformers.evaluation import EmbeddingSimilarityEvaluator
 
 
-def pretrained_model_score(model_name, expected_score: float, max_test_samples: int = 100) -> None:
-    model = SentenceTransformer(model_name)
+def pretrained_model_score(
+    model_name, expected_score: float, max_test_samples: int = 100, cache_dir: Optional[str] = None
+) -> None:
+    model = SentenceTransformer(model_name, cache_folder=cache_dir)
     sts_dataset_path = "datasets/stsbenchmark.tsv.gz"
 
     if not os.path.exists(sts_dataset_path):
@@ -101,51 +104,51 @@ def test_sentence_t5_slow() -> None:
     pretrained_model_score_slow("sentence-t5-base", 85.52)
 
 
-def test_bert_base() -> None:
-    pretrained_model_score("bert-base-nli-mean-tokens", 86.53)
-    pretrained_model_score("bert-base-nli-max-tokens", 87.00)
-    pretrained_model_score("bert-base-nli-cls-token", 85.93)
-    pretrained_model_score("bert-base-nli-stsb-mean-tokens", 89.26)
+def test_bert_base(cache_dir) -> None:
+    pretrained_model_score("bert-base-nli-mean-tokens", 86.53, cache_dir=cache_dir)
+    pretrained_model_score("bert-base-nli-max-tokens", 87.00, cache_dir=cache_dir)
+    pretrained_model_score("bert-base-nli-cls-token", 85.93, cache_dir=cache_dir)
+    pretrained_model_score("bert-base-nli-stsb-mean-tokens", 89.26, cache_dir=cache_dir)
 
 
-def test_bert_large() -> None:
-    pretrained_model_score("bert-large-nli-mean-tokens", 90.06)
-    pretrained_model_score("bert-large-nli-max-tokens", 90.15)
-    pretrained_model_score("bert-large-nli-cls-token", 89.51)
-    pretrained_model_score("bert-large-nli-stsb-mean-tokens", 92.27)
+def test_bert_large(cache_dir) -> None:
+    pretrained_model_score("bert-large-nli-mean-tokens", 90.06, cache_dir=cache_dir)
+    pretrained_model_score("bert-large-nli-max-tokens", 90.15, cache_dir=cache_dir)
+    pretrained_model_score("bert-large-nli-cls-token", 89.51, cache_dir=cache_dir)
+    pretrained_model_score("bert-large-nli-stsb-mean-tokens", 92.27, cache_dir=cache_dir)
 
 
-def test_roberta() -> None:
-    pretrained_model_score("roberta-base-nli-mean-tokens", 87.91)
-    pretrained_model_score("roberta-large-nli-mean-tokens", 89.41)
-    pretrained_model_score("roberta-base-nli-stsb-mean-tokens", 93.39)
-    pretrained_model_score("roberta-large-nli-stsb-mean-tokens", 91.26)
+def test_roberta(cache_dir) -> None:
+    pretrained_model_score("roberta-base-nli-mean-tokens", 87.91, cache_dir=cache_dir)
+    pretrained_model_score("roberta-large-nli-mean-tokens", 89.41, cache_dir=cache_dir)
+    pretrained_model_score("roberta-base-nli-stsb-mean-tokens", 93.39, cache_dir=cache_dir)
+    pretrained_model_score("roberta-large-nli-stsb-mean-tokens", 91.26, cache_dir=cache_dir)
 
 
-def test_distilbert() -> None:
-    pretrained_model_score("distilbert-base-nli-mean-tokens", 88.83)
-    pretrained_model_score("distilbert-base-nli-stsb-mean-tokens", 91.01)
-    pretrained_model_score("paraphrase-distilroberta-base-v1", 90.89)
+def test_distilbert(cache_dir) -> None:
+    pretrained_model_score("distilbert-base-nli-mean-tokens", 88.83, cache_dir=cache_dir)
+    pretrained_model_score("distilbert-base-nli-stsb-mean-tokens", 91.01, cache_dir=cache_dir)
+    pretrained_model_score("paraphrase-distilroberta-base-v1", 90.89, cache_dir=cache_dir)
 
 
-def test_multiling() -> None:
-    pretrained_model_score("distiluse-base-multilingual-cased", 88.79)
-    pretrained_model_score("paraphrase-xlm-r-multilingual-v1", 92.76)
-    pretrained_model_score("paraphrase-multilingual-MiniLM-L12-v2", 92.64)
+def test_multiling(cache_dir) -> None:
+    pretrained_model_score("distiluse-base-multilingual-cased", 88.79, cache_dir=cache_dir)
+    pretrained_model_score("paraphrase-xlm-r-multilingual-v1", 92.76, cache_dir=cache_dir)
+    pretrained_model_score("paraphrase-multilingual-MiniLM-L12-v2", 92.64, cache_dir=cache_dir)
 
 
-def test_mpnet() -> None:
-    pretrained_model_score("paraphrase-mpnet-base-v2", 92.83)
+def test_mpnet(cache_dir) -> None:
+    pretrained_model_score("paraphrase-mpnet-base-v2", 92.83, cache_dir=cache_dir)
 
 
-def test_other_models() -> None:
-    pretrained_model_score("average_word_embeddings_komninos", 68.97)
+def test_other_models(cache_dir) -> None:
+    pretrained_model_score("average_word_embeddings_komninos", 68.97, cache_dir=cache_dir)
 
 
-def test_msmarco() -> None:
-    pretrained_model_score("msmarco-roberta-base-ance-firstp", 83.61)
-    pretrained_model_score("msmarco-distilbert-base-v3", 87.96)
+def test_msmarco(cache_dir) -> None:
+    pretrained_model_score("msmarco-roberta-base-ance-firstp", 83.61, cache_dir=cache_dir)
+    pretrained_model_score("msmarco-distilbert-base-v3", 87.96, cache_dir=cache_dir)
 
 
-def test_sentence_t5() -> None:
-    pretrained_model_score("sentence-t5-base", 92.75)
+def test_sentence_t5(cache_dir) -> None:
+    pretrained_model_score("sentence-t5-base", 92.75, cache_dir=cache_dir)

--- a/tests/test_train_stsb.py
+++ b/tests/test_train_stsb.py
@@ -88,6 +88,7 @@ def test_train_stsb_slow(
     evaluate_stsb_test(model, 80.0, sts_test_samples)
 
 
+@pytest.mark.skipif("CI" in os.environ, reason="This test is too slow for the CI (~8 minutes)")
 def test_train_stsb(
     distilbert_base_uncased_model: SentenceTransformer, sts_resource: Tuple[List[InputExample], List[InputExample]]
 ) -> None:
@@ -134,6 +135,7 @@ def test_train_nli_slow(
     evaluate_stsb_test(model, 50.0, sts_test_samples)
 
 
+@pytest.mark.skipif("CI" in os.environ, reason="This test is too slow for the CI (~25 minutes)")
 def test_train_nli(
     distilbert_base_uncased_model: SentenceTransformer,
     nli_resource: List[InputExample],


### PR DESCRIPTION
Hello!

## Pull Request overview
* On Ubuntu CI runner, use temporary directories as cache folders for some models
* Skip the training tests on CI

## Details
This should resolve the problem caused by GitHub reducing how much disk space is available on Ubuntu runners (https://github.com/actions/runner-images/issues/9344).

- Tom Aarsen