### PR TITLE
[chore] improve ruff config

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -2,10 +2,14 @@
 line-length = 119
 
 [lint]
-# Skip `E731` (do not assign a lambda expression, use a def)
-ignore = ["E731"]
+ignore = [
+    # LineTooLong
+    "E501",
+    # DoNotAssignLambda
+    "E731",
+]
 
-select = ["E4", "E7", "E9", "F", "W"]
+select = ["E", "F", "W", "I"]
 
 [lint.per-file-ignores]
 # Ignore `E402` (import violations) in all examples


### PR DESCRIPTION
Small PR to improve the ruff configuration; just enable all `E` rules except `E501`, add `I`. The code already seems to adhere to the `isort` rules though. Not sure how that happened, since `I` is not shown in the [list of defaults](https://docs.astral.sh/ruff/settings/#lint_select)?