### PR TITLE
[`fix`] Fix retokenization on DDP/DP with GIST losses

### DIFF
--- a/sentence_transformers/losses/CachedGISTEmbedLoss.py
+++ b/sentence_transformers/losses/CachedGISTEmbedLoss.py
@@ -150,7 +150,7 @@ class CachedGISTEmbedLoss(nn.Module):
             model.tokenizer.vocab != guide.tokenizer.vocab or guide.max_seq_length < model.max_seq_length
         )
         if self.must_retokenize:
-            self.guide_tokenize_fn = guide.tokenize
+            self.tokenizer = model.tokenizer
 
     def sim_matrix(self, embed1: Tensor, embed2: Tensor) -> Tensor:
         return self.similarity_fct(embed1.unsqueeze(1), embed2.unsqueeze(0))
@@ -174,10 +174,10 @@ class CachedGISTEmbedLoss(nn.Module):
                 reps = self.model(sentence_feature_minibatch)["sentence_embedding"]  # (mbsz, hdim)
             with torch.no_grad():
                 if self.must_retokenize:
-                    decoded = self.model.tokenizer.batch_decode(
+                    decoded = self.tokenizer.batch_decode(
                         sentence_feature_minibatch["input_ids"], skip_special_tokens=True
                     )
-                    sentence_feature_minibatch = self.guide_tokenize_fn(decoded)
+                    sentence_feature_minibatch = self.guide.tokenize(decoded)
                     sentence_feature_minibatch = {
                         key: value.to(self.guide.device) for key, value in sentence_feature_minibatch.items()
                     }

--- a/sentence_transformers/losses/CachedGISTEmbedLoss.py
+++ b/sentence_transformers/losses/CachedGISTEmbedLoss.py
@@ -149,6 +149,8 @@ class CachedGISTEmbedLoss(nn.Module):
         self.must_retokenize = (
             model.tokenizer.vocab != guide.tokenizer.vocab or guide.max_seq_length < model.max_seq_length
         )
+        if self.must_retokenize:
+            self.guide_tokenize_fn = guide.tokenize
 
     def sim_matrix(self, embed1: Tensor, embed2: Tensor) -> Tensor:
         return self.similarity_fct(embed1.unsqueeze(1), embed2.unsqueeze(0))
@@ -175,7 +177,7 @@ class CachedGISTEmbedLoss(nn.Module):
                     decoded = self.model.tokenizer.batch_decode(
                         sentence_feature_minibatch["input_ids"], skip_special_tokens=True
                     )
-                    sentence_feature_minibatch = self.guide.tokenize(decoded)
+                    sentence_feature_minibatch = self.guide_tokenize_fn(decoded)
                     sentence_feature_minibatch = {
                         key: value.to(self.guide.device) for key, value in sentence_feature_minibatch.items()
                     }

--- a/sentence_transformers/losses/GISTEmbedLoss.py
+++ b/sentence_transformers/losses/GISTEmbedLoss.py
@@ -83,7 +83,7 @@ class GISTEmbedLoss(nn.Module):
             model.tokenizer.vocab != guide.tokenizer.vocab or guide.max_seq_length < model.max_seq_length
         )
         if self.must_retokenize:
-            self.guide_tokenize_fn = guide.tokenize
+            self.tokenizer = self.model.tokenizer
 
     def sim_matrix(self, embed1: Tensor, embed2: Tensor) -> Tensor:
         return self.similarity_fct(embed1.unsqueeze(1), embed2.unsqueeze(0))
@@ -93,10 +93,10 @@ class GISTEmbedLoss(nn.Module):
         with torch.no_grad():
             if self.must_retokenize:
                 decoded = [
-                    self.model.tokenizer.batch_decode(sentence_feature["input_ids"], skip_special_tokens=True)
+                    self.tokenizer.batch_decode(sentence_feature["input_ids"], skip_special_tokens=True)
                     for sentence_feature in sentence_features
                 ]
-                sentence_features = [self.guide_tokenize_fn(sentences) for sentences in decoded]
+                sentence_features = [self.guide.tokenize(sentences) for sentences in decoded]
                 sentence_features = [
                     {key: value.to(self.guide.device) for key, value in sentence_feature.items()}
                     for sentence_feature in sentence_features

--- a/sentence_transformers/losses/GISTEmbedLoss.py
+++ b/sentence_transformers/losses/GISTEmbedLoss.py
@@ -82,6 +82,8 @@ class GISTEmbedLoss(nn.Module):
         self.must_retokenize = (
             model.tokenizer.vocab != guide.tokenizer.vocab or guide.max_seq_length < model.max_seq_length
         )
+        if self.must_retokenize:
+            self.guide_tokenize_fn = guide.tokenize
 
     def sim_matrix(self, embed1: Tensor, embed2: Tensor) -> Tensor:
         return self.similarity_fct(embed1.unsqueeze(1), embed2.unsqueeze(0))
@@ -94,7 +96,7 @@ class GISTEmbedLoss(nn.Module):
                     self.model.tokenizer.batch_decode(sentence_feature["input_ids"], skip_special_tokens=True)
                     for sentence_feature in sentence_features
                 ]
-                sentence_features = [self.guide.tokenize(sentences) for sentences in decoded]
+                sentence_features = [self.guide_tokenize_fn(sentences) for sentences in decoded]
                 sentence_features = [
                     {key: value.to(self.guide.device) for key, value in sentence_feature.items()}
                     for sentence_feature in sentence_features


### PR DESCRIPTION
Resolves #2772

Hello!

## Pull Request overview
* Fix retokenization on DDP/DP with GIST losses

## Details
See #2772 for details on the issue. This PR gets a reference to the tokenization function on loss init rather than during the `forward`, as the model might be wrapped in DDP/DP by then.

- Tom Aarsen