### PR TITLE
Enable saving modules as pytorch_model.bin

### DIFF
--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -619,7 +619,7 @@ class SentenceTransformer(nn.Sequential):
 
             os.makedirs(model_path, exist_ok=True)
             if isinstance(module, Transformer):
-                module.save(model_path, safe_serialization)
+                module.save(model_path, safe_serialization=safe_serialization)
             else:
                 module.save(model_path)
 

--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -576,7 +576,7 @@ class SentenceTransformer(nn.Sequential):
         model_name: Optional[str] = None,
         create_model_card: bool = True,
         train_datasets: Optional[List[str]] = None,
-        safe_serialization: bool = True
+        safe_serialization: bool = True,
     ):
         """
         Saves all elements for this seq. sentence embedder into different sub-folders
@@ -622,7 +622,7 @@ class SentenceTransformer(nn.Sequential):
                 module.save(model_path, safe_serialization)
             else:
                 module.save(model_path)
-            
+
             modules_config.append(
                 {"idx": idx, "name": name, "path": os.path.basename(model_path), "type": type(module).__module__}
             )

--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -576,6 +576,7 @@ class SentenceTransformer(nn.Sequential):
         model_name: Optional[str] = None,
         create_model_card: bool = True,
         train_datasets: Optional[List[str]] = None,
+        safe_serialization: bool = True
     ):
         """
         Saves all elements for this seq. sentence embedder into different sub-folders
@@ -584,6 +585,7 @@ class SentenceTransformer(nn.Sequential):
         :param model_name: Optional model name
         :param create_model_card: If True, create a README.md with basic information about this model
         :param train_datasets: Optional list with the names of the datasets used to to train the model
+        :param safe_serialization: If true, save the model using safetensors. If false, save the model the traditional PyTorch way
         """
         if path is None:
             return
@@ -616,7 +618,11 @@ class SentenceTransformer(nn.Sequential):
                 model_path = os.path.join(path, str(idx) + "_" + type(module).__name__)
 
             os.makedirs(model_path, exist_ok=True)
-            module.save(model_path)
+            if isinstance(module, Transformer):
+                module.save(model_path, safe_serialization)
+            else:
+                module.save(model_path)
+            
             modules_config.append(
                 {"idx": idx, "name": name, "path": os.path.basename(model_path), "type": type(module).__module__}
             )

--- a/sentence_transformers/cross_encoder/CrossEncoder.py
+++ b/sentence_transformers/cross_encoder/CrossEncoder.py
@@ -448,7 +448,7 @@ class CrossEncoder:
                 if save_best_model:
                     self.save(output_path)
 
-    def save(self, path: str) -> None:
+    def save(self, path: str, safe_serialization: bool = True) -> None:
         """
         Saves all model and tokenizer to path
         """
@@ -456,7 +456,7 @@ class CrossEncoder:
             return
 
         logger.info("Save model to {}".format(path))
-        self.model.save_pretrained(path)
+        self.model.save_pretrained(path, safe_serialization=safe_serialization)
         self.tokenizer.save_pretrained(path)
 
     def save_pretrained(self, path: str) -> None:

--- a/sentence_transformers/models/Transformer.py
+++ b/sentence_transformers/models/Transformer.py
@@ -156,7 +156,7 @@ class Transformer(nn.Module):
     def get_config_dict(self):
         return {key: self.__dict__[key] for key in self.config_keys}
 
-    def save(self, output_path: str, safe_serialization: bool):
+    def save(self, output_path: str, safe_serialization: bool = True):
         self.auto_model.save_pretrained(output_path, safe_serialization=safe_serialization)
         self.tokenizer.save_pretrained(output_path)
 

--- a/sentence_transformers/models/Transformer.py
+++ b/sentence_transformers/models/Transformer.py
@@ -156,8 +156,8 @@ class Transformer(nn.Module):
     def get_config_dict(self):
         return {key: self.__dict__[key] for key in self.config_keys}
 
-    def save(self, output_path: str):
-        self.auto_model.save_pretrained(output_path)
+    def save(self, output_path: str, safe_serialization: bool):
+        self.auto_model.save_pretrained(output_path, safe_serialization=safe_serialization)
         self.tokenizer.save_pretrained(output_path)
 
         with open(os.path.join(output_path, "sentence_bert_config.json"), "w") as fOut:

--- a/tests/test_cross_encoder.py
+++ b/tests/test_cross_encoder.py
@@ -154,6 +154,7 @@ def test_rank() -> None:
     pred_ranking = [rank["corpus_id"] for rank in ranks]
     assert pred_ranking == expected_ranking
 
+
 @pytest.mark.parametrize("safe_serialization", [True, False, None])
 def test_safe_serialization(safe_serialization: bool) -> None:
     with tempfile.TemporaryDirectory() as cache_folder:

--- a/tests/test_cross_encoder.py
+++ b/tests/test_cross_encoder.py
@@ -5,6 +5,8 @@ Tests that the pretrained models produce the correct scores on the STSbenchmark 
 import csv
 import gzip
 import os
+from pathlib import Path
+import tempfile
 
 import pytest
 import torch
@@ -151,3 +153,20 @@ def test_rank() -> None:
     ranks = model.rank(query, corpus)
     pred_ranking = [rank["corpus_id"] for rank in ranks]
     assert pred_ranking == expected_ranking
+
+@pytest.mark.parametrize("safe_serialization", [True, False, None])
+def test_safe_serialization(safe_serialization: bool) -> None:
+    with tempfile.TemporaryDirectory() as cache_folder:
+        model = CrossEncoder("cross-encoder/stsb-distilroberta-base")
+        if safe_serialization:
+            model.save(cache_folder, safe_serialization=safe_serialization)
+            model_files = list(Path(cache_folder).glob("**/model.safetensors"))
+            assert 1 == len(model_files)
+        elif safe_serialization is None:
+            model.save(cache_folder)
+            model_files = list(Path(cache_folder).glob("**/model.safetensors"))
+            assert 1 == len(model_files)
+        else:
+            model.save(cache_folder, safe_serialization=safe_serialization)
+            model_files = list(Path(cache_folder).glob("**/pytorch_model.bin"))
+            assert 1 == len(model_files)

--- a/tests/test_sentence_transformer.py
+++ b/tests/test_sentence_transformer.py
@@ -175,6 +175,17 @@ def test_save_to_hub(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureF
             == 'Providing an `organization` to `save_to_hub` is deprecated, please use `repo_id="sentence-transformers-testing/stsb-bert-tiny-safetensors"` instead.'
         )
 
+@pytest.mark.parametrize("safe_serialization", [True, False])
+def test_safe_serialization(safe_serialization: bool) -> None:
+    with tempfile.TemporaryDirectory() as cache_folder:
+        model = SentenceTransformer("sentence-transformers-testing/stsb-bert-tiny-safetensors")
+        model.save(cache_folder, safe_serialization=safe_serialization)
+        if safe_serialization:
+            model_files = list(Path(cache_folder).glob("**/model.safetensors"))
+            assert 1 == len(model_files)
+        else:
+            model_files = list(Path(cache_folder).glob("**/pytorch_model.bin"))
+            assert 1 == len(model_files)
 
 def test_load_with_revision() -> None:
     main_model = SentenceTransformer("sentence-transformers-testing/stsb-bert-tiny-safetensors", revision="main")

--- a/tests/test_sentence_transformer.py
+++ b/tests/test_sentence_transformer.py
@@ -175,6 +175,7 @@ def test_save_to_hub(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureF
             == 'Providing an `organization` to `save_to_hub` is deprecated, please use `repo_id="sentence-transformers-testing/stsb-bert-tiny-safetensors"` instead.'
         )
 
+
 @pytest.mark.parametrize("safe_serialization", [True, False, None])
 def test_safe_serialization(safe_serialization: bool) -> None:
     with tempfile.TemporaryDirectory() as cache_folder:
@@ -191,6 +192,7 @@ def test_safe_serialization(safe_serialization: bool) -> None:
             model.save(cache_folder, safe_serialization=safe_serialization)
             model_files = list(Path(cache_folder).glob("**/pytorch_model.bin"))
             assert 1 == len(model_files)
+
 
 def test_load_with_revision() -> None:
     main_model = SentenceTransformer("sentence-transformers-testing/stsb-bert-tiny-safetensors", revision="main")

--- a/tests/test_sentence_transformer.py
+++ b/tests/test_sentence_transformer.py
@@ -175,15 +175,20 @@ def test_save_to_hub(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureF
             == 'Providing an `organization` to `save_to_hub` is deprecated, please use `repo_id="sentence-transformers-testing/stsb-bert-tiny-safetensors"` instead.'
         )
 
-@pytest.mark.parametrize("safe_serialization", [True, False])
+@pytest.mark.parametrize("safe_serialization", [True, False, None])
 def test_safe_serialization(safe_serialization: bool) -> None:
     with tempfile.TemporaryDirectory() as cache_folder:
         model = SentenceTransformer("sentence-transformers-testing/stsb-bert-tiny-safetensors")
-        model.save(cache_folder, safe_serialization=safe_serialization)
         if safe_serialization:
+            model.save(cache_folder, safe_serialization=safe_serialization)
+            model_files = list(Path(cache_folder).glob("**/model.safetensors"))
+            assert 1 == len(model_files)
+        elif safe_serialization is None:
+            model.save(cache_folder)
             model_files = list(Path(cache_folder).glob("**/model.safetensors"))
             assert 1 == len(model_files)
         else:
+            model.save(cache_folder, safe_serialization=safe_serialization)
             model_files = list(Path(cache_folder).glob("**/pytorch_model.bin"))
             assert 1 == len(model_files)
 


### PR DESCRIPTION
Enables switching between `model.safetensors` and `pytorch_model.bin` when saving a model by setting the `safe_serialization` parameter to `True` (safetensors - default) or `False` (pytorch).

Resolves issue  #2533 .