### PR TITLE
Fix SentenceTransformer encode documentation return type default (numpy vectors)

### DIFF
--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -281,8 +281,8 @@ class SentenceTransformer(nn.Sequential):
         :param normalize_embeddings: Whether to normalize returned vectors to have length 1. In that case,
             the faster dot-product (util.dot_score) instead of cosine similarity can be used.
 
-        :return: By default, a list of numpy vectors is returned. If convert_to_tensor, a stacked tensor is returned.
-            If convert_to_numpy, a list of numpy vectors is returned.
+        :return: By default, a numpy array is returned. If convert_to_tensor, a stacked tensor is returned.
+            If convert_to_numpy, a numpy array is returned.
         """
         self.eval()
         if show_progress_bar is None:

--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -281,8 +281,9 @@ class SentenceTransformer(nn.Sequential):
         :param normalize_embeddings: Whether to normalize returned vectors to have length 1. In that case,
             the faster dot-product (util.dot_score) instead of cosine similarity can be used.
 
-        :return: By default, a numpy array is returned. If convert_to_tensor, a stacked tensor is returned.
-            If convert_to_numpy, a numpy array is returned.
+        :return: By default, a 2d numpy array with shape [num_inputs, output_dimension] is returned. If only one string
+            input is provided, then the output is a 1d array with shape [output_dimension]. If `convert_to_tensor`, a
+            torch Tensor is returned instead.
         """
         self.eval()
         if show_progress_bar is None:

--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -281,7 +281,7 @@ class SentenceTransformer(nn.Sequential):
         :param normalize_embeddings: Whether to normalize returned vectors to have length 1. In that case,
             the faster dot-product (util.dot_score) instead of cosine similarity can be used.
 
-        :return: By default, a list of tensors is returned. If convert_to_tensor, a stacked tensor is returned.
+        :return: By default, a list of numpy vectors is returned. If convert_to_tensor, a stacked tensor is returned.
             If convert_to_numpy, a numpy matrix is returned.
         """
         self.eval()

--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -282,7 +282,7 @@ class SentenceTransformer(nn.Sequential):
             the faster dot-product (util.dot_score) instead of cosine similarity can be used.
 
         :return: By default, a list of numpy vectors is returned. If convert_to_tensor, a stacked tensor is returned.
-            If convert_to_numpy, a numpy matrix is returned.
+            If convert_to_numpy, a list of numpy vectors is returned.
         """
         self.eval()
         if show_progress_bar is None:


### PR DESCRIPTION
Resolves #1922

I have checked the documentation and the code again and have come to the conclusion that this has not yet been fixed. If I am missing something, the PR can be closed again.