### PR TITLE
[`typing`] Improve typing for many functions & add `py.typed` to satisfy `mypy`

### DIFF
--- a/sentence_transformers/LoggingHandler.py
+++ b/sentence_transformers/LoggingHandler.py
@@ -4,10 +4,10 @@ import tqdm
 
 
 class LoggingHandler(logging.Handler):
-    def __init__(self, level=logging.NOTSET):
+    def __init__(self, level=logging.NOTSET) -> None:
         super().__init__(level)
 
-    def emit(self, record):
+    def emit(self, record) -> None:
         try:
             msg = self.format(record)
             tqdm.tqdm.write(msg)
@@ -18,7 +18,7 @@ class LoggingHandler(logging.Handler):
             self.handleError(record)
 
 
-def install_logger(given_logger, level=logging.WARNING, fmt="%(levelname)s:%(name)s:%(message)s"):
+def install_logger(given_logger, level=logging.WARNING, fmt="%(levelname)s:%(name)s:%(message)s") -> None:
     """Configures the given logger; format, logging level, style, etc"""
     import coloredlogs
 

--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -10,8 +10,9 @@ import traceback
 import warnings
 from collections import OrderedDict
 from contextlib import contextmanager
+from multiprocessing import Queue
 from pathlib import Path
-from typing import Any, Callable, Dict, Iterable, List, Literal, Optional, Tuple, Union, overload
+from typing import Any, Callable, Dict, Iterable, Iterator, List, Literal, Optional, Tuple, Union, overload
 
 import numpy as np
 import torch
@@ -159,7 +160,7 @@ class SentenceTransformer(nn.Sequential, FitMixin):
         tokenizer_kwargs: Optional[Dict[str, Any]] = None,
         config_kwargs: Optional[Dict[str, Any]] = None,
         model_card_data: Optional[SentenceTransformerModelCardData] = None,
-    ):
+    ) -> None:
         # Note: self._load_sbert_model can also update `self.prompts` and `self.default_prompt_name`
         self.prompts = prompts or {}
         self.default_prompt_name = default_prompt_name
@@ -689,7 +690,9 @@ class SentenceTransformer(nn.Sequential, FitMixin):
             self.similarity_fn_name = SimilarityFunction.COSINE
         return self._similarity_pairwise
 
-    def start_multi_process_pool(self, target_devices: List[str] = None) -> Dict[str, Any]:
+    def start_multi_process_pool(
+        self, target_devices: List[str] = None
+    ) -> Dict[Literal["input", "output", "processes"], Any]:
         """
         Starts a multi-process pool to process the encoding with several independent processes
         via :meth:`SentenceTransformer.encode_multi_process <sentence_transformers.SentenceTransformer.encode_multi_process>`.
@@ -737,7 +740,7 @@ class SentenceTransformer(nn.Sequential, FitMixin):
         return {"input": input_queue, "output": output_queue, "processes": processes}
 
     @staticmethod
-    def stop_multi_process_pool(pool):
+    def stop_multi_process_pool(pool: Dict[Literal["input", "output", "processes"], Any]) -> None:
         """
         Stops all processes started with start_multi_process_pool.
 
@@ -760,7 +763,7 @@ class SentenceTransformer(nn.Sequential, FitMixin):
     def encode_multi_process(
         self,
         sentences: List[str],
-        pool: Dict[str, object],
+        pool: Dict[Literal["input", "output", "processes"], Any],
         prompt_name: Optional[str] = None,
         prompt: Optional[str] = None,
         batch_size: int = 32,
@@ -776,7 +779,8 @@ class SentenceTransformer(nn.Sequential, FitMixin):
 
         Args:
             sentences (List[str]): List of sentences to encode.
-            pool (Dict[str, object]): A pool of workers started with SentenceTransformer.start_multi_process_pool.
+            pool (Dict[Literal["input", "output", "processes"], Any]): A pool of workers started with
+                :meth:`SentenceTransformer.start_multi_process_pool <sentence_transformers.SentenceTransformer.start_multi_process_pool>`.
             prompt_name (Optional[str], optional): The name of the prompt to use for encoding. Must be a key in the `prompts` dictionary,
                 which is either set in the constructor or loaded from the model configuration. For example if
                 ``prompt_name`` is "query" and the ``prompts`` is {"query": "query: ", ...}, then the sentence "What
@@ -847,7 +851,9 @@ class SentenceTransformer(nn.Sequential, FitMixin):
         return embeddings
 
     @staticmethod
-    def _encode_multi_process_worker(target_device: str, model, input_queue, results_queue):
+    def _encode_multi_process_worker(
+        target_device: str, model: "SentenceTransformer", input_queue: Queue, results_queue: Queue
+    ) -> None:
         """
         Internal working process to encode sentences in multi-process setup
         """
@@ -915,7 +921,7 @@ class SentenceTransformer(nn.Sequential, FitMixin):
         """
         return self._first_module().tokenize(texts)
 
-    def get_sentence_features(self, *features):
+    def get_sentence_features(self, *features) -> Dict[Literal["sentence_embedding"], torch.Tensor]:
         return self._first_module().get_sentence_features(*features)
 
     def get_sentence_embedding_dimension(self) -> Optional[int]:
@@ -938,7 +944,7 @@ class SentenceTransformer(nn.Sequential, FitMixin):
         return output_dim
 
     @contextmanager
-    def truncate_sentence_embeddings(self, truncate_dim: Optional[int]):
+    def truncate_sentence_embeddings(self, truncate_dim: Optional[int]) -> Iterator[None]:
         """
         In this context, :meth:`SentenceTransformer.encode <sentence_transformers.SentenceTransformer.encode>` outputs
         sentence embeddings truncated at dimension ``truncate_dim``.
@@ -967,11 +973,11 @@ class SentenceTransformer(nn.Sequential, FitMixin):
         finally:
             self.truncate_dim = original_output_dim
 
-    def _first_module(self):
+    def _first_module(self) -> torch.nn.Module:
         """Returns the first module of this sequential embedder"""
         return self._modules[next(iter(self._modules))]
 
-    def _last_module(self):
+    def _last_module(self) -> torch.nn.Module:
         """Returns the last module of this sequential embedder"""
         return self._modules[next(reversed(self._modules))]
 
@@ -982,7 +988,7 @@ class SentenceTransformer(nn.Sequential, FitMixin):
         create_model_card: bool = True,
         train_datasets: Optional[List[str]] = None,
         safe_serialization: bool = True,
-    ):
+    ) -> None:
         """
         Saves a model and its configuration files to a directory, so that it can be loaded
         with ``SentenceTransformer(path)`` again.
@@ -1049,7 +1055,7 @@ class SentenceTransformer(nn.Sequential, FitMixin):
         create_model_card: bool = True,
         train_datasets: Optional[List[str]] = None,
         safe_serialization: bool = True,
-    ):
+    ) -> None:
         """
         Saves a model and its configuration files to a directory, so that it can be loaded
         with ``SentenceTransformer(path)`` again.
@@ -1072,7 +1078,7 @@ class SentenceTransformer(nn.Sequential, FitMixin):
 
     def _create_model_card(
         self, path: str, model_name: Optional[str] = None, train_datasets: Optional[List[str]] = "deprecated"
-    ):
+    ) -> None:
         """
         Create an automatic model and stores it in the specified path. If no training was done and the loaded model
         was a Sentence Transformer model already, then its model card is reused.
@@ -1240,7 +1246,7 @@ class SentenceTransformer(nn.Sequential, FitMixin):
         # This isn't expected to ever be reached.
         return folder_url
 
-    def _text_length(self, text: Union[List[int], List[List[int]]]):
+    def _text_length(self, text: Union[List[int], List[List[int]]]) -> int:
         """
         Help function to get the length for the input text. Text can be either
         a list of ints (which means a single text as input), or a tuple of list of ints
@@ -1256,7 +1262,7 @@ class SentenceTransformer(nn.Sequential, FitMixin):
         else:
             return sum([len(t) for t in text])  # Sum of length of individual strings
 
-    def evaluate(self, evaluator: SentenceEvaluator, output_path: str = None):
+    def evaluate(self, evaluator: SentenceEvaluator, output_path: str = None) -> Union[Dict[str, float], float]:
         """
         Evaluate the model based on an evaluator
 
@@ -1504,7 +1510,7 @@ class SentenceTransformer(nn.Sequential, FitMixin):
         return modules
 
     @staticmethod
-    def load(input_path):
+    def load(input_path) -> "SentenceTransformer":
         return SentenceTransformer(input_path)
 
     @property
@@ -1530,14 +1536,14 @@ class SentenceTransformer(nn.Sequential, FitMixin):
                 return torch.device("cpu")
 
     @property
-    def tokenizer(self):
+    def tokenizer(self) -> Any:
         """
         Property to get the tokenizer that is used by this model
         """
         return self._first_module().tokenizer
 
     @tokenizer.setter
-    def tokenizer(self, value):
+    def tokenizer(self, value) -> None:
         """
         Property to set the tokenizer that should be used by this model
         """
@@ -1563,7 +1569,7 @@ class SentenceTransformer(nn.Sequential, FitMixin):
         return self._first_module().max_seq_length
 
     @max_seq_length.setter
-    def max_seq_length(self, value):
+    def max_seq_length(self, value) -> None:
         """
         Property to set the maximal input sequence length for the model. Longer inputs will be truncated.
         """

--- a/sentence_transformers/evaluation/SentenceEvaluator.py
+++ b/sentence_transformers/evaluation/SentenceEvaluator.py
@@ -52,7 +52,7 @@ class SentenceEvaluator:
         """
         pass
 
-    def prefix_name_to_metrics(self, metrics: Dict[str, float], name: str):
+    def prefix_name_to_metrics(self, metrics: Dict[str, float], name: str) -> Dict[str, float]:
         if not name:
             return metrics
         metrics = {name + "_" + key: value for key, value in metrics.items()}

--- a/sentence_transformers/fit_mixin.py
+++ b/sentence_transformers/fit_mixin.py
@@ -11,6 +11,7 @@ import transformers
 from packaging import version
 from torch import Tensor, nn
 from torch.optim import Optimizer
+from torch.optim.lr_scheduler import LambdaLR
 from torch.utils.data import DataLoader
 from tqdm.autonotebook import trange
 from transformers import TrainerCallback, TrainerControl, TrainerState
@@ -68,7 +69,7 @@ class SaveModelCallback(TrainerCallback):
         metrics: Dict[str, Any],
         model: "SentenceTransformer",
         **kwargs,
-    ):
+    ) -> None:
         if self.evaluator is not None and self.save_best_model:
             metric_key = getattr(self.evaluator, "primary_metric", "evaluator")
             for key, value in metrics.items():
@@ -84,7 +85,7 @@ class SaveModelCallback(TrainerCallback):
         control: TrainerControl,
         model: "SentenceTransformer",
         **kwargs,
-    ):
+    ) -> None:
         if self.evaluator is None:
             model.save(self.output_dir)
 
@@ -109,7 +110,7 @@ class EvaluatorCallback(TrainerCallback):
         control: TrainerControl,
         model: "SentenceTransformer",
         **kwargs,
-    ):
+    ) -> None:
         evaluator_metrics = self.evaluator(model, epoch=state.epoch)
         if not isinstance(evaluator_metrics, dict):
             evaluator_metrics = {"evaluator": evaluator_metrics}
@@ -141,7 +142,7 @@ class OriginalCallback(TrainerCallback):
         control: TrainerControl,
         metrics: Dict[str, Any],
         **kwargs,
-    ):
+    ) -> None:
         metric_key = getattr(self.evaluator, "primary_metric", "evaluator")
         for key, value in metrics.items():
             if key.endswith(metric_key):
@@ -172,7 +173,7 @@ class FitMixin:
         checkpoint_path: str = None,
         checkpoint_save_steps: int = 500,
         checkpoint_save_total_limit: int = 0,
-    ):
+    ) -> None:
         """
         Deprecated training method from before Sentence Transformers v3.0, it is recommended to use
         :class:`~sentence_transformers.trainer.SentenceTransformerTrainer` instead. This method uses
@@ -371,7 +372,7 @@ class FitMixin:
         trainer.train()
 
     @staticmethod
-    def _get_scheduler(optimizer, scheduler: str, warmup_steps: int, t_total: int):
+    def _get_scheduler(optimizer, scheduler: str, warmup_steps: int, t_total: int) -> LambdaLR:
         """
         Returns the correct learning rate scheduler. Available scheduler:
 
@@ -450,7 +451,7 @@ class FitMixin:
         checkpoint_path: str = None,
         checkpoint_save_steps: int = 500,
         checkpoint_save_total_limit: int = 0,
-    ):
+    ) -> None:
         """
         Deprecated training method from before Sentence Transformers v3.0, it is recommended to use
         :class:`sentence_transformers.trainer.SentenceTransformerTrainer` instead. This method should
@@ -658,7 +659,7 @@ class FitMixin:
         if checkpoint_path is not None:
             self._save_checkpoint(checkpoint_path, checkpoint_save_total_limit, global_step)
 
-    def _eval_during_training(self, evaluator, output_path, save_best_model, epoch, steps, callback):
+    def _eval_during_training(self, evaluator, output_path, save_best_model, epoch, steps, callback) -> None:
         """Runs evaluation during the training"""
         eval_path = output_path
         if output_path is not None:
@@ -675,7 +676,7 @@ class FitMixin:
                 if save_best_model:
                     self.save(output_path)
 
-    def _save_checkpoint(self, checkpoint_path, checkpoint_save_total_limit, step):
+    def _save_checkpoint(self, checkpoint_path, checkpoint_save_total_limit, step) -> None:
         # Store new checkpoint
         self.save(os.path.join(checkpoint_path, str(step)))
 

--- a/sentence_transformers/losses/AdaptiveLayerLoss.py
+++ b/sentence_transformers/losses/AdaptiveLayerLoss.py
@@ -20,7 +20,7 @@ class TransformerDecorator:
     This is meant to override the forward function of the Transformer.
     """
 
-    def __init__(self, transformer: Transformer, original_forward):
+    def __init__(self, transformer: Transformer, original_forward) -> None:
         self.transformer = transformer
         self.original_forward = original_forward
         self.embeddings: List[Tuple[Tensor]] = []
@@ -29,14 +29,14 @@ class TransformerDecorator:
         self.layer_idx = None
         self.call_idx = 0
 
-    def set_layer_idx(self, layer_idx):
+    def set_layer_idx(self, layer_idx) -> None:
         self.layer_idx = layer_idx
         self.call_idx = 0
 
-    def get_layer_embeddings(self):
+    def get_layer_embeddings(self) -> Tensor:
         return torch.concat([embedding[self.layer_idx] for embedding in self.embeddings], dim=1)
 
-    def __call__(self, features):
+    def __call__(self, features) -> Dict[str, Tensor]:
         if self.layer_idx is None:
             output = self.call_grow_cache(features)
         else:
@@ -44,7 +44,7 @@ class TransformerDecorator:
             self.call_idx += 1
         return output
 
-    def call_grow_cache(self, features):
+    def call_grow_cache(self, features: Dict[str, Tensor]) -> Dict[str, Tensor]:
         """
         Temporarily sets the output_hidden_states to True, runs the model, and then restores the original setting.
         Use the all_layer_embeddings to get the embeddings of all layers.
@@ -70,7 +70,7 @@ class TransformerDecorator:
 
         return output
 
-    def call_use_cache(self, features):
+    def call_use_cache(self, features: Dict[str, Tensor]) -> Dict[str, Tensor]:
         return {**self.features[self.call_idx], "token_embeddings": self.embeddings[self.call_idx][self.layer_idx]}
 
 
@@ -82,16 +82,16 @@ class ForwardDecorator:
     This is meant to override the forward function of the SentenceTransformer.
     """
 
-    def __init__(self, fn):
+    def __init__(self, fn) -> None:
         self.fn = fn
         self.embeddings = []
 
-    def __call__(self, features):
+    def __call__(self, features: Dict[str, Tensor]) -> Dict[str, Tensor]:
         output = self.fn(features)
         self.embeddings.append(output["sentence_embedding"])
         return output
 
-    def get_embeddings(self):
+    def get_embeddings(self) -> Tensor:
         embeddings = torch.concat(self.embeddings, dim=0)
         self.embeddings = []
         return embeddings

--- a/sentence_transformers/losses/AnglELoss.py
+++ b/sentence_transformers/losses/AnglELoss.py
@@ -2,7 +2,7 @@ from sentence_transformers import SentenceTransformer, losses, util
 
 
 class AnglELoss(losses.CoSENTLoss):
-    def __init__(self, model: SentenceTransformer, scale: float = 20.0):
+    def __init__(self, model: SentenceTransformer, scale: float = 20.0) -> None:
         """
         This class implements AnglE (Angle Optimized) loss.
         This is a modification of :class:`CoSENTLoss`, designed to address the following issue:

--- a/sentence_transformers/losses/BatchAllTripletLoss.py
+++ b/sentence_transformers/losses/BatchAllTripletLoss.py
@@ -13,7 +13,7 @@ class BatchAllTripletLoss(nn.Module):
         model: SentenceTransformer,
         distance_metric=BatchHardTripletLossDistanceFunction.eucledian_distance,
         margin: float = 5,
-    ):
+    ) -> None:
         """
         BatchAllTripletLoss takes a batch with (sentence, label) pairs and computes the loss for all possible, valid
         triplets, i.e., anchor and positive must have the same label, anchor and negative a different label. The labels
@@ -83,11 +83,11 @@ class BatchAllTripletLoss(nn.Module):
         self.triplet_margin = margin
         self.distance_metric = distance_metric
 
-    def forward(self, sentence_features: Iterable[Dict[str, Tensor]], labels: Tensor):
+    def forward(self, sentence_features: Iterable[Dict[str, Tensor]], labels: Tensor) -> Tensor:
         rep = self.sentence_embedder(sentence_features[0])["sentence_embedding"]
         return self.batch_all_triplet_loss(labels, rep)
 
-    def batch_all_triplet_loss(self, labels, embeddings):
+    def batch_all_triplet_loss(self, labels: Tensor, embeddings: Tensor) -> Tensor:
         """Build the triplet loss over a batch of embeddings.
         We generate all the valid triplets and average the loss over the positive ones.
         Args:

--- a/sentence_transformers/losses/BatchHardSoftMarginTripletLoss.py
+++ b/sentence_transformers/losses/BatchHardSoftMarginTripletLoss.py
@@ -11,7 +11,7 @@ from .BatchHardTripletLoss import BatchHardTripletLoss, BatchHardTripletLossDist
 class BatchHardSoftMarginTripletLoss(BatchHardTripletLoss):
     def __init__(
         self, model: SentenceTransformer, distance_metric=BatchHardTripletLossDistanceFunction.eucledian_distance
-    ):
+    ) -> None:
         """
         BatchHardSoftMarginTripletLoss takes a batch with (sentence, label) pairs and computes the loss for all possible, valid
         triplets, i.e., anchor and positive must have the same label, anchor and negative a different label. The labels
@@ -83,7 +83,7 @@ class BatchHardSoftMarginTripletLoss(BatchHardTripletLoss):
         self.sentence_embedder = model
         self.distance_metric = distance_metric
 
-    def forward(self, sentence_features: Iterable[Dict[str, Tensor]], labels: Tensor):
+    def forward(self, sentence_features: Iterable[Dict[str, Tensor]], labels: Tensor) -> Tensor:
         rep = self.sentence_embedder(sentence_features[0])["sentence_embedding"]
         return self.batch_hard_triplet_soft_margin_loss(labels, rep)
 

--- a/sentence_transformers/losses/BatchHardTripletLoss.py
+++ b/sentence_transformers/losses/BatchHardTripletLoss.py
@@ -11,12 +11,12 @@ class BatchHardTripletLossDistanceFunction:
     """This class defines distance functions, that can be used with Batch[All/Hard/SemiHard]TripletLoss"""
 
     @staticmethod
-    def cosine_distance(embeddings):
+    def cosine_distance(embeddings: Tensor) -> Tensor:
         """Compute the 2D matrix of cosine distances (1-cosine_similarity) between all embeddings."""
         return 1 - util.pytorch_cos_sim(embeddings, embeddings)
 
     @staticmethod
-    def eucledian_distance(embeddings, squared=False):
+    def eucledian_distance(embeddings: Tensor, squared=False) -> Tensor:
         """
         Compute the 2D matrix of eucledian distances between all the embeddings.
         Args:
@@ -59,7 +59,7 @@ class BatchHardTripletLoss(nn.Module):
         model: SentenceTransformer,
         distance_metric=BatchHardTripletLossDistanceFunction.eucledian_distance,
         margin: float = 5,
-    ):
+    ) -> None:
         """
         BatchHardTripletLoss takes a batch with (sentence, label) pairs and computes the loss for all possible, valid
         triplets, i.e., anchor and positive must have the same label, anchor and negative a different label. It then looks
@@ -189,7 +189,7 @@ class BatchHardTripletLoss(nn.Module):
         return triplet_loss
 
     @staticmethod
-    def get_triplet_mask(labels):
+    def get_triplet_mask(labels: Tensor) -> Tensor:
         """Return a 3D mask where mask[a, p, n] is True iff the triplet (a, p, n) is valid.
         A triplet (i, j, k) is valid if:
             - i, j, k are distinct
@@ -215,7 +215,7 @@ class BatchHardTripletLoss(nn.Module):
         return valid_labels & distinct_indices
 
     @staticmethod
-    def get_anchor_positive_triplet_mask(labels):
+    def get_anchor_positive_triplet_mask(labels: Tensor) -> Tensor:
         """Return a 2D mask where mask[a, p] is True iff a and p are distinct and have same label.
         Args:
             labels: tf.int32 `Tensor` with shape [batch_size]
@@ -234,7 +234,7 @@ class BatchHardTripletLoss(nn.Module):
         return labels_equal & indices_not_equal
 
     @staticmethod
-    def get_anchor_negative_triplet_mask(labels):
+    def get_anchor_negative_triplet_mask(labels: Tensor) -> Tensor:
         """Return a 2D mask where mask[a, n] is True iff a and n have distinct labels.
         Args:
             labels: tf.int32 `Tensor` with shape [batch_size]

--- a/sentence_transformers/losses/BatchSemiHardTripletLoss.py
+++ b/sentence_transformers/losses/BatchSemiHardTripletLoss.py
@@ -14,7 +14,7 @@ class BatchSemiHardTripletLoss(nn.Module):
         model: SentenceTransformer,
         distance_metric=BatchHardTripletLossDistanceFunction.eucledian_distance,
         margin: float = 5,
-    ):
+    ) -> None:
         """
         BatchSemiHardTripletLoss takes a batch with (label, sentence) pairs and computes the loss for all possible, valid
         triplets, i.e., anchor and positive must have the same label, anchor and negative a different label. It then looks
@@ -93,7 +93,7 @@ class BatchSemiHardTripletLoss(nn.Module):
         self.margin = margin
         self.distance_metric = distance_metric
 
-    def forward(self, sentence_features: Iterable[Dict[str, Tensor]], labels: Tensor):
+    def forward(self, sentence_features: Iterable[Dict[str, Tensor]], labels: Tensor) -> Tensor:
         rep = self.sentence_embedder(sentence_features[0])["sentence_embedding"]
         return self.batch_semi_hard_triplet_loss(labels, rep)
 
@@ -150,7 +150,7 @@ class BatchSemiHardTripletLoss(nn.Module):
         return triplet_loss
 
     @staticmethod
-    def _masked_minimum(data, mask, dim=1):
+    def _masked_minimum(data: Tensor, mask: Tensor, dim: int = 1) -> Tensor:
         axis_maximums, _ = data.max(dim, keepdims=True)
         masked_minimums = (data - axis_maximums) * mask
         masked_minimums, _ = masked_minimums.min(dim, keepdims=True)
@@ -159,7 +159,7 @@ class BatchSemiHardTripletLoss(nn.Module):
         return masked_minimums
 
     @staticmethod
-    def _masked_maximum(data, mask, dim=1):
+    def _masked_maximum(data: Tensor, mask: Tensor, dim: int = 1) -> Tensor:
         axis_minimums, _ = data.min(dim, keepdims=True)
         masked_maximums = (data - axis_minimums) * mask
         masked_maximums, _ = masked_maximums.max(dim, keepdims=True)

--- a/sentence_transformers/losses/CachedMultipleNegativesRankingLoss.py
+++ b/sentence_transformers/losses/CachedMultipleNegativesRankingLoss.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from contextlib import nullcontext
 from functools import partial
-from typing import Dict, Iterable, Iterator, List, Optional, Tuple
+from typing import Any, Dict, Iterable, Iterator, List, Optional, Tuple
 
 import torch
 import tqdm
@@ -20,17 +20,17 @@ class RandContext:
     the class will set up the random state with the backed-up one.
     """
 
-    def __init__(self, *tensors):
+    def __init__(self, *tensors) -> None:
         self.fwd_cpu_state = torch.get_rng_state()
         self.fwd_gpu_devices, self.fwd_gpu_states = get_device_states(*tensors)
 
-    def __enter__(self):
+    def __enter__(self) -> None:
         self._fork = torch.random.fork_rng(devices=self.fwd_gpu_devices, enabled=True)
         self._fork.__enter__()
         torch.set_rng_state(self.fwd_cpu_state)
         set_device_states(self.fwd_gpu_devices, self.fwd_gpu_states)
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
         self._fork.__exit__(exc_type, exc_val, exc_tb)
         self._fork = None
 
@@ -39,7 +39,7 @@ def _backward_hook(
     grad_output: Tensor,
     sentence_features: Iterable[Dict[str, Tensor]],
     loss_obj: CachedMultipleNegativesRankingLoss,
-):
+) -> None:
     """A backward hook to backpropagate the cached gradients mini-batch by mini-batch."""
     assert loss_obj.cache is not None
     assert loss_obj.random_states is not None
@@ -66,7 +66,7 @@ class CachedMultipleNegativesRankingLoss(nn.Module):
         similarity_fct: callable[[Tensor, Tensor], Tensor] = util.cos_sim,
         mini_batch_size: int = 32,
         show_progress_bar: bool = False,
-    ):
+    ) -> None:
         """
         Boosted version of MultipleNegativesRankingLoss (https://arxiv.org/pdf/1705.00652.pdf) by GradCache (https://arxiv.org/pdf/2101.06983.pdf).
 
@@ -280,7 +280,7 @@ class CachedMultipleNegativesRankingLoss(nn.Module):
 
         return loss
 
-    def get_config_dict(self):
+    def get_config_dict(self) -> Dict[str, Any]:
         return {"scale": self.scale, "similarity_fct": self.similarity_fct.__name__}
 
     @property

--- a/sentence_transformers/losses/CoSENTLoss.py
+++ b/sentence_transformers/losses/CoSENTLoss.py
@@ -1,4 +1,4 @@
-from typing import Dict, Iterable
+from typing import Any, Dict, Iterable
 
 import torch
 from torch import Tensor, nn
@@ -8,7 +8,7 @@ from sentence_transformers.SentenceTransformer import SentenceTransformer
 
 
 class CoSENTLoss(nn.Module):
-    def __init__(self, model: SentenceTransformer, scale: float = 20.0, similarity_fct=util.pairwise_cos_sim):
+    def __init__(self, model: SentenceTransformer, scale: float = 20.0, similarity_fct=util.pairwise_cos_sim) -> None:
         """
         This class implements CoSENT (Cosine Sentence) loss.
         It expects that each of the InputExamples consists of a pair of texts and a float valued label, representing
@@ -75,7 +75,7 @@ class CoSENTLoss(nn.Module):
         self.similarity_fct = similarity_fct
         self.scale = scale
 
-    def forward(self, sentence_features: Iterable[Dict[str, Tensor]], labels: Tensor):
+    def forward(self, sentence_features: Iterable[Dict[str, Tensor]], labels: Tensor) -> Tensor:
         embeddings = [self.model(sentence_feature)["sentence_embedding"] for sentence_feature in sentence_features]
 
         scores = self.similarity_fct(embeddings[0], embeddings[1])
@@ -95,7 +95,7 @@ class CoSENTLoss(nn.Module):
 
         return loss
 
-    def get_config_dict(self):
+    def get_config_dict(self) -> Dict[str, Any]:
         return {"scale": self.scale, "similarity_fct": self.similarity_fct.__name__}
 
     @property

--- a/sentence_transformers/losses/ContrastiveLoss.py
+++ b/sentence_transformers/losses/ContrastiveLoss.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Dict, Iterable
+from typing import Any, Dict, Iterable
 
 import torch.nn.functional as F
 from torch import Tensor, nn
@@ -22,7 +22,7 @@ class ContrastiveLoss(nn.Module):
         distance_metric=SiameseDistanceMetric.COSINE_DISTANCE,
         margin: float = 0.5,
         size_average: bool = True,
-    ):
+    ) -> None:
         """
         Contrastive loss. Expects as input two texts and a label of either 0 or 1. If the label == 1, then the distance between the
         two embeddings is reduced. If the label == 0, then the distance between the embeddings is increased.
@@ -81,7 +81,7 @@ class ContrastiveLoss(nn.Module):
         self.model = model
         self.size_average = size_average
 
-    def get_config_dict(self):
+    def get_config_dict(self) -> Dict[str, Any]:
         distance_metric_name = self.distance_metric.__name__
         for name, value in vars(SiameseDistanceMetric).items():
             if value == self.distance_metric:
@@ -90,7 +90,7 @@ class ContrastiveLoss(nn.Module):
 
         return {"distance_metric": distance_metric_name, "margin": self.margin, "size_average": self.size_average}
 
-    def forward(self, sentence_features: Iterable[Dict[str, Tensor]], labels: Tensor):
+    def forward(self, sentence_features: Iterable[Dict[str, Tensor]], labels: Tensor) -> Tensor:
         reps = [self.model(sentence_feature)["sentence_embedding"] for sentence_feature in sentence_features]
         assert len(reps) == 2
         rep_anchor, rep_other = reps

--- a/sentence_transformers/losses/ContrastiveTensionLoss.py
+++ b/sentence_transformers/losses/ContrastiveTensionLoss.py
@@ -70,13 +70,13 @@ class ContrastiveTensionLoss(nn.Module):
             )
     """
 
-    def __init__(self, model: SentenceTransformer):
+    def __init__(self, model: SentenceTransformer) -> None:
         super(ContrastiveTensionLoss, self).__init__()
         self.model2 = model  # This will be the final model used during the inference time.
         self.model1 = copy.deepcopy(model)
         self.criterion = nn.BCEWithLogitsLoss(reduction="sum")
 
-    def forward(self, sentence_features: Iterable[Dict[str, Tensor]], labels: Tensor):
+    def forward(self, sentence_features: Iterable[Dict[str, Tensor]], labels: Tensor) -> Tensor:
         sentence_features1, sentence_features2 = tuple(sentence_features)
         reps_1 = self.model1(sentence_features1)["sentence_embedding"]  # (bsz, hdim)
         reps_2 = self.model2(sentence_features2)["sentence_embedding"]
@@ -102,7 +102,7 @@ class ContrastiveTensionLoss(nn.Module):
 
 
 class ContrastiveTensionLossInBatchNegatives(nn.Module):
-    def __init__(self, model: SentenceTransformer, scale: float = 20.0, similarity_fct=util.cos_sim):
+    def __init__(self, model: SentenceTransformer, scale: float = 20.0, similarity_fct=util.cos_sim) -> None:
         """
         This loss expects only single sentences, without any labels. Positive and negative pairs are automatically created via random sampling,
         such that a positive pair consists of two identical sentences and a negative pair consists of two different sentences. An independent
@@ -170,7 +170,7 @@ class ContrastiveTensionLossInBatchNegatives(nn.Module):
         self.cross_entropy_loss = nn.CrossEntropyLoss()
         self.logit_scale = nn.Parameter(torch.ones([]) * np.log(scale))
 
-    def forward(self, sentence_features: Iterable[Dict[str, Tensor]], labels: Tensor):
+    def forward(self, sentence_features: Iterable[Dict[str, Tensor]], labels: Tensor) -> Tensor:
         sentence_features1, sentence_features2 = tuple(sentence_features)
         embeddings_a = self.model1(sentence_features1)["sentence_embedding"]  # (bsz, hdim)
         embeddings_b = self.model2(sentence_features2)["sentence_embedding"]

--- a/sentence_transformers/losses/CosineSimilarityLoss.py
+++ b/sentence_transformers/losses/CosineSimilarityLoss.py
@@ -8,7 +8,12 @@ from sentence_transformers.util import fullname
 
 
 class CosineSimilarityLoss(nn.Module):
-    def __init__(self, model: SentenceTransformer, loss_fct=nn.MSELoss(), cos_score_transformation=nn.Identity()):
+    def __init__(
+        self,
+        model: SentenceTransformer,
+        loss_fct: nn.Module = nn.MSELoss(),
+        cos_score_transformation: nn.Module = nn.Identity(),
+    ) -> None:
         """
         CosineSimilarityLoss expects that the InputExamples consists of two texts and a float label. It computes the
         vectors ``u = model(sentence_A)`` and ``v = model(sentence_B)`` and measures the cosine-similarity between the two.
@@ -67,7 +72,7 @@ class CosineSimilarityLoss(nn.Module):
         self.loss_fct = loss_fct
         self.cos_score_transformation = cos_score_transformation
 
-    def forward(self, sentence_features: Iterable[Dict[str, Tensor]], labels: Tensor):
+    def forward(self, sentence_features: Iterable[Dict[str, Tensor]], labels: Tensor) -> Tensor:
         embeddings = [self.model(sentence_feature)["sentence_embedding"] for sentence_feature in sentence_features]
         output = self.cos_score_transformation(torch.cosine_similarity(embeddings[0], embeddings[1]))
         return self.loss_fct(output, labels.float().view(-1))

--- a/sentence_transformers/losses/DenoisingAutoEncoderLoss.py
+++ b/sentence_transformers/losses/DenoisingAutoEncoderLoss.py
@@ -134,7 +134,7 @@ class DenoisingAutoEncoderLoss(nn.Module):
                     encoder_name_or_path,
                 )
 
-    def retokenize(self, sentence_features):
+    def retokenize(self, sentence_features: Dict[str, Tensor]) -> Dict[str, Tensor]:
         input_ids = sentence_features["input_ids"]
         device = input_ids.device
         sentences_decoded = self.tokenizer_encoder.batch_decode(
@@ -145,7 +145,7 @@ class DenoisingAutoEncoderLoss(nn.Module):
         ).to(device)
         return retokenized
 
-    def forward(self, sentence_features: Iterable[Dict[str, Tensor]], labels: Tensor):
+    def forward(self, sentence_features: Iterable[Dict[str, Tensor]], labels: Tensor) -> Tensor:
         source_features, target_features = tuple(sentence_features)
         if self.need_retokenization:
             # since the sentence_features here are all tokenized by encoder's tokenizer,

--- a/sentence_transformers/losses/GISTEmbedLoss.py
+++ b/sentence_transformers/losses/GISTEmbedLoss.py
@@ -13,7 +13,7 @@ class GISTEmbedLoss(nn.Module):
         model: SentenceTransformer,
         guide: SentenceTransformer,
         temperature: float = 0.01,
-    ):
+    ) -> None:
         """
         This loss is used to train a SentenceTransformer model using the GISTEmbed algorithm.
         It takes a model and a guide model as input, and uses the guide model to guide the
@@ -83,10 +83,10 @@ class GISTEmbedLoss(nn.Module):
             model.tokenizer.vocab != guide.tokenizer.vocab or guide.max_seq_length < model.max_seq_length
         )
 
-    def sim_matrix(self, embed1, embed2):
+    def sim_matrix(self, embed1: Tensor, embed2: Tensor) -> Tensor:
         return self.similarity_fct(embed1.unsqueeze(1), embed2.unsqueeze(0))
 
-    def forward(self, sentence_features: Iterable[Dict[str, Tensor]], labels: Tensor):
+    def forward(self, sentence_features: Iterable[Dict[str, Tensor]], labels: Tensor) -> Tensor:
         embeddings = [self.model(sentence_feature)["sentence_embedding"] for sentence_feature in sentence_features]
         with torch.no_grad():
             if self.must_retokenize:

--- a/sentence_transformers/losses/MSELoss.py
+++ b/sentence_transformers/losses/MSELoss.py
@@ -3,9 +3,11 @@ from typing import Dict, Iterable
 import torch
 from torch import Tensor, nn
 
+from sentence_transformers import SentenceTransformer
+
 
 class MSELoss(nn.Module):
-    def __init__(self, model):
+    def __init__(self, model: SentenceTransformer) -> None:
         """
         Computes the MSE loss between the computed sentence embedding and a target sentence embedding. This loss
         is used when extending sentence embeddings to new languages as described in our publication
@@ -68,7 +70,7 @@ class MSELoss(nn.Module):
         self.model = model
         self.loss_fct = nn.MSELoss()
 
-    def forward(self, sentence_features: Iterable[Dict[str, Tensor]], labels: Tensor):
+    def forward(self, sentence_features: Iterable[Dict[str, Tensor]], labels: Tensor) -> Tensor:
         # Concatenate multiple inputs on the batch dimension
         if len(sentence_features) > 1:
             embeddings = torch.cat([self.model(inputs)["sentence_embedding"] for inputs in sentence_features], dim=0)

--- a/sentence_transformers/losses/MarginMSELoss.py
+++ b/sentence_transformers/losses/MarginMSELoss.py
@@ -2,11 +2,11 @@ from typing import Dict, Iterable
 
 from torch import Tensor, nn
 
-from sentence_transformers import util
+from sentence_transformers import SentenceTransformer, util
 
 
 class MarginMSELoss(nn.Module):
-    def __init__(self, model, similarity_fct=util.pairwise_dot_score):
+    def __init__(self, model: SentenceTransformer, similarity_fct=util.pairwise_dot_score) -> None:
         """
         Compute the MSE loss between the ``|sim(Query, Pos) - sim(Query, Neg)|`` and ``|gold_sim(Query, Pos) - gold_sim(Query, Neg)|``.
         By default, sim() is the dot-product. The gold_sim is often the similarity score from a teacher model.
@@ -113,7 +113,7 @@ class MarginMSELoss(nn.Module):
         self.similarity_fct = similarity_fct
         self.loss_fct = nn.MSELoss()
 
-    def forward(self, sentence_features: Iterable[Dict[str, Tensor]], labels: Tensor):
+    def forward(self, sentence_features: Iterable[Dict[str, Tensor]], labels: Tensor) -> Tensor:
         # sentence_features: query, positive passage, negative passage
         reps = [self.model(sentence_feature)["sentence_embedding"] for sentence_feature in sentence_features]
         embeddings_query = reps[0]

--- a/sentence_transformers/losses/MatryoshkaLoss.py
+++ b/sentence_transformers/losses/MatryoshkaLoss.py
@@ -11,7 +11,7 @@ from sentence_transformers.losses.CachedMultipleNegativesRankingLoss import Cach
 
 
 class ForwardDecorator:
-    def __init__(self, fn):
+    def __init__(self, fn) -> None:
         self.fn = fn
 
         self.dim = None
@@ -19,7 +19,7 @@ class ForwardDecorator:
         self.cache_dim = None
         self.idx = 0
 
-    def set_dim(self, dim):
+    def set_dim(self, dim) -> None:
         self.dim = dim
         self.idx = 0
 
@@ -33,7 +33,7 @@ class ForwardDecorator:
         tensor = F.normalize(tensor, p=2, dim=-1)
         return tensor
 
-    def __call__(self, features):
+    def __call__(self, features: Dict[str, Tensor]) -> Dict[str, Tensor]:
         # Growing cache:
         if self.cache_dim is None or self.cache_dim == self.dim:
             output = self.fn(features)

--- a/sentence_transformers/losses/MegaBatchMarginLoss.py
+++ b/sentence_transformers/losses/MegaBatchMarginLoss.py
@@ -4,18 +4,18 @@ import torch
 import torch.nn.functional as F
 from torch import Tensor, nn
 
-from sentence_transformers import util
+from sentence_transformers import SentenceTransformer, util
 
 
 class MegaBatchMarginLoss(nn.Module):
     def __init__(
         self,
-        model,
+        model: SentenceTransformer,
         positive_margin: float = 0.8,
         negative_margin: float = 0.3,
         use_mini_batched_version: bool = True,
         mini_batch_size: int = 50,
-    ):
+    ) -> None:
         """
         Given a large batch (like 500 or more examples) of (anchor_i, positive_i) pairs, find for each pair in the batch
         the hardest negative, i.e. find j != i such that cos_sim(anchor_i, positive_j) is maximal. Then create from this a
@@ -80,7 +80,7 @@ class MegaBatchMarginLoss(nn.Module):
         self.mini_batch_size = mini_batch_size
         self.forward = self.forward_mini_batched if use_mini_batched_version else self.forward_non_mini_batched
 
-    def forward_mini_batched(self, sentence_features: Iterable[Dict[str, Tensor]], labels: Tensor):
+    def forward_mini_batched(self, sentence_features: Iterable[Dict[str, Tensor]], labels: Tensor) -> Tensor:
         anchor, positive = sentence_features
         feature_names = list(anchor.keys())
 
@@ -137,7 +137,7 @@ class MegaBatchMarginLoss(nn.Module):
         return losses
 
     ##### Non mini-batched version ###
-    def forward_non_mini_batched(self, sentence_features: Iterable[Dict[str, Tensor]], labels: Tensor):
+    def forward_non_mini_batched(self, sentence_features: Iterable[Dict[str, Tensor]], labels: Tensor) -> Tensor:
         reps = [self.model(sentence_feature)["sentence_embedding"] for sentence_feature in sentence_features]
         embeddings_a, embeddings_b = reps
 

--- a/sentence_transformers/losses/MultipleNegativesRankingLoss.py
+++ b/sentence_transformers/losses/MultipleNegativesRankingLoss.py
@@ -1,4 +1,4 @@
-from typing import Dict, Iterable
+from typing import Any, Dict, Iterable
 
 import torch
 from torch import Tensor, nn
@@ -8,7 +8,7 @@ from sentence_transformers.SentenceTransformer import SentenceTransformer
 
 
 class MultipleNegativesRankingLoss(nn.Module):
-    def __init__(self, model: SentenceTransformer, scale: float = 20.0, similarity_fct=util.cos_sim):
+    def __init__(self, model: SentenceTransformer, scale: float = 20.0, similarity_fct=util.cos_sim) -> None:
         """
         This loss expects as input a batch consisting of sentence pairs ``(a_1, p_1), (a_2, p_2)..., (a_n, p_n)``
         where we assume that ``(a_i, p_i)`` are a positive pair and ``(a_i, p_j)`` for ``i != j`` a negative pair.
@@ -89,7 +89,7 @@ class MultipleNegativesRankingLoss(nn.Module):
         self.similarity_fct = similarity_fct
         self.cross_entropy_loss = nn.CrossEntropyLoss()
 
-    def forward(self, sentence_features: Iterable[Dict[str, Tensor]], labels: Tensor):
+    def forward(self, sentence_features: Iterable[Dict[str, Tensor]], labels: Tensor) -> Tensor:
         reps = [self.model(sentence_feature)["sentence_embedding"] for sentence_feature in sentence_features]
         embeddings_a = reps[0]
         embeddings_b = torch.cat(reps[1:])
@@ -99,7 +99,7 @@ class MultipleNegativesRankingLoss(nn.Module):
         range_labels = torch.arange(0, scores.size(0), device=scores.device)
         return self.cross_entropy_loss(scores, range_labels)
 
-    def get_config_dict(self):
+    def get_config_dict(self) -> Dict[str, Any]:
         return {"scale": self.scale, "similarity_fct": self.similarity_fct.__name__}
 
     @property

--- a/sentence_transformers/losses/MultipleNegativesSymmetricRankingLoss.py
+++ b/sentence_transformers/losses/MultipleNegativesSymmetricRankingLoss.py
@@ -1,4 +1,4 @@
-from typing import Dict, Iterable
+from typing import Any, Dict, Iterable
 
 import torch
 from torch import Tensor, nn
@@ -8,7 +8,7 @@ from sentence_transformers.SentenceTransformer import SentenceTransformer
 
 
 class MultipleNegativesSymmetricRankingLoss(nn.Module):
-    def __init__(self, model: SentenceTransformer, scale: float = 20.0, similarity_fct=util.cos_sim):
+    def __init__(self, model: SentenceTransformer, scale: float = 20.0, similarity_fct=util.cos_sim) -> None:
         """
         This loss is an adaptation of MultipleNegativesRankingLoss. MultipleNegativesRankingLoss computes the following loss:
         For a given anchor and a list of candidates, find the positive candidate.
@@ -69,7 +69,7 @@ class MultipleNegativesSymmetricRankingLoss(nn.Module):
         self.similarity_fct = similarity_fct
         self.cross_entropy_loss = nn.CrossEntropyLoss()
 
-    def forward(self, sentence_features: Iterable[Dict[str, Tensor]], labels: Tensor):
+    def forward(self, sentence_features: Iterable[Dict[str, Tensor]], labels: Tensor) -> Tensor:
         reps = [self.model(sentence_feature)["sentence_embedding"] for sentence_feature in sentence_features]
         anchor = reps[0]
         candidates = torch.cat(reps[1:])
@@ -84,5 +84,5 @@ class MultipleNegativesSymmetricRankingLoss(nn.Module):
         backward_loss = self.cross_entropy_loss(anchor_positive_scores.transpose(0, 1), labels)
         return (forward_loss + backward_loss) / 2
 
-    def get_config_dict(self):
+    def get_config_dict(self) -> Dict[str, Any]:
         return {"scale": self.scale, "similarity_fct": self.similarity_fct.__name__}

--- a/sentence_transformers/losses/OnlineContrastiveLoss.py
+++ b/sentence_transformers/losses/OnlineContrastiveLoss.py
@@ -11,7 +11,7 @@ from .ContrastiveLoss import SiameseDistanceMetric
 class OnlineContrastiveLoss(nn.Module):
     def __init__(
         self, model: SentenceTransformer, distance_metric=SiameseDistanceMetric.COSINE_DISTANCE, margin: float = 0.5
-    ):
+    ) -> None:
         """
         This Online Contrastive loss is similar to :class:`ConstrativeLoss`, but it selects hard positive (positives that
         are far apart) and hard negative pairs (negatives that are close) and computes the loss only for these pairs.
@@ -69,7 +69,7 @@ class OnlineContrastiveLoss(nn.Module):
         self.margin = margin
         self.distance_metric = distance_metric
 
-    def forward(self, sentence_features: Iterable[Dict[str, Tensor]], labels: Tensor, size_average=False):
+    def forward(self, sentence_features: Iterable[Dict[str, Tensor]], labels: Tensor, size_average=False) -> Tensor:
         embeddings = [self.model(sentence_feature)["sentence_embedding"] for sentence_feature in sentence_features]
 
         distance_matrix = self.distance_metric(embeddings[0], embeddings[1])

--- a/sentence_transformers/losses/SoftmaxLoss.py
+++ b/sentence_transformers/losses/SoftmaxLoss.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Callable, Dict, Iterable
+from typing import Callable, Dict, Iterable, Tuple, Union
 
 import torch
 from torch import Tensor, nn
@@ -19,7 +19,7 @@ class SoftmaxLoss(nn.Module):
         concatenation_sent_difference: bool = True,
         concatenation_sent_multiplication: bool = False,
         loss_fct: Callable = nn.CrossEntropyLoss(),
-    ):
+    ) -> None:
         """
         This loss was used in our SBERT publication (https://arxiv.org/abs/1908.10084) to train the SentenceTransformer
         model on NLI data. It adds a softmax classifier on top of the output of two transformer networks.
@@ -101,7 +101,9 @@ class SoftmaxLoss(nn.Module):
         )
         self.loss_fct = loss_fct
 
-    def forward(self, sentence_features: Iterable[Dict[str, Tensor]], labels: Tensor):
+    def forward(
+        self, sentence_features: Iterable[Dict[str, Tensor]], labels: Tensor
+    ) -> Union[Tensor, Tuple[Tensor, Tensor]]:
         reps = [self.model(sentence_feature)["sentence_embedding"] for sentence_feature in sentence_features]
         rep_a, rep_b = reps
 

--- a/sentence_transformers/losses/TripletLoss.py
+++ b/sentence_transformers/losses/TripletLoss.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Dict, Iterable
+from typing import Any, Dict, Iterable
 
 import torch.nn.functional as F
 from torch import Tensor, nn
@@ -18,7 +18,7 @@ class TripletDistanceMetric(Enum):
 class TripletLoss(nn.Module):
     def __init__(
         self, model: SentenceTransformer, distance_metric=TripletDistanceMetric.EUCLIDEAN, triplet_margin: float = 5
-    ):
+    ) -> None:
         """
         This class implements triplet loss. Given a triplet of (anchor, positive, negative),
         the loss minimizes the distance between anchor and positive while it maximizes the distance
@@ -75,7 +75,7 @@ class TripletLoss(nn.Module):
         self.distance_metric = distance_metric
         self.triplet_margin = triplet_margin
 
-    def forward(self, sentence_features: Iterable[Dict[str, Tensor]], labels: Tensor):
+    def forward(self, sentence_features: Iterable[Dict[str, Tensor]], labels: Tensor) -> Tensor:
         reps = [self.model(sentence_feature)["sentence_embedding"] for sentence_feature in sentence_features]
 
         rep_anchor, rep_pos, rep_neg = reps
@@ -85,7 +85,7 @@ class TripletLoss(nn.Module):
         losses = F.relu(distance_pos - distance_neg + self.triplet_margin)
         return losses.mean()
 
-    def get_config_dict(self):
+    def get_config_dict(self) -> Dict[str, Any]:
         distance_metric_name = self.distance_metric.__name__
         for name, value in vars(TripletDistanceMetric).items():
             if value == self.distance_metric:

--- a/sentence_transformers/model_card.py
+++ b/sentence_transformers/model_card.py
@@ -64,7 +64,7 @@ class ModelCardCallback(TrainerCallback):
         control: TrainerControl,
         model: "SentenceTransformer",
         **kwargs,
-    ):
+    ) -> None:
         from sentence_transformers.losses import AdaptiveLayerLoss, Matryoshka2dLoss, MatryoshkaLoss
 
         # Try to infer the dataset "name", "id" and "revision" from the dataset cache files
@@ -172,7 +172,7 @@ class ModelCardCallback(TrainerCallback):
         model: "SentenceTransformer",
         logs: Dict[str, float],
         **kwargs,
-    ):
+    ) -> None:
         keys = {"loss"} & set(logs)
         if keys:
             if (
@@ -315,7 +315,7 @@ class SentenceTransformerModelCardData(CardData):
     # Passed via `register_model` only
     model: Optional["SentenceTransformer"] = field(default=None, init=False, repr=False)
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         # We don't want to save "ignore_metadata_errors" in our Model Card
         infer_languages = not self.language
         if isinstance(self.language, str):
@@ -450,7 +450,7 @@ class SentenceTransformerModelCardData(CardData):
                 )
                 self.predict_example = sentences[:3]
 
-    def set_evaluation_metrics(self, evaluator: "SentenceEvaluator", metrics: Dict[str, Any]):
+    def set_evaluation_metrics(self, evaluator: "SentenceEvaluator", metrics: Dict[str, Any]) -> None:
         from sentence_transformers.evaluation import SequentialEvaluator
 
         self.eval_results_dict[evaluator] = copy(metrics)
@@ -893,7 +893,7 @@ class SentenceTransformerModelCardData(CardData):
             "explain_bold_in_eval": "**" in eval_lines,
         }
 
-    def get_codecarbon_data(self):
+    def get_codecarbon_data(self) -> Dict[Literal["co2_eq_emissions"], Dict[str, Any]]:
         emissions_data = self.code_carbon_callback.tracker._prepare_emissions_data()
         results = {
             "co2_eq_emissions": {

--- a/sentence_transformers/model_card_templates.py
+++ b/sentence_transformers/model_card_templates.py
@@ -1,3 +1,8 @@
+"""
+This file contains the templating for model cards prior to the v3.0 release. It still exists to be used alongside
+SentenceTransformer.old_fit for backwards compatibility, but will be removed in a future release.
+"""
+
 import logging
 
 from .util import fullname

--- a/sentence_transformers/models/BoW.py
+++ b/sentence_transformers/models/BoW.py
@@ -1,7 +1,7 @@
 import json
 import logging
 import os
-from typing import Dict, List
+from typing import Dict, List, Literal
 
 import torch
 from torch import Tensor, nn
@@ -65,7 +65,9 @@ class BoW(nn.Module):
     def get_sentence_embedding_dimension(self):
         return self.sentence_embedding_dimension
 
-    def get_sentence_features(self, tokenized_texts: List[List[int]], pad_seq_length: int = 0):
+    def get_sentence_features(
+        self, tokenized_texts: List[List[int]], pad_seq_length: int = 0
+    ) -> Dict[Literal["sentence_embedding"], torch.Tensor]:
         vectors = []
 
         for tokens in tokenized_texts:

--- a/sentence_transformers/models/CLIPModel.py
+++ b/sentence_transformers/models/CLIPModel.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Dict, Union
 
 import torch
 import transformers
@@ -7,7 +7,7 @@ from torch import nn
 
 
 class CLIPModel(nn.Module):
-    def __init__(self, model_name: str = "openai/clip-vit-base-patch32", processor_name=None):
+    def __init__(self, model_name: str = "openai/clip-vit-base-patch32", processor_name=None) -> None:
         super(CLIPModel, self).__init__()
 
         if processor_name is None:
@@ -16,10 +16,10 @@ class CLIPModel(nn.Module):
         self.model = transformers.CLIPModel.from_pretrained(model_name)
         self.processor = transformers.CLIPProcessor.from_pretrained(processor_name)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "CLIPModel()"
 
-    def forward(self, features):
+    def forward(self, features: Dict[str, torch.Tensor]) -> Dict[str, torch.Tensor]:
         image_embeds = []
         text_embeds = []
 
@@ -51,7 +51,7 @@ class CLIPModel(nn.Module):
 
         return features
 
-    def tokenize(self, texts, padding: Union[str, bool] = True):
+    def tokenize(self, texts, padding: Union[str, bool] = True) -> Dict[str, torch.Tensor]:
         images = []
         texts_values = []
         image_text_info = []
@@ -76,13 +76,13 @@ class CLIPModel(nn.Module):
         return dict(encoding)
 
     @property
-    def tokenizer(self):
+    def tokenizer(self) -> transformers.CLIPProcessor:
         return self.processor
 
-    def save(self, output_path: str):
+    def save(self, output_path: str) -> None:
         self.model.save_pretrained(output_path)
         self.processor.save_pretrained(output_path)
 
     @staticmethod
-    def load(input_path: str):
+    def load(input_path: str) -> "CLIPModel":
         return CLIPModel(model_name=input_path)

--- a/sentence_transformers/models/Normalize.py
+++ b/sentence_transformers/models/Normalize.py
@@ -7,16 +7,16 @@ from torch import Tensor, nn
 class Normalize(nn.Module):
     """This layer normalizes embeddings to unit length"""
 
-    def __init__(self):
+    def __init__(self) -> None:
         super(Normalize, self).__init__()
 
-    def forward(self, features: Dict[str, Tensor]):
+    def forward(self, features: Dict[str, Tensor]) -> Dict[str, Tensor]:
         features.update({"sentence_embedding": F.normalize(features["sentence_embedding"], p=2, dim=1)})
         return features
 
-    def save(self, output_path):
+    def save(self, output_path) -> None:
         pass
 
     @staticmethod
-    def load(input_path):
+    def load(input_path) -> "Normalize":
         return Normalize()

--- a/sentence_transformers/models/Pooling.py
+++ b/sentence_transformers/models/Pooling.py
@@ -1,6 +1,6 @@
 import json
 import os
-from typing import Dict
+from typing import Any, Dict
 
 import torch
 from torch import Tensor, nn
@@ -107,7 +107,7 @@ class Pooling(nn.Module):
         )
         self.pooling_output_dimension = pooling_mode_multiplier * word_embedding_dimension
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "Pooling({})".format(self.get_config_dict())
 
     def get_pooling_mode_str(self) -> str:
@@ -128,7 +128,7 @@ class Pooling(nn.Module):
 
         return "+".join(modes)
 
-    def forward(self, features: Dict[str, Tensor]):
+    def forward(self, features: Dict[str, Tensor]) -> Dict[str, Tensor]:
         token_embeddings = features["token_embeddings"]
         attention_mask = features["attention_mask"]
         if not self.include_prompt and "prompt_length" in features:
@@ -223,18 +223,18 @@ class Pooling(nn.Module):
         features["sentence_embedding"] = output_vector
         return features
 
-    def get_sentence_embedding_dimension(self):
+    def get_sentence_embedding_dimension(self) -> int:
         return self.pooling_output_dimension
 
-    def get_config_dict(self):
+    def get_config_dict(self) -> Dict[str, Any]:
         return {key: self.__dict__[key] for key in self.config_keys}
 
-    def save(self, output_path):
+    def save(self, output_path) -> None:
         with open(os.path.join(output_path, "config.json"), "w") as fOut:
             json.dump(self.get_config_dict(), fOut, indent=2)
 
     @staticmethod
-    def load(input_path):
+    def load(input_path) -> "Pooling":
         with open(os.path.join(input_path, "config.json")) as fIn:
             config = json.load(fIn)
 

--- a/sentence_transformers/similarity_functions.py
+++ b/sentence_transformers/similarity_functions.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Callable, Union
+from typing import Callable, List, Union
 
 from numpy import ndarray
 from torch import Tensor
@@ -116,7 +116,7 @@ class SimilarityFunction(Enum):
         )
 
     @staticmethod
-    def possible_values():
+    def possible_values() -> List[str]:
         """
         Returns a list of possible values for the SimilarityFunction enum.
 

--- a/sentence_transformers/trainer.py
+++ b/sentence_transformers/trainer.py
@@ -257,7 +257,7 @@ class SentenceTransformerTrainer(Trainer):
             self.loss = self.override_model_in_loss(self.loss, model)
         return model
 
-    def override_model_in_loss(self, loss: torch.nn.Module, model: "SentenceTransformer"):
+    def override_model_in_loss(self, loss: torch.nn.Module, model: "SentenceTransformer") -> torch.nn.Module:
         from sentence_transformers import SentenceTransformer
 
         for name, child in loss.named_children():
@@ -271,7 +271,7 @@ class SentenceTransformerTrainer(Trainer):
         self,
         loss: Union[Callable[["SentenceTransformer"], torch.nn.Module], torch.nn.Module],
         model: "SentenceTransformer",
-    ):
+    ) -> torch.nn.Module:
         if isinstance(loss, torch.nn.Module):
             return loss.to(model.device)
         return loss(model).to(model.device)
@@ -712,7 +712,7 @@ class SentenceTransformerTrainer(Trainer):
         self._train_dataloader = self.accelerator.prepare(DataLoader(test_dataset, **dataloader_params))
         return self._train_dataloader
 
-    def _save(self, output_dir: Optional[str] = None, state_dict=None):
+    def _save(self, output_dir: Optional[str] = None, state_dict=None) -> None:
         # If we are executing this function, we are the process zero, so we don't check for that.
         output_dir = output_dir if output_dir is not None else self.args.output_dir
         os.makedirs(output_dir, exist_ok=True)
@@ -744,7 +744,7 @@ class SentenceTransformerTrainer(Trainer):
         dataset: Union[str, List[str], None] = None,
         dataset_args: Union[str, List[str], None] = None,
         **kwargs,
-    ):
+    ) -> None:
         if not self.is_world_process_zero():
             return
 

--- a/sentence_transformers/util.py
+++ b/sentence_transformers/util.py
@@ -6,7 +6,7 @@ import os
 import queue
 import sys
 from contextlib import contextmanager
-from typing import Callable, Dict, List, Literal, Optional, Union, overload
+from typing import Any, Callable, Dict, List, Literal, Optional, Type, Union, overload
 
 import numpy as np
 import requests
@@ -508,7 +508,7 @@ def semantic_search(
     return queries_result_list
 
 
-def http_get(url, path) -> None:
+def http_get(url: str, path: str) -> None:
     """
     Downloads a URL to a given path on disk.
 
@@ -545,7 +545,7 @@ def http_get(url, path) -> None:
     progress.close()
 
 
-def batch_to_device(batch, target_device: device):
+def batch_to_device(batch: Dict[str, Any], target_device: device) -> Dict[str, Any]:
     """
     Send a PyTorch batch (i.e., a dictionary of string keys to Tensors) to a device (e.g. "cpu", "cuda", "mps").
 
@@ -590,7 +590,7 @@ def fullname(o) -> str:
         return module + "." + o.__class__.__name__
 
 
-def import_from_string(dotted_path):
+def import_from_string(dotted_path: str) -> Type:
     """
     Import a dotted module path and return the attribute/class designated by the
     last name in the path. Raise ImportError if the import failed.
@@ -844,7 +844,7 @@ def load_file_path(
             local_files_only=local_files_only,
         )
     except Exception:
-        return
+        return None
 
 
 def load_dir_path(


### PR DESCRIPTION
Hello!

## Pull Request overview
* Improve typing for many functions
* add `py.typed` to satisfy `mypy`

## Details
The `py.typed` should be required for `mypy` and other projects to consider this project as "type hinted". Hopefully it'll work like this, without the inclusion in the `MANIFEST.in`. It does look to be included when I build a new package:
```
copying sentence_transformers\py.typed -> sentence_transformers-3.1.0.dev0\sentence_transformers
```

- Tom Aarsen