### PR TITLE
[`fix`] Always override the originally saved __version__ in the ST config

### DIFF
--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -1004,12 +1004,11 @@ class SentenceTransformer(nn.Sequential, FitMixin):
         modules_config = []
 
         # Save some model info
-        if "__version__" not in self._model_config:
-            self._model_config["__version__"] = {
-                "sentence_transformers": __version__,
-                "transformers": transformers.__version__,
-                "pytorch": torch.__version__,
-            }
+        self._model_config["__version__"] = {
+            "sentence_transformers": __version__,
+            "transformers": transformers.__version__,
+            "pytorch": torch.__version__,
+        }
 
         with open(os.path.join(path, "config_sentence_transformers.json"), "w") as fOut:
             config = self._model_config.copy()

--- a/tests/test_sentence_transformer.py
+++ b/tests/test_sentence_transformer.py
@@ -564,3 +564,14 @@ def test_similarity_score_save(stsb_bert_tiny_model: SentenceTransformer) -> Non
     assert loaded_model.similarity_fn_name == "euclidean"
     dot_scores = model.similarity(embeddings, embeddings)
     assert np.not_equal(cosine_scores, dot_scores).all()
+
+
+def test_override_config_versions(stsb_bert_tiny_model: SentenceTransformer) -> None:
+    model = stsb_bert_tiny_model
+
+    assert model._model_config["__version__"]["sentence_transformers"] == "2.2.2"
+    with tempfile.TemporaryDirectory() as tmp_folder:
+        model.save(tmp_folder)
+        loaded_model = SentenceTransformer(tmp_folder)
+    # Verify that the version has now been updated when saving the model again
+    assert loaded_model._model_config["__version__"]["sentence_transformers"] != "2.2.2"


### PR DESCRIPTION
Hello!

## Pull Request overview
* Always override the originally saved __version__ in the ST config

## Details
Currently, the `__version__` data is only determines once, and then all future models finetuned on that model will just adopt the original versions. This can become a problem as e.g. ST v3.0 will save models that have e.g. "2.2.2" in their configuration, which is rather confusing.

## Example
E.g. https://huggingface.co/ammumadhu/indic-bert-nli-matryoshka/blob/main/config_sentence_transformers.json
which shows 2.2.2 whereas the model itself was trained with v3.0.0.

cc @osanseviero 

- Tom Aarsen