### PR TITLE
Fix `Semantic Textual Similarity` example

### DIFF
--- a/docs/usage/semantic_textual_similarity.md
+++ b/docs/usage/semantic_textual_similarity.md
@@ -65,8 +65,8 @@ cosine_scores = util.cos_sim(embeddings, embeddings)
 
 # Find the pairs with the highest cosine similarity scores
 pairs = []
-for i in range(len(cosine_scores) - 1):
-    for j in range(i + 1, len(cosine_scores)):
+for i in range(cosine_scores.shape[0]):
+    for j in range(cosine_scores.shape[1]):
         pairs.append({"index": [i, j], "score": cosine_scores[i][j]})
 
 # Sort scores in decreasing order


### PR DESCRIPTION
Hi here @tomaarsen!

## Description

This PR "fixes" the example presented within `Semantic Textual Similarity` as it assumes that the length of both lists of embeddings is the same i.e. square matrix, and it has been updated so that it's easier for users to reuse the cosine similarity computation and sorting.

The example is working fine and is fully reproducible, but I guess using the `shape` is more consistent on scenarios where the matrix is not squared, and also when the sentences from both embeddings are not the same (no need to skip the ones with 1.0 score).

## Example

With the change in this PR, not only the presented example works, but also:

```python
from sentence_transformers import SentenceTransformer, util

model = SentenceTransformer("all-MiniLM-L6-v2")

sentences_a = [
    "The cat sits outside",
    "A man is playing guitar",
    "I love pasta",
    "The new movie is awesome",
    "The cat plays in the garden",
]
sentences_b = [
    "A woman watches TV",
    "The new movie is so great",
    "Do you like pizza?",
]

# Compute embeddings
embeddings_a = model.encode(sentences_a, convert_to_tensor=True)
embeddings_b = model.encode(sentences_b, convert_to_tensor=True)

# Compute cosine-similarities for each sentence with each other sentence
cosine_scores = util.cos_sim(embeddings_a, embeddings_b)

# Find the pairs with the highest cosine similarity scores
pairs = []
for i in range(cosine_scores.shape[0]):
    for j in range(cosine_scores.shape[1]):
        pairs.append({"index": [i, j], "score": cosine_scores[i][j]})

# Sort scores in decreasing order
pairs = sorted(pairs, key=lambda x: x["score"], reverse=True)
for pair in pairs[0:10]:
    i, j = pair["index"]
    print("{} \t\t {} \t\t Score: {:.4f}".format(
        sentences_a[i], sentences_b[j], pair["score"]
    ))
```