### PR TITLE
[`v3`] Add warning that Evaluators only run on 1 GPU when multi-GPU training

### DIFF
--- a/docs/sentence_transformer/training/distributed.rst
+++ b/docs/sentence_transformer/training/distributed.rst
@@ -47,6 +47,10 @@ In short, **DDP is generally recommended**. You can use DDP by running your norm
       if __name__ == "__main__":
           main()
 
+.. note::
+
+   When using an `Evaluator <../training_overview.html#evaluator>`_, the evaluator only runs on the first device unlike the training and evaluation datasets, which are shared across all devices. 
+
 Comparison
 ----------
 

--- a/docs/sentence_transformer/training_overview.md
+++ b/docs/sentence_transformer/training_overview.md
@@ -360,12 +360,16 @@ Sometimes you don't have the required evaluation data to prepare one of these ev
         )
         # You can run evaluation like so:
         # dev_evaluator(model)
+
+.. warning::
+
+    When using `Distributed Training <training/distributed.html>`_, the evaluator only runs on the first device, unlike the training and evaluation datasets, which are shared across all devices. 
 ```
 
 ## Trainer
 
 ```eval_rst
-The :class:`sentence_transformers.SentenceTransformerTrainer` is where all previous components come together. We only have to specify the trainer with the model, training arguments (optional), training dataset, evaluation dataset (optional), loss function, evaluator (optional) and we can start training. Let's have a look at a script where all of these components come together:
+The :class:`~sentence_transformers.SentenceTransformerTrainer` is where all previous components come together. We only have to specify the trainer with the model, training arguments (optional), training dataset, evaluation dataset (optional), loss function, evaluator (optional) and we can start training. Let's have a look at a script where all of these components come together:
 
 .. sidebar:: Documentation
 


### PR DESCRIPTION
Hello!

## Pull Request overview
* Add warning that Evaluators only run on 1 GPU when multi-GPU training

## Details
This should speak for itself.

- Tom Aarsen