### PR TITLE
[`feat`] Allow saving a model to the Hub without providing a user + Upload Matryoshka models after training

### DIFF
--- a/examples/training/matryoshka/matryoshka_nli.py
+++ b/examples/training/matryoshka/matryoshka_nli.py
@@ -145,7 +145,7 @@ test_evaluator(model, output_path=model_save_path)
 
 # Optionally, save the model to the Hugging Face Hub!
 # It is recommended to run `huggingface-cli login` to log into your Hugging Face account first
-model_name = model_name if "/" not in model_name else model_name.split("/")[1]
+model_name = model_name if "/" not in model_name else model_name.split("/")[-1]
 try:
     model.save_to_hub(f"{model_name}-matryoshka-nli")
 except Exception:

--- a/examples/training/matryoshka/matryoshka_nli.py
+++ b/examples/training/matryoshka/matryoshka_nli.py
@@ -141,3 +141,16 @@ test_evaluator = EmbeddingSimilarityEvaluator(
     name="sts-test",
 )
 test_evaluator(model, output_path=model_save_path)
+
+
+# Optionally, save the model to the Hugging Face Hub!
+# It is recommended to run `huggingface-cli login` to log into your Hugging Face account first
+model_name = model_name if "/" not in model_name else model_name.split("/")[1]
+try:
+    model.save_to_hub(f"{model_name}-matryoshka-nli")
+except Exception:
+    logging.error(
+        "Error uploading model to the Hugging Face Hub. To upload it manually, you can run "
+        f"`huggingface-cli login`, followed by loading the model using `model = SentenceTransformer({model_save_path!r})` "
+        f"and saving it using `model.save_to_hub('{model_name}-matryoshka-nli')`."
+    )

--- a/examples/training/matryoshka/matryoshka_nli.py
+++ b/examples/training/matryoshka/matryoshka_nli.py
@@ -147,10 +147,10 @@ test_evaluator(model, output_path=model_save_path)
 # It is recommended to run `huggingface-cli login` to log into your Hugging Face account first
 model_name = model_name if "/" not in model_name else model_name.split("/")[-1]
 try:
-    model.save_to_hub(f"{model_name}-matryoshka-nli")
+    model.save_to_hub(f"{model_name}-nli-matryoshka")
 except Exception:
     logging.error(
         "Error uploading model to the Hugging Face Hub. To upload it manually, you can run "
         f"`huggingface-cli login`, followed by loading the model using `model = SentenceTransformer({model_save_path!r})` "
-        f"and saving it using `model.save_to_hub('{model_name}-matryoshka-nli')`."
+        f"and saving it using `model.save_to_hub('{model_name}-nli-matryoshka')`."
     )

--- a/examples/training/matryoshka/matryoshka_nli_reduced_dim.py
+++ b/examples/training/matryoshka/matryoshka_nli_reduced_dim.py
@@ -5,8 +5,8 @@ Entailments are positive pairs and the contradiction on AllNLI dataset is added 
 At every 10% training steps, the model is evaluated on the STS benchmark dataset
 
 The difference between this script and matryoshka_nli.py is that this script uses a reduced dimensionality of the base
-model by adding a Dense layer with 256 output dimensions. This might be useful when your desired output dimensionality
-is lower than the base model's default output dimensionality.
+model by adding a Dense layer with `reduced_dim=256` output dimensions. This might be useful when your desired output
+dimensionality is lower than the base model's default output dimensionality.
 
 Usage:
 python matryoshka_nli_reduced_dim.py
@@ -37,6 +37,7 @@ model_name = sys.argv[1] if len(sys.argv) > 1 else "distilroberta-base"
 train_batch_size = 128  # The larger you select this, the better the results (usually). But it requires more GPU memory
 max_seq_length = 75
 num_epochs = 1
+reduced_dim = 256
 
 # Save path of the model
 model_save_path = (
@@ -47,7 +48,7 @@ model_save_path = (
 # Here we define our SentenceTransformer model
 word_embedding_model = models.Transformer(model_name, max_seq_length=max_seq_length)
 pooling_model = models.Pooling(word_embedding_model.get_word_embedding_dimension(), pooling_mode="mean")
-dense = models.Dense(in_features=pooling_model.get_sentence_embedding_dimension(), out_features=256)
+dense = models.Dense(in_features=pooling_model.get_sentence_embedding_dimension(), out_features=reduced_dim)
 model = SentenceTransformer(modules=[word_embedding_model, pooling_model, dense])
 
 # Check if dataset exists. If not, download and extract  it
@@ -146,3 +147,15 @@ test_evaluator = EmbeddingSimilarityEvaluator(
     name="sts-test",
 )
 test_evaluator(model, output_path=model_save_path)
+
+# Optionally, save the model to the Hugging Face Hub!
+# It is recommended to run `huggingface-cli login` to log into your Hugging Face account first
+model_name = model_name if "/" not in model_name else model_name.split("/")[1]
+try:
+    model.save_to_hub(f"{model_name}-matryoshka-nli-{reduced_dim}")
+except Exception:
+    logging.error(
+        "Error uploading model to the Hugging Face Hub. To upload it manually, you can run "
+        f"`huggingface-cli login`, followed by loading the model using `model = SentenceTransformer({model_save_path!r})` "
+        f"and saving it using `model.save_to_hub('{model_name}-matryoshka-nli-{reduced_dim}')`."
+    )

--- a/examples/training/matryoshka/matryoshka_nli_reduced_dim.py
+++ b/examples/training/matryoshka/matryoshka_nli_reduced_dim.py
@@ -150,7 +150,7 @@ test_evaluator(model, output_path=model_save_path)
 
 # Optionally, save the model to the Hugging Face Hub!
 # It is recommended to run `huggingface-cli login` to log into your Hugging Face account first
-model_name = model_name if "/" not in model_name else model_name.split("/")[1]
+model_name = model_name if "/" not in model_name else model_name.split("/")[-1]
 try:
     model.save_to_hub(f"{model_name}-matryoshka-nli-{reduced_dim}")
 except Exception:

--- a/examples/training/matryoshka/matryoshka_nli_reduced_dim.py
+++ b/examples/training/matryoshka/matryoshka_nli_reduced_dim.py
@@ -152,10 +152,10 @@ test_evaluator(model, output_path=model_save_path)
 # It is recommended to run `huggingface-cli login` to log into your Hugging Face account first
 model_name = model_name if "/" not in model_name else model_name.split("/")[-1]
 try:
-    model.save_to_hub(f"{model_name}-matryoshka-nli-{reduced_dim}")
+    model.save_to_hub(f"{model_name}-nli-matryoshka-{reduced_dim}")
 except Exception:
     logging.error(
         "Error uploading model to the Hugging Face Hub. To upload it manually, you can run "
         f"`huggingface-cli login`, followed by loading the model using `model = SentenceTransformer({model_save_path!r})` "
-        f"and saving it using `model.save_to_hub('{model_name}-matryoshka-nli-{reduced_dim}')`."
+        f"and saving it using `model.save_to_hub('{model_name}-nli-matryoshka-{reduced_dim}')`."
     )

--- a/examples/training/matryoshka/matryoshka_sts.py
+++ b/examples/training/matryoshka/matryoshka_sts.py
@@ -112,3 +112,15 @@ model.fit(
 model = SentenceTransformer(model_save_path)
 test_evaluator = EmbeddingSimilarityEvaluator.from_input_examples(test_samples, name="sts-test")
 test_evaluator(model, output_path=model_save_path)
+
+# Optionally, save the model to the Hugging Face Hub!
+# It is recommended to run `huggingface-cli login` to log into your Hugging Face account first
+model_name = model_name if "/" not in model_name else model_name.split("/")[1]
+try:
+    model.save_to_hub(f"{model_name}-matryoshka-sts")
+except Exception:
+    logging.error(
+        "Error uploading model to the Hugging Face Hub. To upload it manually, you can run "
+        f"`huggingface-cli login`, followed by loading the model using `model = SentenceTransformer({model_save_path!r})` "
+        f"and saving it using `model.save_to_hub('{model_name}-matryoshka-sts')`."
+    )

--- a/examples/training/matryoshka/matryoshka_sts.py
+++ b/examples/training/matryoshka/matryoshka_sts.py
@@ -115,7 +115,7 @@ test_evaluator(model, output_path=model_save_path)
 
 # Optionally, save the model to the Hugging Face Hub!
 # It is recommended to run `huggingface-cli login` to log into your Hugging Face account first
-model_name = model_name if "/" not in model_name else model_name.split("/")[1]
+model_name = model_name if "/" not in model_name else model_name.split("/")[-1]
 try:
     model.save_to_hub(f"{model_name}-matryoshka-sts")
 except Exception:

--- a/examples/training/matryoshka/matryoshka_sts.py
+++ b/examples/training/matryoshka/matryoshka_sts.py
@@ -117,10 +117,10 @@ test_evaluator(model, output_path=model_save_path)
 # It is recommended to run `huggingface-cli login` to log into your Hugging Face account first
 model_name = model_name if "/" not in model_name else model_name.split("/")[-1]
 try:
-    model.save_to_hub(f"{model_name}-matryoshka-sts")
+    model.save_to_hub(f"{model_name}-sts-matryoshka")
 except Exception:
     logging.error(
         "Error uploading model to the Hugging Face Hub. To upload it manually, you can run "
         f"`huggingface-cli login`, followed by loading the model using `model = SentenceTransformer({model_save_path!r})` "
-        f"and saving it using `model.save_to_hub('{model_name}-matryoshka-sts')`."
+        f"and saving it using `model.save_to_hub('{model_name}-sts-matryoshka')`."
     )

--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -737,6 +737,7 @@ class SentenceTransformer(nn.Sequential):
             repo_type=None,
             exist_ok=exist_ok,
         )
+        repo_id = repo_url.repo_id  # Update the repo_id in case the old repo_id didn't contain a user or organization
         if local_model_path:
             folder_url = api.upload_folder(
                 repo_id=repo_id, folder_path=local_model_path, commit_message=commit_message


### PR DESCRIPTION
Hello!

## Pull Request overview
* Allow saving a model to the Hub without providing a user
* Upload Matryoshka models after training examples

## Details
### Saving a model
Before this PR, if you want to upload a model by only providing the second part of the repo_id (i.e. no user), then it'll throw an error. The model will be created on the Hub, but the `upload_folder` will fail. So, now we update the repo_id by taking the repo_url output. This adds the user if the `create_repo` was successful.

### Upload models after training examples
The examples folder should also show how to upload Sentence Transformer models to the Hub, so users can reuse the trained models. 

- Tom Aarsen