### PR TITLE
[`deprecation`] Deprecate `save_to_hub` in favor of `push_to_hub`; add safe_serialization support to `push_to_hub`

### DIFF
--- a/docs/hugging_face.md
+++ b/docs/hugging_face.md
@@ -71,19 +71,19 @@ pip install huggingface_hub
 huggingface-cli login
 ```
 
-Then, you can share your SentenceTransformers models by calling the [`save_to_hub` method](https://www.sbert.net/docs/package_reference/SentenceTransformer.html#sentence_transformers.SentenceTransformer.save_to_hub) from a trained model. By default, the model will be uploaded to your account, but you can upload to an [organization](https://huggingface.co/docs/hub/organizations) by passing setting an `organization` parameter. `save_to_hub` automatically generates a model card, an inference widget, example code snippets, and more.
+Then, you can share your SentenceTransformers models by calling the [`push_to_hub` method](https://www.sbert.net/docs/package_reference/SentenceTransformer.html#sentence_transformers.SentenceTransformer.push_to_hub) from a trained model. By default, the model will be uploaded to your account, but you can upload to an [organization](https://huggingface.co/docs/hub/organizations) by providing the organization as a part of the `repo_id`, e.g. `model.push_to_hub("my_organization/my_model_name")`. `push_to_hub` automatically generates a model card, an inference widget, example code snippets, and more.
 
 ```py
 from sentence_transformers import SentenceTransformer
 
 # Load or train a model
-model.save_to_hub("my_new_model")
+model.push_to_hub("my_new_model")
 ```
 
 You can automatically add to the Hub's model card a list of datasets you used to train the model with the argument `train_datasets: Optional[List[str]] = None)`. See the "Datasets used to train" section in the [ITESM/sentece-embeddings-BETO](https://huggingface.co/ITESM/sentece-embeddings-BETO) model for an example of the final result.
 
 ```py
-model.save_to_hub("my_new_model", train_datasets=["GEM/wiki_lingua", "code_search_net"])
+model.  ("my_new_model", train_datasets=["GEM/wiki_lingua", "code_search_net"])
 ```
 
 ## Sharing your embeddings

--- a/docs/hugging_face.md
+++ b/docs/hugging_face.md
@@ -83,7 +83,7 @@ model.push_to_hub("my_new_model")
 You can automatically add to the Hub's model card a list of datasets you used to train the model with the argument `train_datasets: Optional[List[str]] = None)`. See the "Datasets used to train" section in the [ITESM/sentece-embeddings-BETO](https://huggingface.co/ITESM/sentece-embeddings-BETO) model for an example of the final result.
 
 ```py
-model.  ("my_new_model", train_datasets=["GEM/wiki_lingua", "code_search_net"])
+model.push_to_hub("my_new_model", train_datasets=["GEM/wiki_lingua", "code_search_net"])
 ```
 
 ## Sharing your embeddings

--- a/docs/package_reference/SentenceTransformer.md
+++ b/docs/package_reference/SentenceTransformer.md
@@ -10,5 +10,6 @@ model = SentenceTransformer("model-name")
 ```eval_rst
 .. autoclass:: sentence_transformers.SentenceTransformer
    :members:
+   :exclude-members: save_to_hub
 
 ```

--- a/examples/training/adaptive_layer/adaptive_layer_nli.py
+++ b/examples/training/adaptive_layer/adaptive_layer_nli.py
@@ -148,10 +148,10 @@ test_evaluator(model, output_path=model_save_path)
 # It is recommended to run `huggingface-cli login` to log into your Hugging Face account first
 model_name = model_name if "/" not in model_name else model_name.split("/")[-1]
 try:
-    model.save_to_hub(f"{model_name}-nli-adaptive-layer")
+    model.push_to_hub(f"{model_name}-nli-adaptive-layer")
 except Exception:
     logging.error(
         "Error uploading model to the Hugging Face Hub. To upload it manually, you can run "
         f"`huggingface-cli login`, followed by loading the model using `model = SentenceTransformer({model_save_path!r})` "
-        f"and saving it using `model.save_to_hub('{model_name}-nli-adaptive-layer')`."
+        f"and saving it using `model.push_to_hub('{model_name}-nli-adaptive-layer')`."
     )

--- a/examples/training/adaptive_layer/adaptive_layer_sts.py
+++ b/examples/training/adaptive_layer/adaptive_layer_sts.py
@@ -118,10 +118,10 @@ test_evaluator(model, output_path=model_save_path)
 # It is recommended to run `huggingface-cli login` to log into your Hugging Face account first
 model_name = model_name if "/" not in model_name else model_name.split("/")[-1]
 try:
-    model.save_to_hub(f"{model_name}-sts-adaptive-layer")
+    model.push_to_hub(f"{model_name}-sts-adaptive-layer")
 except Exception:
     logging.error(
         "Error uploading model to the Hugging Face Hub. To upload it manually, you can run "
         f"`huggingface-cli login`, followed by loading the model using `model = SentenceTransformer({model_save_path!r})` "
-        f"and saving it using `model.save_to_hub('{model_name}-sts-adaptive-layer')`."
+        f"and saving it using `model.push_to_hub('{model_name}-sts-adaptive-layer')`."
     )

--- a/examples/training/matryoshka/2d_matryoshka_nli.py
+++ b/examples/training/matryoshka/2d_matryoshka_nli.py
@@ -148,10 +148,10 @@ test_evaluator(model, output_path=model_save_path)
 # It is recommended to run `huggingface-cli login` to log into your Hugging Face account first
 model_name = model_name if "/" not in model_name else model_name.split("/")[-1]
 try:
-    model.save_to_hub(f"{model_name}-nli-2d-matryoshka")
+    model.push_to_hub(f"{model_name}-nli-2d-matryoshka")
 except Exception:
     logging.error(
         "Error uploading model to the Hugging Face Hub. To upload it manually, you can run "
         f"`huggingface-cli login`, followed by loading the model using `model = SentenceTransformer({model_save_path!r})` "
-        f"and saving it using `model.save_to_hub('{model_name}-nli-2d-matryoshka')`."
+        f"and saving it using `model.push_to_hub('{model_name}-nli-2d-matryoshka')`."
     )

--- a/examples/training/matryoshka/2d_matryoshka_sts.py
+++ b/examples/training/matryoshka/2d_matryoshka_sts.py
@@ -118,10 +118,10 @@ test_evaluator(model, output_path=model_save_path)
 # It is recommended to run `huggingface-cli login` to log into your Hugging Face account first
 model_name = model_name if "/" not in model_name else model_name.split("/")[-1]
 try:
-    model.save_to_hub(f"{model_name}-sts-2d-matryoshka")
+    model.push_to_hub(f"{model_name}-sts-2d-matryoshka")
 except Exception:
     logging.error(
         "Error uploading model to the Hugging Face Hub. To upload it manually, you can run "
         f"`huggingface-cli login`, followed by loading the model using `model = SentenceTransformer({model_save_path!r})` "
-        f"and saving it using `model.save_to_hub('{model_name}-sts-2d-matryoshka')`."
+        f"and saving it using `model.push_to_hub('{model_name}-sts-2d-matryoshka')`."
     )

--- a/examples/training/matryoshka/matryoshka_nli.py
+++ b/examples/training/matryoshka/matryoshka_nli.py
@@ -148,10 +148,10 @@ test_evaluator(model, output_path=model_save_path)
 # It is recommended to run `huggingface-cli login` to log into your Hugging Face account first
 model_name = model_name if "/" not in model_name else model_name.split("/")[-1]
 try:
-    model.save_to_hub(f"{model_name}-nli-matryoshka")
+    model.push_to_hub(f"{model_name}-nli-matryoshka")
 except Exception:
     logging.error(
         "Error uploading model to the Hugging Face Hub. To upload it manually, you can run "
         f"`huggingface-cli login`, followed by loading the model using `model = SentenceTransformer({model_save_path!r})` "
-        f"and saving it using `model.save_to_hub('{model_name}-nli-matryoshka')`."
+        f"and saving it using `model.push_to_hub('{model_name}-nli-matryoshka')`."
     )

--- a/examples/training/matryoshka/matryoshka_nli_reduced_dim.py
+++ b/examples/training/matryoshka/matryoshka_nli_reduced_dim.py
@@ -153,10 +153,10 @@ test_evaluator(model, output_path=model_save_path)
 # It is recommended to run `huggingface-cli login` to log into your Hugging Face account first
 model_name = model_name if "/" not in model_name else model_name.split("/")[-1]
 try:
-    model.save_to_hub(f"{model_name}-nli-matryoshka-{reduced_dim}")
+    model.push_to_hub(f"{model_name}-nli-matryoshka-{reduced_dim}")
 except Exception:
     logging.error(
         "Error uploading model to the Hugging Face Hub. To upload it manually, you can run "
         f"`huggingface-cli login`, followed by loading the model using `model = SentenceTransformer({model_save_path!r})` "
-        f"and saving it using `model.save_to_hub('{model_name}-nli-matryoshka-{reduced_dim}')`."
+        f"and saving it using `model.push_to_hub('{model_name}-nli-matryoshka-{reduced_dim}')`."
     )

--- a/examples/training/matryoshka/matryoshka_sts.py
+++ b/examples/training/matryoshka/matryoshka_sts.py
@@ -118,10 +118,10 @@ test_evaluator(model, output_path=model_save_path)
 # It is recommended to run `huggingface-cli login` to log into your Hugging Face account first
 model_name = model_name if "/" not in model_name else model_name.split("/")[-1]
 try:
-    model.save_to_hub(f"{model_name}-sts-matryoshka")
+    model.push_to_hub(f"{model_name}-sts-matryoshka")
 except Exception:
     logging.error(
         "Error uploading model to the Hugging Face Hub. To upload it manually, you can run "
         f"`huggingface-cli login`, followed by loading the model using `model = SentenceTransformer({model_save_path!r})` "
-        f"and saving it using `model.save_to_hub('{model_name}-sts-matryoshka')`."
+        f"and saving it using `model.push_to_hub('{model_name}-sts-matryoshka')`."
     )

--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -700,6 +700,7 @@ class SentenceTransformer(nn.Sequential):
         organization: Optional[str] = None,
         token: Optional[str] = None,
         private: Optional[bool] = None,
+        safe_serialization: bool = True,
         commit_message: str = "Add new SentenceTransformer model.",
         local_model_path: Optional[str] = None,
         exist_ok: bool = False,
@@ -712,6 +713,7 @@ class SentenceTransformer(nn.Sequential):
         :param repo_id: Repository name for your model in the Hub, including the user or organization.
         :param token: An authentication token (See https://huggingface.co/settings/token)
         :param private: Set to true, for hosting a private model
+        :param safe_serialization: If true, save the model using safetensors. If false, save the model the traditional PyTorch way
         :param commit_message: Message to commit while pushing.
         :param local_model_path: Path of the model locally. If set, this file path will be uploaded. Otherwise, the current model will be uploaded
         :param exist_ok: If true, saving to an existing repository is OK. If false, saving only to a new repository is possible
@@ -756,6 +758,7 @@ class SentenceTransformer(nn.Sequential):
                     model_name=repo_url.repo_id,
                     create_model_card=create_model_card,
                     train_datasets=train_datasets,
+                    safe_serialization=safe_serialization,
                 )
                 folder_url = api.upload_folder(repo_id=repo_id, folder_path=tmp_dir, commit_message=commit_message)
 

--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -727,7 +727,7 @@ class SentenceTransformer(nn.Sequential):
         """
         logger.warning(
             "The `save_to_hub` method is deprecated and will be removed in a future version of SentenceTransformers."
-            " Please use `push_to_hub` instead."
+            " Please use `push_to_hub` instead for future model uploads."
         )
 
         if organization:

--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -706,8 +706,10 @@ class SentenceTransformer(nn.Sequential):
         exist_ok: bool = False,
         replace_model_card: bool = False,
         train_datasets: Optional[List[str]] = None,
-    ):
+    ) -> str:
         """
+        DEPRECATED, use `push_to_hub` instead.
+
         Uploads all elements of this Sentence Transformer to a new HuggingFace Hub repository.
 
         :param repo_id: Repository name for your model in the Hub, including the user or organization.
@@ -723,6 +725,11 @@ class SentenceTransformer(nn.Sequential):
 
         :return: The url of the commit of your model in the repository on the Hugging Face Hub.
         """
+        logger.warning(
+            "The `save_to_hub` method is deprecated and will be removed in a future version of SentenceTransformers."
+            " Please use `push_to_hub` instead."
+        )
+
         if organization:
             if "/" not in repo_id:
                 logger.warning(
@@ -738,6 +745,45 @@ class SentenceTransformer(nn.Sequential):
                     f'Providing an `organization` to `save_to_hub` is deprecated, please only use `repo_id="{repo_id}"` instead.'
                 )
 
+        return self.push_to_hub(
+            repo_id=repo_id,
+            token=token,
+            private=private,
+            safe_serialization=safe_serialization,
+            commit_message=commit_message,
+            local_model_path=local_model_path,
+            exist_ok=exist_ok,
+            replace_model_card=replace_model_card,
+            train_datasets=train_datasets,
+        )
+
+    def push_to_hub(
+        self,
+        repo_id: str,
+        token: Optional[str] = None,
+        private: Optional[bool] = None,
+        safe_serialization: bool = True,
+        commit_message: str = "Add new SentenceTransformer model.",
+        local_model_path: Optional[str] = None,
+        exist_ok: bool = False,
+        replace_model_card: bool = False,
+        train_datasets: Optional[List[str]] = None,
+    ) -> str:
+        """
+        Uploads all elements of this Sentence Transformer to a new HuggingFace Hub repository.
+
+        :param repo_id: Repository name for your model in the Hub, including the user or organization.
+        :param token: An authentication token (See https://huggingface.co/settings/token)
+        :param private: Set to true, for hosting a private model
+        :param safe_serialization: If true, save the model using safetensors. If false, save the model the traditional PyTorch way
+        :param commit_message: Message to commit while pushing.
+        :param local_model_path: Path of the model locally. If set, this file path will be uploaded. Otherwise, the current model will be uploaded
+        :param exist_ok: If true, saving to an existing repository is OK. If false, saving only to a new repository is possible
+        :param replace_model_card: If true, replace an existing model card in the hub with the automatically created model card
+        :param train_datasets: Datasets used to train the model. If set, the datasets will be added to the model card in the Hub.
+
+        :return: The url of the commit of your model in the repository on the Hugging Face Hub.
+        """
         api = HfApi(token=token)
         repo_url = api.create_repo(
             repo_id=repo_id,


### PR DESCRIPTION
Hello!

## Pull Request overview
* Deprecate `save_to_hub` in favor of `push_to_hub`
* Extends #2542 to add safe_serialization support to `push_to_hub`

## Details
We're deprecating `save_to_hub` in favor of `push_to_hub`, as the latter is more familiar to users of `transformers`.

cc: @LysandreJik

- Tom Aarsen