### PR TITLE
[`v3`] Add "dataset_size:" to the tag denoting the number of training samples

### DIFF
--- a/sentence_transformers/model_card.py
+++ b/sentence_transformers/model_card.py
@@ -702,7 +702,7 @@ class SentenceTransformerModelCardData(CardData):
         if dataset_type == "train":
             num_training_samples = sum([metadata.get("size", 0) for metadata in dataset_metadata])
             if num_training_samples:
-                self.tags += [self.num_training_samples_to_tag(num_training_samples)]
+                self.tags += [self.num_training_samples_to_tag(num_training_samples) + " samples"]
 
         return self.validate_datasets(dataset_metadata)
 

--- a/sentence_transformers/model_card.py
+++ b/sentence_transformers/model_card.py
@@ -702,7 +702,7 @@ class SentenceTransformerModelCardData(CardData):
         if dataset_type == "train":
             num_training_samples = sum([metadata.get("size", 0) for metadata in dataset_metadata])
             if num_training_samples:
-                self.tags += [self.num_training_samples_to_tag(num_training_samples) + " samples"]
+                self.tags += ["dataset_size:" + self.num_training_samples_to_tag(num_training_samples)]
 
         return self.validate_datasets(dataset_metadata)
 


### PR DESCRIPTION
Hello!

## Pull Request overview
* Add " samples" to the tag denoting the number of training samples

## Details
Otherwise it's not clear that the tag denotes the number of training samples - people might think that it's the number of model parameters instead.

- Tom Aarsen