### PR TITLE
[`feat`] Add truncation support

### DIFF
--- a/docs/package_reference/util.md
+++ b/docs/package_reference/util.md
@@ -3,5 +3,5 @@
 
 ```eval_rst
 .. automodule:: sentence_transformers.util
-   :members: cos_sim, dot_score, paraphrase_mining, semantic_search, community_detection, http_get
+   :members: cos_sim, dot_score, paraphrase_mining, semantic_search, community_detection, http_get, truncate_embeddings
 ```

--- a/examples/training/matryoshka/README.md
+++ b/examples/training/matryoshka/README.md
@@ -65,7 +65,7 @@ matryoshka_dim = 64
 model = SentenceTransformer(
     "nomic-ai/nomic-embed-text-v1.5",
     trust_remote_code=True,
-    output_dim=matryoshka_dim,
+    truncate_dim=matryoshka_dim,
 )
 
 embeddings = model.encode(

--- a/examples/training/matryoshka/README.md
+++ b/examples/training/matryoshka/README.md
@@ -54,16 +54,20 @@ loss = Matryoshka2dLoss(model=model, loss=base_loss, matryoshka_dims=[768, 512, 
 
 ## Inference
 
-After a model has been trained using a Matryoshka loss, you can then run inference with it using <a href="../../../docs/package_reference/SentenceTransformer.html#sentence_transformers.SentenceTransformer.encode"><code>SentenceTransformers.encode</code></a>. You must then truncate the resulting embeddings, and it is recommended to renormalize the embeddings.
+After a model has been trained using a Matryoshka loss, you can then run inference with it using <a href="../../../docs/package_reference/SentenceTransformer.html#sentence_transformers.SentenceTransformer.encode"><code>SentenceTransformers.encode</code></a>.
 
 ```python
 from sentence_transformers import SentenceTransformer
 from sentence_transformers.util import cos_sim
 import torch.nn.functional as F
 
-model = SentenceTransformer("nomic-ai/nomic-embed-text-v1.5", trust_remote_code=True)
-
 matryoshka_dim = 64
+model = SentenceTransformer(
+    "nomic-ai/nomic-embed-text-v1.5",
+    trust_remote_code=True,
+    output_dim=matryoshka_dim,
+)
+
 embeddings = model.encode(
     [
         "search_query: What is TSNE?",
@@ -71,7 +75,7 @@ embeddings = model.encode(
         "search_document: Amelia Mary Earhart was an American aviation pioneer and writer.",
     ]
 )
-embeddings = embeddings[..., :matryoshka_dim]  # Shrink the embedding dimensions
+assert embeddings.shape[-1] == matryoshka_dim
 
 similarities = cos_sim(embeddings[0], embeddings[1:])
 # => tensor([[0.7839, 0.4933]])
@@ -86,6 +90,7 @@ See the following scripts as examples of how to apply the <a href="../../../docs
 
 * **[matryoshka_nli.py](matryoshka_nli.py)**: This example uses the MultipleNegativesRankingLoss with MatryoshkaLoss to train a strong embedding model using Natural Language Inference (NLI) data. It is an adaptation of the [NLI](../nli/README) documentation.
 * **[matryoshka_nli_reduced_dim.py](matryoshka_nli_reduced_dim.py)**: This example uses the MultipleNegativesRankingLoss with MatryoshkaLoss to train a strong embedding model with a small maximum output dimension of 256. It trains using Natural Language Inference (NLI) data, and is an adaptation of the [NLI](../nli/README) documentation.
+* **[matryoshka_eval_stsb.py](matryoshka_eval_stsb.py)**: This example evaluates the embedding model trained with MatryoshkaLoss in [matryoshka_nli.py](matryoshka_nli.py) on the test set of the STSBenchmark dataset, and compares it to a non-Matryoshka trained model.
 * **[matryoshka_sts.py](matryoshka_sts.py)**: This example uses the CoSENTLoss with MatryoshkaLoss to train an embedding model on the training set of the STSBenchmark dataset. It is an adaptation of the [STS](../sts/README) documentation.
 
 And the following scripts to see how to apply <a href="../../../docs/package_reference/losses.html#matryoshka2dloss"><code>Matryoshka2dLoss</code></a>:

--- a/examples/training/matryoshka/matryoshka_eval_stsb.py
+++ b/examples/training/matryoshka/matryoshka_eval_stsb.py
@@ -159,7 +159,7 @@ if __name__ == "__main__":
         for dim in tqdm(DIMENSIONS, desc=f"Evaluating {model_name}"):
             output_path = os.path.join(model_name, f"dim-{dim}")
             os.makedirs(output_path)
-            with model.truncate_sentence_embeddings(dim):
+            with model.truncate_dim(dim):
                 score = test_evaluator(model, output_path=output_path)
             print(f"Saved results to {output_path}")
             dim_to_score[dim] = score

--- a/examples/training/matryoshka/matryoshka_eval_stsb.py
+++ b/examples/training/matryoshka/matryoshka_eval_stsb.py
@@ -159,7 +159,7 @@ if __name__ == "__main__":
         for dim in tqdm(DIMENSIONS, desc=f"Evaluating {model_name}"):
             output_path = os.path.join(model_name, f"dim-{dim}")
             os.makedirs(output_path)
-            with model.truncate_dim(dim):
+            with model.truncate_sentence_embeddings(dim):
                 score = test_evaluator(model, output_path=output_path)
             print(f"Saved results to {output_path}")
             dim_to_score[dim] = score

--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -594,7 +594,7 @@ class SentenceTransformer(nn.Sequential):
         return output_dim
 
     @contextmanager
-    def truncate_sentence_embeddings(self, output_dim: Optional[int]):
+    def truncate_dim(self, output_dim: Optional[int]):
         """
         In this context, `model.encode` outputs sentence embeddings truncated at dimension `output_dim`.
 
@@ -609,7 +609,7 @@ class SentenceTransformer(nn.Sequential):
 
             model = SentenceTransformer("model-name")
 
-            with model.truncate_sentence_embeddings(output_dim=16):
+            with model.truncate_dim(output_dim=16):
                 embeddings_truncated = model.encode(["hello there", "hiya"])
             assert embeddings_truncated.shape[-1] == 16
 

--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -70,7 +70,8 @@ class SentenceTransformer(nn.Sequential):
         This option should only be set to True for repositories you trust and in which you have read the code, as it
         will execute code present on the Hub on your local machine.
     :param token: Hugging Face authentication token to download private models.
-    :param truncate_dim: The dimension to truncate sentence embeddings to. `None` does no truncation.
+    :param truncate_dim: The dimension to truncate sentence embeddings to. `None` does no truncation. Truncation is
+        only applicable during inference when `.encode` is called.
     """
 
     def __init__(

--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -594,7 +594,7 @@ class SentenceTransformer(nn.Sequential):
         return output_dim
 
     @contextmanager
-    def truncate_sentence_embeddings(self, output_dim: int | None):
+    def truncate_sentence_embeddings(self, output_dim: Optional[int]):
         """
         In this context, `model.encode` outputs sentence embeddings truncated at dimension `output_dim`.
 

--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -361,6 +361,9 @@ class SentenceTransformer(nn.Sequential):
 
             with torch.no_grad():
                 out_features = self.forward(features)
+                out_features["sentence_embedding"] = truncate_embeddings(
+                    out_features["sentence_embedding"], self.truncate_dim
+                )
 
                 if output_value == "token_embeddings":
                     embeddings = []
@@ -376,9 +379,8 @@ class SentenceTransformer(nn.Sequential):
                         row = {name: out_features[name][sent_idx] for name in out_features}
                         embeddings.append(row)
                 else:  # Sentence embeddings
-                    embeddings: torch.Tensor = out_features[output_value]
+                    embeddings = out_features[output_value]
                     embeddings = embeddings.detach()
-                    embeddings = truncate_embeddings(embeddings, self.truncate_dim)
                     if normalize_embeddings:
                         embeddings = torch.nn.functional.normalize(embeddings, p=2, dim=1)
 

--- a/sentence_transformers/util.py
+++ b/sentence_transformers/util.py
@@ -10,7 +10,7 @@ import torch
 import numpy as np
 import queue
 import logging
-from typing import Dict, Optional, Union
+from typing import Dict, Optional, Union, overload
 
 from transformers import is_torch_npu_available
 from huggingface_hub import snapshot_download, hf_hub_download
@@ -140,6 +140,25 @@ def normalize_embeddings(embeddings: Tensor) -> Tensor:
     Normalizes the embeddings matrix, so that each sentence embedding has unit length
     """
     return torch.nn.functional.normalize(embeddings, p=2, dim=1)
+
+
+@overload
+def truncate_embeddings(embeddings: np.ndarray, output_dim: Optional[int]) -> np.ndarray: ...
+
+
+@overload
+def truncate_embeddings(embeddings: torch.Tensor, output_dim: Optional[int]) -> torch.Tensor: ...
+
+
+def truncate_embeddings(
+    embeddings: Union[np.ndarray, torch.Tensor], output_dim: Optional[int]
+) -> Union[np.ndarray, torch.Tensor]:
+    """
+    :param embeddings: Embeddings to truncate.
+    :param output_dim: Number of dimensions to truncate sentence embeddings to. `None` does no truncation.
+    :return: Truncated embeddings.
+    """
+    return embeddings[..., :output_dim]
 
 
 def paraphrase_mining(

--- a/sentence_transformers/util.py
+++ b/sentence_transformers/util.py
@@ -143,22 +143,22 @@ def normalize_embeddings(embeddings: Tensor) -> Tensor:
 
 
 @overload
-def truncate_embeddings(embeddings: np.ndarray, output_dim: Optional[int]) -> np.ndarray: ...
+def truncate_embeddings(embeddings: np.ndarray, truncate_dim: Optional[int]) -> np.ndarray: ...
 
 
 @overload
-def truncate_embeddings(embeddings: torch.Tensor, output_dim: Optional[int]) -> torch.Tensor: ...
+def truncate_embeddings(embeddings: torch.Tensor, truncate_dim: Optional[int]) -> torch.Tensor: ...
 
 
 def truncate_embeddings(
-    embeddings: Union[np.ndarray, torch.Tensor], output_dim: Optional[int]
+    embeddings: Union[np.ndarray, torch.Tensor], truncate_dim: Optional[int]
 ) -> Union[np.ndarray, torch.Tensor]:
     """
     :param embeddings: Embeddings to truncate.
-    :param output_dim: Number of dimensions to truncate sentence embeddings to. `None` does no truncation.
+    :param truncate_dim: The dimension to truncate sentence embeddings to. `None` does no truncation.
     :return: Truncated embeddings.
     """
-    return embeddings[..., :output_dim]
+    return embeddings[..., :truncate_dim]
 
 
 def paraphrase_mining(

--- a/tests/test_sentence_transformer.py
+++ b/tests/test_sentence_transformer.py
@@ -447,7 +447,7 @@ def test_encode_truncate(
 
     # Test context manager
     final_ouptut_dim = int(original_output_dim / 8)
-    with model.truncate_sentence_embeddings(final_ouptut_dim):
+    with model.truncate_dim(final_ouptut_dim):
         test(model, expected_dim=final_ouptut_dim)
     test(model, expected_dim=new_output_dim)  # b/c we've exited the context
 

--- a/tests/test_sentence_transformer.py
+++ b/tests/test_sentence_transformer.py
@@ -2,12 +2,15 @@
 Tests general behaviour of the SentenceTransformer class
 """
 
+from functools import partial
 import json
 import logging
 import os
 from pathlib import Path
 import re
 import tempfile
+from typing import List, Union
+
 import numpy as np
 import pytest
 
@@ -15,6 +18,7 @@ from huggingface_hub import HfApi, RepoUrl, GitRefs, GitRefInfo
 import torch
 from sentence_transformers import SentenceTransformer
 from sentence_transformers.models import Normalize, Transformer, Pooling
+from sentence_transformers import util
 
 
 def test_load_with_safetensors() -> None:
@@ -380,3 +384,73 @@ def test_encode_quantization(
     else:
         assert embeddings[0].dtype == expected_torch_dtype
         assert isinstance(embeddings, list)
+
+
+@pytest.mark.parametrize("convert_to_tensor", [True, False])
+@pytest.mark.parametrize("convert_to_numpy", [True, False])
+@pytest.mark.parametrize("normalize_embeddings", [True, False])
+@pytest.mark.parametrize("sentences", ("Single sentence", ["One sentence", "Another sentence"]))
+def test_encode_truncate(
+    sentences: Union[str, List[str]], convert_to_tensor: bool, convert_to_numpy: bool, normalize_embeddings: bool
+) -> None:
+    model = SentenceTransformer("sentence-transformers-testing/stsb-bert-tiny-safetensors")
+    embeddings_full_unnormalized: torch.Tensor = model.encode(
+        sentences, convert_to_numpy=False, convert_to_tensor=True
+    )  # These are raw embeddings which serve as the reference to test against
+
+    def test(model: SentenceTransformer, expected_dim: int):
+        embeddings = model.encode(
+            sentences,
+            convert_to_tensor=convert_to_tensor,
+            convert_to_numpy=convert_to_numpy,
+            normalize_embeddings=normalize_embeddings,
+        )
+        # Test shape
+        if isinstance(embeddings, list):  # list of tensors
+            embeddings_shape = (len(embeddings), embeddings[0].shape[-1])
+        else:
+            embeddings_shape = embeddings.shape
+        expected_shape = (expected_dim,) if isinstance(sentences, str) else (len(sentences), expected_dim)
+        assert embeddings_shape == expected_shape
+        assert model.get_sentence_embedding_dimension() == expected_dim
+
+        # Convert embeddings to a torch Tensor for ease of testing
+        if isinstance(embeddings, list):
+            embeddings = torch.stack(embeddings)
+        elif isinstance(embeddings, np.ndarray):
+            embeddings = torch.from_numpy(embeddings).to(embeddings_full_unnormalized.device)
+            # On a non-cpu device, the device of torch.from_numpy(embeddings) is always CPU
+
+        # Test content
+        if not normalize_embeddings:
+            assert torch.allclose(embeddings, util.truncate_embeddings(embeddings_full_unnormalized, expected_dim))
+        else:
+            normalize = partial(torch.nn.functional.normalize, p=2, dim=-1)
+            assert torch.allclose(
+                embeddings,
+                normalize(util.truncate_embeddings(embeddings_full_unnormalized, expected_dim)),
+            )
+
+    # Test init w/o setting output_dim (it's None)
+    original_output_dim: int = model.get_sentence_embedding_dimension()
+    test(model, expected_dim=original_output_dim)
+
+    # Test init w/ a set output_dim
+    output_dim = int(original_output_dim / 4)
+    model = SentenceTransformer("sentence-transformers-testing/stsb-bert-tiny-safetensors", output_dim=output_dim)
+    test(model, expected_dim=output_dim)
+
+    # Test setting the attribute after init to a greater dimension
+    new_output_dim = 2 * output_dim
+    model.output_dim = new_output_dim
+    test(model, expected_dim=new_output_dim)
+
+    # Test context manager
+    final_ouptut_dim = int(original_output_dim / 8)
+    with model.truncate_sentence_embeddings(final_ouptut_dim):
+        test(model, expected_dim=final_ouptut_dim)
+    test(model, expected_dim=new_output_dim)  # b/c we've exited the context
+
+    # Test w/ an ouptut_dim that's larger than the original_output_dim. No truncation ends up happening
+    model.output_dim = 2 * original_output_dim
+    test(model, expected_dim=original_output_dim)

--- a/tests/test_sentence_transformer.py
+++ b/tests/test_sentence_transformer.py
@@ -431,26 +431,26 @@ def test_encode_truncate(
                 normalize(util.truncate_embeddings(embeddings_full_unnormalized, expected_dim)),
             )
 
-    # Test init w/o setting output_dim (it's None)
+    # Test init w/o setting truncate_dim (it's None)
     original_output_dim: int = model.get_sentence_embedding_dimension()
     test(model, expected_dim=original_output_dim)
 
-    # Test init w/ a set output_dim
-    output_dim = int(original_output_dim / 4)
-    model = SentenceTransformer("sentence-transformers-testing/stsb-bert-tiny-safetensors", output_dim=output_dim)
-    test(model, expected_dim=output_dim)
+    # Test init w/ a set truncate_dim
+    truncate_dim = int(original_output_dim / 4)
+    model = SentenceTransformer("sentence-transformers-testing/stsb-bert-tiny-safetensors", truncate_dim=truncate_dim)
+    test(model, expected_dim=truncate_dim)
 
     # Test setting the attribute after init to a greater dimension
-    new_output_dim = 2 * output_dim
-    model.output_dim = new_output_dim
-    test(model, expected_dim=new_output_dim)
+    new_truncate_dim = 2 * truncate_dim
+    model.truncate_dim = new_truncate_dim
+    test(model, expected_dim=new_truncate_dim)
 
     # Test context manager
-    final_ouptut_dim = int(original_output_dim / 8)
-    with model.truncate_dim(final_ouptut_dim):
-        test(model, expected_dim=final_ouptut_dim)
-    test(model, expected_dim=new_output_dim)  # b/c we've exited the context
+    final_truncate_dim = int(original_output_dim / 8)
+    with model.truncate_sentence_embeddings(final_truncate_dim):
+        test(model, expected_dim=final_truncate_dim)
+    test(model, expected_dim=new_truncate_dim)  # b/c we've exited the context
 
     # Test w/ an ouptut_dim that's larger than the original_output_dim. No truncation ends up happening
-    model.output_dim = 2 * original_output_dim
+    model.truncate_dim = 2 * original_output_dim
     test(model, expected_dim=original_output_dim)


### PR DESCRIPTION
Hello,

This PR follows up on the discussion in #2564.

The implementation adds an optional `SentenceTransformer` instance attribute, `output_dim`, so that:

1. the dimension of `model.encode(texts)` agrees with `model.get_sentence_embedding_dimension()`
2. the user doesn't need to change every `model.encode(texts)` call to achieve truncation
3. no changes need to be made to third-party code which internally does `model.encode(texts)` (e.g., the `EmbeddingSimilarityEvaluator`) to achieve truncation.

In case a user wants to change the truncation dimension on the fly, they can use these new utilities:

* `model.truncate_sentence_embeddings`: context manager that sets and resets the truncation dimension, `output_dim`, of the `model`. This has the 3 benefits above
* `util.truncate_embeddings`: just a simple truncation function that works even if the input `embeddings` is 1-D or 2-D. May be useful because `...`-slicing is slightly niche knowledge.


## How has this code been tested?

New unit test:

```bash
pytest tests/test_sentence_transformer.py -k test_encode_truncate -x
```

It adds ~30 sec. to the testing workflow.