### PR TITLE
[`hotfix`] Quantization patch; fix semantic_search_faiss/semantic_search_usearch rescoring

### DIFF
--- a/examples/applications/embedding-quantization/semantic_search_recommended.py
+++ b/examples/applications/embedding-quantization/semantic_search_recommended.py
@@ -94,7 +94,7 @@ def search(query, top_k: int = 10, rescore_multiplier: int = 4):
 
     # 6. Sort the scores and return the top_k
     start_time = time.time()
-    indices = scores.argsort()[:top_k]
+    indices = (-scores).argsort()[:top_k]
     top_k_indices = binary_ids[indices]
     top_k_scores = scores[indices]
     sort_time = time.time() - start_time

--- a/sentence_transformers/quantization.py
+++ b/sentence_transformers/quantization.py
@@ -140,7 +140,7 @@ def semantic_search_faiss(
         rescored_scores = np.einsum("ij,ikj->ik", rescore_embeddings, top_k_embeddings)
         rescored_indices = np.argsort(-rescored_scores)[:, :top_k]
         indices = indices[np.arange(len(query_embeddings))[:, None], rescored_indices]
-        scores = rescored_scores[:, :top_k]
+        scores = rescored_scores[np.arange(len(query_embeddings))[:, None], rescored_indices]
 
     delta_t = time.time() - start_t
 
@@ -293,7 +293,7 @@ def semantic_search_usearch(
         rescored_scores = np.einsum("ij,ikj->ik", rescore_embeddings, top_k_embeddings)
         rescored_indices = np.argsort(-rescored_scores)[:, :top_k]
         indices = indices[np.arange(len(query_embeddings))[:, None], rescored_indices]
-        scores = rescored_scores[:, :top_k]
+        scores = rescored_scores[np.arange(len(query_embeddings))[:, None], rescored_indices]
 
     delta_t = time.time() - start_t
 


### PR DESCRIPTION
Hello!

## Pull Request overview
* Fix semantic_search_faiss/semantic_search_usearch rescoring
* Fix incorrect sorting in `semantic_search_recommended.py`

## Details
### Fix semantic_search_faiss/semantic_search_usearch rescoring
In these helper methods, the rescoring would update the corpus indices based on the new scores, but the returned scores corresponded to the original ranking, not the new one. As a result, the returned score for the first sample would not strictly have to be the highest, even if it should be.

This has been resolved now.

### Fix incorrect sorting in `semantic_search_recommended.py`
The rescoring results were sorted the wrong way around: low to high rather than high to low. This resulted in worse performance than should be expected. This is also resolved with this PR.

- Tom Aarsen