### PR TITLE
[`v3`] Use `torch.arange` instead of `torch.tensor(range(...))`

### DIFF
--- a/sentence_transformers/losses/MultipleNegativesRankingLoss.py
+++ b/sentence_transformers/losses/MultipleNegativesRankingLoss.py
@@ -87,10 +87,9 @@ class MultipleNegativesRankingLoss(nn.Module):
         embeddings_b = torch.cat(reps[1:])
 
         scores = self.similarity_fct(embeddings_a, embeddings_b) * self.scale
-        labels = torch.tensor(
-            range(len(scores)), dtype=torch.long, device=scores.device
-        )  # Example a[i] should match with b[i]
-        return self.cross_entropy_loss(scores, labels)
+        # Example a[i] should match with b[i]
+        range_labels = torch.arange(0, scores.size(0), device=scores.device)
+        return self.cross_entropy_loss(scores, range_labels)
 
     def get_config_dict(self):
         return {"scale": self.scale, "similarity_fct": self.similarity_fct.__name__}


### PR DESCRIPTION
See https://github.com/UKPLab/sentence-transformers/pull/2449#issuecomment-2114787400

Hello!

## Pull Request overview
* Don't override the labels variable to avoid inplace operation

## Details
I'm not sure if this is the cause of the issue as it doesn't really seem like an inplace operation; but I think it might be, and it's one of the only places with a LongTensor.

@Jakobhenningjensen would you be able to rerun your experiment with this branch instead?
i.e.
```
pip install git+https://github.com/tomaarsen/sentence-transformers.git@v3/mnrl_avoid_inplace_op
```
or 
```
git clone https://github.com/tomaarsen/sentence-transformers
cd sentence-transformers
git checkout v3/mnrl_avoid_inplace_op
```
or related commands.

- Tom Aarsen