### PR TITLE
feat: add trust remote code to cross encoders

### DIFF
--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -64,11 +64,11 @@ class SentenceTransformer(nn.Sequential):
     :param default_prompt_name: The name of the prompt that should be used by default. If not set,
         no prompt will be applied.
     :param cache_folder: Path to store models. Can also be set by the SENTENCE_TRANSFORMERS_HOME environment variable.
-    :param revision: The specific model version to use. It can be a branch name, a tag name, or a commit id,
-        for a stored model on Hugging Face.
     :param trust_remote_code: Whether or not to allow for custom models defined on the Hub in their own modeling files.
         This option should only be set to True for repositories you trust and in which you have read the code, as it
         will execute code present on the Hub on your local machine.
+    :param revision: The specific model version to use. It can be a branch name, a tag name, or a commit id,
+        for a stored model on Hugging Face.
     :param token: Hugging Face authentication token to download private models.
     :param truncate_dim: The dimension to truncate sentence embeddings to. `None` does no truncation. Truncation is
         only applicable during inference when `.encode` is called.

--- a/sentence_transformers/cross_encoder/CrossEncoder.py
+++ b/sentence_transformers/cross_encoder/CrossEncoder.py
@@ -79,7 +79,7 @@ class CrossEncoder(PushToHubMixin):
         if num_labels is not None:
             self.config.num_labels = num_labels
         self.model = AutoModelForSequenceClassification.from_pretrained(
-            model_name, config=self.config, **automodel_args
+            model_name, config=self.config, revision=revision, **automodel_args
         )
         self.tokenizer = AutoTokenizer.from_pretrained(model_name, revision=revision, **tokenizer_args)
         self.max_length = max_length

--- a/sentence_transformers/cross_encoder/CrossEncoder.py
+++ b/sentence_transformers/cross_encoder/CrossEncoder.py
@@ -79,7 +79,7 @@ class CrossEncoder(PushToHubMixin):
         if num_labels is not None:
             self.config.num_labels = num_labels
         self.model = AutoModelForSequenceClassification.from_pretrained(
-            model_name, config=self.config, revision=revision, **automodel_args
+            model_name, config=self.config, revision=revision, trust_remote_code=trust_remote_code, **automodel_args
         )
         self.tokenizer = AutoTokenizer.from_pretrained(model_name, revision=revision, **tokenizer_args)
         self.max_length = max_length

--- a/sentence_transformers/cross_encoder/CrossEncoder.py
+++ b/sentence_transformers/cross_encoder/CrossEncoder.py
@@ -39,6 +39,9 @@ class CrossEncoder(PushToHubMixin):
     :param device: Device that should be used for the model. If None, it will use CUDA if available.
     :param tokenizer_args: Arguments passed to AutoTokenizer
     :param automodel_args: Arguments passed to AutoModelForSequenceClassification
+    :param trust_remote_code: Whether or not to allow for custom models defined on the Hub in their own modeling files.
+        This option should only be set to True for repositories you trust and in which you have read the code, as it
+        will execute code present on the Hub on your local machine.
     :param revision: The specific model version to use. It can be a branch name, a tag name, or a commit id,
         for a stored model on Hugging Face.
     :param default_activation_function: Callable (like nn.Sigmoid) about the default activation function that
@@ -55,11 +58,16 @@ class CrossEncoder(PushToHubMixin):
         device: str = None,
         tokenizer_args: Dict = {},
         automodel_args: Dict = {},
+        trust_remote_code: bool = False,
         revision: Optional[str] = None,
         default_activation_function=None,
         classifier_dropout: float = None,
     ):
-        self.config = AutoConfig.from_pretrained(model_name, revision=revision)
+        self.config = AutoConfig.from_pretrained(
+            model_name,
+            trust_remote_code=trust_remote_code,
+            revision=revision
+        )
         classifier_trained = True
         if self.config.architectures is not None:
             classifier_trained = any(
@@ -74,9 +82,8 @@ class CrossEncoder(PushToHubMixin):
 
         if num_labels is not None:
             self.config.num_labels = num_labels
-
         self.model = AutoModelForSequenceClassification.from_pretrained(
-            model_name, config=self.config, revision=revision, **automodel_args
+            model_name, config=self.config, **automodel_args
         )
         self.tokenizer = AutoTokenizer.from_pretrained(model_name, revision=revision, **tokenizer_args)
         self.max_length = max_length

--- a/sentence_transformers/cross_encoder/CrossEncoder.py
+++ b/sentence_transformers/cross_encoder/CrossEncoder.py
@@ -63,11 +63,7 @@ class CrossEncoder(PushToHubMixin):
         default_activation_function=None,
         classifier_dropout: float = None,
     ):
-        self.config = AutoConfig.from_pretrained(
-            model_name,
-            trust_remote_code=trust_remote_code,
-            revision=revision
-        )
+        self.config = AutoConfig.from_pretrained(model_name, trust_remote_code=trust_remote_code, revision=revision)
         classifier_trained = True
         if self.config.architectures is not None:
             classifier_trained = any(


### PR DESCRIPTION
A tiny PR to allow `trust_remote_code` in `CrossEncoder` to align with `SentenceTransformer` signature.

Also a bit cleaning of the code, remove duplicate variables and re-order the docstring.