### PR TITLE
[`feat`] Add Matryoshka loss + examples + docs

### DIFF
--- a/docs/package_reference/losses.md
+++ b/docs/package_reference/losses.md
@@ -15,6 +15,7 @@ Feel free to consider the following tables to help narrow down your choice of lo
 | `(anchor, positive/negative) pairs`           | `1 if positive, 0 if negative`                                | <a href="#contrastiveloss">`ContrastiveLoss`</a><br><a href="#onlinecontrastiveloss">`OnlineContrastiveLoss`</a>                                                                                                                                                                                                                 |
 | `(sentence_A, sentence_B) pairs`              | `float similarity score`                                      | <a href="#cosentloss">`CoSENTLoss`</a><br><a href="#angleloss">`AnglELoss`</a><br><a href="#cosinesimilarityloss">`CosineSimilarityLoss`</a>                                                                                                                                                                                     |
 | `(anchor, positive, negative) triplets`       | `none`                                                        | <a href="#cachedmultiplenegativesrankingloss">`CachedMultipleNegativesRankingLoss`</a><br><a href="#multiplenegativesrankingloss">`MultipleNegativesRankingLoss`</a><br><a href="#tripletloss">`TripletLoss`</a>                                                                                                                 |
+| `any`                                         | `any`                                                         | <a href="#matryoshkaloss">`MatryoshkaLoss`</a>                                                                                                                                                                                                                                                                                   |
 
 Note that you can often convert one training data format into another, allowing more loss functions to be viable for your case. For example, (sentence_A, sentence_B) pairs with classes can be converted into (anchor, positive, negative) by sampling sentences with the same or different classes.
 
@@ -107,6 +108,11 @@ This allows our network to be fine-tuned to recognize the similarity of sentence
 ## MarginMSELoss
 ```eval_rst
 .. autoclass:: sentence_transformers.losses.MarginMSELoss
+```
+
+## MatryoshkaLoss
+```eval_rst
+.. autoclass:: sentence_transformers.losses.MatryoshkaLoss
 ```
 
 ## MegaBatchMarginLoss

--- a/examples/training/matryoshka/README.md
+++ b/examples/training/matryoshka/README.md
@@ -46,6 +46,8 @@ similarities = cos_sim(embeddings[0], embeddings[1:])
 ```
 As you can see, the similarity between the search query and the correct document is much higher than that of an unrelated document, despite the very small matryoshka dimension applied. Feel free to copy this script locally, modify the `matryoshka_dim`, and observe the difference in similarities.
 
+**Note**: Despite the embeddings being smaller, training and inference of a Matryoshka model is not faster, not more memory-efficient, and not smaller. Only the processing and storage of the resulting embeddings will be faster and cheaper.
+
 ## Code Examples
 
 See the following scripts as examples of how to apply the [`MatryoshkaLoss`](../../../docs/package_reference/losses.html#matryoshkaloss) in practice:

--- a/examples/training/matryoshka/README.md
+++ b/examples/training/matryoshka/README.md
@@ -53,4 +53,5 @@ As you can see, the similarity between the search query and the correct document
 See the following scripts as examples of how to apply the [`MatryoshkaLoss`](../../../docs/package_reference/losses.html#matryoshkaloss) in practice:
 
 * **[matryoshka_nli.py](matryoshka_nli.py)**: This example uses the MultipleNegativesRankingLoss with MatryoshkaLoss to train a strong embedding model using Natural Language Inference (NLI) data. It is an adaptation of the [NLI](../nli/README) documentation.
+* **[matryoshka_nli_reduced_dim.py](matryoshka_nli_reduced_dim.py)**: This example uses the MultipleNegativesRankingLoss with MatryoshkaLoss to train a strong embedding model with a small maximum output dimension of 256. It trains using Natural Language Inference (NLI) data, and is an adaptation of the [NLI](../nli/README) documentation.
 * **[matryoshka_sts.py](matryoshka_sts.py)**: This example uses the CoSENTLoss with MatryoshkaLoss to train an embedding model on the training set of the STSBenchmark dataset. It is an adaptation of the [STS](../sts/README) documentation.

--- a/examples/training/matryoshka/README.md
+++ b/examples/training/matryoshka/README.md
@@ -1,6 +1,6 @@
 # Matryoshka Embeddings
 
-Dense embedding models normally produce embeddings with a fixed size, such as 768 or 1024. All further computations (clustering, classification, semantic search, retrieval, reranking, etc.) must then be done on these full embeddings. [Matryoshka Representation Learning](https://arxiv.org/abs/2205.13147) revisits this idea, and proposes a solution to train embedding models whose embeddings are still useful after truncation to much smaller sizes. This allows for considerably faster (bulk) processing.
+Dense embedding models typically produce embeddings with a fixed size, such as 768 or 1024. All further computations (clustering, classification, semantic search, retrieval, reranking, etc.) must then be done on these full embeddings. [Matryoshka Representation Learning](https://arxiv.org/abs/2205.13147) revisits this idea, and proposes a solution to train embedding models whose embeddings are still useful after truncation to much smaller sizes. This allows for considerably faster (bulk) processing.
 
 ## Use Cases
 

--- a/examples/training/matryoshka/README.md
+++ b/examples/training/matryoshka/README.md
@@ -1,0 +1,54 @@
+# Matryoshka Embeddings
+
+Dense embedding models normally produce embeddings with a fixed size, such as 768 or 1024. All further computations (clustering, classification, semantic search, retrieval, reranking, etc.) must then be done on these full embeddings. [Matryoshka Representation Learning](https://arxiv.org/abs/2205.13147) revisits this idea, and proposes a solution to train embedding models whose embeddings are still useful after truncation to much smaller sizes. This allows for considerably faster (bulk) processing.
+
+## Use Cases
+
+A particularly interesting use cases are to split up processing into two steps: 1) pre-processing with much smaller vectors and then 2) processing the remaining vectors as full size (also called "shortlisting and reranking"). Additionally, Matryoshka models will allow you to scale your embedding solutions to your desired storage cost, processing speed and performance.
+
+## Training
+
+Training using Matryoshka Representation Learning (MRL) is quite elementary: rather than applying some loss function on only the full-size embeddings, we also apply that same loss function on truncated portions of the embeddings. For example, if a model has an embedding dimension of 768 by default, it can now be trained on 768, 512, 256, 128, 64 and 32. Each of these losses will be added together, optionally with some weight:
+
+```python
+from sentence_transformers import SentenceTransformer
+from sentence_transformers.losses import CoSENTLoss, MatryoshkaLoss
+
+model = SentenceTransformer("microsoft/mpnet-base")
+
+base_loss = CoSENTLoss(model=model)
+loss = MatryoshkaLoss(model=model, loss=base_loss, matryoshka_dims=[768, 512, 256, 128, 64])
+```
+* **Reference**: [`MatryoshkaLoss`](../../../docs/package_reference/losses#matryoshkaloss)
+
+## Inference
+
+When a model has been trained using a Matryoshka loss, then you can run inference with it using [`SentenceTransformers.encode`](../../../docs/package_reference/SentenceTransformer.html#sentence_transformers.SentenceTransformer.encode). You must then truncate the resulting embeddings, and it is recommended to renormalize the embeddings.
+
+```python
+from sentence_transformers import SentenceTransformer
+from sentence_transformers.util import cos_sim
+
+model = SentenceTransformer("nomic-ai/nomic-embed-text-v1.5", trust_remote_code=True)
+
+matryoshka_dim = 64
+embeddings = model.encode(
+    [
+        "search_query: What is TSNE?",
+        "search_document: t-distributed stochastic neighbor embedding (t-SNE) is a statistical method for visualizing high-dimensional data by giving each datapoint a location in a two or three-dimensional map.",
+        "search_document: Amelia Mary Earhart was an American aviation pioneer and writer.",
+    ]
+)
+embeddings[..., :matryoshka_dim]  # Shrink the embedding dimensions
+
+similarities = cos_sim(embeddings[0], embeddings[1:])
+# => tensor([[0.7839, 0.4933]])
+```
+As you can see, the similarity between the search query and the correct document is much higher than that of an unrelated document, despite the very small matryoshka dimension applied. Feel free to copy this script locally, modify the `matryoshka_dim`, and observe the difference in similarities.
+
+## Code Examples
+
+See the following scripts as examples of how to apply the [`MatryoshkaLoss`](../../../docs/package_reference/losses.html#matryoshkaloss) in practice:
+
+* **[matryoshka_nli.py](matryoshka_nli.py)**: This example uses the MultipleNegativesRankingLoss with MatryoshkaLoss to train a strong embedding model using Natural Language Inference (NLI) data. It is an adaptation of the [NLI](../nli/README) documentation.
+* **[matryoshka_sts.py](matryoshka_sts.py)**: This example uses the CoSENTLoss with MatryoshkaLoss to train an embedding model on the training set of the STSBenchmark dataset. It is an adaptation of the [STS](../sts/README) documentation.

--- a/examples/training/matryoshka/README.md
+++ b/examples/training/matryoshka/README.md
@@ -4,7 +4,7 @@ Dense embedding models typically produce embeddings with a fixed size, such as 7
 
 ## Use Cases
 
-A particularly interesting use cases are to split up processing into two steps: 1) pre-processing with much smaller vectors and then 2) processing the remaining vectors as full size (also called "shortlisting and reranking"). Additionally, Matryoshka models will allow you to scale your embedding solutions to your desired storage cost, processing speed and performance.
+A particularly interesting use case is to split up processing into two steps: 1) pre-processing with much smaller vectors and then 2) processing the remaining vectors as full size (also called "shortlisting and reranking"). Additionally, Matryoshka models will allow you to scale your embedding solutions to your desired storage cost, processing speed and performance.
 
 ## Training
 
@@ -23,7 +23,7 @@ loss = MatryoshkaLoss(model=model, loss=base_loss, matryoshka_dims=[768, 512, 25
 
 ## Inference
 
-When a model has been trained using a Matryoshka loss, then you can run inference with it using [`SentenceTransformers.encode`](../../../docs/package_reference/SentenceTransformer.html#sentence_transformers.SentenceTransformer.encode). You must then truncate the resulting embeddings, and it is recommended to renormalize the embeddings.
+After a model has been trained using a Matryoshka loss, you can then run inference with it using [`SentenceTransformers.encode`](../../../docs/package_reference/SentenceTransformer.html#sentence_transformers.SentenceTransformer.encode). You must then truncate the resulting embeddings, and it is recommended to renormalize the embeddings.
 
 ```python
 from sentence_transformers import SentenceTransformer

--- a/examples/training/matryoshka/matryoshka_nli.py
+++ b/examples/training/matryoshka/matryoshka_nli.py
@@ -1,0 +1,143 @@
+"""
+The system trains BERT (or any other transformer model like RoBERTa, DistilBERT etc.) on the SNLI + MultiNLI (AllNLI) dataset
+with MatryoshkaLoss using MultipleNegativesRankingLoss. This trains a model at output dimensions [768, 512, 258, 128, 64].
+Entailments are positive pairs and the contradiction on AllNLI dataset is added as a hard negative.
+At every 10% training steps, the model is evaluated on the STS benchmark dataset
+
+Usage:
+python matryoshka_nli.py
+
+OR
+python matryoshka_nli.py pretrained_transformer_model_name
+"""
+import math
+from datasets import load_dataset
+from sentence_transformers import models, losses, datasets
+from sentence_transformers import LoggingHandler, SentenceTransformer, util, InputExample
+from sentence_transformers.evaluation import EmbeddingSimilarityEvaluator, SimilarityFunction
+import logging
+from datetime import datetime
+import sys
+import os
+import gzip
+import csv
+import random
+
+#### Just some code to print debug information to stdout
+logging.basicConfig(
+    format="%(asctime)s - %(message)s", datefmt="%Y-%m-%d %H:%M:%S", level=logging.INFO, handlers=[LoggingHandler()]
+)
+#### /print debug information to stdout
+
+model_name = sys.argv[1] if len(sys.argv) > 1 else "distilroberta-base"
+train_batch_size = 128  # The larger you select this, the better the results (usually). But it requires more GPU memory
+max_seq_length = 75
+num_epochs = 1
+
+# Save path of the model
+model_save_path = (
+    "output/matryoshka_nli_" + model_name.replace("/", "-") + "-" + datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+)
+
+
+# Here we define our SentenceTransformer model
+word_embedding_model = models.Transformer(model_name, max_seq_length=max_seq_length)
+pooling_model = models.Pooling(word_embedding_model.get_word_embedding_dimension(), pooling_mode="mean")
+model = SentenceTransformer(modules=[word_embedding_model, pooling_model])
+
+# Check if dataset exists. If not, download and extract  it
+nli_dataset_path = "data/AllNLI.tsv.gz"
+
+if not os.path.exists(nli_dataset_path):
+    util.http_get("https://sbert.net/datasets/AllNLI.tsv.gz", nli_dataset_path)
+
+# Read the AllNLI.tsv.gz file and create the training dataset
+logging.info("Read AllNLI train dataset")
+
+
+def add_to_samples(sent1, sent2, label):
+    if sent1 not in train_data:
+        train_data[sent1] = {"contradiction": set(), "entailment": set(), "neutral": set()}
+    train_data[sent1][label].add(sent2)
+
+
+train_data = {}
+with gzip.open(nli_dataset_path, "rt", encoding="utf8") as fIn:
+    reader = csv.DictReader(fIn, delimiter="\t", quoting=csv.QUOTE_NONE)
+    for row in reader:
+        if row["split"] == "train":
+            sent1 = row["sentence1"].strip()
+            sent2 = row["sentence2"].strip()
+
+            add_to_samples(sent1, sent2, row["label"])
+            add_to_samples(sent2, sent1, row["label"])  # Also add the opposite
+
+
+train_samples = []
+for sent1, others in train_data.items():
+    if len(others["entailment"]) > 0 and len(others["contradiction"]) > 0:
+        train_samples.append(
+            InputExample(
+                texts=[sent1, random.choice(list(others["entailment"])), random.choice(list(others["contradiction"]))]
+            )
+        )
+        train_samples.append(
+            InputExample(
+                texts=[random.choice(list(others["entailment"])), sent1, random.choice(list(others["contradiction"]))]
+            )
+        )
+
+logging.info("Train samples: {}".format(len(train_samples)))
+
+
+# Special data loader that avoid duplicates within a batch
+train_dataloader = datasets.NoDuplicatesDataLoader(train_samples, batch_size=train_batch_size)
+
+
+# Our training loss
+train_loss = losses.MultipleNegativesRankingLoss(model)
+train_loss = losses.MatryoshkaLoss(model, train_loss, [768, 512, 256, 128, 64])
+
+stsb_dev = load_dataset("mteb/stsbenchmark-sts", split="validation")
+dev_evaluator = EmbeddingSimilarityEvaluator(
+    stsb_dev["sentence1"],
+    stsb_dev["sentence2"],
+    [score / 5 for score in stsb_dev["score"]],
+    main_similarity=SimilarityFunction.COSINE,
+    name="sts-dev",
+)
+
+# Configure the training
+warmup_steps = math.ceil(len(train_dataloader) * num_epochs * 0.1)  # 10% of train data for warm-up
+logging.info("Warmup-steps: {}".format(warmup_steps))
+
+
+# Train the model
+model.fit(
+    train_objectives=[(train_dataloader, train_loss)],
+    evaluator=dev_evaluator,
+    epochs=num_epochs,
+    evaluation_steps=int(len(train_dataloader) * 0.1),
+    warmup_steps=warmup_steps,
+    output_path=model_save_path,
+    use_amp=False,  # Set to True, if your GPU supports FP16 operations
+)
+
+
+##############################################################################
+#
+# Load the stored model and evaluate its performance on STS benchmark dataset
+#
+##############################################################################
+
+
+model = SentenceTransformer(model_save_path)
+stsb_test = load_dataset("mteb/stsbenchmark-sts", split="test")
+test_evaluator = EmbeddingSimilarityEvaluator(
+    stsb_test["sentence1"],
+    stsb_test["sentence2"],
+    [score / 5 for score in stsb_test["score"]],
+    main_similarity=SimilarityFunction.COSINE,
+    name="sts-test",
+)
+test_evaluator(model, output_path=model_save_path)

--- a/examples/training/matryoshka/matryoshka_nli.py
+++ b/examples/training/matryoshka/matryoshka_nli.py
@@ -1,6 +1,6 @@
 """
 The system trains BERT (or any other transformer model like RoBERTa, DistilBERT etc.) on the SNLI + MultiNLI (AllNLI) dataset
-with MatryoshkaLoss using MultipleNegativesRankingLoss. This trains a model at output dimensions [768, 512, 258, 128, 64].
+with MatryoshkaLoss using MultipleNegativesRankingLoss. This trains a model at output dimensions [768, 512, 256, 128, 64].
 Entailments are positive pairs and the contradiction on AllNLI dataset is added as a hard negative.
 At every 10% training steps, the model is evaluated on the STS benchmark dataset
 

--- a/examples/training/matryoshka/matryoshka_nli_reduced_dim.py
+++ b/examples/training/matryoshka/matryoshka_nli_reduced_dim.py
@@ -1,0 +1,148 @@
+"""
+The system trains BERT (or any other transformer model like RoBERTa, DistilBERT etc.) on the SNLI + MultiNLI (AllNLI) dataset
+with MatryoshkaLoss using MultipleNegativesRankingLoss. This trains a model at output dimensions [768, 512, 256, 128, 64].
+Entailments are positive pairs and the contradiction on AllNLI dataset is added as a hard negative.
+At every 10% training steps, the model is evaluated on the STS benchmark dataset
+
+The difference between this script and matryoshka_nli.py is that this script uses a reduced dimensionality of the base
+model by adding a Dense layer with 256 output dimensions. This might be useful when your desired output dimensionality
+is lower than the base model's default output dimensionality.
+
+Usage:
+python matryoshka_nli_reduced_dim.py
+
+OR
+python matryoshka_nli_reduced_dim.py pretrained_transformer_model_name
+"""
+import math
+from datasets import load_dataset
+from sentence_transformers import models, losses, datasets
+from sentence_transformers import LoggingHandler, SentenceTransformer, util, InputExample
+from sentence_transformers.evaluation import EmbeddingSimilarityEvaluator, SimilarityFunction
+import logging
+from datetime import datetime
+import sys
+import os
+import gzip
+import csv
+import random
+
+#### Just some code to print debug information to stdout
+logging.basicConfig(
+    format="%(asctime)s - %(message)s", datefmt="%Y-%m-%d %H:%M:%S", level=logging.INFO, handlers=[LoggingHandler()]
+)
+#### /print debug information to stdout
+
+model_name = sys.argv[1] if len(sys.argv) > 1 else "distilroberta-base"
+train_batch_size = 128  # The larger you select this, the better the results (usually). But it requires more GPU memory
+max_seq_length = 75
+num_epochs = 1
+
+# Save path of the model
+model_save_path = (
+    "output/matryoshka_nli_" + model_name.replace("/", "-") + "-" + datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+)
+
+
+# Here we define our SentenceTransformer model
+word_embedding_model = models.Transformer(model_name, max_seq_length=max_seq_length)
+pooling_model = models.Pooling(word_embedding_model.get_word_embedding_dimension(), pooling_mode="mean")
+dense = models.Dense(in_features=pooling_model.get_sentence_embedding_dimension(), out_features=256)
+model = SentenceTransformer(modules=[word_embedding_model, pooling_model, dense])
+
+# Check if dataset exists. If not, download and extract  it
+nli_dataset_path = "data/AllNLI.tsv.gz"
+
+if not os.path.exists(nli_dataset_path):
+    util.http_get("https://sbert.net/datasets/AllNLI.tsv.gz", nli_dataset_path)
+
+# Read the AllNLI.tsv.gz file and create the training dataset
+logging.info("Read AllNLI train dataset")
+
+
+def add_to_samples(sent1, sent2, label):
+    if sent1 not in train_data:
+        train_data[sent1] = {"contradiction": set(), "entailment": set(), "neutral": set()}
+    train_data[sent1][label].add(sent2)
+
+
+train_data = {}
+with gzip.open(nli_dataset_path, "rt", encoding="utf8") as fIn:
+    reader = csv.DictReader(fIn, delimiter="\t", quoting=csv.QUOTE_NONE)
+    for row in reader:
+        if row["split"] == "train":
+            sent1 = row["sentence1"].strip()
+            sent2 = row["sentence2"].strip()
+
+            add_to_samples(sent1, sent2, row["label"])
+            add_to_samples(sent2, sent1, row["label"])  # Also add the opposite
+
+
+train_samples = []
+for sent1, others in train_data.items():
+    if len(others["entailment"]) > 0 and len(others["contradiction"]) > 0:
+        train_samples.append(
+            InputExample(
+                texts=[sent1, random.choice(list(others["entailment"])), random.choice(list(others["contradiction"]))]
+            )
+        )
+        train_samples.append(
+            InputExample(
+                texts=[random.choice(list(others["entailment"])), sent1, random.choice(list(others["contradiction"]))]
+            )
+        )
+
+logging.info("Train samples: {}".format(len(train_samples)))
+
+
+# Special data loader that avoid duplicates within a batch
+train_dataloader = datasets.NoDuplicatesDataLoader(train_samples, batch_size=train_batch_size)
+
+
+# Our training loss
+train_loss = losses.MultipleNegativesRankingLoss(model)
+train_loss = losses.MatryoshkaLoss(model, train_loss, [256, 128, 64, 32, 16])
+
+stsb_dev = load_dataset("mteb/stsbenchmark-sts", split="validation")
+dev_evaluator = EmbeddingSimilarityEvaluator(
+    stsb_dev["sentence1"],
+    stsb_dev["sentence2"],
+    [score / 5 for score in stsb_dev["score"]],
+    main_similarity=SimilarityFunction.COSINE,
+    name="sts-dev",
+)
+
+# Configure the training
+warmup_steps = math.ceil(len(train_dataloader) * num_epochs * 0.1)  # 10% of train data for warm-up
+logging.info("Warmup-steps: {}".format(warmup_steps))
+
+
+# Train the model
+model.fit(
+    train_objectives=[(train_dataloader, train_loss)],
+    evaluator=dev_evaluator,
+    epochs=num_epochs,
+    evaluation_steps=int(len(train_dataloader) * 0.1),
+    warmup_steps=warmup_steps,
+    output_path=model_save_path,
+    use_amp=False,  # Set to True, if your GPU supports FP16 operations
+)
+
+
+##############################################################################
+#
+# Load the stored model and evaluate its performance on STS benchmark dataset
+#
+##############################################################################
+
+
+model = SentenceTransformer(model_save_path)
+stsb_test = load_dataset("mteb/stsbenchmark-sts", split="test")
+test_evaluator = EmbeddingSimilarityEvaluator(
+    stsb_test["sentence1"],
+    stsb_test["sentence2"],
+    [score / 5 for score in stsb_test["score"]],
+    main_similarity=SimilarityFunction.COSINE,
+    name="sts-test",
+)
+test_evaluator(model, output_path=model_save_path)

--- a/examples/training/matryoshka/matryoshka_sts.py
+++ b/examples/training/matryoshka/matryoshka_sts.py
@@ -1,6 +1,6 @@
 """
 This examples trains BERT (or any other transformer model like RoBERTa, DistilBERT etc.) for the STSbenchmark from scratch.
-It uses MatryoshkaLoss with the powerful CoSENTLoss to train models that perform well at output dimensions [768, 512, 258, 128, 64].
+It uses MatryoshkaLoss with the powerful CoSENTLoss to train models that perform well at output dimensions [768, 512, 256, 128, 64].
 It generates sentence embeddings that can be compared using cosine-similarity to measure the similarity.
 
 Usage:

--- a/examples/training/matryoshka/matryoshka_sts.py
+++ b/examples/training/matryoshka/matryoshka_sts.py
@@ -1,0 +1,114 @@
+"""
+This examples trains BERT (or any other transformer model like RoBERTa, DistilBERT etc.) for the STSbenchmark from scratch.
+It uses MatryoshkaLoss with the powerful CoSENTLoss to train models that perform well at output dimensions [768, 512, 258, 128, 64].
+It generates sentence embeddings that can be compared using cosine-similarity to measure the similarity.
+
+Usage:
+python matryoshka_sts.py
+
+OR
+python matryoshka_sts.py pretrained_transformer_model_name
+"""
+from torch.utils.data import DataLoader
+import math
+from sentence_transformers import SentenceTransformer, LoggingHandler, losses, models, util
+from sentence_transformers.evaluation import EmbeddingSimilarityEvaluator
+from sentence_transformers.readers import InputExample
+import logging
+from datetime import datetime
+import sys
+import os
+import gzip
+import csv
+
+#### Just some code to print debug information to stdout
+logging.basicConfig(
+    format="%(asctime)s - %(message)s", datefmt="%Y-%m-%d %H:%M:%S", level=logging.INFO, handlers=[LoggingHandler()]
+)
+#### /print debug information to stdout
+
+
+# Check if dataset exists. If not, download and extract  it
+sts_dataset_path = "datasets/stsbenchmark.tsv.gz"
+
+if not os.path.exists(sts_dataset_path):
+    util.http_get("https://sbert.net/datasets/stsbenchmark.tsv.gz", sts_dataset_path)
+
+
+# You can specify any huggingface/transformers pre-trained model here, for example, bert-base-uncased, roberta-base, xlm-roberta-base
+model_name = sys.argv[1] if len(sys.argv) > 1 else "distilbert-base-uncased"
+
+# Read the dataset
+train_batch_size = 16
+num_epochs = 4
+model_save_path = (
+    "output/matryoshka_sts_" + model_name.replace("/", "-") + "-" + datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+)
+
+# Use Huggingface/transformers model (like BERT, RoBERTa, XLNet, XLM-R) for mapping tokens to embeddings
+word_embedding_model = models.Transformer(model_name)
+
+# Apply mean pooling to get one fixed sized sentence vector
+pooling_model = models.Pooling(
+    word_embedding_model.get_word_embedding_dimension(),
+    pooling_mode_mean_tokens=True,
+    pooling_mode_cls_token=False,
+    pooling_mode_max_tokens=False,
+)
+
+model = SentenceTransformer(modules=[word_embedding_model, pooling_model])
+
+# Convert the dataset to a DataLoader ready for training
+logging.info("Read STSbenchmark train dataset")
+
+train_samples = []
+dev_samples = []
+test_samples = []
+with gzip.open(sts_dataset_path, "rt", encoding="utf8") as fIn:
+    reader = csv.DictReader(fIn, delimiter="\t", quoting=csv.QUOTE_NONE)
+    for row in reader:
+        score = float(row["score"]) / 5.0  # Normalize score to range 0 ... 1
+        inp_example = InputExample(texts=[row["sentence1"], row["sentence2"]], label=score)
+
+        if row["split"] == "dev":
+            dev_samples.append(inp_example)
+        elif row["split"] == "test":
+            test_samples.append(inp_example)
+        else:
+            train_samples.append(inp_example)
+
+
+train_dataloader = DataLoader(train_samples, shuffle=True, batch_size=train_batch_size)
+train_loss = losses.CoSENTLoss(model=model)
+train_loss = losses.MatryoshkaLoss(model, train_loss, [768, 512, 256, 128, 64])
+
+
+logging.info("Read STSbenchmark dev dataset")
+evaluator = EmbeddingSimilarityEvaluator.from_input_examples(dev_samples, name="sts-dev")
+
+
+# Configure the training. We skip evaluation in this example
+warmup_steps = math.ceil(len(train_dataloader) * num_epochs * 0.1)  # 10% of train data for warm-up
+logging.info("Warmup-steps: {}".format(warmup_steps))
+
+
+# Train the model
+model.fit(
+    train_objectives=[(train_dataloader, train_loss)],
+    evaluator=evaluator,
+    epochs=num_epochs,
+    evaluation_steps=1000,
+    warmup_steps=warmup_steps,
+    output_path=model_save_path,
+)
+
+
+##############################################################################
+#
+# Load the stored model and evaluate its performance on STS benchmark dataset
+#
+##############################################################################
+
+model = SentenceTransformer(model_save_path)
+test_evaluator = EmbeddingSimilarityEvaluator.from_input_examples(test_samples, name="sts-test")
+test_evaluator(model, output_path=model_save_path)

--- a/index.rst
+++ b/index.rst
@@ -156,6 +156,7 @@ If you use the code for `data augmentation <https://github.com/UKPLab/sentence-t
    :caption: Training
 
    docs/training/overview
+   examples/training/matryoshka/README
    examples/training/multilingual/README
    examples/training/distillation/README
    examples/training/cross-encoder/README

--- a/sentence_transformers/losses/MatryoshkaLoss.py
+++ b/sentence_transformers/losses/MatryoshkaLoss.py
@@ -1,6 +1,8 @@
 from typing import Dict, Iterable, List, Optional, Union
+import warnings
 from torch import Tensor, nn
 from sentence_transformers import SentenceTransformer
+from sentence_transformers.losses.CachedMultipleNegativesRankingLoss import CachedMultipleNegativesRankingLoss
 
 
 class MatryoshkaLoss(nn.Module):
@@ -26,7 +28,7 @@ class MatryoshkaLoss(nn.Module):
             - The concept was introduced in this paper: https://arxiv.org/abs/2205.13147
 
         Requirements:
-            1. Whatever the `loss` requires.
+            1. The base loss cannot be :class:`CachedMultipleNegativesRankingLoss`.
 
         Input:
             +---------------------------------------+--------+
@@ -57,6 +59,8 @@ class MatryoshkaLoss(nn.Module):
         super().__init__()
         self.model = model
         self.loss = loss
+        if isinstance(loss, CachedMultipleNegativesRankingLoss):
+            warnings.warn("MatryoshkaLoss is not compatible with CachedMultipleNegativesRankingLoss.")
         self.matryoshka_dims = matryoshka_dims
         if matryoshka_weights is None:
             matryoshka_weights = [1] * len(matryoshka_dims)

--- a/sentence_transformers/losses/MatryoshkaLoss.py
+++ b/sentence_transformers/losses/MatryoshkaLoss.py
@@ -1,0 +1,109 @@
+from typing import Dict, Iterable, List, Optional, Union
+from torch import Tensor, nn
+from sentence_transformers import SentenceTransformer
+
+
+class MatryoshkaLoss(nn.Module):
+    def __init__(
+        self,
+        model: SentenceTransformer,
+        loss: nn.Module,
+        matryoshka_dims: List[int],
+        matryoshka_weights: Optional[List[Union[float, int]]] = None,
+    ) -> None:
+        """
+        The MatryoshkaLoss can be seen as a loss *modifier* that allows you to use other loss functions at various
+        different embedding dimensions. This is useful for when you want to train a model where users have the option
+        to lower the embedding dimension to improve their embedding comparison speed and costs.
+
+        :param model: SentenceTransformerModel
+        :param loss: The loss function to be used, e.g. :class:`MultipleNegativesRankingLoss`, :class:`CoSENTLoss`, etc.
+        :param matryoshka_dims: A list of embedding dimensions to be used for the loss function, e.g. [768, 512, 256, 128, 64].
+        :param matryoshka_weights: A list of weights to be used for the loss function, e.g. [1, 1, 1, 1, 1]. If None, then the
+            weights will be set to 1 for all dimensions.
+        
+        References:
+            - The concept was introduced in this paper: https://arxiv.org/abs/2205.13147
+
+        Requirements:
+            1. Whatever the `loss` requires.
+
+        Input:
+            +---------------------------------------+--------+
+            | Texts                                 | Labels |
+            +=======================================+========+
+            | any                                   | any    |
+            +---------------------------------------+--------+
+
+        Example:
+            ::
+
+                from sentence_transformers import SentenceTransformer, losses, InputExample
+                from torch.utils.data import DataLoader
+
+                model = SentenceTransformer('microsoft/mpnet-base')
+                train_examples = [
+                    InputExample(texts=['Anchor 1', 'Positive 1']),
+                    InputExample(texts=['Anchor 2', 'Positive 2']),
+                ]
+                train_dataloader = DataLoader(train_examples, shuffle=True, batch_size=32)
+                train_loss = losses.MultipleNegativesRankingLoss(model=model)
+                train_loss = losses.MatryoshkaLoss(model, train_loss, [768, 512, 256, 128, 64])
+                model.fit(
+                    [(train_dataloader, train_loss)],
+                    epochs=10,
+                )
+        """
+        super().__init__()
+        self.model = model
+        self.loss = loss
+        self.matryoshka_dims = matryoshka_dims
+        if matryoshka_weights is None:
+            matryoshka_weights = [1] * len(matryoshka_dims)
+        self.matryoshka_weights = matryoshka_weights
+
+    def forward(self, sentence_features: Iterable[Dict[str, Tensor]], labels: Tensor) -> Tensor:
+        class FirstModuleDecorator:
+            def __init__(self, fn):
+                self.fn = fn
+
+                self.dim = None
+                self.cache = []
+                self.cache_dim = None
+                self.idx = 0
+
+            def set_dim(self, dim):
+                self.dim = dim
+                self.idx = 0
+
+            def __call__(self, features):
+                # Growing cache:
+                if self.cache_dim is None or self.cache_dim == self.dim:
+                    output = self.fn(features)
+                    self.cache.append(output)
+                    self.cache_dim = self.dim
+                # Using cache:
+                else:
+                    output = self.cache[self.idx]
+                output["token_embeddings"] = output["token_embeddings"][..., : self.dim]
+                self.idx += 1
+                return output
+
+        original_forward = self.model[0].forward
+        decorated_forward = FirstModuleDecorator(original_forward)
+        self.model[0].forward = decorated_forward
+
+        loss = 0.0
+        for dim, weight in zip(self.matryoshka_dims, self.matryoshka_weights):
+            decorated_forward.set_dim(dim)
+            loss += weight * self.loss(sentence_features, labels)
+
+        self.model[0].forward = original_forward
+        return loss
+
+    def get_config_dict(self):
+        return {
+            "loss": self.loss.__class__.__name__,
+            "matryoshka_dims": self.matryoshka_dims,
+            "matryoshka_weights": self.matryoshka_weights,
+        }

--- a/sentence_transformers/losses/MatryoshkaLoss.py
+++ b/sentence_transformers/losses/MatryoshkaLoss.py
@@ -21,7 +21,7 @@ class MatryoshkaLoss(nn.Module):
         :param matryoshka_dims: A list of embedding dimensions to be used for the loss function, e.g. [768, 512, 256, 128, 64].
         :param matryoshka_weights: A list of weights to be used for the loss function, e.g. [1, 1, 1, 1, 1]. If None, then the
             weights will be set to 1 for all dimensions.
-        
+
         References:
             - The concept was introduced in this paper: https://arxiv.org/abs/2205.13147
 

--- a/sentence_transformers/losses/__init__.py
+++ b/sentence_transformers/losses/__init__.py
@@ -4,6 +4,7 @@ from .MultipleNegativesRankingLoss import MultipleNegativesRankingLoss
 from .MultipleNegativesSymmetricRankingLoss import MultipleNegativesSymmetricRankingLoss
 from .TripletLoss import TripletDistanceMetric, TripletLoss
 from .MarginMSELoss import MarginMSELoss
+from .MatryoshkaLoss import MatryoshkaLoss
 from .MSELoss import MSELoss
 from .CachedMultipleNegativesRankingLoss import CachedMultipleNegativesRankingLoss
 from .ContrastiveLoss import SiameseDistanceMetric, ContrastiveLoss
@@ -32,6 +33,7 @@ __all__ = [
     "TripletLoss",
     "TripletDistanceMetric",
     "MarginMSELoss",
+    "MatryoshkaLoss",
     "MSELoss",
     "ContrastiveLoss",
     "SiameseDistanceMetric",


### PR DESCRIPTION
Hello!

## Pull Request overview
* Implement Matryoshka loss based on https://arxiv.org/abs/2205.13147
* plus example code
* plus docs

## Details
Dense embedding models normally produce embeddings with a fixed size, such as 768 or 1024. All further computations (clustering, classification, semantic search, retrieval, reranking, etc.) must then be done on these full embeddings. [Matryoshka Representation Learning](https://arxiv.org/abs/2205.13147) revisits this idea, and proposes a solution to train embedding models whose embeddings are still useful after truncation to much smaller sizes. This allows for considerably faster (bulk) processing.

### Use Cases
A particularly interesting use cases are to split up processing into two steps: 1) pre-processing with much smaller vectors and then 2) processing the remaining vectors as full size (also called "shortlisting and reranking"). Additionally, Matryoshka models will allow you to scale your embedding solutions to your desired storage cost, processing speed and performance.

### Training

Training using Matryoshka Representation Learning (MRL) is quite elementary: rather than applying some loss function on only the full-size embeddings, we also apply that same loss function on truncated portions of the embeddings. For example, if a model has an embedding dimension of 768 by default, it can now be trained on 768, 512, 256, 128, 64 and 32. Each of these losses will be added together, optionally with some weight:

```python
from sentence_transformers import SentenceTransformer
from sentence_transformers.losses import CoSENTLoss, MatryoshkaLoss

model = SentenceTransformer("microsoft/mpnet-base")

base_loss = CoSENTLoss(model=model)
loss = MatryoshkaLoss(model=model, loss=base_loss, matryoshka_dims=[768, 512, 256, 128, 64])
```

### Inference

When a model has been trained using a Matryoshka loss, then you can run inference with it using `SentenceTransformers.encode`. You must then truncate the resulting embeddings, and it is recommended to renormalize the embeddings.

```python
from sentence_transformers import SentenceTransformer
from sentence_transformers.util import cos_sim

model = SentenceTransformer("nomic-ai/nomic-embed-text-v1.5", trust_remote_code=True)

matryoshka_dim = 64
embeddings = model.encode(
    [
        "search_query: What is TSNE?",
        "search_document: t-distributed stochastic neighbor embedding (t-SNE) is a statistical method for visualizing high-dimensional data by giving each datapoint a location in a two or three-dimensional map.",
        "search_document: Amelia Mary Earhart was an American aviation pioneer and writer.",
    ]
)
embeddings[..., :matryoshka_dim]  # Shrink the embedding dimensions

similarities = cos_sim(embeddings[0], embeddings[1:])
# => tensor([[0.7839, 0.4933]])
```
As you can see, the similarity between the search query and the correct document is much higher than that of an unrelated document, despite the very small matryoshka dimension applied. Feel free to copy this script locally, modify the `matryoshka_dim`, and observe the difference in similarities.

---

## Implementation
In the implementation, I override the `forward` method of the first module in the Sentence Transformer. Usually this'll be a `Transformer` instance, but it doesn't have to be. I expect that this method is called with the same batches every time that the "real" `loss` is called, and I abuse that with a caching mechanism. With other words, only for the first set of matryoshka dimensions do I actually compute the `forward` call, in all subsequent occasions I simply use the cached outputs. Afterwards, I truncate the `forward` outputs or the cache outputs to the correct matryoshka dimension.

### Training efficiency
As far as I can tell, this trains roughly as quickly as just applying the loss with the maximum embedding dimension.

### Note
This may not work on models that use Dense modules, and it may also cause issues with `CachedMultipleRankedNegativesLoss`.

cc: @Xenova for your interest in Matryoshka embedding models
cc: @zanussbaum as you've also implemented Matryoshka learning + because I mention Nomic in the documentation.

- Tom Aarsen