### PR TITLE
[`clip`] Prevent warning with `padding` when tokenizing for CLIP

### DIFF
--- a/sentence_transformers/models/CLIPModel.py
+++ b/sentence_transformers/models/CLIPModel.py
@@ -63,14 +63,16 @@ class CLIPModel(nn.Module):
                 texts_values.append(data)
                 image_text_info.append(1)
 
-        if len(texts_values) == 0:
-            texts_values = None
-        if len(images) == 0:
-            images = None
+        encoding = {}
+        if len(texts_values):
+            encoding = self.processor.tokenizer(texts_values, return_tensors="pt", padding=padding)
 
-        inputs = self.processor(text=texts_values, images=images, return_tensors="pt", padding=padding)
-        inputs["image_text_info"] = image_text_info
-        return inputs
+        if len(images):
+            image_features = self.processor.image_processor(images, return_tensors="pt")
+            encoding["pixel_values"] = image_features.pixel_values
+
+        encoding["image_text_info"] = image_text_info
+        return encoding
 
     def save(self, output_path: str):
         self.model.save_pretrained(output_path)


### PR DESCRIPTION
Hello!

## Pull Request overview
* Prevent a warning caused by `padding` when tokenizing for CLIP models

## Details
Since #2557 we pass the `padding` to the `self.processor` for CLIP to allow for batch tokenizing text. However, the `self.processor` call would pass the `padding` to `image_processor`, which gives a very spammy warning. This avoids that warning, without updating the outputs of the tokenizer itself.

- Tom Aarsen