### PR TITLE
[`v3`] Fix trainer `compute_loss` when evaluating/predicting if the `loss` updated the inputs in-place

### DIFF
--- a/sentence_transformers/__init__.py
+++ b/sentence_transformers/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.8.0.dev0"
+__version__ = "3.0.0.dev0"
 __MODEL_HUB_ORGANIZATION__ = "sentence-transformers"
 
 import importlib
@@ -7,6 +7,7 @@ import os
 from .datasets import SentencesDataset, ParallelSentencesDataset
 from .LoggingHandler import LoggingHandler
 from .SentenceTransformer import SentenceTransformer
+from .similarity_functions import SimilarityFunction
 from .readers import InputExample
 from .cross_encoder.CrossEncoder import CrossEncoder
 from .trainer import SentenceTransformerTrainer
@@ -25,6 +26,7 @@ __all__ = [
     "SentencesDataset",
     "ParallelSentencesDataset",
     "SentenceTransformer",
+    "SimilarityFunction",
     "InputExample",
     "CrossEncoder",
     "SentenceTransformerTrainer",

--- a/sentence_transformers/trainer.py
+++ b/sentence_transformers/trainer.py
@@ -153,6 +153,8 @@ class SentenceTransformerTrainer(Trainer):
             loss_fn.model = model
         loss = loss_fn(features, labels)
         if return_outputs:
+            # Get fresh features, as the loss function has likely modified them
+            features, _ = self.collect_features(inputs)
             output = torch.cat([model(row)["sentence_embedding"][:, None] for row in features], dim=1)
             return loss, output
         return loss


### PR DESCRIPTION
Hello!

## Pull Request overview
* Fix trainer `compute_loss` when evaluating/predicting if the `loss` updated the inputs in-place
* Add SimilarityFunction to __init__
* Increment dev version to 3.0.0.dev

## Details
If the loss function updates the inputs (i.e., `features["sentence_embedding"]`), then the model forward call will fail during evaluation and/or predicting. This PR counteracts that.
It also updates the dev version to 3.0.0.dev.

- Tom Aarsen