### PR TITLE
Enable intfloat/e5-mistral-7b-instruct model with 32k token len on hpu device

### DIFF
--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -385,7 +385,10 @@ class SentenceTransformer(nn.Sequential):
             if self.device.type == "hpu":
                 if "input_ids" in features:
                     curr_tokenize_len = features["input_ids"].shape
-                    additional_pad_len = 2 ** math.ceil(math.log2(curr_tokenize_len[1])) - curr_tokenize_len[1]
+                    if curr_tokenize_len[1] > 4096:
+                        additional_pad_len = math.ceil(curr_tokenize_len[1] / 128) * 128 - curr_tokenize_len[1]
+                    else:
+                        additional_pad_len = 2 ** math.ceil(math.log2(curr_tokenize_len[1])) - curr_tokenize_len[1]
                     features["input_ids"] = torch.cat(
                         (
                             features["input_ids"],


### PR DESCRIPTION
This PR belongs to one of enabling Intel's Gaudi2 GPU supported tasks for Sentence Transformer's inference/training

This PR enables intfloat/e5-mistral-7b-instruct model with 32k token lens input on hpu device.

There are two parts for updates -
1. Efficient new padding for bigger token lens input by using multiple of 128 instead of original power of 2 to reduce the padding overhead when the input token lens is bigger which is not efficient for power of 2.

2. Bring in the 7b FP16 support with gaudi in the forward setting by using the specific arguments for gaudi 7b's forward. It can not bring in from class argument because we don't have model_args from ST class now. Even in future 3.0 release the model_args not saved into self.model_args and in forward side we still cannot setup the specific args from top level directly.  So suggested maybe we can save the .args into self member variables then forward also can use the args...

any questions please comments. 

thanks.