### PR TITLE
[`v3`] Remove "return_outputs" as it's not strictly necessary. Avoids OOM & speeds up training

### DIFF
--- a/sentence_transformers/trainer.py
+++ b/sentence_transformers/trainer.py
@@ -158,10 +158,11 @@ class SentenceTransformerTrainer(Trainer):
             loss_fn.model = model
         loss = loss_fn(features, labels)
         if return_outputs:
-            # Get fresh features, as the loss function has likely modified them
-            features, _ = self.collect_features(inputs)
-            output = torch.cat([model(row)["sentence_embedding"][:, None] for row in features], dim=1)
-            return loss, output
+            # During prediction/evaluation, `compute_loss` will be called with `return_outputs=True`.
+            # However, Sentence Transformer losses do not return outputs, so we return an empty dictionary.
+            # This does not result in any problems, as the SentenceTransformersTrainingArguments sets
+            # `prediction_loss_only=True` which means that the output is not used.
+            return loss, {}
         return loss
 
     def collect_features(

--- a/sentence_transformers/training_args.py
+++ b/sentence_transformers/training_args.py
@@ -37,3 +37,7 @@ class SentenceTransformerTrainingArguments(TransformersTrainingArguments):
 
         self.batch_sampler = BatchSamplers(self.batch_sampler)
         self.multi_dataset_batch_sampler = MultiDatasetBatchSamplers(self.multi_dataset_batch_sampler)
+
+        # The `compute_loss` method in `SentenceTransformerTrainer` is overridden to only compute the prediction loss,
+        # so we set `prediction_loss_only` to `True` here to avoid
+        self.prediction_loss_only = True


### PR DESCRIPTION
Hello!

## Pull Request overview
* Remove "return_outputs" from `compute_loss`

## Details
This is used during evaluation and predictions, but our loss functions don't return the model outputs. As a result, we had to recompute these values, which has some issues:
- It was slow
- It caused OOMs for the Cached... loss functions, as it tried to compute values for an entire batch at once (while the Cached... losses often deal with really large batches)

Instead, we use `prediction_loss_only = True` in the training args. Then the outputs are ignored in the Trainer, which means that we can just return an empty dict as the outputs without any negative repercussions.

---

- Tom Aarsen