### PR TITLE
Add version range for numpy to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 transformers>=4.32.0,<5.0.0
 tqdm
 torch>=1.11.0
-numpy
+numpy>=1.17,<1.24.0
 scikit-learn
 scipy
 huggingface-hub>=0.15.1


### PR DESCRIPTION
#### Description

I ran into problems while trying to use `cross-encoder/nli-deberta-v3-xsmall` model with CrossEncoder. By default, sentence-transfomers will install latest numpy available from pip, unfortunately this introduces some breaking changes.
Specifically, while trying to fit the CrossEncoder(`cross-encoder/nli-deberta-v3-xsmall`), I'm getting the `np.int` depreciation error.

#### Additional comments

`np.int` was depricated in numpy 1.20 and removed in numpy 1.24. numpy 1.17 is the minimum version required for HF Transformers and that's why it is set here as well as the minimum version.

#### Fix

Fixed by specifying the version range for numpy.