### PR TITLE
[`v3`] Simplify `load_from_checkpoint` using `load_state_dict`

### DIFF
--- a/sentence_transformers/trainer.py
+++ b/sentence_transformers/trainer.py
@@ -563,23 +563,5 @@ class SentenceTransformerTrainer(Trainer):
     def _load_from_checkpoint(self, checkpoint_path: str) -> None:
         from sentence_transformers import SentenceTransformer
 
-        self.model = SentenceTransformer(checkpoint_path)
-        # Naively try and update the wrapped model as well
-        model_wrapped = self.model_wrapped
-        if isinstance(model_wrapped, SentenceTransformer):
-            self.model_wrapped = self.model
-        else:
-            while hasattr(model_wrapped, "module"):
-                if isinstance(model_wrapped.module, SentenceTransformer):
-                    model_wrapped.module = self.model
-                    break
-                model_wrapped = model_wrapped.module
-
-        # Naively try and update the model in the loss function(s)
-        if isinstance(self.loss, dict):
-            for loss_fn in self.loss.values():
-                if hasattr(loss_fn, "model"):
-                    loss_fn.model = self.model
-        else:
-            if hasattr(self.loss, "model"):
-                self.loss.model = self.model
+        loaded_model = SentenceTransformer(checkpoint_path)
+        self.model.load_state_dict(loaded_model.state_dict())


### PR DESCRIPTION
Hello!

## Pull Request overview
* Use `load_state_dict` to inject checkpoint weights into the existing ST model

## Details
Overriding the model had several downsides, e.g. regarding the model card generation. This is much more convenient, as we can reuse the existing object and just inject the model weights into it instead.
Also e.g. prompts, prompt_names, truncate_dim, etc. should be preserved.

- Tom Aarsen