### PR TITLE
Fix bug that restricts users from specifying custom primary_function in InformationRetrievalEvaluator

### DIFF
--- a/sentence_transformers/evaluation/InformationRetrievalEvaluator.py
+++ b/sentence_transformers/evaluation/InformationRetrievalEvaluator.py
@@ -254,14 +254,15 @@ class InformationRetrievalEvaluator(SentenceEvaluator):
             fOut.write("\n")
             fOut.close()
 
-        if self.main_score_function is None:
-            score_function = max(
-                [(name, scores[name]["map@k"][max(self.map_at_k)]) for name in self.score_function_names],
-                key=lambda x: x[1],
-            )[0]
-            self.primary_metric = f"{score_function}_map@{max(self.map_at_k)}"
-        else:
-            self.primary_metric = f"{self.main_score_function.value}_map@{max(self.map_at_k)}"
+        if not self.primary_metric:
+            if self.main_score_function is None:
+                score_function = max(
+                    [(name, scores[name]["map@k"][max(self.map_at_k)]) for name in self.score_function_names],
+                    key=lambda x: x[1],
+                )[0]
+                self.primary_metric = f"{score_function}_map@{max(self.map_at_k)}"
+            else:
+                self.primary_metric = f"{self.main_score_function.value}_map@{max(self.map_at_k)}"
 
         metrics = {
             f"{score_function}_{metric_name.replace('@k', '@' + str(k))}": value


### PR DESCRIPTION
This change allows users to specify `primary_metric` without being overwritten during the evaluation call.

Currently the `primary_function` is always overwritten by the `__call__` method.