### PR TITLE
[`requirements`] Set minimum transformers version to 4.34.0 for is_nltk_available

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-transformers>=4.32.0,<5.0.0
+transformers>=4.34.0,<5.0.0
 tqdm
 torch>=1.11.0
 numpy


### PR DESCRIPTION
Resolves #2560

Hello!

## Pull Request overview
* Set minimum transformers version to 4.34.0 for `is_nltk_available`

## Details
See #2560 for details.

- Tom Aarsen