### PR TITLE
[`fix`] Fix edge case with evaluator being None

### DIFF
--- a/sentence_transformers/trainer.py
+++ b/sentence_transformers/trainer.py
@@ -223,7 +223,7 @@ class SentenceTransformerTrainer(Trainer):
         else:
             self.loss = self.prepare_loss(loss, model)
         # If evaluator is a list, we wrap it in a SequentialEvaluator
-        if not isinstance(evaluator, SentenceEvaluator):
+        if evaluator is not None and not isinstance(evaluator, SentenceEvaluator):
             evaluator = SequentialEvaluator(evaluator)
         self.evaluator = evaluator
 


### PR DESCRIPTION
Hello!

## Pull Request overview
* Fix edge case with evaluator being None

## Details
If the `evaluator` is not specified, currently it wraps it in `SequentialEvaluator` regardless, which causes a crash if you specify `eval_strategy` in the training arguments.

- Tom Aarsen