### PR TITLE
Add "generated_from_trainer" tag to auto-generated model cards

### DIFF
--- a/sentence_transformers/model_card.py
+++ b/sentence_transformers/model_card.py
@@ -283,6 +283,7 @@ class SentenceTransformerModelCardData(CardData):
             "sentence-transformers",
             "sentence-similarity",
             "feature-extraction",
+            "generated_from_trainer",
         ]
     )
     generate_widget_examples: bool = True

--- a/sentence_transformers/model_card.py
+++ b/sentence_transformers/model_card.py
@@ -55,6 +55,8 @@ class ModelCardCallback(TrainerCallback):
             trainer.model.model_card_data.code_carbon_callback = callbacks[0]
 
         trainer.model.model_card_data.trainer = trainer
+        if "generated_from_trainer" not in trainer.model.model_card_data.tags:
+            trainer.model.model_card_data.tags.append("generated_from_trainer")
 
     def on_init_end(
         self,
@@ -283,7 +285,6 @@ class SentenceTransformerModelCardData(CardData):
             "sentence-transformers",
             "sentence-similarity",
             "feature-extraction",
-            "generated_from_trainer",
         ]
     )
     generate_widget_examples: bool = True

--- a/tests/test_model_card_data.py
+++ b/tests/test_model_card_data.py
@@ -1,6 +1,6 @@
 import pytest
 
-from sentence_transformers import SentenceTransformer
+from sentence_transformers import SentenceTransformer, SentenceTransformerTrainer
 
 
 @pytest.mark.parametrize(
@@ -22,3 +22,11 @@ def test_model_card_data(revision, expected_base_revision) -> None:
         assert len(model.model_card_data.base_model_revision) == 40
     else:
         assert model.model_card_data.base_model_revision == expected_base_revision
+
+
+def test_generated_from_trainer_tag(stsb_bert_tiny_model: SentenceTransformer) -> None:
+    model = stsb_bert_tiny_model
+
+    assert "generated_from_trainer" not in model.model_card_data.tags
+    SentenceTransformerTrainer(model)
+    assert "generated_from_trainer" in model.model_card_data.tags


### PR DESCRIPTION
Hello!

## Pull Request overview
* Add "generated_from_trainer" tag to auto-generated model cards

## Details
This allows us to more easily track models and allows others to easily check out other models trained with ST v3.0.0.

cc @osanseviero 

- Tom Aarsen