### PR TITLE
Enable intfloat/e5-mistral-7b-instruct model with 32k token lens on hpu device

### DIFF
--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -363,6 +363,7 @@ class SentenceTransformer(nn.Sequential, FitMixin):
         convert_to_tensor: bool = False,
         device: str = None,
         normalize_embeddings: bool = False,
+        kwargs: Optional[Dict[str, Any]] = None,
     ) -> Union[List[Tensor], ndarray, Tensor]:
         """
         Computes sentence embeddings.
@@ -485,11 +486,17 @@ class SentenceTransformer(nn.Sequential, FitMixin):
             if self.device.type == "hpu":
                 if "input_ids" in features:
                     curr_tokenize_len = features["input_ids"].shape
-                    additional_pad_len = 2 ** math.ceil(math.log2(curr_tokenize_len[1])) - curr_tokenize_len[1]
+                    if curr_tokenize_len[1] > 4096:
+                        additional_pad_len = math.ceil(curr_tokenize_len[1] / 128) * 128 - curr_tokenize_len[1]
+
+                        extra_features.update(kwargs["gaudi_kwargs"])
+                    else:
+                        additional_pad_len = 2 ** math.ceil(math.log2(curr_tokenize_len[1])) - curr_tokenize_len[1]
+
                     features["input_ids"] = torch.cat(
                         (
                             features["input_ids"],
-                            torch.ones((curr_tokenize_len[0], additional_pad_len), dtype=torch.int8),
+                            torch.zeros((curr_tokenize_len[0], additional_pad_len), dtype=torch.int8),
                         ),
                         -1,
                     )


### PR DESCRIPTION
This PR belongs to one of enabling Intel's Gaudi2 GPU supported tasks for Sentence Transformer's inference/training

This PR enables intfloat/e5-mistral-7b-instruct model with 32k token lens input on hpu device and it is the revision of [PR#2656.](https://github.com/UKPLab/sentence-transformers/pull/2656)

There are two parts for updates -

1) Efficient new padding for bigger token lens input by using multiple of 128 instead of original power of 2 to reduce the padding overhead when the input token lens is bigger which is not efficient for power of 2.

2) Bring in the 7b mistral 32k token lens support with hpu device by using the specific arguments in high level encode arguments which is not hard coded as previous PR.  

The usage example for 7b mistral with 32k token lens will be -

gaudi_kwargs = {"attn_softmax_bf16": True, "reuse_cache": True, "use_flash_attention":True,"flash_attention_recompute": True,"flash_attention_causal_mask": True, }
emb = model.encode(sentences, batch_size=32, kwargs={"gaudi_kwargs" : guadi_kwargs})

any questions please comments.

thanks.