### PR TITLE
Add truncation support in evaluators

### DIFF
--- a/examples/training/matryoshka/matryoshka_nli.py
+++ b/examples/training/matryoshka/matryoshka_nli.py
@@ -2,7 +2,7 @@
 The system trains BERT (or any other transformer model like RoBERTa, DistilBERT etc.) on the SNLI + MultiNLI (AllNLI) dataset
 with MatryoshkaLoss using MultipleNegativesRankingLoss. This trains a model at output dimensions [768, 512, 256, 128, 64].
 Entailments are positive pairs and the contradiction on AllNLI dataset is added as a hard negative.
-At every 10% training steps, the model is evaluated on the STS benchmark dataset
+At every 10% training steps, the model is evaluated on the STS benchmark dataset at the different output dimensions.
 
 Usage:
 python matryoshka_nli.py
@@ -15,7 +15,7 @@ import math
 from datasets import load_dataset
 from sentence_transformers import models, losses, datasets
 from sentence_transformers import LoggingHandler, SentenceTransformer, util, InputExample
-from sentence_transformers.evaluation import EmbeddingSimilarityEvaluator, SimilarityFunction
+from sentence_transformers.evaluation import EmbeddingSimilarityEvaluator, SequentialEvaluator, SimilarityFunction
 import logging
 from datetime import datetime
 import sys
@@ -34,6 +34,7 @@ model_name = sys.argv[1] if len(sys.argv) > 1 else "distilroberta-base"
 train_batch_size = 128  # The larger you select this, the better the results (usually). But it requires more GPU memory
 max_seq_length = 75
 num_epochs = 1
+matryoshka_dims = [768, 512, 256, 128, 64]
 
 # Save path of the model
 model_save_path = (
@@ -97,16 +98,22 @@ train_dataloader = datasets.NoDuplicatesDataLoader(train_samples, batch_size=tra
 
 # Our training loss
 train_loss = losses.MultipleNegativesRankingLoss(model)
-train_loss = losses.MatryoshkaLoss(model, train_loss, [768, 512, 256, 128, 64])
+train_loss = losses.MatryoshkaLoss(model, train_loss, matryoshka_dims=matryoshka_dims)
 
 stsb_dev = load_dataset("mteb/stsbenchmark-sts", split="validation")
-dev_evaluator = EmbeddingSimilarityEvaluator(
-    stsb_dev["sentence1"],
-    stsb_dev["sentence2"],
-    [score / 5 for score in stsb_dev["score"]],
-    main_similarity=SimilarityFunction.COSINE,
-    name="sts-dev",
-)
+evaluators = []
+for dim in matryoshka_dims:
+    evaluators.append(
+        EmbeddingSimilarityEvaluator(
+            stsb_dev["sentence1"],
+            stsb_dev["sentence2"],
+            [score / 5 for score in stsb_dev["score"]],
+            main_similarity=SimilarityFunction.COSINE,
+            name=f"sts-dev-{dim}",
+            truncate_dim=dim,
+        )
+    )
+dev_evaluator = SequentialEvaluator(evaluators, main_score_function=lambda scores: scores[0])
 
 # Configure the training
 warmup_steps = math.ceil(len(train_dataloader) * num_epochs * 0.1)  # 10% of train data for warm-up
@@ -134,13 +141,19 @@ model.fit(
 
 model = SentenceTransformer(model_save_path)
 stsb_test = load_dataset("mteb/stsbenchmark-sts", split="test")
-test_evaluator = EmbeddingSimilarityEvaluator(
-    stsb_test["sentence1"],
-    stsb_test["sentence2"],
-    [score / 5 for score in stsb_test["score"]],
-    main_similarity=SimilarityFunction.COSINE,
-    name="sts-test",
-)
+evaluators = []
+for dim in matryoshka_dims:
+    evaluators.append(
+        EmbeddingSimilarityEvaluator(
+            stsb_test["sentence1"],
+            stsb_test["sentence2"],
+            [score / 5 for score in stsb_test["score"]],
+            main_similarity=SimilarityFunction.COSINE,
+            name=f"sts-test-{dim}",
+            truncate_dim=dim,
+        )
+    )
+test_evaluator = SequentialEvaluator(evaluators)
 test_evaluator(model, output_path=model_save_path)
 
 

--- a/sentence_transformers/evaluation/BinaryClassificationEvaluator.py
+++ b/sentence_transformers/evaluation/BinaryClassificationEvaluator.py
@@ -114,13 +114,15 @@ class BinaryClassificationEvaluator(SentenceEvaluator):
     def __call__(self, model, output_path: str = None, epoch: int = -1, steps: int = -1) -> float:
         if epoch != -1:
             if steps == -1:
-                out_txt = f" after epoch {epoch}:"
+                out_txt = f" after epoch {epoch}"
             else:
-                out_txt = f" in epoch {epoch} after {steps} steps:"
+                out_txt = f" in epoch {epoch} after {steps} steps"
         else:
-            out_txt = ":"
+            out_txt = ""
+        if self.truncate_dim is not None:
+            out_txt += f" (truncated to {self.truncate_dim})"
 
-        logger.info("Binary Accuracy Evaluation of the model on " + self.name + " dataset" + out_txt)
+        logger.info(f"Binary Accuracy Evaluation of the model on the {self.name} dataset{out_txt}:")
 
         scores = self.compute_metrices(model)
 

--- a/sentence_transformers/evaluation/BinaryClassificationEvaluator.py
+++ b/sentence_transformers/evaluation/BinaryClassificationEvaluator.py
@@ -1,3 +1,4 @@
+from contextlib import nullcontext
 from . import SentenceEvaluator
 import logging
 import os
@@ -5,7 +6,7 @@ import csv
 from sklearn.metrics.pairwise import paired_cosine_distances, paired_euclidean_distances, paired_manhattan_distances
 from sklearn.metrics import average_precision_score
 import numpy as np
-from typing import List
+from typing import List, Optional
 from ..readers import InputExample
 
 
@@ -30,6 +31,8 @@ class BinaryClassificationEvaluator(SentenceEvaluator):
     :param batch_size: Batch size used to compute embeddings
     :param show_progress_bar: If true, prints a progress bar
     :param write_csv: Write results to a CSV file
+    :param truncate_dim: The dimension to truncate sentence embeddings to. `None` uses the model's current truncation
+        dimension. Defaults to None.
     """
 
     def __init__(
@@ -41,10 +44,12 @@ class BinaryClassificationEvaluator(SentenceEvaluator):
         batch_size: int = 32,
         show_progress_bar: bool = False,
         write_csv: bool = True,
+        truncate_dim: Optional[int] = None,
     ):
         self.sentences1 = sentences1
         self.sentences2 = sentences2
         self.labels = labels
+        self.truncate_dim = truncate_dim
 
         assert len(self.sentences1) == len(self.sentences2)
         assert len(self.sentences1) == len(self.labels)
@@ -144,25 +149,31 @@ class BinaryClassificationEvaluator(SentenceEvaluator):
         return main_score
 
     def compute_metrices(self, model):
-        try:
-            # If the sentences are hashable, then we can use a set to avoid embedding the same sentences multiple times
-            sentences = list(set(self.sentences1 + self.sentences2))
-            embeddings = model.encode(
-                sentences, batch_size=self.batch_size, show_progress_bar=self.show_progress_bar, convert_to_numpy=True
-            )
-            emb_dict = {sent: emb for sent, emb in zip(sentences, embeddings)}
-            embeddings1 = [emb_dict[sent] for sent in self.sentences1]
-            embeddings2 = [emb_dict[sent] for sent in self.sentences2]
-        except TypeError:
-            # Otherwise we just embed everything, e.g. if the sentences are images for evaluating a CLIP model
-            embeddings = model.encode(
-                self.sentences1 + self.sentences2,
-                batch_size=self.batch_size,
-                show_progress_bar=self.show_progress_bar,
-                convert_to_numpy=True,
-            )
-            embeddings1 = embeddings[: len(self.sentences1)]
-            embeddings2 = embeddings[len(self.sentences1) :]
+        with nullcontext() if self.truncate_dim is None else model.truncate_sentence_embeddings(self.truncate_dim):
+            try:
+                # If the sentences are hashable, then we can use a set to avoid embedding the same sentences multiple
+                # times
+                sentences = list(set(self.sentences1 + self.sentences2))
+            except TypeError:
+                # Otherwise we just embed everything, e.g. if the sentences are images for evaluating a CLIP model
+                embeddings = model.encode(
+                    self.sentences1 + self.sentences2,
+                    batch_size=self.batch_size,
+                    show_progress_bar=self.show_progress_bar,
+                    convert_to_numpy=True,
+                )
+                embeddings1 = embeddings[: len(self.sentences1)]
+                embeddings2 = embeddings[len(self.sentences1) :]
+            else:
+                embeddings = model.encode(
+                    sentences,
+                    batch_size=self.batch_size,
+                    show_progress_bar=self.show_progress_bar,
+                    convert_to_numpy=True,
+                )
+                emb_dict = {sent: emb for sent, emb in zip(sentences, embeddings)}
+                embeddings1 = [emb_dict[sent] for sent in self.sentences1]
+                embeddings2 = [emb_dict[sent] for sent in self.sentences2]
 
         cosine_scores = 1 - paired_cosine_distances(embeddings1, embeddings2)
         manhattan_distances = paired_manhattan_distances(embeddings1, embeddings2)

--- a/sentence_transformers/evaluation/EmbeddingSimilarityEvaluator.py
+++ b/sentence_transformers/evaluation/EmbeddingSimilarityEvaluator.py
@@ -104,13 +104,15 @@ class EmbeddingSimilarityEvaluator(SentenceEvaluator):
     def __call__(self, model, output_path: str = None, epoch: int = -1, steps: int = -1) -> float:
         if epoch != -1:
             if steps == -1:
-                out_txt = " after epoch {}:".format(epoch)
+                out_txt = f" after epoch {epoch}"
             else:
-                out_txt = " in epoch {} after {} steps:".format(epoch, steps)
+                out_txt = f" in epoch {epoch} after {steps} steps"
         else:
-            out_txt = ":"
+            out_txt = ""
+        if self.truncate_dim is not None:
+            out_txt += f" (truncated to {self.truncate_dim})"
 
-        logger.info("EmbeddingSimilarityEvaluator: Evaluating the model on " + self.name + " dataset" + out_txt)
+        logger.info(f"EmbeddingSimilarityEvaluator: Evaluating the model on the {self.name} dataset{out_txt}:")
 
         with nullcontext() if self.truncate_dim is None else model.truncate_sentence_embeddings(self.truncate_dim):
             embeddings1 = model.encode(

--- a/sentence_transformers/evaluation/InformationRetrievalEvaluator.py
+++ b/sentence_transformers/evaluation/InformationRetrievalEvaluator.py
@@ -1,3 +1,4 @@
+from contextlib import nullcontext
 from . import SentenceEvaluator
 import torch
 from torch import Tensor
@@ -6,7 +7,7 @@ from tqdm import trange
 from ..util import cos_sim, dot_score
 import os
 import numpy as np
-from typing import List, Dict, Set, Callable
+from typing import List, Dict, Optional, Set, Callable
 import heapq
 
 
@@ -36,6 +37,7 @@ class InformationRetrievalEvaluator(SentenceEvaluator):
         batch_size: int = 32,
         name: str = "",
         write_csv: bool = True,
+        truncate_dim: Optional[int] = None,
         score_functions: Dict[str, Callable[[Tensor, Tensor], Tensor]] = {
             "cos_sim": cos_sim,
             "dot_score": dot_score,
@@ -67,6 +69,7 @@ class InformationRetrievalEvaluator(SentenceEvaluator):
         self.score_functions = score_functions
         self.score_function_names = sorted(list(self.score_functions.keys()))
         self.main_score_function = main_score_function
+        self.truncate_dim = truncate_dim
 
         if name:
             name = "_" + name
@@ -156,9 +159,13 @@ class InformationRetrievalEvaluator(SentenceEvaluator):
         )
 
         # Compute embedding for the queries
-        query_embeddings = model.encode(
-            self.queries, show_progress_bar=self.show_progress_bar, batch_size=self.batch_size, convert_to_tensor=True
-        )
+        with nullcontext() if self.truncate_dim is None else model.truncate_sentence_embeddings(self.truncate_dim):
+            query_embeddings = model.encode(
+                self.queries,
+                show_progress_bar=self.show_progress_bar,
+                batch_size=self.batch_size,
+                convert_to_tensor=True,
+            )
 
         queries_result_list = {}
         for name in self.score_functions:
@@ -172,12 +179,15 @@ class InformationRetrievalEvaluator(SentenceEvaluator):
 
             # Encode chunk of corpus
             if corpus_embeddings is None:
-                sub_corpus_embeddings = corpus_model.encode(
-                    self.corpus[corpus_start_idx:corpus_end_idx],
-                    show_progress_bar=False,
-                    batch_size=self.batch_size,
-                    convert_to_tensor=True,
-                )
+                with nullcontext() if self.truncate_dim is None else corpus_model.truncate_sentence_embeddings(
+                    self.truncate_dim
+                ):
+                    sub_corpus_embeddings = corpus_model.encode(
+                        self.corpus[corpus_start_idx:corpus_end_idx],
+                        show_progress_bar=False,
+                        batch_size=self.batch_size,
+                        convert_to_tensor=True,
+                    )
             else:
                 sub_corpus_embeddings = corpus_embeddings[corpus_start_idx:corpus_end_idx]
 

--- a/sentence_transformers/evaluation/InformationRetrievalEvaluator.py
+++ b/sentence_transformers/evaluation/InformationRetrievalEvaluator.py
@@ -96,15 +96,16 @@ class InformationRetrievalEvaluator(SentenceEvaluator):
 
     def __call__(self, model, output_path: str = None, epoch: int = -1, steps: int = -1, *args, **kwargs) -> float:
         if epoch != -1:
-            out_txt = (
-                " after epoch {}:".format(epoch)
-                if steps == -1
-                else " in epoch {} after {} steps:".format(epoch, steps)
-            )
+            if steps == -1:
+                out_txt = f" after epoch {epoch}"
+            else:
+                out_txt = f" in epoch {epoch} after {steps} steps"
         else:
-            out_txt = ":"
+            out_txt = ""
+        if self.truncate_dim is not None:
+            out_txt += f" (truncated to {self.truncate_dim})"
 
-        logger.info("Information Retrieval Evaluation on " + self.name + " dataset" + out_txt)
+        logger.info(f"Information Retrieval Evaluation of the model on the {self.name} dataset{out_txt}:")
 
         scores = self.compute_metrices(model, *args, **kwargs)
 

--- a/sentence_transformers/evaluation/MSEEvaluator.py
+++ b/sentence_transformers/evaluation/MSEEvaluator.py
@@ -60,11 +60,13 @@ class MSEEvaluator(SentenceEvaluator):
     def __call__(self, model, output_path, epoch=-1, steps=-1):
         if epoch != -1:
             if steps == -1:
-                out_txt = " after epoch {}:".format(epoch)
+                out_txt = f" after epoch {epoch}"
             else:
-                out_txt = " in epoch {} after {} steps:".format(epoch, steps)
+                out_txt = f" in epoch {epoch} after {steps} steps"
         else:
-            out_txt = ":"
+            out_txt = ""
+        if self.truncate_dim is not None:
+            out_txt += f" (truncated to {self.truncate_dim})"
 
         with nullcontext() if self.truncate_dim is None else model.truncate_sentence_embeddings(self.truncate_dim):
             target_embeddings = model.encode(
@@ -77,7 +79,7 @@ class MSEEvaluator(SentenceEvaluator):
         mse = ((self.source_embeddings - target_embeddings) ** 2).mean()
         mse *= 100
 
-        logger.info("MSE evaluation (lower = better) on " + self.name + " dataset" + out_txt)
+        logger.info(f"MSE evaluation (lower = better) on the {self.name} dataset{out_txt}:")
         logger.info("MSE (*100):\t{:4f}".format(mse))
 
         if output_path is not None and self.write_csv:

--- a/sentence_transformers/evaluation/MSEEvaluatorFromDataFrame.py
+++ b/sentence_transformers/evaluation/MSEEvaluatorFromDataFrame.py
@@ -1,6 +1,7 @@
+from contextlib import nullcontext
 from sentence_transformers.evaluation import SentenceEvaluator
 from sentence_transformers import SentenceTransformer
-from typing import List, Tuple, Dict
+from typing import List, Optional, Tuple, Dict
 import numpy as np
 import logging
 import os
@@ -17,12 +18,18 @@ class MSEEvaluatorFromDataFrame(SentenceEvaluator):
     :param dataframe: It must have the following format. Rows contains different, parallel sentences.
         Columns are the respective language codes::
 
-            [{'en': 'My sentence', 'es': 'Sentence in Spanisch', 'fr': 'Sentence in French'...},
+            [{'en': 'My sentence in English', 'es': 'Oración en español', 'fr': 'Phrase en français'...},
              {'en': 'My second sentence', ...}]
+
     :param combinations: Must be of the format ``[('en', 'es'), ('en', 'fr'), ...]``.
         First entry in a tuple is the source language. The sentence in the respective language will be fetched from
         the dataframe and passed to the teacher model. Second entry in a tuple the the target language. Sentence
         will be fetched from the dataframe and passed to the student model
+    :param batch_size: Batch size to compute sentence embeddings
+    :param name: Name of the evaluator
+    :param write_csv: Write results to CSV file
+    :param truncate_dim: The dimension to truncate sentence embeddings to. `None` uses the model's current truncation
+        dimension. Defaults to None.
     """
 
     def __init__(
@@ -31,8 +38,9 @@ class MSEEvaluatorFromDataFrame(SentenceEvaluator):
         teacher_model: SentenceTransformer,
         combinations: List[Tuple[str, str]],
         batch_size: int = 8,
-        name="",
+        name: str = "",
         write_csv: bool = True,
+        truncate_dim: Optional[int] = None,
     ):
         self.combinations = combinations
         self.name = name
@@ -44,6 +52,7 @@ class MSEEvaluatorFromDataFrame(SentenceEvaluator):
         self.csv_file = "mse_evaluation" + name + "_results.csv"
         self.csv_headers = ["epoch", "steps"]
         self.write_csv = write_csv
+        self.truncate_dim = truncate_dim
         self.data = {}
 
         logger.info("Compute teacher embeddings")
@@ -62,7 +71,10 @@ class MSEEvaluatorFromDataFrame(SentenceEvaluator):
             self.csv_headers.append("{}-{}".format(src_lang, trg_lang))
 
         all_source_sentences = list(all_source_sentences)
-        all_src_embeddings = teacher_model.encode(all_source_sentences, batch_size=self.batch_size)
+        with nullcontext() if self.truncate_dim is None else teacher_model.truncate_sentence_embeddings(
+            self.truncate_dim
+        ):
+            all_src_embeddings = teacher_model.encode(all_source_sentences, batch_size=self.batch_size)
         self.teacher_embeddings = {sent: emb for sent, emb in zip(all_source_sentences, all_src_embeddings)}
 
     def __call__(self, model, output_path: str = None, epoch: int = -1, steps: int = -1):
@@ -73,7 +85,8 @@ class MSEEvaluatorFromDataFrame(SentenceEvaluator):
             src_sentences, trg_sentences = self.data[(src_lang, trg_lang)]
 
             src_embeddings = np.asarray([self.teacher_embeddings[sent] for sent in src_sentences])
-            trg_embeddings = np.asarray(model.encode(trg_sentences, batch_size=self.batch_size))
+            with nullcontext() if self.truncate_dim is None else model.truncate_sentence_embeddings(self.truncate_dim):
+                trg_embeddings = np.asarray(model.encode(trg_sentences, batch_size=self.batch_size))
 
             mse = ((src_embeddings - trg_embeddings) ** 2).mean()
             mse *= 100

--- a/sentence_transformers/evaluation/ParaphraseMiningEvaluator.py
+++ b/sentence_transformers/evaluation/ParaphraseMiningEvaluator.py
@@ -1,10 +1,11 @@
+from contextlib import nullcontext
 from . import SentenceEvaluator
 import logging
 from sentence_transformers.util import paraphrase_mining
 import os
 import csv
 
-from typing import List, Tuple, Dict
+from typing import List, Optional, Tuple, Dict
 from collections import defaultdict
 
 
@@ -32,6 +33,7 @@ class ParaphraseMiningEvaluator(SentenceEvaluator):
         batch_size: int = 16,
         name: str = "",
         write_csv: bool = True,
+        truncate_dim: Optional[int] = None,
     ):
         """
 
@@ -47,6 +49,9 @@ class ParaphraseMiningEvaluator(SentenceEvaluator):
         :param batch_size: Batch size for computing sentence embeddings
         :param name: Name of the experiment
         :param write_csv: Write results to CSV file
+        :param truncate_dim: The dimension to truncate sentence embeddings to. `None` uses the model's current truncation
+            dimension. Defaults to None.
+
         """
         self.sentences = []
         self.ids = []
@@ -62,6 +67,7 @@ class ParaphraseMiningEvaluator(SentenceEvaluator):
         self.corpus_chunk_size = corpus_chunk_size
         self.max_pairs = max_pairs
         self.top_k = top_k
+        self.truncate_dim = truncate_dim
 
         self.duplicates = duplicates_dict if duplicates_dict is not None else defaultdict(lambda: defaultdict(bool))
         if duplicates_list is not None:
@@ -95,23 +101,29 @@ class ParaphraseMiningEvaluator(SentenceEvaluator):
 
     def __call__(self, model, output_path: str = None, epoch: int = -1, steps: int = -1) -> float:
         if epoch != -1:
-            out_txt = f" after epoch {epoch}:" if steps == -1 else f" in epoch {epoch} after {steps} steps:"
+            if steps == -1:
+                out_txt = f" after epoch {epoch}"
+            else:
+                out_txt = f" in epoch {epoch} after {steps} steps"
         else:
-            out_txt = ":"
+            out_txt = ""
+        if self.truncate_dim is not None:
+            out_txt += f" (truncated to {self.truncate_dim})"
 
-        logger.info("Paraphrase Mining Evaluation on " + self.name + " dataset" + out_txt)
+        logger.info(f"Paraphrase Mining Evaluation of the model on the {self.name} dataset{out_txt}:")
 
         # Compute embedding for the sentences
-        pairs_list = paraphrase_mining(
-            model,
-            self.sentences,
-            self.show_progress_bar,
-            self.batch_size,
-            self.query_chunk_size,
-            self.corpus_chunk_size,
-            self.max_pairs,
-            self.top_k,
-        )
+        with nullcontext() if self.truncate_dim is None else model.truncate_sentence_embeddings(self.truncate_dim):
+            pairs_list = paraphrase_mining(
+                model,
+                self.sentences,
+                self.show_progress_bar,
+                self.batch_size,
+                self.query_chunk_size,
+                self.corpus_chunk_size,
+                self.max_pairs,
+                self.top_k,
+            )
 
         logger.info("Number of candidate pairs: " + str(len(pairs_list)))
 

--- a/sentence_transformers/evaluation/RerankingEvaluator.py
+++ b/sentence_transformers/evaluation/RerankingEvaluator.py
@@ -1,3 +1,4 @@
+from contextlib import nullcontext
 from . import SentenceEvaluator
 import logging
 import numpy as np
@@ -7,7 +8,7 @@ from ..util import cos_sim
 import torch
 from sklearn.metrics import average_precision_score, ndcg_score
 import tqdm
-from typing import Optional
+from typing import Callable, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -19,8 +20,20 @@ class RerankingEvaluator(SentenceEvaluator):
     Given a query and a list of documents, it computes the score [query, doc_i] for all possible
     documents and sorts them in decreasing order. Then, MRR@10, NDCG@10 and MAP is compute to measure the quality of the ranking.
 
-    :param samples: Must be a list and each element is of the form: {'query': '', 'positive': [], 'negative': []}. Query is the search query,
-     positive is a list of positive (relevant) documents, negative is a list of negative (irrelevant) documents.
+    :param samples: Must be a list and each element is of the form: {'query': '', 'positive': [], 'negative': []}.
+        Query is the search query, positive is a list of positive (relevant) documents, negative is a list of negative
+        (irrelevant) documents.
+
+    :param at_k: Only consider the top k most similar documents to each query for the evaluation
+    :param name: Name of the evaluator
+    :param write_csv: Write results to CSV file
+    :param similarity_fct: similarity function between sentence embeddings. By default, cosine similarity.
+    :param batch_size: Batch size to compute sentence embeddings
+    :param show_progress_bar: Show progress bar when computing embeddings
+    :param use_batched_encoding: Whether or not to encode queries and documents in batches for greater speed, or 1-by-1
+        to save memory
+    :param truncate_dim: The dimension to truncate sentence embeddings to. `None` uses the model's current truncation
+        dimension. Defaults to None.
     """
 
     def __init__(
@@ -29,23 +42,27 @@ class RerankingEvaluator(SentenceEvaluator):
         at_k: int = 10,
         name: str = "",
         write_csv: bool = True,
-        similarity_fct=cos_sim,
+        similarity_fct: Callable[[torch.Tensor, torch.Tensor], torch.Tensor] = cos_sim,
         batch_size: int = 64,
         show_progress_bar: bool = False,
         use_batched_encoding: bool = True,
+        truncate_dim: Optional[int] = None,
         mrr_at_k: Optional[int] = None,
     ):
         self.samples = samples
         self.name = name
+
         if mrr_at_k is not None:
             logger.warning(f"The `mrr_at_k` parameter has been deprecated; please use `at_k={mrr_at_k}` instead.")
             self.at_k = mrr_at_k
         else:
             self.at_k = at_k
+
         self.similarity_fct = similarity_fct
         self.batch_size = batch_size
         self.show_progress_bar = show_progress_bar
         self.use_batched_encoding = use_batched_encoding
+        self.truncate_dim = truncate_dim
 
         if isinstance(self.samples, dict):
             self.samples = list(self.samples.values())
@@ -129,22 +146,23 @@ class RerankingEvaluator(SentenceEvaluator):
         all_ndcg_scores = []
         all_ap_scores = []
 
-        all_query_embs = model.encode(
-            [sample["query"] for sample in self.samples],
-            convert_to_tensor=True,
-            batch_size=self.batch_size,
-            show_progress_bar=self.show_progress_bar,
-        )
+        with nullcontext() if self.truncate_dim is None else model.truncate_sentence_embeddings(self.truncate_dim):
+            all_query_embs = model.encode(
+                [sample["query"] for sample in self.samples],
+                convert_to_tensor=True,
+                batch_size=self.batch_size,
+                show_progress_bar=self.show_progress_bar,
+            )
 
-        all_docs = []
+            all_docs = []
 
-        for sample in self.samples:
-            all_docs.extend(sample["positive"])
-            all_docs.extend(sample["negative"])
+            for sample in self.samples:
+                all_docs.extend(sample["positive"])
+                all_docs.extend(sample["negative"])
 
-        all_docs_embs = model.encode(
-            all_docs, convert_to_tensor=True, batch_size=self.batch_size, show_progress_bar=self.show_progress_bar
-        )
+            all_docs_embs = model.encode(
+                all_docs, convert_to_tensor=True, batch_size=self.batch_size, show_progress_bar=self.show_progress_bar
+            )
 
         # Compute scores
         query_idx, docs_idx = 0, 0
@@ -210,10 +228,13 @@ class RerankingEvaluator(SentenceEvaluator):
             docs = positive + negative
             is_relevant = [1] * len(positive) + [0] * len(negative)
 
-            query_emb = model.encode(
-                [query], convert_to_tensor=True, batch_size=self.batch_size, show_progress_bar=False
-            )
-            docs_emb = model.encode(docs, convert_to_tensor=True, batch_size=self.batch_size, show_progress_bar=False)
+            with nullcontext() if self.truncate_dim is None else model.truncate_sentence_embeddings(self.truncate_dim):
+                query_emb = model.encode(
+                    [query], convert_to_tensor=True, batch_size=self.batch_size, show_progress_bar=False
+                )
+                docs_emb = model.encode(
+                    docs, convert_to_tensor=True, batch_size=self.batch_size, show_progress_bar=False
+                )
 
             pred_scores = self.similarity_fct(query_emb, docs_emb)
             if len(pred_scores.shape) > 1:

--- a/sentence_transformers/evaluation/RerankingEvaluator.py
+++ b/sentence_transformers/evaluation/RerankingEvaluator.py
@@ -85,13 +85,15 @@ class RerankingEvaluator(SentenceEvaluator):
     def __call__(self, model, output_path: str = None, epoch: int = -1, steps: int = -1) -> float:
         if epoch != -1:
             if steps == -1:
-                out_txt = " after epoch {}:".format(epoch)
+                out_txt = f" after epoch {epoch}"
             else:
-                out_txt = " in epoch {} after {} steps:".format(epoch, steps)
+                out_txt = f" in epoch {epoch} after {steps} steps"
         else:
-            out_txt = ":"
+            out_txt = ""
+        if self.truncate_dim is not None:
+            out_txt += f" (truncated to {self.truncate_dim})"
 
-        logger.info("RerankingEvaluator: Evaluating the model on " + self.name + " dataset" + out_txt)
+        logger.info(f"RerankingEvaluator: Evaluating the model on the {self.name} dataset{out_txt}:")
 
         scores = self.compute_metrices(model)
         mean_ap = scores["map"]

--- a/sentence_transformers/evaluation/TranslationEvaluator.py
+++ b/sentence_transformers/evaluation/TranslationEvaluator.py
@@ -1,10 +1,11 @@
+from contextlib import nullcontext
 from . import SentenceEvaluator
 import logging
 from ..util import pytorch_cos_sim
 import os
 import csv
 import numpy as np
-from typing import List
+from typing import List, Optional
 import torch
 
 
@@ -27,6 +28,7 @@ class TranslationEvaluator(SentenceEvaluator):
         name: str = "",
         print_wrong_matches: bool = False,
         write_csv: bool = True,
+        truncate_dim: Optional[int] = None,
     ):
         """
         Constructs an evaluator based for the dataset
@@ -37,10 +39,19 @@ class TranslationEvaluator(SentenceEvaluator):
             List of sentences in source language
         :param target_sentences:
             List of sentences in target language
+        :param show_progress_bar:
+            Show progress bar when computing embeddings
+        :param batch_size:
+            Batch size to compute sentence embeddings
+        :param name:
+            Name of the evaluator
         :param print_wrong_matches:
             Prints incorrect matches
         :param write_csv:
             Write results to CSV file
+        :param truncate_dim:
+            The dimension to truncate sentence embeddings to. `None` uses the model's current truncation dimension.
+            Defaults to None.
         """
         self.source_sentences = source_sentences
         self.target_sentences = target_sentences
@@ -48,6 +59,7 @@ class TranslationEvaluator(SentenceEvaluator):
         self.batch_size = batch_size
         self.show_progress_bar = show_progress_bar
         self.print_wrong_matches = print_wrong_matches
+        self.truncate_dim = truncate_dim
 
         assert len(self.source_sentences) == len(self.target_sentences)
 
@@ -69,22 +81,23 @@ class TranslationEvaluator(SentenceEvaluator):
 
         logger.info("Evaluating translation matching Accuracy on " + self.name + " dataset" + out_txt)
 
-        embeddings1 = torch.stack(
-            model.encode(
-                self.source_sentences,
-                show_progress_bar=self.show_progress_bar,
-                batch_size=self.batch_size,
-                convert_to_numpy=False,
+        with nullcontext() if self.truncate_dim is None else model.truncate_sentence_embeddings(self.truncate_dim):
+            embeddings1 = torch.stack(
+                model.encode(
+                    self.source_sentences,
+                    show_progress_bar=self.show_progress_bar,
+                    batch_size=self.batch_size,
+                    convert_to_numpy=False,
+                )
             )
-        )
-        embeddings2 = torch.stack(
-            model.encode(
-                self.target_sentences,
-                show_progress_bar=self.show_progress_bar,
-                batch_size=self.batch_size,
-                convert_to_numpy=False,
+            embeddings2 = torch.stack(
+                model.encode(
+                    self.target_sentences,
+                    show_progress_bar=self.show_progress_bar,
+                    batch_size=self.batch_size,
+                    convert_to_numpy=False,
+                )
             )
-        )
 
         cos_sims = pytorch_cos_sim(embeddings1, embeddings2).detach().cpu().numpy()
 

--- a/sentence_transformers/evaluation/TranslationEvaluator.py
+++ b/sentence_transformers/evaluation/TranslationEvaluator.py
@@ -73,13 +73,15 @@ class TranslationEvaluator(SentenceEvaluator):
     def __call__(self, model, output_path: str = None, epoch: int = -1, steps: int = -1) -> float:
         if epoch != -1:
             if steps == -1:
-                out_txt = " after epoch {}:".format(epoch)
+                out_txt = f" after epoch {epoch}"
             else:
-                out_txt = " in epoch {} after {} steps:".format(epoch, steps)
+                out_txt = f" in epoch {epoch} after {steps} steps"
         else:
-            out_txt = ":"
+            out_txt = ""
+        if self.truncate_dim is not None:
+            out_txt += f" (truncated to {self.truncate_dim})"
 
-        logger.info("Evaluating translation matching Accuracy on " + self.name + " dataset" + out_txt)
+        logger.info(f"Evaluating translation matching Accuracy of the model on the {self.name} dataset{out_txt}:")
 
         with nullcontext() if self.truncate_dim is None else model.truncate_sentence_embeddings(self.truncate_dim):
             embeddings1 = torch.stack(

--- a/sentence_transformers/evaluation/TripletEvaluator.py
+++ b/sentence_transformers/evaluation/TripletEvaluator.py
@@ -78,13 +78,15 @@ class TripletEvaluator(SentenceEvaluator):
     def __call__(self, model, output_path: str = None, epoch: int = -1, steps: int = -1) -> float:
         if epoch != -1:
             if steps == -1:
-                out_txt = " after epoch {}:".format(epoch)
+                out_txt = f" after epoch {epoch}"
             else:
-                out_txt = " in epoch {} after {} steps:".format(epoch, steps)
+                out_txt = f" in epoch {epoch} after {steps} steps"
         else:
-            out_txt = ":"
+            out_txt = ""
+        if self.truncate_dim is not None:
+            out_txt += f" (truncated to {self.truncate_dim})"
 
-        logger.info("TripletEvaluator: Evaluating the model on " + self.name + " dataset" + out_txt)
+        logger.info(f"TripletEvaluator: Evaluating the model on the {self.name} dataset{out_txt}:")
 
         num_triplets = 0
         num_correct_cos_triplets, num_correct_manhattan_triplets, num_correct_euclidean_triplets = 0, 0, 0


### PR DESCRIPTION
Hello,

This PR is a follow-up to #2573. As you suggested [in this comment](https://github.com/UKPLab/sentence-transformers/pull/2573#issuecomment-2038176178), a `truncate_dim` parameter makes it easy to construct a sequential evaluator.

## How has this been tested?

It hasn't 🥴 
I tested `EmbeddingSimilarityEvaluator` in #2573 by running a notebook offline. I'll think about how to test this change soon. Lmk what you think would make for a sufficient test, e.g., offline runs or actual tests in `tests/test_evaluator.py`.