### PR TITLE
Enable Sentence Transformer Inference with Intel Gaudi2 GPU Supported ( 'hpu' ) - Follow up for #2557

### DIFF
--- a/sentence_transformers/models/CLIPModel.py
+++ b/sentence_transformers/models/CLIPModel.py
@@ -3,7 +3,7 @@ from torch import nn
 import transformers
 import torch
 from PIL import Image
-
+from sentence_transformers.util import get_device_name
 
 class CLIPModel(nn.Module):
     def __init__(self, model_name: str = "openai/clip-vit-base-patch32", processor_name=None):
@@ -72,7 +72,11 @@ class CLIPModel(nn.Module):
             encoding["pixel_values"] = image_features.pixel_values
 
         encoding["image_text_info"] = image_text_info
-        return encoding
+        device = get_device_name()
+        if device == "hpu":
+            return dict(encoding)
+        else:
+            return encoding
 
     def save(self, output_path: str):
         self.model.save_pretrained(output_path)

--- a/tests/test_compute_embeddings.py
+++ b/tests/test_compute_embeddings.py
@@ -5,7 +5,6 @@ Computes embeddings
 import numpy as np
 
 from sentence_transformers import SentenceTransformer
-from sentence_transformers.util import get_device_name
 
 
 def test_encode_token_embeddings(paraphrase_distilroberta_base_v1_model: SentenceTransformer) -> None:
@@ -24,13 +23,8 @@ def test_encode_token_embeddings(paraphrase_distilroberta_base_v1_model: Sentenc
     emb = model.encode(sent, output_value="token_embeddings", batch_size=2)
     assert len(emb) == len(sent)
 
-    device = get_device_name()
-    if device == "hpu":
-        for s, e in zip(sent, emb):
-            assert len(model.tokenize([s])["input_ids"][0]) == model.get_max_seq_length()
-    else:
-        for s, e in zip(sent, emb):
-            assert len(model.tokenize([s])["input_ids"][0]) == e.shape[0]
+    for s, e in zip(sent, emb):
+        assert len(model.tokenize([s])["input_ids"][0]) == e.shape[0]
 
 
 def test_encode_single_sentences(paraphrase_distilroberta_base_v1_model: SentenceTransformer) -> None:


### PR DESCRIPTION
This PR belongs to one of enabling Intel's Gaudi2 GPU supported tasks for Sentence Transformer's inference/training.

This is the follow up PR to [2557](https://github.com/UKPLab/sentence-transformers/pull/2557). There are few following considerations/modifications in this new PR on hpu device  -

1.  Padding strategy for hpu device

    We have tested the performance over all 37 models listed in [pretrained models page ](https://www.sbert.net/docs/pretrained_models.html) and compared the performance between padding strategy of 'max_length' (str) and 'longest_length' (default value = True).  Found over 2/3 of all 37 models the padding strategy from 'longest_length' is better than 'max_length' option for hpu device based on the [eval](https://github.com/UKPLab/sentence-transformers/blob/master/examples/evaluation/evaluation_inference_speed.py) over 100000 sentences. So we propose to also change hpu's padding setting into 'longest_length' (value = True) and same as previous default setting. 
   But also we want to expose this padding setting as one argument in SentenceTransformer class definition which the users can easily/freely choose what they want for padding strategy and in some cases the 'max_length' padding strategy will show better performance. 

2. hpu support for PR ( [2573](https://github.com/UKPLab/sentence-transformers/pull/2573)

    Test this PR on hpu device/ failed. So we proposed the revision version to support this PR with hpu device. So now the test case of this PR (# test_encode_truncate) under tests/test_sentence_transformer.py also successfully passed. 

3. hpu support for PR [2599](https://github.com/UKPLab/sentence-transformers/pull/2599)

    Test this PR on hpu device/ failed. So we proposed the revision version to support this PR with hpu device. So now the test case of this PR (# test_simple_encode ) under tests/test_image_embeddings.py also successfully passed

Welcome for any questions/comments!

Thanks.