### PR TITLE
Bug in DenoisingAutoEncoderLoss.py

### DIFF
--- a/sentence_transformers/losses/DenoisingAutoEncoderLoss.py
+++ b/sentence_transformers/losses/DenoisingAutoEncoderLoss.py
@@ -116,14 +116,19 @@ class DenoisingAutoEncoderLoss(nn.Module):
             try:
                 # Compatibility with transformers <4.40.0
                 PreTrainedModel._tie_encoder_decoder_weights(
-                    model[0].auto_model, self.decoder._modules[decoder_base_model_prefix], self.decoder.base_model_prefix
+                    model[0].auto_model,
+                    self.decoder._modules[decoder_base_model_prefix],
+                    self.decoder.base_model_prefix,
                 )
             except TypeError:
                 # Compatibility with transformers >=4.40.0
                 PreTrainedModel._tie_encoder_decoder_weights(
-                    model[0].auto_model, self.decoder._modules[decoder_base_model_prefix], self.decoder.base_model_prefix, encoder_name_or_path
+                    model[0].auto_model,
+                    self.decoder._modules[decoder_base_model_prefix],
+                    self.decoder.base_model_prefix,
+                    encoder_name_or_path,
                 )
-            
+
     def retokenize(self, sentence_features):
         input_ids = sentence_features["input_ids"]
         device = input_ids.device

--- a/sentence_transformers/losses/DenoisingAutoEncoderLoss.py
+++ b/sentence_transformers/losses/DenoisingAutoEncoderLoss.py
@@ -114,7 +114,7 @@ class DenoisingAutoEncoderLoss(nn.Module):
                 )
             decoder_base_model_prefix = self.decoder.base_model_prefix
             PreTrainedModel._tie_encoder_decoder_weights(
-                model[0].auto_model, self.decoder._modules[decoder_base_model_prefix], self.decoder.base_model_prefix
+                model[0].auto_model, self.decoder._modules[decoder_base_model_prefix], self.decoder.base_model_prefix, encoder_name_or_path
             )
 
     def retokenize(self, sentence_features):

--- a/sentence_transformers/losses/DenoisingAutoEncoderLoss.py
+++ b/sentence_transformers/losses/DenoisingAutoEncoderLoss.py
@@ -113,10 +113,17 @@ class DenoisingAutoEncoderLoss(nn.Module):
                     "Since the encoder vocabulary has been changed and --tie_encoder_decoder=True, now the new vocabulary has also been used for the decoder."
                 )
             decoder_base_model_prefix = self.decoder.base_model_prefix
-            PreTrainedModel._tie_encoder_decoder_weights(
-                model[0].auto_model, self.decoder._modules[decoder_base_model_prefix], self.decoder.base_model_prefix, encoder_name_or_path
-            )
-
+            try:
+                # Compatibility with transformers <4.40.0
+                PreTrainedModel._tie_encoder_decoder_weights(
+                    model[0].auto_model, self.decoder._modules[decoder_base_model_prefix], self.decoder.base_model_prefix
+                )
+            except TypeError:
+                # Compatibility with transformers >=4.40.0
+                PreTrainedModel._tie_encoder_decoder_weights(
+                    model[0].auto_model, self.decoder._modules[decoder_base_model_prefix], self.decoder.base_model_prefix, encoder_name_or_path
+                )
+            
     def retokenize(self, sentence_features):
         input_ids = sentence_features["input_ids"]
         device = input_ids.device


### PR DESCRIPTION

transformers [**PreTrainedModel._tie_encoder_decoder_weight**](https://github.com/huggingface/transformers/blob/main/src/transformers/modeling_utils.py) in [DenoisingAutoEncoderLoss](https://github.com/UKPLab/sentence-transformers/blob/master/sentence_transformers/losses/DenoisingAutoEncoderLoss.py#L116) requires positional argument base_encoder_name.

![image](https://github.com/UKPLab/sentence-transformers/assets/25299377/4ff241b9-e551-4446-8081-09483d01fdaf)
![image](https://github.com/UKPLab/sentence-transformers/assets/25299377/919fbe8b-c1cf-452d-a780-a50972499747)
![image](https://github.com/UKPLab/sentence-transformers/assets/25299377/4b3f2f01-433b-4a43-b818-edc652616763)

