### PR TITLE
[`docs`] Add simple Makefile for building docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,6 @@ nr_*/
 /TODO.txt
 /docs/_build/
 /docs/make.bat
-/docs/Makefile
 /examples/training/quora_duplicate_questions/quora-IR-dataset/
 build
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,3 @@
+
+docs:
+	sphinx-build -c . -a -E .. _build

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,8 +14,6 @@
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
 
-# sphinx-build -c . -a -E .. _build
-
 from recommonmark.transform import AutoStructify
 import os
 from sphinx.domains import Domain


### PR DESCRIPTION
Hello!

## Pull Request overview
* Add simple Makefile for building docs

## Details
This should make it a tad easier to build the docs: `make docs` from the `docs` directory.

- Tom Aarsen