### PR TITLE
Use `b1` quantization for USearch

### DIFF
--- a/sentence_transformers/quantization.py
+++ b/sentence_transformers/quantization.py
@@ -239,7 +239,7 @@ def semantic_search_usearch(
             corpus_index = Index(
                 ndim=corpus_embeddings.shape[1],
                 metric="hamming",
-                dtype="i8",
+                dtype="b1",
             )
         corpus_index.add(np.arange(len(corpus_embeddings)), corpus_embeddings)
 


### PR DESCRIPTION
As suggested by @adolfogc (in https://github.com/unum-cloud/usearch/issues/405) the USearch implementation should use `b1` instead of `i8` for binary representations.