### PR TITLE
[`fix`] Fix gradient checkpointing to allow for much lower memory usage

### DIFF
--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -1593,3 +1593,9 @@ class SentenceTransformer(nn.Sequential, FitMixin):
             return self._first_module()._keys_to_ignore_on_save
         except AttributeError:
             return []
+
+    def gradient_checkpointing_enable(self, gradient_checkpointing_kwargs=None) -> None:
+        # Propagate the gradient checkpointing to the transformer model
+        for module in self:
+            if isinstance(module, Transformer):
+                return module.auto_model.gradient_checkpointing_enable(gradient_checkpointing_kwargs)


### PR DESCRIPTION
Hello!

## Pull Request overview
* Propagate the gradient checkpointing enabling to the underlying Transformer model

## Details
By setting `gradient_checkpointing=True`, you can save a lot of memory when training at a ~10-20% speed decrease. This can allow for bigger batch sizes, which is very beneficial for in-batch negatives training. 

Thanks @philschmid for reporting this.

- Tom Aarsen