### PR TITLE
Passing arbitrary keyword arguments to submodules

### DIFF
--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -208,7 +208,7 @@ class SentenceTransformer(nn.ModuleDict):
                 )
 
         if modules is not None and not isinstance(modules, OrderedDict):
-            modules = [(str(idx), module) for idx, module in enumerate(modules)]
+            modules = OrderedDict([(str(idx), module) for idx, module in enumerate(modules)])
 
         if module_kwargs is None:
             module_kwargs = OrderedDict([(str(idx), []) for idx in range(len(modules))])

--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -1096,7 +1096,7 @@ class SentenceTransformer(nn.Module):
             tokenizer_args={"token": token, "trust_remote_code": trust_remote_code, "revision": revision},
         )
         pooling_model = Pooling(transformer_model.get_word_embedding_dimension(), "mean")
-        return [transformer_model, pooling_model], OrderedDict()
+        return [transformer_model, pooling_model], OrderedDict([("0", []), ("1", [])])
 
     def _load_sbert_model(
         self,

--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -267,7 +267,6 @@ class SentenceTransformer(nn.Module):
     def forward(self, *args, **kwargs):
         split_kwargs = self._split_kwargs(kwargs)
         result = self._first_module()(*args, **split_kwargs[0])
-        print(self._submodules.values(), split_kwargs)
         for mod, current_kwargs in islice(zip(self._submodules.values(), split_kwargs), 1, None):
             result = mod(result, **current_kwargs)
         return result

--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -53,6 +53,8 @@ class SentenceTransformer(nn.Module):
         from the Hugging Face Hub with that name.
     :param modules: A list of torch Modules that should be called sequentially, can be used to create custom
         SentenceTransformer models from scratch.
+    :param module_kwargs: An iterable of lists that specifies which keyword arguments of `forward` that are passed
+        to which components in `modules`. If None, no keyword arguments are forwarded to the modules.
     :param device: Device (like "cuda", "cpu", "mps", "npu") that should be used for computation. If None, checks if a GPU
         can be used.
     :param prompts: A dictionary with prompts for the model. The key is the prompt name, the value is the prompt text.

--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -53,7 +53,7 @@ class SentenceTransformer(nn.Module):
         from the Hugging Face Hub with that name.
     :param modules: A list of torch Modules that should be called sequentially, can be used to create custom
         SentenceTransformer models from scratch.
-    :param module_kwargs: An iterable of lists that specifies which keyword arguments of `forward` that are passed
+    :param module_kwargs: An iterable of lists that specifies which keyword arguments of `forward` are passed
         to which components in `modules`. If None, no keyword arguments are forwarded to the modules.
     :param device: Device (like "cuda", "cpu", "mps", "npu") that should be used for computation. If None, checks if a GPU
         can be used.

--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -207,7 +207,7 @@ class SentenceTransformer(nn.Module):
 
         if modules is not None and not isinstance(modules, OrderedDict):
             modules = [(str(idx), module) for idx, module in enumerate(modules)]
-        self._submodules =  nn.ModuleDict(modules)
+        self._submodules = nn.ModuleDict(modules)
         # self._module_kwargs maps submodule names to the kwargs they receive in `forward`
         self._module_kwargs = module_kwargs
 
@@ -256,8 +256,10 @@ class SentenceTransformer(nn.Module):
         for keys in self._module_kwargs.values():
             required_keys = required_keys.union(set(keys))
         if provided_keys != required_keys:
-            raise ValueError(f"Expected keyword arguments {required_keys if len(required_keys)>0 else '{}'} "
-                             f"but got {provided_keys if len(provided_keys)>0 else '{}'}")
+            raise ValueError(
+                f"Expected keyword arguments {required_keys if len(required_keys)>0 else '{}'} "
+                f"but got {provided_keys if len(provided_keys)>0 else '{}'}"
+            )
         result = []
         for mod_keys in self._module_kwargs.values():
             current_kwargs = {key: kwargs[key] for key in mod_keys}
@@ -283,7 +285,7 @@ class SentenceTransformer(nn.Module):
         convert_to_tensor: bool = False,
         device: str = None,
         normalize_embeddings: bool = False,
-        **kwargs
+        **kwargs,
     ) -> Union[List[Tensor], ndarray, Tensor]:
         """
         Computes sentence embeddings.
@@ -1155,7 +1157,7 @@ class SentenceTransformer(nn.Module):
             modules_config = json.load(fIn)
 
         modules = OrderedDict()
-        modules_keys = OrderedDict() # maps module names to the kwargs they receive in `forward`
+        modules_keys = OrderedDict()  # maps module names to the kwargs they receive in `forward`
         for module_config in modules_config:
             module_class = import_from_string(module_config["type"])
             # For Transformer, don't load the full directory, rely on `transformers` instead

--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -208,6 +208,7 @@ class SentenceTransformer(nn.Module):
         if modules is not None and not isinstance(modules, OrderedDict):
             modules = [(str(idx), module) for idx, module in enumerate(modules)]
         self._submodules =  nn.ModuleDict(modules)
+        # self._module_kwargs maps submodule names to the kwargs they receive in `forward`
         self._module_kwargs = module_kwargs
 
         if device is None:
@@ -1155,7 +1156,7 @@ class SentenceTransformer(nn.Module):
             modules_config = json.load(fIn)
 
         modules = OrderedDict()
-        modules_keys = OrderedDict()
+        modules_keys = OrderedDict() # maps module names to the kwargs they receive in `forward`
         for module_config in modules_config:
             module_class = import_from_string(module_config["type"])
             # For Transformer, don't load the full directory, rely on `transformers` instead

--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -74,6 +74,7 @@ class SentenceTransformer(nn.Module):
         self,
         model_name_or_path: Optional[str] = None,
         modules: Optional[Iterable[nn.Module]] = None,
+        module_kwargs: Optional[Iterable[List[str]]] = None,
         device: Optional[str] = None,
         prompts: Optional[Dict[str, str]] = None,
         default_prompt_name: Optional[str] = None,
@@ -207,6 +208,17 @@ class SentenceTransformer(nn.Module):
 
         if modules is not None and not isinstance(modules, OrderedDict):
             modules = [(str(idx), module) for idx, module in enumerate(modules)]
+
+        if module_kwargs is None:
+            module_kwargs = OrderedDict([(str(idx), []) for idx in range(len(modules))])
+        elif module_kwargs is not None and not isinstance(module_kwargs, OrderedDict):
+            if len(module_kwargs) != len(modules):
+                raise ValueError(
+                    f"Length of 'module_kwargs' should match length "
+                    f"of 'modules' but got {len(module_kwargs)} and {len(modules)}."
+                )
+            module_kwargs = OrderedDict([(str(idx), kwargs) for idx, kwargs in enumerate(module_kwargs)])
+
         self._submodules = nn.ModuleDict(modules)
         # self._module_kwargs maps submodule names to the kwargs they receive in `forward`
         self._module_kwargs = module_kwargs

--- a/sentence_transformers/models/Transformer.py
+++ b/sentence_transformers/models/Transformer.py
@@ -89,13 +89,13 @@ class Transformer(nn.Module):
             self.get_config_dict(), self.auto_model.__class__.__name__
         )
 
-    def forward(self, features):
+    def forward(self, features, **kwargs):
         """Returns token_embeddings, cls_token"""
         trans_features = {"input_ids": features["input_ids"], "attention_mask": features["attention_mask"]}
         if "token_type_ids" in features:
             trans_features["token_type_ids"] = features["token_type_ids"]
 
-        output_states = self.auto_model(**trans_features, return_dict=False)
+        output_states = self.auto_model(**trans_features, **kwargs, return_dict=False)
         output_tokens = output_states[0]
 
         features.update({"token_embeddings": output_tokens, "attention_mask": features["attention_mask"]})


### PR DESCRIPTION
This PR implements a prototype of the proposal #2538. I.e., it allows arbitrary keyword arguments to be passed through `SentenceTransformer.encode` to the model.

Users may now specify in `modules.json` what keyword arguments are expected by which module. The `SentenceTransformer` class no longer inherits from `nn.Sequential`, but instead from `nn.ModuleDict`. We implement the `forward` method ourselves and distribute keyword arguments to the modules.

A model may then provide a `modules.json` file like this:

```json
[
  {
    "idx": 0,
    "name": "0",
    "path": "",
    "type": "sentence_transformers.models.Transformer",
    "kwargs": ["task", "embedding_dim", "foobar"]
  },
  {
    "idx": 1,
    "name": "1",
    "path": "1_Pooling",
    "type": "sentence_transformers.models.Pooling"
  }
]
```

and users may use the sentence-transformer model like this:

```python
model = SentenceTransformer('<MODEL>', trust_remote_code=True)
model.encode(['Hello world'], task='sts', embedding_dim=32, foobar=0)
```

### Todo
- These changes will be breaking if there is someone using the `.append` method, which was previously inherited from `nn.Sequential`. However, we could also implement it here
- It would make sense to also implement arbitrary kwargs for the tokenizer


