### PR TITLE
[`v3`] For the Cached losses; ignore gradients if grad is disabled (e.g. eval)

### DIFF
--- a/sentence_transformers/losses/AdaptiveLayerLoss.py
+++ b/sentence_transformers/losses/AdaptiveLayerLoss.py
@@ -6,6 +6,7 @@ from torch.nn import functional as F
 import torch
 from sentence_transformers import SentenceTransformer
 from sentence_transformers.losses.CachedMultipleNegativesRankingLoss import CachedMultipleNegativesRankingLoss
+from sentence_transformers.losses.CachedGISTEmbedLoss import CachedGISTEmbedLoss
 from sentence_transformers.models import Transformer
 
 
@@ -130,7 +131,7 @@ class AdaptiveLayerLoss(nn.Module):
             - `Adaptive Layers <../../examples/training/adaptive_layer/README.html>`_
 
         Requirements:
-            1. The base loss cannot be :class:`CachedMultipleNegativesRankingLoss`.
+            1. The base loss cannot be :class:`CachedMultipleNegativesRankingLoss` or :class:`CachedGISTEmbedLoss`.
 
         Relations:
             - :class:`Matryoshka2dLoss` uses this loss in combination with :class:`MatryoshkaLoss` which allows for
@@ -173,6 +174,8 @@ class AdaptiveLayerLoss(nn.Module):
         assert isinstance(self.model[0], Transformer)
         if isinstance(loss, CachedMultipleNegativesRankingLoss):
             warnings.warn("MatryoshkaLoss is not compatible with CachedMultipleNegativesRankingLoss.", stacklevel=2)
+        if isinstance(loss, CachedGISTEmbedLoss):
+            warnings.warn("MatryoshkaLoss is not compatible with CachedGISTEmbedLoss.", stacklevel=2)
 
     def forward(self, sentence_features: Iterable[Dict[str, Tensor]], labels: Tensor) -> Tensor:
         # Decorate the forward function of the transformer to cache the embeddings of all layers

--- a/sentence_transformers/losses/MatryoshkaLoss.py
+++ b/sentence_transformers/losses/MatryoshkaLoss.py
@@ -4,6 +4,7 @@ import warnings
 from torch import Tensor, nn
 import torch.nn.functional as F
 from sentence_transformers import SentenceTransformer
+from sentence_transformers.losses.CachedGISTEmbedLoss import CachedGISTEmbedLoss
 from sentence_transformers.losses.CachedMultipleNegativesRankingLoss import CachedMultipleNegativesRankingLoss
 
 
@@ -72,7 +73,7 @@ class MatryoshkaLoss(nn.Module):
             - `Matryoshka Embeddings <../../examples/training/matryoshka/README.html>`_
 
         Requirements:
-            1. The base loss cannot be :class:`CachedMultipleNegativesRankingLoss`.
+            1. The base loss cannot be :class:`CachedMultipleNegativesRankingLoss` or :class:`CachedGISTEmbedLoss`.
 
         Relations:
             - :class:`Matryoshka2dLoss` uses this loss in combination with :class:`AdaptiveLayerLoss` which allows for
@@ -109,6 +110,8 @@ class MatryoshkaLoss(nn.Module):
         self.loss = loss
         if isinstance(loss, CachedMultipleNegativesRankingLoss):
             warnings.warn("MatryoshkaLoss is not compatible with CachedMultipleNegativesRankingLoss.", stacklevel=2)
+        if isinstance(loss, CachedGISTEmbedLoss):
+            warnings.warn("MatryoshkaLoss is not compatible with CachedGISTEmbedLoss.", stacklevel=2)
         self.matryoshka_dims = matryoshka_dims
         if matryoshka_weights is None:
             matryoshka_weights = [1] * len(matryoshka_dims)


### PR DESCRIPTION
Resolves #2667

Hello!

## Pull Request overview
* Fix `RuntimeError: element 0 of tensors does not require grad and does not have a grad_fn` when running evaluation with `CachedGISTEmbedLoss`.
* Also specify that `CachedGISTEmbedLoss` is incompatible with `MatryoshkaLoss` and `AdaptiveLayerLoss` as they both do a similar kind of (incompatible) magic.

## Details
I've experienced this same error as #2667 before with `CachedMultipleNegativesRankingLoss`, which I resolved with this line:
https://github.com/UKPLab/sentence-transformers/blob/v3.0-pre-release/sentence_transformers/losses/CachedMultipleNegativesRankingLoss.py#L235-L237

There, I re-enabled gradients (even in evaluations), and just trusted that the Trainer would not call `loss.backward()` on the returned loss to prevent the model from actually training on the evaluation set. However, this is a bit suboptimal. After all, why would we compute the intermediary backward calls and then re-connect those cached gradients if we don't even use the gradients (because we're in evaluation).

So, now I've resolved it with a bit more of an advanced fix: just calculate the loss without gradients if torch's `is_grad_enabled` is False anyways. This should fix #2667 while making evaluation slightly faster than before with these 2 losses.

cc @smerrill first of all, big thanks for reporting this issue! The issue originates in `CachedGISTEmbedLoss`, which seems to not have been compatible with evaluating (because it expected the gradients to always be enabled). Could you install the code at this PR and retry it? For reference, your toy reproduction (big thanks for posting that!) runs well for me now, and indeed failed before this fix.

I think this should work:
```
pip install -U git+https://github.com/tomaarsen/sentence-transformers.git@v3/fix_cached_eval
```

- Tom Aarsen