### PR TITLE
[fix] Add tests for 3.12 in cicd

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
     name: Run unit tests
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
         os: [ubuntu-latest, windows-latest]
       fail-fast: false
     runs-on: ${{ matrix.os }}

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ wandb
 checkpoints
 tmp
 .venv
+venv


### PR DESCRIPTION
Repo mentions it supports Python 3.12, but it does not seem to be tested for 3.12 yet. This PR proposes to enable that. 

Additionally, add `venv` to `.gitignore`.