### PR TITLE
[`v3`] Add `similarity` and `similarity_pairwise` methods to Sentence Transformers

### DIFF
--- a/examples/applications/image-search/README.md
+++ b/examples/applications/image-search/README.md
@@ -12,7 +12,7 @@ Ensure that you have [transformers](https://pypi.org/project/transformers/) inst
 SentenceTransformers provides a wrapper for the [OpenAI CLIP Model](https://github.com/openai/CLIP), which was trained on a variety of (image, text)-pairs.
 
 ```python
-from sentence_transformers import SentenceTransformer, util
+from sentence_transformers import SentenceTransformer
 from PIL import Image
 
 # Load CLIP model
@@ -26,9 +26,9 @@ text_emb = model.encode(
     ["Two dogs in the snow", "A cat on a table", "A picture of London at night"]
 )
 
-# Compute cosine similarities
-cos_scores = util.cos_sim(img_emb, text_emb)
-print(cos_scores)
+# Compute similarities
+similarity_scores = model.similarity(img_emb, text_emb)
+print(similarity_scores)
 ```
 
 You can use the CLIP model for:

--- a/examples/applications/semantic-search/semantic_search.py
+++ b/examples/applications/semantic-search/semantic_search.py
@@ -7,7 +7,7 @@ we want to find the most similar sentence in this corpus.
 This script outputs for various queries the top 5 most similar sentences in the corpus.
 """
 
-from sentence_transformers import SentenceTransformer, util
+from sentence_transformers import SentenceTransformer
 import torch
 
 embedder = SentenceTransformer("all-MiniLM-L6-v2")
@@ -40,8 +40,8 @@ for query in queries:
     query_embedding = embedder.encode(query, convert_to_tensor=True)
 
     # We use cosine-similarity and torch.topk to find the highest 5 scores
-    cos_scores = util.cos_sim(query_embedding, corpus_embeddings)[0]
-    top_results = torch.topk(cos_scores, k=top_k)
+    similarity_scores = embedder.similarity(query_embedding, corpus_embeddings)[0]
+    top_results = torch.topk(similarity_scores, k=top_k)
 
     print("\n\n======================\n\n")
     print("Query:", query)

--- a/examples/applications/text-summarization/text-summarization.py
+++ b/examples/applications/text-summarization/text-summarization.py
@@ -19,7 +19,7 @@ Note: Requires NLTK: `pip install nltk`
 """
 
 import nltk
-from sentence_transformers import SentenceTransformer, util
+from sentence_transformers import SentenceTransformer
 import numpy as np
 from LexRank import degree_centrality_scores
 
@@ -43,13 +43,13 @@ sentences = nltk.sent_tokenize(document)
 print("Num sentences:", len(sentences))
 
 # Compute the sentence embeddings
-embeddings = model.encode(sentences, convert_to_tensor=True)
+embeddings = model.encode(sentences)
 
-# Compute the pair-wise cosine similarities
-cos_scores = util.cos_sim(embeddings, embeddings).numpy()
+# Compute the similarity scores
+similarity_scores = model.similarity(embeddings, embeddings).numpy()
 
 # Compute the centrality for each sentence
-centrality_scores = degree_centrality_scores(cos_scores, threshold=None)
+centrality_scores = degree_centrality_scores(similarity_scores, threshold=None)
 
 # We argsort so that the first element is the sentence with the highest score
 most_central_sentence_indices = np.argsort(-centrality_scores)

--- a/examples/training/adaptive_layer/README.md
+++ b/examples/training/adaptive_layer/README.md
@@ -120,7 +120,6 @@ Then we can run inference with it using <a href="../../../docs/package_reference
 
 ```python
 from sentence_transformers import SentenceTransformer
-from sentence_transformers.util import cos_sim
 
 model = SentenceTransformer("tomaarsen/mpnet-base-nli-adaptive-layer")
 new_num_layers = 3
@@ -134,7 +133,7 @@ embeddings = model.encode(
     ]
 )
 # Similarity of the first sentence with the other two
-similarities = cos_sim(embeddings[0], embeddings[1:])
+similarities = model.similarity(embeddings[0], embeddings[1:])
 # => tensor([[0.7761, 0.1655]])
 # compared to tensor([[ 0.7547, -0.0162]]) for the full model
 ```

--- a/examples/training/matryoshka/README.md
+++ b/examples/training/matryoshka/README.md
@@ -58,7 +58,6 @@ After a model has been trained using a Matryoshka loss, you can then run inferen
 
 ```python
 from sentence_transformers import SentenceTransformer
-from sentence_transformers.util import cos_sim
 import torch.nn.functional as F
 
 matryoshka_dim = 64
@@ -77,7 +76,7 @@ embeddings = model.encode(
 )
 assert embeddings.shape[-1] == matryoshka_dim
 
-similarities = cos_sim(embeddings[0], embeddings[1:])
+similarities = model.similarity(embeddings[0], embeddings[1:])
 # => tensor([[0.7839, 0.4933]])
 ```
 As you can see, the similarity between the search query and the correct document is much higher than that of an unrelated document, despite the very small matryoshka dimension applied. Feel free to copy this script locally, modify the `matryoshka_dim`, and observe the difference in similarities.

--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -776,7 +776,8 @@ class SentenceTransformer(nn.Sequential, FitMixin):
         safe_serialization: bool = True,
     ):
         """
-        Saves all elements for this seq. sentence embedder into different sub-folders
+        Saves a model and its configuration files to a directory, so that it can be loaded
+        with `SentenceTransformer(path)` again.
 
         :param path: Path on disc
         :param model_name: Optional model name
@@ -831,6 +832,32 @@ class SentenceTransformer(nn.Sequential, FitMixin):
         # Create model card
         if create_model_card:
             self._create_model_card(path, model_name, train_datasets)
+
+    def save_pretrained(
+        self,
+        path: str,
+        model_name: Optional[str] = None,
+        create_model_card: bool = True,
+        train_datasets: Optional[List[str]] = None,
+        safe_serialization: bool = True,
+    ):
+        """
+        Saves a model and its configuration files to a directory, so that it can be loaded
+        with `SentenceTransformer(path)` again. Alias of `SentenceTransformer.save`.
+
+        :param path: Path on disc
+        :param model_name: Optional model name
+        :param create_model_card: If True, create a README.md with basic information about this model
+        :param train_datasets: Optional list with the names of the datasets used to to train the model
+        :param safe_serialization: If true, save the model using safetensors. If false, save the model the traditional PyTorch way
+        """
+        self.save(
+            path,
+            model_name=model_name,
+            create_model_card=create_model_card,
+            train_datasets=train_datasets,
+            safe_serialization=safe_serialization,
+        )
 
     def _create_model_card(
         self, path: str, model_name: Optional[str] = None, train_datasets: Optional[List[str]] = "deprecated"

--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -5,7 +5,7 @@ import os
 from collections import OrderedDict
 from pathlib import Path
 import warnings
-from typing import List, Dict, Literal, Tuple, Iterable, Union, Optional
+from typing import Callable, List, Dict, Literal, Tuple, Iterable, Union, Optional, overload
 import numpy as np
 from numpy import ndarray
 import transformers
@@ -20,7 +20,7 @@ import queue
 import tempfile
 
 from sentence_transformers.model_card import SentenceTransformerModelCardData, generate_model_card
-
+from sentence_transformers.similarity_functions import SimilarityFunction
 
 from . import __MODEL_HUB_ORGANIZATION__
 from .evaluation import SentenceEvaluator
@@ -59,6 +59,9 @@ class SentenceTransformer(nn.Sequential, FitMixin):
         titles in "}`.
     :param default_prompt_name: The name of the prompt that should be used by default. If not set,
         no prompt will be applied.
+    :param score_function_name: The name of the similarity function to use. Valid options are "cosine", "dot_product",
+        "euclidean", and "manhattan". If not set, it is automatically set after training or automatically set to
+        "cosine" if `compare` or `compare_pairwise` are called while `score_function_name` is still None.
     :param cache_folder: Path to store models. Can also be set by the SENTENCE_TRANSFORMERS_HOME environment variable.
     :param trust_remote_code: Whether or not to allow for custom models defined on the Hub in their own modeling files.
         This option should only be set to True for repositories you trust and in which you have read the code, as it
@@ -78,6 +81,7 @@ class SentenceTransformer(nn.Sequential, FitMixin):
         device: Optional[str] = None,
         prompts: Optional[Dict[str, str]] = None,
         default_prompt_name: Optional[str] = None,
+        score_function_name: Optional[Union[str, SimilarityFunction]] = None,
         cache_folder: Optional[str] = None,
         trust_remote_code: bool = False,
         revision: Optional[str] = None,
@@ -90,6 +94,7 @@ class SentenceTransformer(nn.Sequential, FitMixin):
         # Note: self._load_sbert_model can also update `self.prompts` and `self.default_prompt_name`
         self.prompts = prompts or {}
         self.default_prompt_name = default_prompt_name
+        self.similarity_fn_name = score_function_name
         self.truncate_dim = truncate_dim
         self.model_card_data = model_card_data or SentenceTransformerModelCardData()
         self._model_card_vars = {}
@@ -436,6 +441,105 @@ class SentenceTransformer(nn.Sequential, FitMixin):
 
         return all_embeddings
 
+    @property
+    def similarity_fn_name(self) -> Optional[str]:
+        return self._similarity_fn_name
+
+    @similarity_fn_name.setter
+    def similarity_fn_name(self, value: Union[str, SimilarityFunction]) -> None:
+        if isinstance(value, SimilarityFunction):
+            value = value.value
+        self._similarity_fn_name = value
+
+        if value is not None:
+            self._similarity = SimilarityFunction.to_similarity_fn(value)
+            self._similarity_pairwise = SimilarityFunction.to_similarity_pairwise_fn(value)
+
+    @overload
+    def similarity(self, embeddings1: Tensor, embeddings2: Tensor) -> Tensor: ...
+
+    @overload
+    def similarity(self, embeddings1: ndarray, embeddings2: ndarray) -> Tensor: ...
+
+    @property
+    def similarity(self) -> Callable[[Union[Tensor, ndarray], Union[Tensor, ndarray]], Tensor]:
+        """
+        Compute the similarity between two collections of embeddings. The output will be a matrix with the similarity
+        scores between all embeddings from the first parameter and all embeddings from the second parameter. This
+        differs from `similarity_pairwise` which computes the similarity between each pair of embeddings.
+
+        Example
+            ::
+
+                >>> model = SentenceTransformer("all-mpnet-base-v2")
+                >>> sentences = [
+                ...     "The weather is so nice!",
+                ...     "It's so sunny outside.",
+                ...     "He's driving to the movie theater.",
+                ...     "She's going to the cinema.",
+                ... ]
+                >>> embeddings = model.encode(sentences, normalize_embeddings=True)
+                >>> model.similarity(embeddings, embeddings)
+                tensor([[1.0000, 0.7235, 0.0290, 0.1309],
+                        [0.7235, 1.0000, 0.0613, 0.1129],
+                        [0.0290, 0.0613, 1.0000, 0.5027],
+                        [0.1309, 0.1129, 0.5027, 1.0000]])
+                >>> model.similarity_fn_name
+                "cosine"
+                >>> model.similarity_fn_name = "euclidean"
+                >>> model.similarity(embeddings, embeddings)
+                tensor([[-0.0000, -0.7437, -1.3935, -1.3184],
+                        [-0.7437, -0.0000, -1.3702, -1.3320],
+                        [-1.3935, -1.3702, -0.0000, -0.9973],
+                        [-1.3184, -1.3320, -0.9973, -0.0000]])
+
+        :param embeddings1: [num_embeddings_1, embedding_dim] or [embedding_dim]-shaped numpy array or torch tensor.
+        :param embeddings2: [num_embeddings_2, embedding_dim] or [embedding_dim]-shaped numpy array or torch tensor.
+        :return: A [num_embeddings_1, num_embeddings_2]-shaped torch tensor with similarity scores.
+        """
+        if self.similarity_fn_name is None:
+            self.similarity_fn_name = SimilarityFunction.COSINE
+        return self._similarity
+
+    @overload
+    def similarity_pairwise(self, embeddings1: Tensor, embeddings2: Tensor) -> Tensor: ...
+
+    @overload
+    def similarity_pairwise(self, embeddings1: ndarray, embeddings2: ndarray) -> Tensor: ...
+
+    @property
+    def similarity_pairwise(self) -> Callable[[Union[Tensor, ndarray], Union[Tensor, ndarray]], Tensor]:
+        """
+        Compute the similarity between two collections of embeddings. The output will be a vector with the similarity
+        scores between each pair of embeddings.
+
+        Example
+            ::
+
+                >>> model = SentenceTransformer("all-mpnet-base-v2")
+                >>> sentences = [
+                ...     "The weather is so nice!",
+                ...     "It's so sunny outside.",
+                ...     "He's driving to the movie theater.",
+                ...     "She's going to the cinema.",
+                ... ]
+                >>> embeddings = model.encode(sentences, normalize_embeddings=True)
+                >>> model.similarity_pairwise(embeddings[::2], embeddings[1::2])
+                tensor([0.7235, 0.5027])
+                >>> model.similarity_fn_name
+                "cosine"
+                >>> model.similarity_fn_name = "euclidean"
+                >>> model.similarity_pairwise(embeddings[::2], embeddings[1::2])
+                tensor([-0.7437, -0.9973])
+
+        :param embeddings1: [num_embeddings, embedding_dim] or [embedding_dim]-shaped numpy array or torch tensor.
+        :param embeddings2: [num_embeddings, embedding_dim] or [embedding_dim]-shaped numpy array or torch tensor.
+        :return: A [num_embeddings]-shaped torch tensor with pairwise similarity scores.
+        """
+        if self.similarity_fn_name is None:
+            self.similarity_fn_name = SimilarityFunction.COSINE
+        return self._similarity_pairwise
+
     def start_multi_process_pool(self, target_devices: List[str] = None):
         """
         Starts multi process to process the encoding with several, independent processes.
@@ -700,6 +804,7 @@ class SentenceTransformer(nn.Sequential, FitMixin):
             config = self._model_config.copy()
             config["prompts"] = self.prompts
             config["default_prompt_name"] = self.default_prompt_name
+            config["similarity_fn_name"] = self.similarity_fn_name
             json.dump(config, fOut, indent=2)
 
         # Save modules
@@ -982,7 +1087,9 @@ class SentenceTransformer(nn.Sequential, FitMixin):
                     )
                 )
 
-            # Set prompts if not already overridden by the __init__ calls
+            # Set score functions & prompts if not already overridden by the __init__ calls
+            if self.similarity_fn_name is None:
+                self.similarity_fn_name = self._model_config.get("similarity_fn_name", None)
             if not self.prompts:
                 self.prompts = self._model_config.get("prompts", {})
             if not self.default_prompt_name:

--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -59,9 +59,9 @@ class SentenceTransformer(nn.Sequential, FitMixin):
         titles in "}`.
     :param default_prompt_name: The name of the prompt that should be used by default. If not set,
         no prompt will be applied.
-    :param score_function_name: The name of the similarity function to use. Valid options are "cosine", "dot_product",
-        "euclidean", and "manhattan". If not set, it is automatically set after training or automatically set to
-        "cosine" if `compare` or `compare_pairwise` are called while `score_function_name` is still None.
+    :param similarity_fn_name: The name of the similarity function to use. Valid options are "cosine", "dot",
+        "euclidean", and "manhattan". If not set, it is automatically to "cosine" if `similarity` or
+        `similarity_pairwise` are called while `model.similarity_fn_name` is still `None`.
     :param cache_folder: Path to store models. Can also be set by the SENTENCE_TRANSFORMERS_HOME environment variable.
     :param trust_remote_code: Whether or not to allow for custom models defined on the Hub in their own modeling files.
         This option should only be set to True for repositories you trust and in which you have read the code, as it
@@ -81,7 +81,7 @@ class SentenceTransformer(nn.Sequential, FitMixin):
         device: Optional[str] = None,
         prompts: Optional[Dict[str, str]] = None,
         default_prompt_name: Optional[str] = None,
-        score_function_name: Optional[Union[str, SimilarityFunction]] = None,
+        similarity_fn_name: Optional[Union[str, SimilarityFunction]] = None,
         cache_folder: Optional[str] = None,
         trust_remote_code: bool = False,
         revision: Optional[str] = None,
@@ -94,7 +94,7 @@ class SentenceTransformer(nn.Sequential, FitMixin):
         # Note: self._load_sbert_model can also update `self.prompts` and `self.default_prompt_name`
         self.prompts = prompts or {}
         self.default_prompt_name = default_prompt_name
-        self.similarity_fn_name = score_function_name
+        self.similarity_fn_name = similarity_fn_name
         self.truncate_dim = truncate_dim
         self.model_card_data = model_card_data or SentenceTransformerModelCardData()
         self._model_card_vars = {}

--- a/sentence_transformers/evaluation/EmbeddingSimilarityEvaluator.py
+++ b/sentence_transformers/evaluation/EmbeddingSimilarityEvaluator.py
@@ -1,14 +1,15 @@
 from contextlib import nullcontext
 
 from sentence_transformers import SentenceTransformer
-from . import SentenceEvaluator, SimilarityFunction
+from . import SentenceEvaluator
+from sentence_transformers.similarity_functions import SimilarityFunction
 import logging
 import os
 import csv
 from sklearn.metrics.pairwise import paired_cosine_distances, paired_euclidean_distances, paired_manhattan_distances
 from scipy.stats import pearsonr, spearmanr
 import numpy as np
-from typing import Dict, List, Literal, Optional
+from typing import Dict, List, Literal, Optional, Union
 from ..readers import InputExample
 
 
@@ -31,7 +32,7 @@ class EmbeddingSimilarityEvaluator(SentenceEvaluator):
         sentences2: List[str],
         scores: List[float],
         batch_size: int = 16,
-        main_similarity: SimilarityFunction = None,
+        main_similarity: Optional[Union[str, SimilarityFunction]] = None,
         name: str = "",
         show_progress_bar: bool = False,
         write_csv: bool = True,
@@ -63,7 +64,7 @@ class EmbeddingSimilarityEvaluator(SentenceEvaluator):
         assert len(self.sentences1) == len(self.sentences2)
         assert len(self.sentences1) == len(self.scores)
 
-        self.main_similarity = main_similarity
+        self.main_similarity = SimilarityFunction(main_similarity) if main_similarity else None
         self.name = name
 
         self.batch_size = batch_size

--- a/sentence_transformers/evaluation/SimilarityFunction.py
+++ b/sentence_transformers/evaluation/SimilarityFunction.py
@@ -1,0 +1,3 @@
+from sentence_transformers.similarity_functions import SimilarityFunction
+
+__all__ = ["SimilarityFunction"]

--- a/sentence_transformers/evaluation/SimilarityFunction.py
+++ b/sentence_transformers/evaluation/SimilarityFunction.py
@@ -1,8 +1,0 @@
-from enum import Enum
-
-
-class SimilarityFunction(Enum):
-    COSINE = 0
-    EUCLIDEAN = 1
-    MANHATTAN = 2
-    DOT_PRODUCT = 3

--- a/sentence_transformers/evaluation/__init__.py
+++ b/sentence_transformers/evaluation/__init__.py
@@ -1,5 +1,4 @@
 from .SentenceEvaluator import SentenceEvaluator
-from .SimilarityFunction import SimilarityFunction
 from .BinaryClassificationEvaluator import BinaryClassificationEvaluator
 from .EmbeddingSimilarityEvaluator import EmbeddingSimilarityEvaluator
 from .InformationRetrievalEvaluator import InformationRetrievalEvaluator
@@ -14,7 +13,6 @@ from .RerankingEvaluator import RerankingEvaluator
 
 __all__ = [
     "SentenceEvaluator",
-    "SimilarityFunction",
     "BinaryClassificationEvaluator",
     "EmbeddingSimilarityEvaluator",
     "InformationRetrievalEvaluator",

--- a/sentence_transformers/evaluation/__init__.py
+++ b/sentence_transformers/evaluation/__init__.py
@@ -1,4 +1,5 @@
 from .SentenceEvaluator import SentenceEvaluator
+from .SimilarityFunction import SimilarityFunction
 from .BinaryClassificationEvaluator import BinaryClassificationEvaluator
 from .EmbeddingSimilarityEvaluator import EmbeddingSimilarityEvaluator
 from .InformationRetrievalEvaluator import InformationRetrievalEvaluator
@@ -13,6 +14,7 @@ from .RerankingEvaluator import RerankingEvaluator
 
 __all__ = [
     "SentenceEvaluator",
+    "SimilarityFunction",
     "BinaryClassificationEvaluator",
     "EmbeddingSimilarityEvaluator",
     "InformationRetrievalEvaluator",

--- a/sentence_transformers/model_card.py
+++ b/sentence_transformers/model_card.py
@@ -10,9 +10,6 @@ from textwrap import indent
 from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Tuple, Union
 import logging
 
-import accelerate
-import datasets
-import tokenizers
 import torch
 from torch import nn
 import transformers
@@ -206,6 +203,22 @@ YAML_FIELDS = [
 IGNORED_FIELDS = ["model", "trainer", "eval_results_dict"]
 
 
+def get_versions() -> Dict[str, Any]:
+    from accelerate import __version__ as accelerate_version
+    from datasets import __version__ as datasets_version
+    from tokenizers import __version__ as tokenizers_version
+
+    return {
+        "python": python_version(),
+        "sentence_transformers": sentence_transformers_version,
+        "transformers": transformers.__version__,
+        "torch": torch.__version__,
+        "accelerate": accelerate_version,
+        "datasets": datasets_version,
+        "tokenizers": tokenizers_version,
+    }
+
+
 @dataclass
 class SentenceTransformerModelCardData(CardData):
     """A dataclass storing data used in the model card.
@@ -290,18 +303,7 @@ class SentenceTransformerModelCardData(CardData):
     # Computed once, always unchanged
     pipeline_tag: str = field(default="sentence-similarity", init=False)
     library_name: str = field(default="sentence-transformers", init=False)
-    version: Dict[str, str] = field(
-        default_factory=lambda: {
-            "python": python_version(),
-            "sentence_transformers": sentence_transformers_version,
-            "transformers": transformers.__version__,
-            "torch": torch.__version__,
-            "accelerate": accelerate.__version__,
-            "datasets": datasets.__version__,
-            "tokenizers": tokenizers.__version__,
-        },
-        init=False,
-    )
+    version: Dict[str, str] = field(default_factory=get_versions, init=False)
 
     # Passed via `register_model` only
     model: Optional["SentenceTransformer"] = field(default=None, init=False, repr=False)

--- a/sentence_transformers/model_card.py
+++ b/sentence_transformers/model_card.py
@@ -901,6 +901,12 @@ class SentenceTransformerModelCardData(CardData):
         super_dict["model_max_length"] = self.model.get_max_seq_length()
         super_dict["output_dimensionality"] = self.model.get_sentence_embedding_dimension()
         super_dict["model_string"] = str(self.model)
+        super_dict["similarity_fn_name"] = {
+            "cosine": "Cosine Similarity",
+            "dot": "Dot Product",
+            "euclidean": "Euclidean Distance",
+            "manhattan": "Manhattan Distance",
+        }.get(self.model.similarity_fn_name, self.model.similarity_fn_name.replace("_", " ").title())
 
         self.first_save = False
 

--- a/sentence_transformers/model_card_template.md
+++ b/sentence_transformers/model_card_template.md
@@ -23,6 +23,7 @@ This is a [sentence-transformers](https://www.SBERT.net) model{% if base_model %
 {%- endif %}
 - **Maximum Sequence Length:** {{ model_max_length }} tokens
 - **Output Dimensionality:** {{ output_dimensionality }} tokens
+- **Similarity Function:** {{ similarity_fn_name }}
 {% if train_datasets | selectattr("name") | list -%}
     - **Training Dataset{{"s" if train_datasets | selectattr("name") | list | length > 1 else ""}}:**
     {%- for dataset in (train_datasets | selectattr("name")) %}
@@ -88,6 +89,11 @@ sentences = [
 embeddings = model.encode(sentences)
 print(embeddings.shape)
 # [{{ (predict_example or ["The weather is lovely today.", "It's so sunny outside!", "He drove to the stadium."]) | length}}, {{ output_dimensionality | default(1024, true) }}]
+
+# Get the similarity scores for the embeddings
+similarities = model.similarity(embeddings)
+print(similarities.shape)
+# [{{ (predict_example or ["The weather is lovely today.", "It's so sunny outside!", "He drove to the stadium."]) | length}}, {{ (predict_example or ["The weather is lovely today.", "It's so sunny outside!", "He drove to the stadium."]) | length}}]
 ```
 
 <!--

--- a/sentence_transformers/similarity_functions.py
+++ b/sentence_transformers/similarity_functions.py
@@ -18,6 +18,7 @@ from .util import (
 class SimilarityFunction(Enum):
     COSINE = "cosine"
     DOT_PRODUCT = "dot"
+    DOT = "dot"  # Alias for DOT_PRODUCT
     EUCLIDEAN = "euclidean"
     MANHATTAN = "manhattan"
 

--- a/sentence_transformers/similarity_functions.py
+++ b/sentence_transformers/similarity_functions.py
@@ -1,0 +1,68 @@
+from enum import Enum
+from typing import Callable, Union
+
+from numpy import ndarray
+from torch import Tensor
+from .util import (
+    cos_sim,
+    manhattan_sim,
+    euclidean_sim,
+    dot_score,
+    pairwise_cos_sim,
+    pairwise_manhattan_sim,
+    pairwise_euclidean_sim,
+    pairwise_dot_score,
+)
+
+
+class SimilarityFunction(Enum):
+    COSINE = "cosine"
+    DOT_PRODUCT = "dot"
+    EUCLIDEAN = "euclidean"
+    MANHATTAN = "manhattan"
+
+    @staticmethod
+    def to_similarity_fn(
+        similarity_function: Union[str, "SimilarityFunction"],
+    ) -> Callable[[Union[Tensor, ndarray], Union[Tensor, ndarray]], Tensor]:
+        similarity_function = SimilarityFunction(similarity_function)
+
+        if similarity_function == SimilarityFunction.COSINE:
+            return cos_sim
+        if similarity_function == SimilarityFunction.DOT_PRODUCT:
+            return dot_score
+        if similarity_function == SimilarityFunction.MANHATTAN:
+            return manhattan_sim
+        if similarity_function == SimilarityFunction.EUCLIDEAN:
+            return euclidean_sim
+
+        raise ValueError(
+            "The provided function {} is not supported. Use one of the supported values: {}.".format(
+                similarity_function, SimilarityFunction.possible_values()
+            )
+        )
+
+    @staticmethod
+    def to_similarity_pairwise_fn(
+        similarity_function: Union[str, "SimilarityFunction"],
+    ) -> Callable[[Union[Tensor, ndarray], Union[Tensor, ndarray]], Tensor]:
+        similarity_function = SimilarityFunction(similarity_function)
+
+        if similarity_function == SimilarityFunction.COSINE:
+            return pairwise_cos_sim
+        if similarity_function == SimilarityFunction.DOT_PRODUCT:
+            return pairwise_dot_score
+        if similarity_function == SimilarityFunction.MANHATTAN:
+            return pairwise_manhattan_sim
+        if similarity_function == SimilarityFunction.EUCLIDEAN:
+            return pairwise_euclidean_sim
+
+        raise ValueError(
+            "The provided function {} is not supported. Use one of the supported values: {}.".format(
+                similarity_function, SimilarityFunction.possible_values()
+            )
+        )
+
+    @staticmethod
+    def possible_values():
+        return [m.value for m in SimilarityFunction]

--- a/sentence_transformers/util.py
+++ b/sentence_transformers/util.py
@@ -2,7 +2,7 @@ from contextlib import contextmanager
 import functools
 import requests
 from torch import Tensor, device
-from typing import List, Callable, Literal
+from typing import List, Callable, Literal, overload
 from tqdm.autonotebook import tqdm
 import sys
 import importlib
@@ -11,13 +11,31 @@ import torch
 import numpy as np
 import queue
 import logging
-from typing import Dict, Optional, Union, overload
+from typing import Dict, Optional, Union
 
 from transformers import is_torch_npu_available
 from huggingface_hub import snapshot_download, hf_hub_download
 import heapq
 
 logger = logging.getLogger(__name__)
+
+
+def _convert_to_tensor(a: Union[list, np.ndarray, Tensor]) -> Tensor:
+    if not isinstance(a, Tensor):
+        a = torch.tensor(a)
+    return a
+
+
+def _convert_to_batch(a: Tensor) -> Tensor:
+    if a.dim() == 1:
+        a = a.unsqueeze(0)
+    return a
+
+
+def _convert_to_batch_tensor(a: Union[list, np.ndarray, Tensor]) -> Tensor:
+    a = _convert_to_tensor(a)
+    a = _convert_to_batch(a)
+    return a
 
 
 def pytorch_cos_sim(a: Tensor, b: Tensor) -> Tensor:
@@ -29,46 +47,40 @@ def pytorch_cos_sim(a: Tensor, b: Tensor) -> Tensor:
     return cos_sim(a, b)
 
 
-def cos_sim(a: Tensor, b: Tensor) -> Tensor:
+def cos_sim(a: Union[list, np.ndarray, Tensor], b: Union[list, np.ndarray, Tensor]) -> Tensor:
     """
     Computes the cosine similarity cos_sim(a[i], b[j]) for all i and j.
 
     :return: Matrix with res[i][j]  = cos_sim(a[i], b[j])
     """
-    if not isinstance(a, torch.Tensor):
-        a = torch.tensor(a)
+    a = _convert_to_batch_tensor(a)
+    b = _convert_to_batch_tensor(b)
 
-    if not isinstance(b, torch.Tensor):
-        b = torch.tensor(b)
-
-    if len(a.shape) == 1:
-        a = a.unsqueeze(0)
-
-    if len(b.shape) == 1:
-        b = b.unsqueeze(0)
-
-    a_norm = torch.nn.functional.normalize(a, p=2, dim=1)
-    b_norm = torch.nn.functional.normalize(b, p=2, dim=1)
+    a_norm = normalize_embeddings(a)
+    b_norm = normalize_embeddings(b)
     return torch.mm(a_norm, b_norm.transpose(0, 1))
 
 
-def dot_score(a: Tensor, b: Tensor) -> Tensor:
+def pairwise_cos_sim(a: Tensor, b: Tensor) -> Tensor:
+    """
+    Computes the pairwise cossim cos_sim(a[i], b[i])
+
+    :return: Vector with res[i] = cos_sim(a[i], b[i])
+    """
+    a = _convert_to_tensor(a)
+    b = _convert_to_tensor(b)
+
+    return pairwise_dot_score(normalize_embeddings(a), normalize_embeddings(b))
+
+
+def dot_score(a: Union[list, np.ndarray, Tensor], b: Union[list, np.ndarray, Tensor]) -> Tensor:
     """
     Computes the dot-product dot_prod(a[i], b[j]) for all i and j.
 
     :return: Matrix with res[i][j]  = dot_prod(a[i], b[j])
     """
-    if not isinstance(a, torch.Tensor):
-        a = torch.tensor(a)
-
-    if not isinstance(b, torch.Tensor):
-        b = torch.tensor(b)
-
-    if len(a.shape) == 1:
-        a = a.unsqueeze(0)
-
-    if len(b.shape) == 1:
-        b = b.unsqueeze(0)
+    a = _convert_to_batch_tensor(a)
+    b = _convert_to_batch_tensor(b)
 
     return torch.mm(a, b.transpose(0, 1))
 
@@ -79,28 +91,58 @@ def pairwise_dot_score(a: Tensor, b: Tensor) -> Tensor:
 
     :return: Vector with res[i] = dot_prod(a[i], b[i])
     """
-    if not isinstance(a, torch.Tensor):
-        a = torch.tensor(a)
-
-    if not isinstance(b, torch.Tensor):
-        b = torch.tensor(b)
+    a = _convert_to_tensor(a)
+    b = _convert_to_tensor(b)
 
     return (a * b).sum(dim=-1)
 
 
-def pairwise_cos_sim(a: Tensor, b: Tensor) -> Tensor:
+def manhattan_sim(a: Union[list, np.ndarray, Tensor], b: Union[list, np.ndarray, Tensor]) -> Tensor:
     """
-    Computes the pairwise cossim cos_sim(a[i], b[i])
+    Computes the manhattan similarity manhattan_sim(a[i], b[j]) for all i and j.
 
-    :return: Vector with res[i] = cos_sim(a[i], b[i])
+    :return: Matrix with res[i][j] = manhattan_sim(a[i], b[j])
     """
-    if not isinstance(a, torch.Tensor):
-        a = torch.tensor(a)
+    a = _convert_to_batch_tensor(a)
+    b = _convert_to_batch_tensor(b)
 
-    if not isinstance(b, torch.Tensor):
-        b = torch.tensor(b)
+    return -torch.cdist(a, b, p=1.0)
 
-    return pairwise_dot_score(normalize_embeddings(a), normalize_embeddings(b))
+
+def pairwise_manhattan_sim(a: Union[list, np.ndarray, Tensor], b: Union[list, np.ndarray, Tensor]):
+    """
+    Computes the negative manhattan distance.
+
+    :return: Vector with res[i] = -manhattan_distance(a[i], b[i])
+    """
+    a = _convert_to_tensor(a)
+    b = _convert_to_tensor(b)
+
+    return -torch.sum(torch.abs(a - b), dim=-1)
+
+
+def euclidean_sim(a: Union[list, np.ndarray, Tensor], b: Union[list, np.ndarray, Tensor]) -> Tensor:
+    """
+    Computes the euclidean similarity euclidean_sim(a[i], b[j]) for all i and j.
+
+    :return: Matrix with res[i][j] = euclidean_sim(a[i], b[j])
+    """
+    a = _convert_to_batch_tensor(a)
+    b = _convert_to_batch_tensor(b)
+
+    return -torch.cdist(a, b, p=2.0)
+
+
+def pairwise_euclidean_sim(a: Union[list, np.ndarray, Tensor], b: Union[list, np.ndarray, Tensor]):
+    """
+    Computes the negative euclidean distance.
+
+    :return: Vector with res[i]  = -euclidean(a[i], b[i])
+    """
+    a = _convert_to_tensor(a)
+    b = _convert_to_tensor(b)
+
+    return -torch.sqrt(torch.sum((a - b) ** 2, dim=-1))
 
 
 def pairwise_angle_sim(x: Tensor, y: Tensor) -> Tensor:
@@ -112,11 +154,8 @@ def pairwise_angle_sim(x: Tensor, y: Tensor) -> Tensor:
     :return: Vector with res[i] = angle_sim(a[i], b[i])
     """
 
-    if not isinstance(x, torch.Tensor):
-        x = torch.tensor(x)
-
-    if not isinstance(y, torch.Tensor):
-        y = torch.tensor(y)
+    x = _convert_to_tensor(x)
+    y = _convert_to_tensor(y)
 
     # modified from https://github.com/SeanLee97/AnglE/blob/main/angle_emb/angle.py
     # chunk both tensors to obtain complex components

--- a/tests/test_sentence_transformer.py
+++ b/tests/test_sentence_transformer.py
@@ -19,6 +19,7 @@ import torch
 from sentence_transformers import SentenceTransformer
 from sentence_transformers.models import Normalize, Transformer, Pooling
 from sentence_transformers import util
+from sentence_transformers.similarity_functions import SimilarityFunction
 
 
 def test_load_with_safetensors() -> None:
@@ -477,3 +478,32 @@ def test_encode_truncate(
     # Test w/ an ouptut_dim that's larger than the original_output_dim. No truncation ends up happening
     model.truncate_dim = 2 * original_output_dim
     test(model, expected_dim=original_output_dim)
+
+
+@pytest.mark.parametrize("similarity_fn_name", SimilarityFunction.possible_values())
+def test_similarity_score(stsb_bert_tiny_model_reused: SentenceTransformer, similarity_fn_name: str) -> None:
+    model = stsb_bert_tiny_model_reused
+    model.similarity_fn_name = similarity_fn_name
+    sentences = [
+        "The weather is so nice!",
+        "It's so sunny outside.",
+        "He's driving to the movie theater.",
+        "She's going to the cinema.",
+    ]
+    embeddings = model.encode(sentences, normalize_embeddings=True)
+    scores = model.similarity(embeddings, embeddings)
+    assert scores.shape == (len(sentences), len(sentences))
+    if similarity_fn_name in ("cosine", "dot"):
+        expected = np.ones(4, dtype=float)
+    else:
+        expected = np.zeros(4, dtype=float)
+    np.testing.assert_almost_equal(np.diag(scores), expected, decimal=4)
+    assert scores[1][0] > scores[2][0]
+    assert scores[1][0] > scores[3][0]
+    assert scores[2][3] > scores[2][0]
+    assert scores[2][3] > scores[2][1]
+
+    pairwise_scores = model.similarity_pairwise(embeddings[::2], embeddings[1::2])
+    assert pairwise_scores.shape == (len(sentences) // 2,)
+    if similarity_fn_name in ("cosine", "dot"):
+        assert (pairwise_scores > 0.5).all()

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -71,11 +71,75 @@ def test_paraphrase_mining() -> None:
             assert (a, b) in [(0, 1), (2, 3), (2, 4), (3, 4), (5, 6), (5, 7), (6, 7)]
 
 
-def test_pairwise_scores() -> None:
+def test_pairwise_cos_sim() -> None:
     a = np.random.randn(50, 100)
     b = np.random.randn(50, 100)
 
     # Pairwise cos
     sklearn_pairwise = 1 - sklearn.metrics.pairwise.paired_cosine_distances(a, b)
     pytorch_cos_scores = util.pairwise_cos_sim(a, b).numpy()
+
     assert np.allclose(sklearn_pairwise, pytorch_cos_scores)
+
+
+def test_pairwise_euclidean_sim() -> None:
+    a = np.array([[1, 0], [1, 1]], dtype=np.float32)
+    b = np.array([[0, 0], [0, 0]], dtype=np.float32)
+
+    euclidean_expected = np.array([-1.0, -np.sqrt(2.0)])
+    euclidean_calculated = util.pairwise_euclidean_sim(a, b).numpy()
+
+    assert np.allclose(euclidean_expected, euclidean_calculated)
+
+
+def test_pairwise_manhattan_sim() -> None:
+    a = np.array([[1, 0], [1, 1]], dtype=np.float32)
+    b = np.array([[0, 0], [0, 0]], dtype=np.float32)
+
+    manhattan_expected = np.array([-1.0, -2.0])
+    manhattan_calculated = util.pairwise_manhattan_sim(a, b).numpy()
+
+    assert np.allclose(manhattan_expected, manhattan_calculated)
+
+
+def test_pairwise_dot_score_cos_sim() -> None:
+    a = np.array([[1, 0], [1, 0], [1, 0]], dtype=np.float32)
+    b = np.array([[1, 0], [0, 1], [-1, 0]], dtype=np.float32)
+
+    dot_and_cosine_expected = np.array([1.0, 0.0, -1.0])
+    cosine_calculated = util.pairwise_cos_sim(a, b)
+    dot_calculated = util.pairwise_dot_score(a, b)
+
+    assert np.allclose(cosine_calculated, dot_and_cosine_expected)
+    assert np.allclose(dot_calculated, dot_and_cosine_expected)
+
+
+def test_euclidean_sim() -> None:
+    a = np.array([[1, 0], [0, 1]], dtype=np.float32)
+    b = np.array([[0, 0], [0, 1]], dtype=np.float32)
+
+    euclidean_expected = np.array([[-1.0, -np.sqrt(2.0)], [-1.0, 0.0]])
+    euclidean_calculated = util.euclidean_sim(a, b).detach().numpy()
+
+    assert np.allclose(euclidean_expected, euclidean_calculated)
+
+
+def test_manhattan_sim() -> None:
+    a = np.array([[1, 0], [0, 1]], dtype=np.float32)
+    b = np.array([[0, 0], [0, 1]], dtype=np.float32)
+
+    manhattan_expected = np.array([[-1.0, -2.0], [-1.0, 0]])
+    manhattan_calculated = util.manhattan_sim(a, b).detach().numpy()
+    assert np.allclose(manhattan_expected, manhattan_calculated)
+
+
+def test_dot_score_cos_sim() -> None:
+    a = np.array([[1, 0]], dtype=np.float32)
+    b = np.array([[1, 0], [0, 1], [-1, 0]], dtype=np.float32)
+
+    dot_and_cosine_expected = np.array([[1.0, 0.0, -1.0]])
+    cosine_calculated = util.cos_sim(a, b)
+    dot_calculated = util.dot_score(a, b)
+
+    assert np.allclose(cosine_calculated, dot_and_cosine_expected)
+    assert np.allclose(dot_calculated, dot_and_cosine_expected)


### PR DESCRIPTION
Hello!

## Pull Request overview
* Add `similarity` and `similarity_pairwise` methods to Sentence Transformers
* Add `similarity_fn_name` property to Sentence Transformers
* Save `similarity_fn_name` in configuration, allowing models to save which similarity measure should be used.
* Create `save_pretrained` as an alias for `save`.

## Details
Based on #2490 by @ir2718 minus the automatic setting of `similarity_fn_name` based on the evaluators.

- Tom Aarsen