### PR TITLE
[`versions`] Increment transformers/hf-hub versions to prevent training crash

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-transformers>=4.37.2,<5.0.0
+transformers>=4.38.0,<5.0.0
 tqdm
 torch>=1.11.0
 numpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
-transformers>=4.34.0,<5.0.0
+transformers>=4.37.2,<5.0.0
 tqdm
 torch>=1.11.0
 numpy
 scikit-learn
 scipy
-huggingface-hub>=0.15.1
+huggingface-hub>=0.19.3
 Pillow
 datasets
 accelerate>=0.20.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 transformers>=4.38.0,<5.0.0
 tqdm
 torch>=1.11.0
-numpy
+numpy<2.0.0
 scikit-learn
 scipy
 huggingface-hub>=0.19.3

--- a/setup.py
+++ b/setup.py
@@ -19,13 +19,13 @@ setup(
     include_package_data=True,
     python_requires=">=3.8.0",
     install_requires=[
-        "transformers>=4.34.0,<5.0.0",
+        "transformers>=4.37.2,<5.0.0",
         "tqdm",
         "torch>=1.11.0",
         "numpy",
         "scikit-learn",
         "scipy",
-        "huggingface-hub>=0.15.1",
+        "huggingface-hub>=0.19.3",
         "Pillow",
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     include_package_data=True,
     python_requires=">=3.8.0",
     install_requires=[
-        "transformers>=4.37.2,<5.0.0",
+        "transformers>=4.38.0,<5.0.0",
         "tqdm",
         "torch>=1.11.0",
         "numpy",

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
         "transformers>=4.38.0,<5.0.0",
         "tqdm",
         "torch>=1.11.0",
-        "numpy",
+        "numpy<2.0.0",
         "scikit-learn",
         "scipy",
         "huggingface-hub>=0.19.3",


### PR DESCRIPTION
Resolves #2741

Hello!

## Pull Request overview
* Increment `transformers` and `huggingface-hub` to prevent a crash when training.

## Details
See #2741 for details. The `prefetch_factor` was only introduced in https://github.com/huggingface/transformers/pull/28498, which was released in `transformers` v4.38.0, so we need to require at least that version (for training, anyways).

- Tom Aarsen