### PR TITLE
Fix a bug in SequentialEvaluator to use primary_metric if defined in evaluator.

### DIFF
--- a/sentence_transformers/evaluation/SequentialEvaluator.py
+++ b/sentence_transformers/evaluation/SequentialEvaluator.py
@@ -47,8 +47,8 @@ class SequentialEvaluator(SentenceEvaluator):
                 scores.append(evaluation)
                 evaluation = {f"evaluator_{evaluator_idx}": evaluation}
             else:
-                if hasattr(evaluation, "primary_metric"):
-                    scores.append(evaluation[evaluation.primary_metric])
+                if hasattr(evaluator, "primary_metric"):
+                    scores.append(evaluation[evaluator.primary_metric])
                 else:
                     scores.append(evaluation[list(evaluation.keys())[0]])
 


### PR DESCRIPTION
Fixed `SequentialEvaluator` to use `primary_metric` if defined. Before this change, it was using `evaluation` instead of `evaluator`.