### PR TITLE
[`model_cards`] Specify the exact dataset size as a tag, will be bucketized by HF 

### DIFF
--- a/sentence_transformers/model_card.py
+++ b/sentence_transformers/model_card.py
@@ -711,27 +711,9 @@ class SentenceTransformerModelCardData(CardData):
         if dataset_type == "train":
             num_training_samples = sum([metadata.get("size", 0) for metadata in dataset_metadata])
             if num_training_samples:
-                self.add_tags("dataset_size:" + self.num_training_samples_to_tag(num_training_samples))
+                self.add_tags(f"dataset_size:{num_training_samples}")
 
         return self.validate_datasets(dataset_metadata)
-
-    def num_training_samples_to_tag(self, num_samples: int) -> str:
-        sizes_mapping = {
-            1_000: "n<1K",
-            10_000: "1K<n<10K",
-            100_000: "10K<n<100K",
-            1_000_000: "100K<n<1M",
-            10_000_000: "1M<n<10M",
-            100_000_000: "10M<n<100M",
-            1_000_000_000: "100M<n<1B",
-            10_000_000_000: "1B<n<10B",
-            100_000_000_000: "10B<n<100B",
-            1_000_000_000_000: "100B<n<1T",
-        }
-        for size, tag in sizes_mapping.items():
-            if num_samples < size:
-                return tag
-        return "n>1T"
 
     def register_model(self, model: "SentenceTransformer") -> None:
         self.model = model


### PR DESCRIPTION
Hello!

## Pull Request overview
* Specify the exact dataset size as a tag

## Details
Rather than Sentence Transformers doing the bucketizing, we can rely on HF to do that for easy filtering.

cc @julien-c @osanseviero 

- Tom Aarsen