### PR TITLE
Update transformers requirement in setup.py to match requirements.txt

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     packages=find_packages(),
     python_requires=">=3.8.0",
     install_requires=[
-        "transformers>=4.32.0,<5.0.0",
+        "transformers>=4.34.0,<5.0.0",
         "tqdm",
         "torch>=1.11.0",
         "numpy",


### PR DESCRIPTION
Hi, #2574 was not enough to set a new minimum transformers version, pip will still install version 4.32.0 even though it's not compatible.

e.g.

```bash
> pip install transformers==4.31.0 git+https://github.com/UKPLab/sentence-transformers.git
ERROR: Cannot install sentence-transformers==2.7.0.dev0 and transformers==4.31.0 because these
package versions have conflicting dependencies.

> pip install transformers==4.32.0 git+https://github.com/UKPLab/sentence-transformers.git
(works fine)
```
