### PR TITLE
[`v3`] Trainer: Implement resume from checkpoint support

### DIFF
--- a/sentence_transformers/trainer.py
+++ b/sentence_transformers/trainer.py
@@ -553,3 +553,8 @@ class SentenceTransformerTrainer(Trainer):
 
         # Good practice: save your training arguments together with the trained model
         torch.save(self.args, os.path.join(output_dir, TRAINING_ARGS_NAME))
+
+    def _load_from_checkpoint(self, checkpoint_path: str) -> None:
+        from sentence_transformers import SentenceTransformer
+
+        self.model = SentenceTransformer(checkpoint_path)


### PR DESCRIPTION
Hello!

## Pull Request overview
* Implement resume from checkpoint support

## Details
Tested with a large knowledge distillation run. There was an odd quirk resulting in higher loss, but the model could be loaded & training could continue. Perhaps this could have issues with e.g. `trust_remote_code` or other loading parameters (`truncate_dim`?)

- Tom Aarsen