### PR TITLE
Document dev reqs, add ruff pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    # Ruff version.
+    rev: v0.3.5
+    hooks:
+      # These hooks are equivalent to running `make quality`
+      - id: ruff
+      - id: ruff-format
+        args: [ --check ]

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,7 @@
-
-check_dirs := examples sentence_transformers tests docs setup.py
-
 quality:
-	ruff check $(check_dirs)
-	ruff format --check $(check_dirs)
+	ruff check
+	ruff format --check
 
 style:
-	ruff check $(check_dirs) --fix
-	ruff format $(check_dirs)
+	ruff check --fix
+	ruff format

--- a/README.md
+++ b/README.md
@@ -145,6 +145,22 @@ and many more use-cases.
 
 For all examples, see [examples/applications](https://github.com/UKPLab/sentence-transformers/tree/master/examples/applications).
 
+## Development setup
+
+After cloning the repo (or a fork) to your machine, in a virtual environment, run:
+
+```
+python -m pip install -e ".[dev]"
+
+pre-commit install
+```
+
+To test your changes, run:
+
+```
+pytest
+```
+
 ## Citing & Authors
 
 If you find this repository helpful, feel free to cite our publication [Sentence-BERT: Sentence Embeddings using Siamese BERT-Networks](https://arxiv.org/abs/1908.10084):

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,3 +1,5 @@
+include = ["examples/**/*.py", "sentence_transformers/**/*.py", "tests/**/*.py", "docs/**/*.py", "setup.py"]
+
 lint.ignore-init-module-imports = true
 
 line-length = 119

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,5 +1,3 @@
-include = ["examples/**/*.py", "sentence_transformers/**/*.py", "tests/**/*.py", "docs/**/*.py", "setup.py"]
-
 lint.ignore-init-module-imports = true
 
 line-length = 119

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,13 @@ setup(
         "huggingface-hub>=0.15.1",
         "Pillow",
     ],
+    extras_require={
+        "dev": [
+            "pre-commit",
+            "pytest",
+            "ruff>=0.3.0",
+        ],
+    },
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Science/Research",


### PR DESCRIPTION
Hello,

This PR does 3 things:

1. Document local/development requirements so that it's slightly easier to know how to get started and test changes
2. Document the paths to apply ruff in `ruff.toml` instead of `Makefile` so that it applies to any `ruff` command (see [ruff docs](https://docs.astral.sh/ruff/configuration/#default-inclusions))
3.  Add [pre-commit ruff](https://docs.astral.sh/ruff/integrations/#pre-commit) hooks which are [equivalent](https://github.com/astral-sh/ruff-pre-commit/blob/main/.pre-commit-hooks.yaml) to `make quality`. Since there's a `quality.yml` check in the workflow, I figured it'd be nice to know whether or not a PR will pass it before pushing