### PR TITLE
[`v3`] Move training dependencies into a "train" extra

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,7 +45,7 @@ jobs:
         if: steps.restore-cache.outputs.cache-hit != 'true'
 
       - name: Install the checked-out sentence-transformers
-        run: python -m pip install .
+        run: python -m pip install .[train]
 
       - name: Run unit tests
         shell: bash

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,35 +1,115 @@
 # Installation
 
-We recommend **Python 3.8+**, **[PyTorch 1.11.0+](https://pytorch.org/get-started/locally/)**, and **[transformers v4.34.0+](https://github.com/huggingface/transformers)**.
+We recommend **Python 3.8+**, **[PyTorch 1.11.0+](https://pytorch.org/get-started/locally/)**, and **[transformers v4.34.0+](https://github.com/huggingface/transformers)**. There are three options to install Sentence Transformers:
+* **Default:** This allows for loading, saving, and inference (i.e., getting embeddings) of models.
+* **Default and Training**: All of the above plus training.
+* **Development**: All of the above plus some dependencies for developing Sentence Transformers, see [Editable Install](#editable-install).
 
 ## Install with pip
 
-Install the *sentence-transformers* with `pip`:
-```
-pip install -U sentence-transformers
+```eval_rst
+
+.. tab:: Default
+
+    ::
+
+        pip install -U sentence-transformers
+
+.. tab:: Default and Training
+
+    ::
+
+        pip install -U "sentence-transformers[train]"
+
+    To use `Weights and Biases <https://wandb.ai/>`_ to track your training logs, you should also install ``wandb`` **(recommended)**::
+
+        pip install wandb
+    
+    And to track your Carbon Emissions while training and have this information automatically included in your model cards, also install ``codecarbon`` **(recommended)**::
+
+        pip install codecarbon
+
+.. tab:: Development
+
+    ::
+
+        pip install -U "sentence-transformers[train,dev]"
+
 ```
 
-## Install with conda
+## Install with Conda
 
-Apple silicon installation of *sentence-transformers*
+```eval_rst
+
+.. tab:: Default
+
+    ::
+
+        conda install -c conda-forge sentence-transformers
+
+.. tab:: Default and Training
+
+    ::
+
+        conda install -c conda-forge sentence-transformers accelerate datasets
+
+    To use `Weights and Biases <https://wandb.ai/>`_ to track your training logs, you should also install ``wandb`` **(recommended)**::
+
+        pip install wandb
+    
+    And to track your Carbon Emissions while training and have this information automatically included in your model cards, also install ``codecarbon`` **(recommended)**::
+
+        pip install codecarbon
+
+.. tab:: Development
+
+    ::
+
+        conda install -c conda-forge sentence-transformers accelerate datasets pre-commit pytest ruff
+
 ```
-conda install -c conda-forge sentence-transformers
+
+## Install from Source
+
+You can install ``sentence-transformers`` directly from source to take advantage of the bleeding edge `master` branch rather than the latest stable release:
+
+```eval_rst
+
+.. tab:: Default
+
+    ::
+
+        pip install git+https://github.com/UKPLab/sentence-transformers.git
+
+.. tab:: Default and Training
+
+    ::
+
+        pip install -U "sentence-transformers[train] @ git+https://github.com/UKPLab/sentence-transformers.git"
+
+    To use `Weights and Biases <https://wandb.ai/>`_ to track your training logs, you should also install ``wandb`` **(recommended)**::
+
+        pip install wandb
+    
+    And to track your carbon emissions while training and have this information automatically included in your model cards, also install ``codecarbon`` **(recommended)**::
+
+        pip install codecarbon
+
+.. tab:: Development
+
+    ::
+
+        pip install -U "sentence-transformers[train, dev] @ git+https://github.com/UKPLab/sentence-transformers.git"
+
 ```
 
-## Install from source
+## Editable Install
 
-You can install *sentence-transformers* directly from source to take advantage of the bleeding edge `master` branch rather than the latest stable release:
-```
-pip install git+https://github.com/UKPLab/sentence-transformers
-```
-
-## Editable install
-
-If you want to make changes to *sentence-transformers*, you will need an editable install. Clone the repository and install it with these commands:
+If you want to make changes to ``sentence-transformers``, you will need an editable install. Clone the repository and install it with these commands:
 ```
 git clone https://github.com/UKPLab/sentence-transformers
 cd sentence-transformers
-pip install -e .
+pip install -e ".[train,dev]"
 ```
 
 These commands will link the new `sentence-transformers` folder and your Python library paths, such that this folder will be used when importing `sentence-transformers`.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -33,7 +33,7 @@ We recommend **Python 3.8+**, **[PyTorch 1.11.0+](https://pytorch.org/get-starte
 
     ::
 
-        pip install -U "sentence-transformers[train,dev]"
+        pip install -U "sentence-transformers[dev]"
 
 ```
 
@@ -99,7 +99,7 @@ You can install ``sentence-transformers`` directly from source to take advantage
 
     ::
 
-        pip install -U "sentence-transformers[train, dev] @ git+https://github.com/UKPLab/sentence-transformers.git"
+        pip install -U "sentence-transformers[dev] @ git+https://github.com/UKPLab/sentence-transformers.git"
 
 ```
 

--- a/docs/package_reference/util.md
+++ b/docs/package_reference/util.md
@@ -4,7 +4,7 @@
 ## Helper Functions
 ```eval_rst
 .. automodule:: sentence_transformers.util
-   :members: paraphrase_mining, semantic_search, community_detection, http_get, truncate_embeddings, normalize_embeddings
+   :members: paraphrase_mining, semantic_search, community_detection, http_get, truncate_embeddings, normalize_embeddings, is_training_available
 ```
 
 ## Similarity Metrics

--- a/sentence_transformers/fit_mixin.py
+++ b/sentence_transformers/fit_mixin.py
@@ -14,8 +14,8 @@ from torch.optim import Optimizer
 from torch.utils.data import DataLoader
 from tqdm.autonotebook import trange
 from transformers import TrainerCallback, TrainerControl, TrainerState
+from transformers.utils import is_datasets_available
 
-from datasets import Dataset, DatasetDict
 from sentence_transformers.datasets.NoDuplicatesDataLoader import NoDuplicatesDataLoader
 from sentence_transformers.datasets.SentenceLabelDataset import SentenceLabelDataset
 from sentence_transformers.training_args import (
@@ -30,6 +30,9 @@ from .util import (
     batch_to_device,
     fullname,
 )
+
+if is_datasets_available():
+    from datasets import Dataset, DatasetDict
 
 logger = logging.getLogger(__name__)
 

--- a/sentence_transformers/fit_mixin.py
+++ b/sentence_transformers/fit_mixin.py
@@ -14,7 +14,6 @@ from torch.optim import Optimizer
 from torch.utils.data import DataLoader
 from tqdm.autonotebook import trange
 from transformers import TrainerCallback, TrainerControl, TrainerState
-from transformers.utils import is_datasets_available
 
 from sentence_transformers.datasets.NoDuplicatesDataLoader import NoDuplicatesDataLoader
 from sentence_transformers.datasets.SentenceLabelDataset import SentenceLabelDataset
@@ -23,13 +22,10 @@ from sentence_transformers.training_args import (
     MultiDatasetBatchSamplers,
     SentenceTransformerTrainingArguments,
 )
+from sentence_transformers.util import batch_to_device, fullname, is_datasets_available
 
 from .evaluation import SentenceEvaluator
 from .model_card_templates import ModelCardTemplate
-from .util import (
-    batch_to_device,
-    fullname,
-)
 
 if is_datasets_available():
     from datasets import Dataset, DatasetDict

--- a/sentence_transformers/model_card.py
+++ b/sentence_transformers/model_card.py
@@ -23,12 +23,11 @@ from transformers import TrainerCallback
 from transformers.integrations import CodeCarbonCallback
 from transformers.modelcard import make_markdown_table
 from transformers.trainer_callback import TrainerControl, TrainerState
-from transformers.utils import is_accelerate_available, is_datasets_available
 
 from sentence_transformers import __version__ as sentence_transformers_version
 from sentence_transformers.models import Transformer
 from sentence_transformers.training_args import SentenceTransformerTrainingArguments
-from sentence_transformers.util import cos_sim, fullname
+from sentence_transformers.util import cos_sim, fullname, is_accelerate_available, is_datasets_available
 
 if is_datasets_available():
     from datasets import Dataset, DatasetDict

--- a/sentence_transformers/model_card.py
+++ b/sentence_transformers/model_card.py
@@ -23,12 +23,15 @@ from transformers import TrainerCallback
 from transformers.integrations import CodeCarbonCallback
 from transformers.modelcard import make_markdown_table
 from transformers.trainer_callback import TrainerControl, TrainerState
+from transformers.utils import is_accelerate_available, is_datasets_available
 
-from datasets import Dataset, DatasetDict
 from sentence_transformers import __version__ as sentence_transformers_version
 from sentence_transformers.models import Transformer
 from sentence_transformers.training_args import SentenceTransformerTrainingArguments
 from sentence_transformers.util import cos_sim, fullname
+
+if is_datasets_available():
+    from datasets import Dataset, DatasetDict
 
 logger = logging.getLogger(__name__)
 
@@ -204,20 +207,25 @@ IGNORED_FIELDS = ["model", "trainer", "eval_results_dict"]
 
 
 def get_versions() -> Dict[str, Any]:
-    from accelerate import __version__ as accelerate_version
-    from tokenizers import __version__ as tokenizers_version
-
-    from datasets import __version__ as datasets_version
-
-    return {
+    versions = {
         "python": python_version(),
         "sentence_transformers": sentence_transformers_version,
         "transformers": transformers.__version__,
         "torch": torch.__version__,
-        "accelerate": accelerate_version,
-        "datasets": datasets_version,
-        "tokenizers": tokenizers_version,
     }
+    if is_accelerate_available():
+        from accelerate import __version__ as accelerate_version
+
+        versions["accelerate"] = accelerate_version
+    if is_datasets_available():
+        from datasets import __version__ as datasets_version
+
+        versions["datasets"] = datasets_version
+    from tokenizers import __version__ as tokenizers_version
+
+    versions["tokenizers"] = tokenizers_version
+
+    return versions
 
 
 @dataclass
@@ -387,7 +395,7 @@ class SentenceTransformerModelCardData(CardData):
     def set_best_model_step(self, step: int) -> None:
         self.best_model_step = step
 
-    def set_widget_examples(self, dataset: Union[Dataset, DatasetDict]) -> None:
+    def set_widget_examples(self, dataset: Union["Dataset", "DatasetDict"]) -> None:
         if isinstance(dataset, Dataset):
             dataset = DatasetDict(dataset=dataset)
 
@@ -465,7 +473,7 @@ class SentenceTransformerModelCardData(CardData):
                     }
                 )
 
-    def set_label_examples(self, dataset: Dataset) -> None:
+    def set_label_examples(self, dataset: "Dataset") -> None:
         num_examples_per_label = 3
         examples = defaultdict(list)
         finished_labels = set()
@@ -487,7 +495,7 @@ class SentenceTransformerModelCardData(CardData):
         ]
 
     def infer_datasets(
-        self, dataset: Union[Dataset, DatasetDict], dataset_name: Optional[str] = None
+        self, dataset: Union["Dataset", "DatasetDict"], dataset_name: Optional[str] = None
     ) -> List[Dict[str, str]]:
         if isinstance(dataset, DatasetDict):
             return [
@@ -661,7 +669,7 @@ class SentenceTransformerModelCardData(CardData):
         return dataset_info
 
     def extract_dataset_metadata(
-        self, dataset: Union[Dataset, DatasetDict], dataset_metadata, dataset_type: Literal["train", "eval"]
+        self, dataset: Union["Dataset", "DatasetDict"], dataset_metadata, dataset_type: Literal["train", "eval"]
     ) -> Dict[str, Any]:
         if dataset:
             if dataset_metadata and (

--- a/sentence_transformers/sampler.py
+++ b/sentence_transformers/sampler.py
@@ -5,8 +5,10 @@ from typing import List
 
 import torch
 from torch.utils.data import BatchSampler, ConcatDataset, SubsetRandomSampler
+from transformers.utils import is_datasets_available
 
-from datasets import Dataset
+if is_datasets_available():
+    from datasets import Dataset
 
 logger = logging.getLogger(__name__)
 
@@ -33,7 +35,7 @@ class DefaultBatchSampler(SetEpochMixin, BatchSampler):
 class GroupByLabelBatchSampler(SetEpochMixin, BatchSampler):
     def __init__(
         self,
-        dataset: Dataset,
+        dataset: "Dataset",
         batch_size: int,
         drop_last: bool,
         valid_label_columns: List[str] = None,
@@ -89,7 +91,7 @@ class GroupByLabelBatchSampler(SetEpochMixin, BatchSampler):
 class NoDuplicatesBatchSampler(SetEpochMixin, BatchSampler):
     def __init__(
         self,
-        dataset: Dataset,
+        dataset: "Dataset",
         batch_size: int,
         drop_last: bool,
         valid_label_columns: List[str] = [],

--- a/sentence_transformers/sampler.py
+++ b/sentence_transformers/sampler.py
@@ -5,7 +5,8 @@ from typing import List
 
 import torch
 from torch.utils.data import BatchSampler, ConcatDataset, SubsetRandomSampler
-from transformers.utils import is_datasets_available
+
+from sentence_transformers.util import is_datasets_available
 
 if is_datasets_available():
     from datasets import Dataset

--- a/sentence_transformers/trainer.py
+++ b/sentence_transformers/trainer.py
@@ -13,7 +13,6 @@ from transformers.integrations import WandbCallback
 from transformers.trainer import TRAINING_ARGS_NAME
 from transformers.trainer_utils import EvalLoopOutput
 from transformers.training_args import ParallelMode
-from transformers.utils import is_accelerate_available, is_datasets_available
 
 from sentence_transformers.data_collator import SentenceTransformerDataCollator
 from sentence_transformers.evaluation.SentenceEvaluator import SentenceEvaluator
@@ -32,7 +31,7 @@ from sentence_transformers.training_args import (
     MultiDatasetBatchSamplers,
     SentenceTransformerTrainingArguments,
 )
-from sentence_transformers.util import disable_logging
+from sentence_transformers.util import disable_logging, is_datasets_available, is_training_available
 
 if is_datasets_available():
     from datasets import Dataset, DatasetDict
@@ -133,11 +132,11 @@ class SentenceTransformerTrainer(Trainer):
         optimizers: Tuple[torch.optim.Optimizer, torch.optim.lr_scheduler.LambdaLR] = (None, None),
         preprocess_logits_for_metrics: Optional[Callable[[torch.Tensor, torch.Tensor], torch.Tensor]] = None,
     ) -> None:
-        if not is_accelerate_available() or not is_datasets_available():
+        if not is_training_available():
             raise RuntimeError(
                 "To train a SentenceTransformer model, you need to install the `accelerate` and `datasets` modules. "
                 "You can do so with the `train` extra:\n"
-                'pip install "sentence-transformers[train]"'
+                'pip install -U "sentence-transformers[train]"'
             )
 
         if args is None:

--- a/sentence_transformers/util.py
+++ b/sentence_transformers/util.py
@@ -936,3 +936,24 @@ def get_device_name() -> Literal["mps", "cuda", "npu", "hpu", "cpu"]:
         if hthpu.is_available():
             return "hpu"
     return "cpu"
+
+
+def is_accelerate_available() -> bool:
+    """
+    Returns True if the accelerate library is available.
+    """
+    return importlib.util.find_spec("accelerate") is not None
+
+
+def is_datasets_available() -> bool:
+    """
+    Returns True if the datasets library is available.
+    """
+    return importlib.util.find_spec("datasets") is not None
+
+
+def is_training_available() -> bool:
+    """
+    Returns True if we have the required dependencies for training Sentence Transformer models
+    """
+    return is_accelerate_available() and is_datasets_available()

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,8 @@ setup(
             "accelerate>=0.20.3",
         ],
         "dev": [
+            "datasets",
+            "accelerate>=0.20.3",
             "pre-commit",
             "pytest",
             "ruff>=0.3.0",

--- a/setup.py
+++ b/setup.py
@@ -27,10 +27,12 @@ setup(
         "scipy",
         "huggingface-hub>=0.15.1",
         "Pillow",
-        "datasets",
-        "accelerate>=0.20.3",
     ],
     extras_require={
+        "train": [
+            "datasets",
+            "accelerate>=0.20.3",
+        ],
         "dev": [
             "pre-commit",
             "pytest",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,10 +3,13 @@ import platform
 import tempfile
 
 import pytest
+from transformers.utils import is_datasets_available
 
-from datasets import DatasetDict, load_dataset
 from sentence_transformers import CrossEncoder, SentenceTransformer
 from sentence_transformers.models import Pooling, Transformer
+
+if is_datasets_available():
+    from datasets import DatasetDict, load_dataset
 
 
 @pytest.fixture()
@@ -43,7 +46,7 @@ def distilbert_base_uncased_model() -> SentenceTransformer:
 
 
 @pytest.fixture(scope="session")
-def stsb_dataset_dict() -> DatasetDict:
+def stsb_dataset_dict() -> "DatasetDict":
     return load_dataset("mteb/stsbenchmark-sts")
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,10 +3,10 @@ import platform
 import tempfile
 
 import pytest
-from transformers.utils import is_datasets_available
 
 from sentence_transformers import CrossEncoder, SentenceTransformer
 from sentence_transformers.models import Pooling, Transformer
+from sentence_transformers.util import is_datasets_available
 
 if is_datasets_available():
     from datasets import DatasetDict, load_dataset

--- a/tests/test_train_stsb.py
+++ b/tests/test_train_stsb.py
@@ -10,6 +10,7 @@ from typing import Generator, List, Tuple
 import pytest
 import torch
 from torch.utils.data import DataLoader
+from transformers.utils import is_accelerate_available, is_datasets_available
 
 from sentence_transformers import (
     SentencesDataset,
@@ -71,6 +72,10 @@ def evaluate_stsb_test(model, expected_score, test_samples) -> None:
 
 
 @pytest.mark.slow
+@pytest.mark.skipif(
+    not is_accelerate_available() or not is_datasets_available(),
+    reason='Sentence Transformers was not installed with the `["train"]` extra.',
+)
 def test_train_stsb_slow(
     distilbert_base_uncased_model: SentenceTransformer, sts_resource: Tuple[List[InputExample], List[InputExample]]
 ) -> None:
@@ -92,6 +97,10 @@ def test_train_stsb_slow(
 
 
 @pytest.mark.skipif("CI" in os.environ, reason="This test is too slow for the CI (~8 minutes)")
+@pytest.mark.skipif(
+    not is_accelerate_available() or not is_datasets_available(),
+    reason='Sentence Transformers was not installed with the `["train"]` extra.',
+)
 def test_train_stsb(
     distilbert_base_uncased_model: SentenceTransformer, sts_resource: Tuple[List[InputExample], List[InputExample]]
 ) -> None:
@@ -113,6 +122,10 @@ def test_train_stsb(
 
 
 @pytest.mark.slow
+@pytest.mark.skipif(
+    not is_accelerate_available() or not is_datasets_available(),
+    reason='Sentence Transformers was not installed with the `["train"]` extra.',
+)
 def test_train_nli_slow(
     distilbert_base_uncased_model: SentenceTransformer,
     nli_resource: List[InputExample],
@@ -139,6 +152,10 @@ def test_train_nli_slow(
 
 
 @pytest.mark.skipif("CI" in os.environ, reason="This test is too slow for the CI (~25 minutes)")
+@pytest.mark.skipif(
+    not is_accelerate_available() or not is_datasets_available(),
+    reason='Sentence Transformers was not installed with the `["train"]` extra.',
+)
 def test_train_nli(
     distilbert_base_uncased_model: SentenceTransformer,
     nli_resource: List[InputExample],

--- a/tests/test_train_stsb.py
+++ b/tests/test_train_stsb.py
@@ -10,7 +10,6 @@ from typing import Generator, List, Tuple
 import pytest
 import torch
 from torch.utils.data import DataLoader
-from transformers.utils import is_accelerate_available, is_datasets_available
 
 from sentence_transformers import (
     SentencesDataset,
@@ -20,6 +19,7 @@ from sentence_transformers import (
 )
 from sentence_transformers.evaluation import EmbeddingSimilarityEvaluator
 from sentence_transformers.readers import InputExample
+from sentence_transformers.util import is_training_available
 
 
 @pytest.fixture()
@@ -73,7 +73,7 @@ def evaluate_stsb_test(model, expected_score, test_samples) -> None:
 
 @pytest.mark.slow
 @pytest.mark.skipif(
-    not is_accelerate_available() or not is_datasets_available(),
+    not is_training_available(),
     reason='Sentence Transformers was not installed with the `["train"]` extra.',
 )
 def test_train_stsb_slow(
@@ -98,7 +98,7 @@ def test_train_stsb_slow(
 
 @pytest.mark.skipif("CI" in os.environ, reason="This test is too slow for the CI (~8 minutes)")
 @pytest.mark.skipif(
-    not is_accelerate_available() or not is_datasets_available(),
+    not is_training_available(),
     reason='Sentence Transformers was not installed with the `["train"]` extra.',
 )
 def test_train_stsb(
@@ -123,7 +123,7 @@ def test_train_stsb(
 
 @pytest.mark.slow
 @pytest.mark.skipif(
-    not is_accelerate_available() or not is_datasets_available(),
+    not is_training_available(),
     reason='Sentence Transformers was not installed with the `["train"]` extra.',
 )
 def test_train_nli_slow(
@@ -153,7 +153,7 @@ def test_train_nli_slow(
 
 @pytest.mark.skipif("CI" in os.environ, reason="This test is too slow for the CI (~25 minutes)")
 @pytest.mark.skipif(
-    not is_accelerate_available() or not is_datasets_available(),
+    not is_training_available(),
     reason='Sentence Transformers was not installed with the `["train"]` extra.',
 )
 def test_train_nli(

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -3,16 +3,16 @@ import tempfile
 from pathlib import Path
 
 import pytest
-from transformers.utils import is_accelerate_available, is_datasets_available
 
 from sentence_transformers import SentenceTransformer, SentenceTransformerTrainer, losses
+from sentence_transformers.util import is_datasets_available, is_training_available
 
 if is_datasets_available():
     from datasets import DatasetDict
 
 
 @pytest.mark.skipif(
-    not is_accelerate_available() or not is_datasets_available(),
+    not is_training_available(),
     reason='Sentence Transformers was not installed with the `["train"]` extra.',
 )
 def test_trainer_multi_dataset_errors(
@@ -81,7 +81,7 @@ def test_trainer_multi_dataset_errors(
 
 
 @pytest.mark.skipif(
-    not is_accelerate_available() or not is_datasets_available(),
+    not is_training_available(),
     reason='Sentence Transformers was not installed with the `["train"]` extra.',
 )
 def test_trainer_invalid_column_names(
@@ -118,7 +118,7 @@ def test_trainer_invalid_column_names(
 
 
 @pytest.mark.skipif(
-    not is_accelerate_available() or not is_datasets_available(),
+    not is_training_available(),
     reason='Sentence Transformers was not installed with the `["train"]` extra.',
 )
 def test_model_card_reuse(stsb_bert_tiny_model: SentenceTransformer):

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -3,13 +3,20 @@ import tempfile
 from pathlib import Path
 
 import pytest
+from transformers.utils import is_accelerate_available, is_datasets_available
 
-from datasets import DatasetDict
 from sentence_transformers import SentenceTransformer, SentenceTransformerTrainer, losses
 
+if is_datasets_available():
+    from datasets import DatasetDict
 
+
+@pytest.mark.skipif(
+    not is_accelerate_available() or not is_datasets_available(),
+    reason='Sentence Transformers was not installed with the `["train"]` extra.',
+)
 def test_trainer_multi_dataset_errors(
-    stsb_bert_tiny_model: SentenceTransformer, stsb_dataset_dict: DatasetDict
+    stsb_bert_tiny_model: SentenceTransformer, stsb_dataset_dict: "DatasetDict"
 ) -> None:
     train_dataset = stsb_dataset_dict["train"]
     loss = {
@@ -73,8 +80,12 @@ def test_trainer_multi_dataset_errors(
         )
 
 
+@pytest.mark.skipif(
+    not is_accelerate_available() or not is_datasets_available(),
+    reason='Sentence Transformers was not installed with the `["train"]` extra.',
+)
 def test_trainer_invalid_column_names(
-    stsb_bert_tiny_model: SentenceTransformer, stsb_dataset_dict: DatasetDict
+    stsb_bert_tiny_model: SentenceTransformer, stsb_dataset_dict: "DatasetDict"
 ) -> None:
     train_dataset = stsb_dataset_dict["train"]
     for column_name in ("return_loss", "dataset_name"):
@@ -106,6 +117,10 @@ def test_trainer_invalid_column_names(
             trainer.train()
 
 
+@pytest.mark.skipif(
+    not is_accelerate_available() or not is_datasets_available(),
+    reason='Sentence Transformers was not installed with the `["train"]` extra.',
+)
 def test_model_card_reuse(stsb_bert_tiny_model: SentenceTransformer):
     assert stsb_bert_tiny_model._model_card_text
     # Reuse the model card if no training was done


### PR DESCRIPTION
Hello!

## Pull Request overview
* Move training dependencies into a "train" extra

## Details
Training/finetuning now requires you to install
```
pip install sentence_transformers[train]
```
rather than just `sentence_transformers`. This is to avoid 2 additional dependencies (`datasets`, `accelerate`) from being required when you're only interested in inference.

The changes are primarily moving `datasets` imports behind `is_datasets_available()`, converting e.g. `Dataset` type hints into `"Dataset"`, and updating the docs.

cc @osanseviero 

- Tom Aarsen