### PR TITLE
[`v3`] Make the "primary_metric" for evaluators a bit more robust

### DIFF
--- a/sentence_transformers/evaluation/SentenceEvaluator.py
+++ b/sentence_transformers/evaluation/SentenceEvaluator.py
@@ -13,8 +13,17 @@ class SentenceEvaluator:
     """
 
     def __init__(self):
+        """
+        Base class for all evaluators. Notably, this class introduces the ``greater_is_better`` and ``primary_metric``
+        attributes. The former is a boolean indicating whether a higher evaluation score is better, which is used
+        for choosing the best checkpoint if ``load_best_model_at_end`` is set to ``True`` in the training arguments.
+
+        The latter is a string indicating the primary metric for the evaluator. This has to be defined whenever
+        the evaluator returns a dictionary of metrics, and the primary metric is the key pointing to the primary
+        metric, i.e. the one that is used for model selection and/or logging.
+        """
         self.greater_is_better = True
-        # TODO: Add better `primary_metrics` support
+        self.primary_metric = None
 
     def __call__(
         self, model: "SentenceTransformer", output_path: str = None, epoch: int = -1, steps: int = -1

--- a/sentence_transformers/fit_mixin.py
+++ b/sentence_transformers/fit_mixin.py
@@ -53,7 +53,6 @@ class SaveModelCallback(TrainerCallback):
         super().__init__()
         self.output_dir = output_dir
         self.evaluator = evaluator
-        # TODO: ^ has to implement `greater_is_better` and `primary_metric`
         self.save_best_model = save_best_model
         self.best_metric = None
 

--- a/sentence_transformers/fit_mixin.py
+++ b/sentence_transformers/fit_mixin.py
@@ -244,7 +244,7 @@ class FitMixin:
         batch_size = 8
         batch_sampler = BatchSamplers.BATCH_SAMPLER
         # Convert dataloaders into a DatasetDict
-        # TODO: This should be done in a more efficient way
+        # TODO: This is rather inefficient, as we load all data into memory. We might benefit from a more efficient solution
         train_dataset_dict = {}
         for loader_idx, data_loader in enumerate(data_loaders, start=1):
             if isinstance(data_loader, NoDuplicatesDataLoader):
@@ -283,7 +283,6 @@ class FitMixin:
 
         # Convert loss_fns into a dict with `dataset_{idx}` keys
         loss_fn_dict = {f"_dataset_{idx}": loss_fn for idx, loss_fn in enumerate(loss_fns, start=1)}
-        # TODO: Test model checkpointing & loading
 
         # Use steps_per_epoch to perhaps set max_steps
         max_steps = -1

--- a/sentence_transformers/model_card.py
+++ b/sentence_transformers/model_card.py
@@ -441,8 +441,7 @@ class SentenceTransformerModelCardData(CardData):
         self.eval_results_dict[evaluator] = copy(metrics)
 
         # If the evaluator has a primary metric and we have a trainer, then add the primary metric to the training logs
-        if hasattr(evaluator, "primary_metric"):
-            primary_metrics = evaluator.primary_metric
+        if hasattr(evaluator, "primary_metric") and (primary_metrics := evaluator.primary_metric):
             if isinstance(evaluator, SequentialEvaluator):
                 primary_metrics = [sub_evaluator.primary_metric for sub_evaluator in evaluator.evaluators]
             elif isinstance(primary_metrics, str):

--- a/sentence_transformers/model_card.py
+++ b/sentence_transformers/model_card.py
@@ -340,7 +340,6 @@ class SentenceTransformerModelCardData(CardData):
                     )
                     del dataset["id"]
                 else:
-                    # TODO: Perhaps we can try to infer the dataset name from the dataset card
                     if info.cardData and infer_languages and "language" in info.cardData:
                         dataset_language = info.cardData.get("language")
                         if dataset_language is None:

--- a/tests/test_sentence_transformer.py
+++ b/tests/test_sentence_transformer.py
@@ -461,7 +461,6 @@ def test_encode_truncate(
                 embeddings = outputs["sentence_embedding"]
             else:
                 outputs = cast(List[Dict[str, torch.Tensor]], outputs)
-                # TODO: can overload model.encode if ppl want type checker compatibility
                 embeddings = [out_features["sentence_embedding"] for out_features in outputs]
         else:
             embeddings = outputs


### PR DESCRIPTION
Hello!

## Pull Request overview
* Make the "primary_metric" for evaluators a bit more robust

## Details
The intention is that `primary_metric` now exists for all evaluators, although I won't strictly enforce that at this time (i.e., I still do `if hasattr(...)`, etc.).

- Tom Aarsen