### PR TITLE
[`docs`] Fix search bar on sbert.net

### DIFF
--- a/docs/_themes/sphinx_rtd_theme/search.html
+++ b/docs/_themes/sphinx_rtd_theme/search.html
@@ -5,22 +5,23 @@
     Template for the search page.
 
     :copyright: Copyright 2007-2013 by the Sphinx team, see AUTHORS.
-    :license: BSD, see LICENSE for details.
+    :license: BSD, see https://github.com/sphinx-doc/sphinx/blob/master/LICENSE for details.
 #}
 {%- extends "layout.html" %}
 {% set title = _('Search') %}
 {% set display_vcs_links = False %}
 {%- block scripts %}
     {{ super() }}
-    <script type="text/javascript" src="{{ pathto('_static/searchtools.js', 1) }}"></script>
+    <script src="{{ pathto('_static/searchtools.js', 1) }}"></script>
+    <script src="{{ pathto('_static/language_data.js', 1) }}"></script>
 {%- endblock %}
 {% block footer %}
-  <script type="text/javascript">
+  <script>
     jQuery(function() { Search.loadIndex("{{ pathto('searchindex.js', 1) }}"); });
   </script>
   {# this is used when loading the search index using $.ajax fails,
      such as on Chrome for documents on localhost #}
-  <script type="text/javascript" id="searchindexloader"></script>
+  <script id="searchindexloader"></script>
   {{ super() }}
 {% endblock %}
 {% block body %}

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,5 +3,5 @@
 sphinx<4
 Jinja2<3.1
 sphinx_markdown_tables
-recommonmark
+recommonmark==0.7.1
 -e ..


### PR DESCRIPTION
Hello!

## Pull Request overview
* Fix search bar on sbert.net

## Details
The following issue pops up when searching on sbert.net:
![image](https://github.com/UKPLab/sentence-transformers/assets/37621491/ca072f1a-713b-41df-bf06-ff93e36451ce)

![image](https://github.com/UKPLab/sentence-transformers/assets/37621491/adaa8c03-d624-42cf-9683-9fdf6c3c84ca)

This updates the `search.html` according to a more recent https://github.com/readthedocs/sphinx_rtd_theme version. The same fix had to be applied there: https://github.com/readthedocs/sphinx_rtd_theme/pull/1021

- Tom Aarsen