### PR TITLE
Adding `push_to_hub` to CrossEncoder

### DIFF
--- a/sentence_transformers/cross_encoder/CrossEncoder.py
+++ b/sentence_transformers/cross_encoder/CrossEncoder.py
@@ -1,3 +1,5 @@
+from functools import wraps
+
 from transformers import AutoModelForSequenceClassification, AutoTokenizer, AutoConfig
 import numpy as np
 import logging
@@ -9,6 +11,8 @@ from torch.optim import Optimizer
 from torch.utils.data import DataLoader
 from tqdm.autonotebook import tqdm, trange
 from transformers import is_torch_npu_available
+from transformers.utils import PushToHubMixin
+
 from .. import SentenceTransformer, util
 from ..evaluation import SentenceEvaluator
 from ..util import get_device_name
@@ -17,7 +21,7 @@ from ..util import get_device_name
 logger = logging.getLogger(__name__)
 
 
-class CrossEncoder:
+class CrossEncoder(PushToHubMixin):
     """
     A CrossEncoder takes exactly two sentences / texts as input and either predicts
     a score or label for this sentence pair. It can for example predict the similarity of the sentence pair
@@ -448,7 +452,7 @@ class CrossEncoder:
                 if save_best_model:
                     self.save(output_path)
 
-    def save(self, path: str) -> None:
+    def save(self, path: str, **kwargs) -> None:
         """
         Saves all model and tokenizer to path
         """
@@ -456,11 +460,17 @@ class CrossEncoder:
             return
 
         logger.info("Save model to {}".format(path))
-        self.model.save_pretrained(path)
-        self.tokenizer.save_pretrained(path)
+        self.model.save_pretrained(path, **kwargs)
+        self.tokenizer.save_pretrained(path, **kwargs)
 
-    def save_pretrained(self, path: str) -> None:
+    def save_pretrained(self, path: str, **kwargs) -> None:
         """
         Same function as save
         """
-        return self.save(path)
+        return self.save(path, **kwargs)
+
+    @wraps(PushToHubMixin.push_to_hub)
+    def push_to_hub(self, *args, **kwargs):
+        tags = kwargs.get("tags", [])
+        kwargs["tags"] = [tags] if isinstance(tags, str) else tags
+        return super().push_to_hub(*args, **kwargs)


### PR DESCRIPTION
Hi, 
I've noticed that many new cool features have recently been added, so first of all, thank you for your work!

#### Description
The great CrossEncoder class currently lacks support for auto-uploading to huggingface through the `push_to_hub` function(although it's achievable using the transformers models API directly)
This PR adds inheritance from `PushToHubMixin`, which is the standard mechanism for performing `push_to_hub` in the Transformers library. 

As a result, it's possible to do it:
```python
from sentence_transformers import CrossEncoder

model = CrossEncoder("./mpnet-base-nli-matryoshka")
repo_id = "imvladikon/mpnet-base-nli-matryoshka"
model.push_to_hub(repo_id)
```

The resulting repo is here: https://huggingface.co/imvladikon/mpnet-base-nli-matryoshka where the README.md is generated automatically (which is the behavior that we have in the transformers library)


