### PR TITLE
[`feat`] Add 'get_config_dict' method to GISTEmbedLoss for better model cards

### DIFF
--- a/sentence_transformers/losses/GISTEmbedLoss.py
+++ b/sentence_transformers/losses/GISTEmbedLoss.py
@@ -1,4 +1,4 @@
-from typing import Iterable, Dict
+from typing import Any, Iterable, Dict
 import torch
 from torch import nn, Tensor
 from sentence_transformers.SentenceTransformer import SentenceTransformer
@@ -146,3 +146,9 @@ class GISTEmbedLoss(nn.Module):
         labels = torch.arange(scores.size(0)).long().to(scores.device)
 
         return nn.CrossEntropyLoss()(scores, labels)
+
+    def get_config_dict(self) -> Dict[str, Any]:
+        return {
+            "guide": self.guide,
+            "temperature": self.temperature,
+        }


### PR DESCRIPTION
Hello!

## Pull Request overview
* Add 'get_config_dict' method to GISTEmbedLoss

## Details
This should allow for better generation of model cards, as the guide & temperature will be included in the README. Sadly, it's not possible to get the model name without a hacky approach, so I'll just leave it with the printed Sentence Transformer, although that won't inform the reader on what model was actually used.

- Tom Aarsen