### PR TITLE
Fix pooling ONNX export

### DIFF
--- a/sentence_transformers/models/Pooling.py
+++ b/sentence_transformers/models/Pooling.py
@@ -184,7 +184,13 @@ class Pooling(nn.Module):
             # attention_mask shape: (bs, seq_len)
             # Get shape [bs] indices of the last token (i.e. the last token for each batch item)
             # Use flip and max() to get the last index of 1 in the attention mask
+
+            if torch.jit.is_tracing():
+                # Avoid tracing the argmax with int64 input that can not be handled by ONNX Runtime: https://github.com/microsoft/onnxruntime/issues/10068
+                attention_mask = attention_mask.to(torch.int32)
+
             values, indices = attention_mask.flip(1).max(1)
+
             indices = torch.where(values == 0, seq_len - 1, indices)
             gather_indices = seq_len - indices - 1
 

--- a/sentence_transformers/models/Pooling.py
+++ b/sentence_transformers/models/Pooling.py
@@ -190,7 +190,6 @@ class Pooling(nn.Module):
                 attention_mask = attention_mask.to(torch.int32)
 
             values, indices = attention_mask.flip(1).max(1)
-
             indices = torch.where(values == 0, seq_len - 1, indices)
             gather_indices = seq_len - indices - 1
 


### PR DESCRIPTION
Currently, the exported ONNX model of `Pooling` with `pooling_mode_lasttoken` can not be consumed by ORT due to an `ArgMax` operator in int64, that ORT is not able to consume.

The issue can be reproduced with: `optimum-cli export onnx --model fxmarty/tiny-dummy-mistral-sentence-transformer mistral_st_onnx`

As reported in https://github.com/huggingface/optimum/issues/1731

See also https://github.com/microsoft/onnxruntime/issues/10068

@tomaarsen I could also patch the `Pooling` in Optimum, but its forward is rather big so I rather have it directly in sentence-transformers. Are you OK with that?