### PR TITLE
fix loss link

### DIFF
--- a/docs/sentence_transformer/training_overview.md
+++ b/docs/sentence_transformer/training_overview.md
@@ -171,8 +171,8 @@ Most loss functions can be initialized with just the :class:`SentenceTransformer
 .. sidebar:: Documentation
 
     - :class:`sentence_transformers.losses.CoSENTLoss`
-    - `Losses API Reference <../package_reference/sentence_transformer/losses>`_
-    - `Loss Overview <loss_overview>`_
+    - `Losses API Reference <../package_reference/sentence_transformer/losses.html>`_
+    - `Loss Overview <loss_overview.html>`_
 
 ::
 


### PR DESCRIPTION
Currently, this links leads to losses and loss_overview, but they should to losses.html and loss_overview.html
![image](https://github.com/UKPLab/sentence-transformers/assets/36135455/117a7fdc-6080-4617-a829-53fd782d7b70)
