### PR TITLE
[`fix`] Fix `MatryoshkaLoss` crash if the first dimension is not the biggest

### DIFF
--- a/sentence_transformers/losses/MatryoshkaLoss.py
+++ b/sentence_transformers/losses/MatryoshkaLoss.py
@@ -121,10 +121,12 @@ class MatryoshkaLoss(nn.Module):
             warnings.warn("MatryoshkaLoss is not compatible with CachedMultipleNegativesRankingLoss.", stacklevel=2)
         if isinstance(loss, CachedGISTEmbedLoss):
             warnings.warn("MatryoshkaLoss is not compatible with CachedGISTEmbedLoss.", stacklevel=2)
-        self.matryoshka_dims = matryoshka_dims
+        
         if matryoshka_weights is None:
             matryoshka_weights = [1] * len(matryoshka_dims)
-        self.matryoshka_weights = matryoshka_weights
+        # Sort the dimensions and weights in descending order
+        dims_weights = zip(matryoshka_dims, matryoshka_weights)
+        self.matryoshka_dims, self.matryoshka_weights = zip(*sorted(dims_weights, key=lambda x: x[0], reverse=True))
         self.n_dims_per_step = n_dims_per_step
 
     def forward(self, sentence_features: Iterable[Dict[str, Tensor]], labels: Tensor) -> Tensor:

--- a/sentence_transformers/losses/MatryoshkaLoss.py
+++ b/sentence_transformers/losses/MatryoshkaLoss.py
@@ -121,7 +121,7 @@ class MatryoshkaLoss(nn.Module):
             warnings.warn("MatryoshkaLoss is not compatible with CachedMultipleNegativesRankingLoss.", stacklevel=2)
         if isinstance(loss, CachedGISTEmbedLoss):
             warnings.warn("MatryoshkaLoss is not compatible with CachedGISTEmbedLoss.", stacklevel=2)
-        
+
         if matryoshka_weights is None:
             matryoshka_weights = [1] * len(matryoshka_dims)
         # Sort the dimensions and weights in descending order


### PR DESCRIPTION
Hello!

## Pull Request overview
* Fix `MatryoshkaLoss` crash if the first dimension is not the biggest

## Details
The first dimension is ran "normally", while all future ones use the cached results from the first run and then truncate to the required dimension. Consequently, if you use a non-largest dimension as the first dimension, then you'll cache a dimension that's too small. This PR sorts the Matryoshka dimensions from large to small to ensure that we cache the largest dimension.

Thanks @philschmid for reporting this.

- Tom Aarsen