### PR TITLE
Add `trust_remote_code` to `CrossEncoder.tokenizer`

### DIFF
--- a/sentence_transformers/cross_encoder/CrossEncoder.py
+++ b/sentence_transformers/cross_encoder/CrossEncoder.py
@@ -91,7 +91,11 @@ class CrossEncoder(PushToHubMixin):
             **automodel_args,
         )
         self.tokenizer = AutoTokenizer.from_pretrained(
-            model_name, revision=revision, local_files_only=local_files_only, **tokenizer_args
+            model_name,
+            revision=revision,
+            local_files_only=local_files_only,
+            trust_remote_code=trust_remote_code,
+            **tokenizer_args,
         )
         self.max_length = max_length
 


### PR DESCRIPTION
I added so far the `trust_remote_code` kwarg to `automodel_args` and to `tokenizer_args` -> With the latest version, trust_remote_code has been added to `CrossEncoder`.

Not many tokenizers ship with `trust_remote_code`, expecting no comparability issues therefore.

Let me know if I need to format the changes in some way!