### PR TITLE
Add ST annotation to evaluators

### DIFF
--- a/sentence_transformers/evaluation/BinaryClassificationEvaluator.py
+++ b/sentence_transformers/evaluation/BinaryClassificationEvaluator.py
@@ -1,3 +1,4 @@
+from sentence_transformers import SentenceTransformer
 from . import SentenceEvaluator
 import logging
 import os
@@ -106,7 +107,7 @@ class BinaryClassificationEvaluator(SentenceEvaluator):
             scores.append(example.label)
         return cls(sentences1, sentences2, scores, **kwargs)
 
-    def __call__(self, model, output_path: str = None, epoch: int = -1, steps: int = -1) -> float:
+    def __call__(self, model: SentenceTransformer, output_path: str = None, epoch: int = -1, steps: int = -1) -> float:
         if epoch != -1:
             if steps == -1:
                 out_txt = f" after epoch {epoch}:"

--- a/sentence_transformers/evaluation/EmbeddingSimilarityEvaluator.py
+++ b/sentence_transformers/evaluation/EmbeddingSimilarityEvaluator.py
@@ -1,4 +1,6 @@
 from contextlib import nullcontext
+
+from sentence_transformers import SentenceTransformer
 from . import SentenceEvaluator, SimilarityFunction
 import logging
 import os
@@ -101,7 +103,7 @@ class EmbeddingSimilarityEvaluator(SentenceEvaluator):
             scores.append(example.label)
         return cls(sentences1, sentences2, scores, **kwargs)
 
-    def __call__(self, model, output_path: str = None, epoch: int = -1, steps: int = -1) -> float:
+    def __call__(self, model: SentenceTransformer, output_path: str = None, epoch: int = -1, steps: int = -1) -> float:
         if epoch != -1:
             if steps == -1:
                 out_txt = " after epoch {}:".format(epoch)

--- a/sentence_transformers/evaluation/InformationRetrievalEvaluator.py
+++ b/sentence_transformers/evaluation/InformationRetrievalEvaluator.py
@@ -1,3 +1,4 @@
+from sentence_transformers import SentenceTransformer
 from . import SentenceEvaluator
 import torch
 from torch import Tensor
@@ -91,7 +92,9 @@ class InformationRetrievalEvaluator(SentenceEvaluator):
             for k in map_at_k:
                 self.csv_headers.append("{}-MAP@{}".format(score_name, k))
 
-    def __call__(self, model, output_path: str = None, epoch: int = -1, steps: int = -1, *args, **kwargs) -> float:
+    def __call__(
+        self, model: SentenceTransformer, output_path: str = None, epoch: int = -1, steps: int = -1, *args, **kwargs
+    ) -> float:
         if epoch != -1:
             out_txt = (
                 " after epoch {}:".format(epoch)
@@ -143,7 +146,9 @@ class InformationRetrievalEvaluator(SentenceEvaluator):
         else:
             return scores[self.main_score_function]["map@k"][max(self.map_at_k)]
 
-    def compute_metrices(self, model, corpus_model=None, corpus_embeddings: Tensor = None) -> Dict[str, float]:
+    def compute_metrices(
+        self, model: SentenceTransformer, corpus_model=None, corpus_embeddings: Tensor = None
+    ) -> Dict[str, float]:
         if corpus_model is None:
             corpus_model = model
 

--- a/sentence_transformers/evaluation/LabelAccuracyEvaluator.py
+++ b/sentence_transformers/evaluation/LabelAccuracyEvaluator.py
@@ -1,3 +1,4 @@
+from sentence_transformers import SentenceTransformer
 from . import SentenceEvaluator
 import torch
 from torch.utils.data import DataLoader
@@ -37,7 +38,7 @@ class LabelAccuracyEvaluator(SentenceEvaluator):
         self.csv_file = "accuracy_evaluation" + name + "_results.csv"
         self.csv_headers = ["epoch", "steps", "accuracy"]
 
-    def __call__(self, model, output_path: str = None, epoch: int = -1, steps: int = -1) -> float:
+    def __call__(self, model: SentenceTransformer, output_path: str = None, epoch: int = -1, steps: int = -1) -> float:
         model.eval()
         total = 0
         correct = 0

--- a/sentence_transformers/evaluation/MSEEvaluator.py
+++ b/sentence_transformers/evaluation/MSEEvaluator.py
@@ -1,3 +1,4 @@
+from sentence_transformers import SentenceTransformer
 from sentence_transformers.evaluation import SentenceEvaluator
 import logging
 import os
@@ -49,7 +50,7 @@ class MSEEvaluator(SentenceEvaluator):
         self.csv_headers = ["epoch", "steps", "MSE"]
         self.write_csv = write_csv
 
-    def __call__(self, model, output_path, epoch=-1, steps=-1):
+    def __call__(self, model: SentenceTransformer, output_path, epoch=-1, steps=-1):
         if epoch != -1:
             if steps == -1:
                 out_txt = " after epoch {}:".format(epoch)

--- a/sentence_transformers/evaluation/MSEEvaluatorFromDataFrame.py
+++ b/sentence_transformers/evaluation/MSEEvaluatorFromDataFrame.py
@@ -65,7 +65,7 @@ class MSEEvaluatorFromDataFrame(SentenceEvaluator):
         all_src_embeddings = teacher_model.encode(all_source_sentences, batch_size=self.batch_size)
         self.teacher_embeddings = {sent: emb for sent, emb in zip(all_source_sentences, all_src_embeddings)}
 
-    def __call__(self, model, output_path: str = None, epoch: int = -1, steps: int = -1):
+    def __call__(self, model: SentenceTransformer, output_path: str = None, epoch: int = -1, steps: int = -1):
         model.eval()
 
         mse_scores = []

--- a/sentence_transformers/evaluation/ParaphraseMiningEvaluator.py
+++ b/sentence_transformers/evaluation/ParaphraseMiningEvaluator.py
@@ -1,3 +1,4 @@
+from sentence_transformers import SentenceTransformer
 from . import SentenceEvaluator
 import logging
 from sentence_transformers.util import paraphrase_mining
@@ -93,7 +94,7 @@ class ParaphraseMiningEvaluator(SentenceEvaluator):
         self.csv_headers = ["epoch", "steps", "precision", "recall", "f1", "threshold", "average_precision"]
         self.write_csv = write_csv
 
-    def __call__(self, model, output_path: str = None, epoch: int = -1, steps: int = -1) -> float:
+    def __call__(self, model: SentenceTransformer, output_path: str = None, epoch: int = -1, steps: int = -1) -> float:
         if epoch != -1:
             out_txt = f" after epoch {epoch}:" if steps == -1 else f" in epoch {epoch} after {steps} steps:"
         else:

--- a/sentence_transformers/evaluation/RerankingEvaluator.py
+++ b/sentence_transformers/evaluation/RerankingEvaluator.py
@@ -1,3 +1,4 @@
+from sentence_transformers import SentenceTransformer
 from . import SentenceEvaluator
 import logging
 import numpy as np
@@ -65,7 +66,7 @@ class RerankingEvaluator(SentenceEvaluator):
         ]
         self.write_csv = write_csv
 
-    def __call__(self, model, output_path: str = None, epoch: int = -1, steps: int = -1) -> float:
+    def __call__(self, model: SentenceTransformer, output_path: str = None, epoch: int = -1, steps: int = -1) -> float:
         if epoch != -1:
             if steps == -1:
                 out_txt = " after epoch {}:".format(epoch)

--- a/sentence_transformers/evaluation/SentenceEvaluator.py
+++ b/sentence_transformers/evaluation/SentenceEvaluator.py
@@ -1,3 +1,6 @@
+from sentence_transformers import SentenceTransformer
+
+
 class SentenceEvaluator:
     """
     Base class for all evaluators
@@ -5,7 +8,7 @@ class SentenceEvaluator:
     Extend this class and implement __call__ for custom evaluators.
     """
 
-    def __call__(self, model, output_path: str = None, epoch: int = -1, steps: int = -1) -> float:
+    def __call__(self, model: SentenceTransformer, output_path: str = None, epoch: int = -1, steps: int = -1) -> float:
         """
         This is called during training to evaluate the model.
         It returns a score for the evaluation with a higher score indicating a better result.

--- a/sentence_transformers/evaluation/SequentialEvaluator.py
+++ b/sentence_transformers/evaluation/SequentialEvaluator.py
@@ -1,3 +1,4 @@
+from sentence_transformers import SentenceTransformer
 from . import SentenceEvaluator
 from typing import Iterable
 
@@ -14,7 +15,7 @@ class SequentialEvaluator(SentenceEvaluator):
         self.evaluators = evaluators
         self.main_score_function = main_score_function
 
-    def __call__(self, model, output_path: str = None, epoch: int = -1, steps: int = -1) -> float:
+    def __call__(self, model: SentenceTransformer, output_path: str = None, epoch: int = -1, steps: int = -1) -> float:
         scores = []
         for evaluator in self.evaluators:
             scores.append(evaluator(model, output_path, epoch, steps))

--- a/sentence_transformers/evaluation/TranslationEvaluator.py
+++ b/sentence_transformers/evaluation/TranslationEvaluator.py
@@ -1,3 +1,4 @@
+from sentence_transformers import SentenceTransformer
 from . import SentenceEvaluator
 import logging
 from ..util import pytorch_cos_sim
@@ -58,7 +59,7 @@ class TranslationEvaluator(SentenceEvaluator):
         self.csv_headers = ["epoch", "steps", "src2trg", "trg2src"]
         self.write_csv = write_csv
 
-    def __call__(self, model, output_path: str = None, epoch: int = -1, steps: int = -1) -> float:
+    def __call__(self, model: SentenceTransformer, output_path: str = None, epoch: int = -1, steps: int = -1) -> float:
         if epoch != -1:
             if steps == -1:
                 out_txt = " after epoch {}:".format(epoch)

--- a/sentence_transformers/evaluation/TripletEvaluator.py
+++ b/sentence_transformers/evaluation/TripletEvaluator.py
@@ -1,3 +1,4 @@
+from sentence_transformers import SentenceTransformer
 from . import SentenceEvaluator, SimilarityFunction
 import logging
 import os
@@ -70,7 +71,7 @@ class TripletEvaluator(SentenceEvaluator):
             negatives.append(example.texts[2])
         return cls(anchors, positives, negatives, **kwargs)
 
-    def __call__(self, model, output_path: str = None, epoch: int = -1, steps: int = -1) -> float:
+    def __call__(self, model: SentenceTransformer, output_path: str = None, epoch: int = -1, steps: int = -1) -> float:
         if epoch != -1:
             if steps == -1:
                 out_txt = " after epoch {}:".format(epoch)


### PR DESCRIPTION
Hello,

Small follow-up. There isn't a circular import (in fact there's [already an import in main](https://github.com/UKPLab/sentence-transformers/blob/53a247048433b56ad93d83224ac27fae5f981c8d/sentence_transformers/evaluation/MSEEvaluatorFromDataFrame.py#L2)).

Another small thing is that the imports aren't in isort-like order. In case you want to apply that order, run—

```
ruff check sentence_transformers/evaluation --fix --select I
```

—and add `extend-select = ["I"]` to `ruff.toml`.

But I'm not sure if you want this style enforced. I'll leave that up to you to commit :-)