### PR TITLE
[`v3`] Never return None in infer_datasets, could result in crash

### DIFF
--- a/sentence_transformers/model_card.py
+++ b/sentence_transformers/model_card.py
@@ -487,7 +487,9 @@ class SentenceTransformerModelCardData(CardData):
             for label, example_set in examples.items()
         ]
 
-    def infer_datasets(self, dataset: Union[Dataset, DatasetDict], dataset_name: Optional[str] = None) -> None:
+    def infer_datasets(
+        self, dataset: Union[Dataset, DatasetDict], dataset_name: Optional[str] = None
+    ) -> List[Dict[str, str]]:
         if isinstance(dataset, DatasetDict):
             return [
                 dataset
@@ -514,7 +516,7 @@ class SentenceTransformerModelCardData(CardData):
             subtuple = ("huggingface", "datasets")
             index = subtuple_finder(cache_path_parts, subtuple)
             if index == -1:
-                return
+                return [dataset_output]
 
             # Get the folder after "huggingface/datasets"
             cache_dataset_name = cache_path_parts[index + len(subtuple)]


### PR DESCRIPTION
Hello!

## Pull Request overview
* Never return None in infer_datasets, could result in crash

## Details
Just return the preliminary `dataset_output` instead if the dataset cached file is just in a local folder.

- Tom Aarsen