### PR TITLE
[`v3`] Set `broadcast_buffers = False` when training with DDP

### DIFF
--- a/sentence_transformers/training_args.py
+++ b/sentence_transformers/training_args.py
@@ -41,3 +41,7 @@ class SentenceTransformerTrainingArguments(TransformersTrainingArguments):
         # The `compute_loss` method in `SentenceTransformerTrainer` is overridden to only compute the prediction loss,
         # so we set `prediction_loss_only` to `True` here to avoid
         self.prediction_loss_only = True
+
+        # Disable broadcasting of buffers to avoid `RuntimeError: one of the variables needed for gradient computation
+        # has been modified by an inplace operation.` when training with DDP & a BertModel-based model.
+        self.ddp_broadcast_buffers = False


### PR DESCRIPTION
@Jakobhenningjensen

Hello!

## Pull Request overview
* Set `broadcast_buffers = False` when training with DDP to avoid `RuntimeError: one of the variables needed for gradient computation has been modified by an inplace operation.`

## Details
This PR *should* resolve the issue from https://github.com/UKPLab/sentence-transformers/pull/2654#issuecomment-2123849962. First of all, I was able to reproduce @Jakobhenningjensen his issue by also finetuning a bert-based model, rather than the MPNet-based model that I was using in my previous tests. After a full morning of experimentation, I found https://github.com/huggingface/transformers/issues/24996 which showed that the `buffers` as they are used in `transformers` do not play nicely with the default `broadcast_buffers` option in `DistributedDataParallel`. Following a recommendedation by https://github.com/huggingface/transformers/issues/24996#issuecomment-1956907209 (Thanks @nguyentanthong!), I was able to get training working with bert-based models.

Apologies for continuously asking this; but could you experiment with these changes @Jakobhenningjensen?

## Reproduction
I used this script to perform the training. Before this PR, it would fail:
```python
from sentence_transformers import SentenceTransformer, SentenceTransformerTrainingArguments, losses, SentenceTransformerTrainer
from datasets import load_dataset

def train_model():
    model = SentenceTransformer("intfloat/multilingual-e5-small", device="cuda")
    loss = losses.MultipleNegativesRankingLoss(model)
    training_args = SentenceTransformerTrainingArguments(
        # Required parameter:
        output_dir="./sbert_fitted/",
        # Optional training parameters:
        num_train_epochs=1,
        per_device_train_batch_size=64,
        per_device_eval_batch_size=32,
        warmup_ratio=0.1,
        fp16=False,  # Set to False if you get an error that your GPU can't run on FP16
        bf16=False,  # Set to True if you have a GPU that supports BF16
        # Optional tracking/debugging parameters:
        eval_steps=100,
        save_strategy="steps",
        save_steps=100,
        save_total_limit=2,
        logging_steps=100,
        run_name="sts",  # Will be used in W&B if `wandb` is installed,
        report_to="none",
        dataloader_drop_last=True, # <- This seems necessary to prevent halting at the end of the training
    )
    train_dataset = load_dataset("sentence-transformers/all-nli", "triplet", split="train")

    trainer = SentenceTransformerTrainer(
        model=model,
        args=training_args,
        train_dataset=train_dataset,
        loss=loss,
    )
    print("Training ...")
    trainer.train()


if __name__=="__main__":
    train_model()
```

- Tom Aarsen