### PR TITLE
Fix semantic_search_usearch() for single query

### DIFF
--- a/sentence_transformers/quantization.py
+++ b/sentence_transformers/quantization.py
@@ -277,6 +277,11 @@ def semantic_search_usearch(
     scores = matches.distances
     indices = matches.keys
 
+    if scores.ndim < 2:
+        scores = np.atleast_2d(scores)
+    if indices.ndim < 2:
+        indices = np.atleast_2d(indices)
+
     # If rescoring is enabled, we need to rescore the results using the rescore_embeddings
     if rescore_embeddings is not None:
         top_k_embeddings = np.array([corpus_index.get(query_indices) for query_indices in indices])


### PR DESCRIPTION
This patch fixes a bug where the `sentence_transformers.quantization.semantic_search_usearch()` method would fail with `TypeError: 'numpy.float32' object is not iterable` where only a single query is used.

Example code:

```python
import numpy as np
import sentence_transformers

query_embeddings = np.array([[1, 2, 3]], dtype=np.int8)
corpus_embeddings = np.array([[1, 2, 3], [4, 5, 6]], dtype=np.int8)

hits, duration = sentence_transformers.quantization.semantic_search_usearch(
  query_embeddings=query_embeddings,
  corpus_embeddings=corpus_embeddings,
  corpus_precision="binary",
  rescore=False,
  top_k=min(len(corpus_embeddings), 10))
```

This raises `TypeError: 'numpy.float32' object is not iterable` without this patch, because the code expects the `scores` and `indices` to be a 2D array: https://github.com/UKPLab/sentence-transformers/blob/0253363934cf71c89f85fbf7af9e1beb7299b751/sentence_transformers/quantization.py#L300-L309

However, the `usearch` [implementation](https://github.com/unum-cloud/usearch/blob/ee1a5d95aac51e3986d2b89abe5c7db7aadc5028/python/usearch/client.py#L87-L91) in the Python client returns 1D arrays for a single query, and a 2D array for multiple queries:

```python
def search(self, vectors: np.ndarray, count: int) -> Matches:
    if vectors.ndim == 1 or (vectors.ndim == 2 and vectors.shape[0] == 1):
        return self.search_one(vectors, count)
    else:
        return self.search_many(vectors, count)
```

The problem also manifests in the example code here:

https://github.com/UKPLab/sentence-transformers/blob/0253363934cf71c89f85fbf7af9e1beb7299b751/examples/applications/embedding-quantization/semantic_search_usearch.py#L16-L19

When just a single query is passed, it fails with the error above.

I wasn't sure if I should add tests for this patch — I can definitely do so, when needed.
