### PR TITLE
Cast predict scores to float before converting to numpy

### DIFF
--- a/sentence_transformers/cross_encoder/CrossEncoder.py
+++ b/sentence_transformers/cross_encoder/CrossEncoder.py
@@ -441,7 +441,7 @@ class CrossEncoder(PushToHubMixin):
         if convert_to_tensor:
             pred_scores = torch.stack(pred_scores)
         elif convert_to_numpy:
-            pred_scores = np.asarray([score.cpu().detach().numpy() for score in pred_scores])
+            pred_scores = np.asarray([score.cpu().detach().float().numpy() for score in pred_scores])
 
         if input_was_string:
             pred_scores = pred_scores[0]

--- a/tests/test_cross_encoder.py
+++ b/tests/test_cross_encoder.py
@@ -9,6 +9,7 @@ import tempfile
 from pathlib import Path
 from typing import Generator, List, Tuple
 
+import numpy as np
 import pytest
 import torch
 from torch.utils.data import DataLoader
@@ -171,3 +172,12 @@ def test_safe_serialization(safe_serialization: bool) -> None:
             model.save(cache_folder, safe_serialization=safe_serialization)
             model_files = list(Path(cache_folder).glob("**/pytorch_model.bin"))
             assert 1 == len(model_files)
+
+
+def test_bfloat16() -> None:
+    model = CrossEncoder("cross-encoder/stsb-distilroberta-base", automodel_args={"torch_dtype": torch.bfloat16})
+    score = model.predict([["Hello there!", "Hello, World!"]])
+    assert isinstance(score, np.ndarray)
+
+    ranking = model.rank("Hello there!", ["Hello, World!", "Heya!"])
+    assert isinstance(ranking, list)


### PR DESCRIPTION
Torch might throw a type error (see https://github.com/pytorch/pytorch/issues/109873) when a model uses a different precision (e.g., bf16). Casting the scores to float first fixes this.

I encountered this error when evaluating the recent Jina reranker (https://huggingface.co/jinaai/jina-reranker-v2-base-multilingual).