### PR TITLE
[`simplify`] Set can_return_loss=True globally, instead of via the data collator

### DIFF
--- a/sentence_transformers/data_collator.py
+++ b/sentence_transformers/data_collator.py
@@ -19,7 +19,7 @@ class SentenceTransformerDataCollator:
         columns = list(features[0].keys())
 
         # We should always be able to return a loss, label or not:
-        batch = {"return_loss": True}
+        batch = {}
 
         if "dataset_name" in columns:
             columns.remove("dataset_name")

--- a/sentence_transformers/trainer.py
+++ b/sentence_transformers/trainer.py
@@ -197,7 +197,13 @@ class SentenceTransformerTrainer(Trainer):
             optimizers=optimizers,
             preprocess_logits_for_metrics=preprocess_logits_for_metrics,
         )
+        # Every Sentence Transformer model can always return a loss, so we set this to True
+        # to avoid having to specify it in the data collator or model's forward
+        self.can_return_loss = True
+
         self.model: SentenceTransformer
+        self.args: SentenceTransformerTrainingArguments
+        self.data_collator: SentenceTransformerDataCollator
         # Set the W&B project via environment variables if it's not already set
         if any([isinstance(callback, WandbCallback) for callback in self.callback_handler.callbacks]):
             os.environ.setdefault("WANDB_PROJECT", "sentence-transformers")


### PR DESCRIPTION
Hello!

## Pull Request overview
* Set can_return_loss=True globally instead of via the data collator
* Also override the typings for `args` and `data_collator` for easier intellisense etc.

## Details
The global `can_return_loss` should always be used unless the data has a `return_loss` sample, which we specifically forbid via `validate_column_names`. Sentence Transformer models can always return a loss during training, so this helps simplify our code somewhat.

- Tom Aarsen