### PR TITLE
[`v3`] Prevent warning with 'model.fit' with transformers >= 4.41.0 due to evaluation_strategy

### DIFF
--- a/sentence_transformers/fit_mixin.py
+++ b/sentence_transformers/fit_mixin.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, List, Optional,
 import numpy as np
 import torch
 import transformers
+from packaging import version
 from torch import Tensor, nn
 from torch.optim import Optimizer
 from torch.utils.data import DataLoader
@@ -22,7 +23,6 @@ from sentence_transformers.training_args import (
     MultiDatasetBatchSamplers,
     SentenceTransformerTrainingArguments,
 )
-from packaging import version
 
 from .evaluation import SentenceEvaluator
 from .model_card_templates import ModelCardTemplate
@@ -299,7 +299,11 @@ class FitMixin:
                 steps_per_epoch = None
 
         # Transformers renamed `evaluation_strategy` to `eval_strategy` in v4.41.0
-        eval_strategy_key = "eval_strategy" if version.parse(transformers.__version__) >= version.parse("4.41.0") else "evaluation_strategy"
+        eval_strategy_key = (
+            "eval_strategy"
+            if version.parse(transformers.__version__) >= version.parse("4.41.0")
+            else "evaluation_strategy"
+        )
         args = SentenceTransformerTrainingArguments(
             output_dir=checkpoint_path or _default_checkpoint_dir(),
             batch_sampler=batch_sampler,

--- a/sentence_transformers/fit_mixin.py
+++ b/sentence_transformers/fit_mixin.py
@@ -20,6 +20,7 @@ from sentence_transformers.training_args import (
     MultiDatasetBatchSamplers,
     BatchSamplers,
 )
+from packaging import version
 
 from .evaluation import SentenceEvaluator
 from .util import (
@@ -295,6 +296,8 @@ class FitMixin:
                 )
                 steps_per_epoch = None
 
+        # Transformers renamed `evaluation_strategy` to `eval_strategy` in v4.41.0
+        eval_strategy_key = "eval_strategy" if version.parse(transformers.__version__) >= version.parse("4.41.0") else "evaluation_strategy"
         args = SentenceTransformerTrainingArguments(
             output_dir=checkpoint_path or _default_checkpoint_dir(),
             batch_sampler=batch_sampler,
@@ -303,7 +306,9 @@ class FitMixin:
             per_device_eval_batch_size=batch_size,
             num_train_epochs=epochs,
             max_steps=max_steps,
-            evaluation_strategy="steps" if evaluation_steps is not None and evaluation_steps > 0 else "no",
+            **{
+                eval_strategy_key: "steps" if evaluation_steps is not None and evaluation_steps > 0 else "no",
+            },
             eval_steps=evaluation_steps,
             # load_best_model_at_end=save_best_model, # <- TODO: Look into a good solution for save_best_model
             max_grad_norm=max_grad_norm,


### PR DESCRIPTION
Hello!

## Pull Request overview
* `transformers` deprecated `evaluation_strategy` in 4.41.0 in favor of `eval_strategy`. This PR fixes any warnings.

## Details
This PR should look at the transformers version to determine which key is recommended in the training arguments. As a result: no errors, no warnings.

- Tom Aarsen