### PR TITLE
[`docs`] Update return docstring of encode_multi_process

### DIFF
--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -476,7 +476,7 @@ class SentenceTransformer(nn.Sequential):
         :param chunk_size: Sentences are chunked and sent to the individual processes. If none, it determine a sensible size.
         :param normalize_embeddings: Whether to normalize returned vectors to have length 1. In that case,
             the faster dot-product (util.dot_score) instead of cosine similarity can be used.
-        :return: Numpy matrix with all embeddings
+        :return: 2d numpy array with shape [num_inputs, output_dimension]
         """
 
         if chunk_size is None:


### PR DESCRIPTION
Hello!

## Pull Request overview
* Update return docstring of `encode_multi_process`

## Details
Follow-up of #2546, but for the multi_process variant of encode.

- Tom Aarsen