### PR TITLE
[`model cards`] Replace 'sentence_transformers_model_id' from reused model if possible

### DIFF
--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -1095,11 +1095,12 @@ class SentenceTransformer(nn.Sequential, FitMixin):
         # we don't generate a new model card, but reuse the old one instead.
         if self._model_card_text and self.model_card_data.trainer is None:
             model_card = self._model_card_text
-            # If the original model card was saved without a model_id, we replace the model_id with the new model_id
-            model_card = model_card.replace(
-                'model = SentenceTransformer("sentence_transformers_model_id"',
-                f'model = SentenceTransformer("{self.model_card_data.model_id}"',
-            )
+            if self.model_card_data.model_id:
+                # If the original model card was saved without a model_id, we replace the model_id with the new model_id
+                model_card = model_card.replace(
+                    'model = SentenceTransformer("sentence_transformers_model_id"',
+                    f'model = SentenceTransformer("{self.model_card_data.model_id}"',
+                )
         else:
             try:
                 model_card = generate_model_card(self)

--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -1095,6 +1095,11 @@ class SentenceTransformer(nn.Sequential, FitMixin):
         # we don't generate a new model card, but reuse the old one instead.
         if self._model_card_text and self.model_card_data.trainer is None:
             model_card = self._model_card_text
+            # If the original model card was saved without a model_id, we replace the model_id with the new model_id
+            model_card = model_card.replace(
+                'model = SentenceTransformer("sentence_transformers_model_id"',
+                f'model = SentenceTransformer("{self.model_card_data.model_id}"',
+            )
         else:
             try:
                 model_card = generate_model_card(self)

--- a/tests/test_sentence_transformer.py
+++ b/tests/test_sentence_transformer.py
@@ -565,6 +565,7 @@ def test_similarity_score_save(stsb_bert_tiny_model: SentenceTransformer) -> Non
     dot_scores = model.similarity(embeddings, embeddings)
     assert np.not_equal(cosine_scores, dot_scores).all()
 
+
 def test_model_card_save_update_model_id(stsb_bert_tiny_model: SentenceTransformer) -> None:
     model = stsb_bert_tiny_model
     # Removing the saved model card will cause a fresh one to be generated when we save
@@ -578,7 +579,7 @@ def test_model_card_save_update_model_id(stsb_bert_tiny_model: SentenceTransform
         # When we reload this saved model and then re-save it, we want to override the 'sentence_transformers_model_id'
         # if we have it set
         loaded_model = SentenceTransformer(tmp_folder)
-        
+
     with tempfile.TemporaryDirectory() as tmp_folder:
         loaded_model.save(tmp_folder, model_name="test_user/test_model")
 


### PR DESCRIPTION
Hello!

## Pull Request overview
* Replace 'sentence_transformers_model_id' from reused model if possible

## Details
A common occurrence is saving a model locally with `model.save_pretrained("my_model")`, then later loading the model again with `SentenceTransformer("my_model")` and uploading that model with `model.push_to_hub("my_user/my_model")`. Sentence Transformers reuses the model card if no training is carried out, so you still get all of your training logs, hyperparameters, etc., but the original save likely resulted in a usage snippet of:
```python
from sentence_transformers import SentenceTransformer

# Download from the 🤗 Hub
model = SentenceTransformer("sentence_transformers_model_id")
# Run inference
sentences = [
    'Then he ran.',
    'The people are running.',
    'The man is on his bike.',
]
embeddings = model.encode(sentences)
print(embeddings.shape)
# [3, 768]

# Get the similarity scores for the embeddings
similarities = model.similarity(embeddings, embeddings)
print(similarities.shape)
# [3, 3]
```

This'll get fully reused, even if with the `push_to_hub` the code should know the final model ID. This PR fixes that, i.e. the `sentence_transformers_model_id` will get updated.

- Tom Aarsen