### PR TITLE
Matryoshka training always patch original forward

### DIFF
--- a/sentence_transformers/losses/MatryoshkaLoss.py
+++ b/sentence_transformers/losses/MatryoshkaLoss.py
@@ -112,21 +112,22 @@ class MatryoshkaLoss(nn.Module):
 
     def forward(self, sentence_features: Iterable[Dict[str, Tensor]], labels: Tensor) -> Tensor:
         original_forward = self.model.forward
-        decorated_forward = ForwardDecorator(original_forward)
-        self.model.forward = decorated_forward
+        try:
+            decorated_forward = ForwardDecorator(original_forward)
+            self.model.forward = decorated_forward
 
-        dim_indices = range(len(self.matryoshka_dims))
-        if self.n_dims_per_step > 0 and self.n_dims_per_step < len(dim_indices):
-            dim_indices = random.sample(dim_indices, self.n_dims_per_step)
+            dim_indices = range(len(self.matryoshka_dims))
+            if self.n_dims_per_step > 0 and self.n_dims_per_step < len(dim_indices):
+                dim_indices = random.sample(dim_indices, self.n_dims_per_step)
 
-        loss = 0.0
-        for idx in dim_indices:
-            dim = self.matryoshka_dims[idx]
-            weight = self.matryoshka_weights[idx]
-            decorated_forward.set_dim(dim)
-            loss += weight * self.loss(sentence_features, labels)
-
-        self.model.forward = original_forward
+            loss = 0.0
+            for idx in dim_indices:
+                dim = self.matryoshka_dims[idx]
+                weight = self.matryoshka_weights[idx]
+                decorated_forward.set_dim(dim)
+                loss += weight * self.loss(sentence_features, labels)
+        finally:
+            self.model.forward = original_forward
         return loss
 
     def get_config_dict(self) -> Dict[str, Any]:


### PR DESCRIPTION
Hello,

In case there's an error in, e.g., `self.loss(sentence_features, labels)`, the closing `self.model.forward = original_forward` line won't get hit. So if a user is training a model in an interactive session (e.g., a notebook) and doesn't re-create the `MatryoshkaLoss` object, then on a second `.fit` run, I think the forward method will start by effectively doing:

```python
original_forward = self.model.forward  # is already a ForwardDecorator b/c of the first (failed) run
decorated_forward = ForwardDecorator(original_forward)  # is now doubly-decorated
self.model.forward = decorated_forward
```

I believe the result will be that the model silently doesn't actually Matryoshka-train, it will only train up to the last dimension that was set before erroring out. Call this dim `err_dim`. Reasoning: we will always have—

```python
output["sentence_embedding"].shape[-1] == err_dim
```

—b/c `self.fn` is the last `ForwardDecorator` that was created and set before erroring-out. Next—

```python
tensor = tensor[..., : self.dim]
```

—will give back the exact same tensor if `self.dim > err_dim`, as this slicing style doesn't raise an error if `self.dim > tensor.shape[-1]`. In other words, `self.shrink` trains at `err_dim` when `self.dim > err_dim`. For example, if the `err_dim` is at index 3 in `matryoshka weights`, then the user's second attempt at training effectively makes `matryoshka_weights` look something like this:

```python
[weight0, weight1, weight2, 5 * weight3, 0, 0, 0, 0]
```

I haven't yet verified that the bug is there and it's silent. And my reasoning could be wrong. Though I think regardless, the intention of the code was to patch back the original forward method, even after an error.