### PR TITLE
[`example`] Don't always normalize the embeddings in clustering example

### DIFF
--- a/examples/applications/clustering/agglomerative.py
+++ b/examples/applications/clustering/agglomerative.py
@@ -6,7 +6,6 @@ Sentences are mapped to sentence embeddings and then agglomerative clustering wi
 
 from sentence_transformers import SentenceTransformer
 from sklearn.cluster import AgglomerativeClustering
-import numpy as np
 
 embedder = SentenceTransformer("all-MiniLM-L6-v2")
 
@@ -26,8 +25,8 @@ corpus = [
 ]
 corpus_embeddings = embedder.encode(corpus)
 
-# Normalize the embeddings to unit length
-corpus_embeddings = corpus_embeddings / np.linalg.norm(corpus_embeddings, axis=1, keepdims=True)
+# Some models don't automatically normalize the embeddings, in which case you should normalize the embeddings:
+# corpus_embeddings = corpus_embeddings / np.linalg.norm(corpus_embeddings, axis=1, keepdims=True)
 
 # Perform kmean clustering
 clustering_model = AgglomerativeClustering(


### PR DESCRIPTION
Closes #2519

Hello!

## Pull Request overview
* Don't always normalize the embeddings in clustering example

## Details
This change no longer automatically normalizes the embeddings, but does still show that it might be beneficial if the model doesn't already automatically do it.

- Tom Aarsen