### PR TITLE
Make Cleaning Of Strings In NoDuplicatesDataLoader Optional

### DIFF
--- a/sentence_transformers/datasets/NoDuplicatesDataLoader.py
+++ b/sentence_transformers/datasets/NoDuplicatesDataLoader.py
@@ -3,7 +3,7 @@ import random
 
 
 class NoDuplicatesDataLoader:
-    def __init__(self, train_examples, batch_size):
+    def __init__(self, train_examples, batch_size, clean=True):
         """
         A special data loader to be used with MultipleNegativesRankingLoss.
         The data loader ensures that there are no duplicate sentences within the same batch
@@ -12,6 +12,7 @@ class NoDuplicatesDataLoader:
         self.data_pointer = 0
         self.collate_fn = None
         self.train_examples = train_examples
+        self.clean = clean
         random.shuffle(self.train_examples)
 
     def __iter__(self):
@@ -24,14 +25,16 @@ class NoDuplicatesDataLoader:
 
                 valid_example = True
                 for text in example.texts:
-                    if text.strip().lower() in texts_in_batch:
+                    clean_text = text.strip().lower() if self.clean else text
+                    if clean_text in texts_in_batch:
                         valid_example = False
                         break
 
                 if valid_example:
                     batch.append(example)
                     for text in example.texts:
-                        texts_in_batch.add(text.strip().lower())
+                        clean_text = text.strip().lower() if self.clean else text
+                        texts_in_batch.add(clean_text)
 
                 self.data_pointer += 1
                 if self.data_pointer >= len(self.train_examples):


### PR DESCRIPTION
With very large datasets with a high percentage of duplicates you will some times need to sys.intern the strings to save memory by only having each uniq string in memory once.

Currently the NoDuplicatesDataLoader calls strip and lower on all the strings as part of the dedupe process which then means a new string is added to memory.

To this end we propose adding an option to NoDuplicatesDataLoader that will allow you to skip the text cleaning portion of the DataLoader to ensure that multiples of the same string are not pulled into memory.

Default behavior will be to clean the strings to ensure backwards compatibility.