### PR TITLE
[`feat`] Add support for streaming datasets

### DIFF
--- a/sentence_transformers/model_card.py
+++ b/sentence_transformers/model_card.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass, field, fields
 from pathlib import Path
 from platform import python_version
 from textwrap import indent
-from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Union
 
 import torch
 import transformers
@@ -30,7 +30,7 @@ from sentence_transformers.training_args import SentenceTransformerTrainingArgum
 from sentence_transformers.util import fullname, is_accelerate_available, is_datasets_available
 
 if is_datasets_available():
-    from datasets import Dataset, DatasetDict, Value
+    from datasets import Dataset, DatasetDict, IterableDataset, Value
 
 logger = logging.getLogger(__name__)
 
@@ -400,6 +400,10 @@ class SentenceTransformerModelCardData(CardData):
         self.best_model_step = step
 
     def set_widget_examples(self, dataset: Union["Dataset", "DatasetDict"]) -> None:
+        if isinstance(dataset, IterableDataset):
+            # We can't set widget examples from an IterableDataset without losing data
+            return
+
         if isinstance(dataset, Dataset):
             dataset = DatasetDict(dataset=dataset)
 
@@ -512,53 +516,32 @@ class SentenceTransformerModelCardData(CardData):
                 for dataset in self.infer_datasets(sub_dataset, dataset_name=dataset_name)
             ]
 
-        def subtuple_finder(tuple: Tuple[str], subtuple: Tuple[str]) -> int:
-            for i, element in enumerate(tuple):
-                if element == subtuple[0] and tuple[i : i + len(subtuple)] == subtuple:
-                    return i
-            return -1
-
-        cache_files = dataset.cache_files
-        dataset_output = {}
         # Ignore the dataset name if it is a default name from the FitMixin backwards compatibility
         if dataset_name and re.match(r"_dataset_\d+", dataset_name):
             dataset_name = None
-        if dataset_name:
-            dataset_output["name"] = dataset_name
-        if cache_files and "filename" in cache_files[0]:
-            cache_path_parts = Path(cache_files[0]["filename"]).parts
-            # Check if the cachefile is under "huggingface/datasets"
-            subtuple = ("huggingface", "datasets")
-            index = subtuple_finder(cache_path_parts, subtuple)
-            if index == -1:
-                return [dataset_output]
 
-            # Get the folder after "huggingface/datasets"
-            cache_dataset_name = cache_path_parts[index + len(subtuple)]
-            # If the dataset has an author:
-            if "___" in cache_dataset_name:
-                author, dataset_name = cache_dataset_name.split("___")
-                dataset_output["id"] = f"{author}/{dataset_name}"
-            else:
-                author = None
-                dataset_name = cache_dataset_name
-                # We can still be dealing with a local dataset here, so we wrap this with try-except
-                try:
-                    dataset_output["id"] = get_dataset_info(dataset_name).id
-                except Exception:
-                    # We can have a wide range of errors here, such as the dataset not existing, no internet, etc.
-                    # So we use the generic Exception
-                    pass
+        dataset_output = {
+            "name": dataset_name or dataset.info.dataset_name,
+            "split": str(dataset.split),
+        }
+        if dataset.info.splits and dataset.split in dataset.info.splits:
+            dataset_output["size"] = dataset.info.splits[dataset.split].num_examples
 
-            # If the cache path ends with a 40 character hash, it is the current revision
-            if len(cache_path_parts[-2]) == 40:
-                dataset_output["revision"] = cache_path_parts[-2]
+        # The download checksums seems like a fairly safe way to extract the dataset ID and revision
+        # for iterable datasets as well as regular datasets from the Hub
+        if checksums := dataset.download_checksums:
+            source = list(checksums.keys())[0]
+            if source.startswith("hf://datasets/") and "@" in source:
+                source_parts = source[len("hf://datasets/") :].split("@")
+                dataset_output["id"] = source_parts[0]
+                if (revision := source_parts[1].split("/")[0]) and len(revision) == 40:
+                    dataset_output["revision"] = revision
 
         return [dataset_output]
 
     def compute_dataset_metrics(
         self,
-        dataset: Dict[str, str],
+        dataset: Optional[Union[Dataset, IterableDataset]],
         dataset_info: Dict[str, Any],
         loss: Optional[Union[Dict[str, nn.Module], nn.Module]],
     ) -> Dict[str, str]:
@@ -578,91 +561,93 @@ class SentenceTransformerModelCardData(CardData):
         if not dataset:
             return {}
 
-        dataset_info["size"] = len(dataset)
+        if "size" not in dataset_info and isinstance(dataset, Dataset):
+            dataset_info["size"] = len(dataset)
         dataset_info["columns"] = [f"<code>{column}</code>" for column in dataset.column_names]
         dataset_info["stats"] = {}
-        for column in dataset.column_names:
-            subsection = dataset[:1000][column]
-            first = subsection[0]
-            if isinstance(first, str):
-                tokenized = self.model.tokenize(subsection)
-                if isinstance(tokenized, dict) and "attention_mask" in tokenized:
-                    lengths = tokenized["attention_mask"].sum(dim=1).tolist()
-                    suffix = "tokens"
-                else:
-                    lengths = [len(sentence) for sentence in subsection]
-                    suffix = "characters"
-                dataset_info["stats"][column] = {
-                    "dtype": "string",
-                    "data": {
-                        "min": f"{round(min(lengths), 2)} {suffix}",
-                        "mean": f"{round(sum(lengths) / len(lengths), 2)} {suffix}",
-                        "max": f"{round(max(lengths), 2)} {suffix}",
-                    },
-                }
-            elif isinstance(first, (int, bool)):
-                counter = Counter(subsection)
-                dataset_info["stats"][column] = {
-                    "dtype": "int",
-                    "data": {
-                        key: f"{'~' if len(counter) > 1 else ''}{counter[key] / len(subsection):.2%}"
-                        for key in sorted(counter)
-                    },
-                }
-            elif isinstance(first, float):
-                dataset_info["stats"][column] = {
-                    "dtype": "float",
-                    "data": {
-                        "min": round(min(dataset[column]), 2),
-                        "mean": round(sum(dataset[column]) / len(dataset), 2),
-                        "max": round(max(dataset[column]), 2),
-                    },
-                }
-            elif isinstance(first, list):
-                counter = Counter([len(lst) for lst in subsection])
-                if len(counter) == 1:
-                    dataset_info["stats"][column] = {
-                        "dtype": "list",
-                        "data": {
-                            "size": f"{len(first)} elements",
-                        },
-                    }
-                else:
-                    dataset_info["stats"][column] = {
-                        "dtype": "list",
-                        "data": {
-                            "min": f"{min(counter)} elements",
-                            "mean": f"{sum(counter) / len(counter):.2f} elements",
-                            "max": f"{max(counter)} elements",
-                        },
-                    }
-            else:
-                dataset_info["stats"][column] = {"dtype": fullname(first), "data": {}}
-
-        def to_html_list(data: dict):
-            return "<ul><li>" + "</li><li>".join(f"{key}: {value}" for key, value in data.items()) + "</li></ul>"
-
-        stats_lines = [
-            {"": "type", **{key: value["dtype"] for key, value in dataset_info["stats"].items()}},
-            {"": "details", **{key: to_html_list(value["data"]) for key, value in dataset_info["stats"].items()}},
-        ]
-        dataset_info["stats_table"] = indent(make_markdown_table(stats_lines).replace("-:|", "--|"), "  ")
-
-        dataset_info["examples"] = dataset[:3]
-        num_samples = len(dataset_info["examples"][list(dataset_info["examples"])[0]])
-        examples_lines = []
-        for sample_idx in range(num_samples):
-            columns = {}
+        if isinstance(dataset, Dataset):
             for column in dataset.column_names:
-                value = dataset_info["examples"][column][sample_idx]
-                # If the value is a long list, truncate it
-                if isinstance(value, list) and len(value) > 5:
-                    value = str(value[:5])[:-1] + ", ...]"
-                # Avoid newlines in the table
-                value = str(value).replace("\n", "<br>")
-                columns[column] = f"<code>{value}</code>"
-            examples_lines.append(columns)
-        dataset_info["examples_table"] = indent(make_markdown_table(examples_lines).replace("-:|", "--|"), "  ")
+                subsection = dataset[:1000][column]
+                first = subsection[0]
+                if isinstance(first, str):
+                    tokenized = self.model.tokenize(subsection)
+                    if isinstance(tokenized, dict) and "attention_mask" in tokenized:
+                        lengths = tokenized["attention_mask"].sum(dim=1).tolist()
+                        suffix = "tokens"
+                    else:
+                        lengths = [len(sentence) for sentence in subsection]
+                        suffix = "characters"
+                    dataset_info["stats"][column] = {
+                        "dtype": "string",
+                        "data": {
+                            "min": f"{round(min(lengths), 2)} {suffix}",
+                            "mean": f"{round(sum(lengths) / len(lengths), 2)} {suffix}",
+                            "max": f"{round(max(lengths), 2)} {suffix}",
+                        },
+                    }
+                elif isinstance(first, (int, bool)):
+                    counter = Counter(subsection)
+                    dataset_info["stats"][column] = {
+                        "dtype": "int",
+                        "data": {
+                            key: f"{'~' if len(counter) > 1 else ''}{counter[key] / len(subsection):.2%}"
+                            for key in sorted(counter)
+                        },
+                    }
+                elif isinstance(first, float):
+                    dataset_info["stats"][column] = {
+                        "dtype": "float",
+                        "data": {
+                            "min": round(min(dataset[column]), 2),
+                            "mean": round(sum(dataset[column]) / len(dataset), 2),
+                            "max": round(max(dataset[column]), 2),
+                        },
+                    }
+                elif isinstance(first, list):
+                    counter = Counter([len(lst) for lst in subsection])
+                    if len(counter) == 1:
+                        dataset_info["stats"][column] = {
+                            "dtype": "list",
+                            "data": {
+                                "size": f"{len(first)} elements",
+                            },
+                        }
+                    else:
+                        dataset_info["stats"][column] = {
+                            "dtype": "list",
+                            "data": {
+                                "min": f"{min(counter)} elements",
+                                "mean": f"{sum(counter) / len(counter):.2f} elements",
+                                "max": f"{max(counter)} elements",
+                            },
+                        }
+                else:
+                    dataset_info["stats"][column] = {"dtype": fullname(first), "data": {}}
+
+            def to_html_list(data: dict):
+                return "<ul><li>" + "</li><li>".join(f"{key}: {value}" for key, value in data.items()) + "</li></ul>"
+
+            stats_lines = [
+                {"": "type", **{key: value["dtype"] for key, value in dataset_info["stats"].items()}},
+                {"": "details", **{key: to_html_list(value["data"]) for key, value in dataset_info["stats"].items()}},
+            ]
+            dataset_info["stats_table"] = indent(make_markdown_table(stats_lines).replace("-:|", "--|"), "  ")
+
+            dataset_info["examples"] = dataset[:3]
+            num_samples = len(dataset_info["examples"][list(dataset_info["examples"])[0]])
+            examples_lines = []
+            for sample_idx in range(num_samples):
+                columns = {}
+                for column in dataset.column_names:
+                    value = dataset_info["examples"][column][sample_idx]
+                    # If the value is a long list, truncate it
+                    if isinstance(value, list) and len(value) > 5:
+                        value = str(value[:5])[:-1] + ", ...]"
+                    # Avoid newlines in the table
+                    value = str(value).replace("\n", "<br>")
+                    columns[column] = f"<code>{value}</code>"
+                examples_lines.append(columns)
+            dataset_info["examples_table"] = indent(make_markdown_table(examples_lines).replace("-:|", "--|"), "  ")
 
         dataset_info["loss"] = {
             "fullname": fullname(loss),
@@ -966,7 +951,7 @@ class SentenceTransformerModelCardData(CardData):
 
     def to_yaml(self, line_break=None) -> str:
         return yaml_dump(
-            {key: value for key, value in self.to_dict().items() if key in YAML_FIELDS and value is not None},
+            {key: value for key, value in self.to_dict().items() if key in YAML_FIELDS and value not in (None, [])},
             sort_keys=False,
             line_break=line_break,
         ).strip()

--- a/sentence_transformers/model_card_template.md
+++ b/sentence_transformers/model_card_template.md
@@ -152,9 +152,9 @@ You can finetune this model on your own dataset.
 {%- if 'revision' in dataset and 'id' in dataset %} at [{{ dataset['revision'][:7] }}](https://huggingface.co/datasets/{{ dataset['id'] }}/tree/{{ dataset['revision'] }}){% endif %}{% endif %}
 * Size: {{ "{:,}".format(dataset['size']) }} {{ dataset_type }} samples
 * Columns: {% if dataset['columns'] | length == 1 %}{{ dataset['columns'][0] }}{% elif dataset['columns'] | length == 2 %}{{ dataset['columns'][0] }} and {{ dataset['columns'][1] }}{% else %}{{ dataset['columns'][:-1] | join(', ') }}, and {{ dataset['columns'][-1] }}{% endif %}
-* Approximate statistics based on the first 1000 samples:
-{{ dataset['stats_table'] }}* Samples:
-{{ dataset['examples_table'] }}* Loss: {% if dataset["loss"]["fullname"].startswith("sentence_transformers.") %}[<code>{{ dataset["loss"]["fullname"].split(".")[-1] }}</code>](https://sbert.net/docs/package_reference/sentence_transformer/losses.html#{{ dataset["loss"]["fullname"].split(".")[-1].lower() }}){% else %}<code>{{ dataset["loss"]["fullname"] }}</code>{% endif %}{% if "config_code" in dataset["loss"] %} with these parameters:
+{% if dataset['stats_table'] %}* Approximate statistics based on the first {{ [dataset['size'], 1000] | min }} samples:
+{{ dataset['stats_table'] }}{% endif %}{% if dataset['examples_table'] %}* Samples:
+{{ dataset['examples_table'] }}{% endif %}* Loss: {% if dataset["loss"]["fullname"].startswith("sentence_transformers.") %}[<code>{{ dataset["loss"]["fullname"].split(".")[-1] }}</code>](https://sbert.net/docs/package_reference/sentence_transformer/losses.html#{{ dataset["loss"]["fullname"].split(".")[-1].lower() }}){% else %}<code>{{ dataset["loss"]["fullname"] }}</code>{% endif %}{% if "config_code" in dataset["loss"] %} with these parameters:
 {{ dataset["loss"]["config_code"] }}{% endif %}
 {% endfor %}{% endif %}{% endfor -%}
 

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -1,14 +1,18 @@
+from contextlib import nullcontext
+from copy import deepcopy
 import re
 import tempfile
 from pathlib import Path
 
 import pytest
+import torch
 
 from sentence_transformers import SentenceTransformer, SentenceTransformerTrainer, losses
+from sentence_transformers.training_args import SentenceTransformerTrainingArguments
 from sentence_transformers.util import is_datasets_available, is_training_available
 
 if is_datasets_available():
-    from datasets import DatasetDict
+    from datasets import DatasetDict, load_dataset
 
 
 @pytest.mark.skipif(
@@ -142,3 +146,84 @@ def test_model_card_reuse(stsb_bert_tiny_model: SentenceTransformer):
         with open(model_path / "README.md", "r") as f:
             model_card_text = f.read()
         assert model_card_text != stsb_bert_tiny_model._model_card_text
+
+
+@pytest.mark.skipif(
+    not is_training_available(),
+    reason='Sentence Transformers was not installed with the `["train"]` extra.',
+)
+@pytest.mark.parametrize("streaming", [False, True])
+@pytest.mark.parametrize("train_dict", [False, True])
+@pytest.mark.parametrize("eval_dict", [False, True])
+@pytest.mark.parametrize("loss_dict", [False, True])
+def test_trainer(
+    stsb_bert_tiny_model: SentenceTransformer, streaming: bool, train_dict: bool, eval_dict: bool, loss_dict: bool
+) -> None:
+    """
+    Some cases are not allowed:
+    * streaming=True and train_dict=True: streaming is not supported with DatasetDict, because our DatasetDict
+      implementation concatenates the individual datasets and uses their sizes for tracking which original dataset the samples are from.
+      This is not possible with streaming datasets as they don't have a known size.
+      (Note: streaming=True and eval_dict=True does not throw an error because the transformers Trainer already allows for
+      dictionaries of evaluation datasets. In that case, the evaluation dataloader is created with just a normal IterableDataset multiple
+      times instead of a ConcatDataset of IterableDatasets.)
+    * loss_dict=True and (train_dict=False or eval_dict=False): if loss is a dict, then train_dataset and eval_dataset must be dicts too,
+      otherwise the trainer doesn't know which loss to use.
+    """
+    context = nullcontext()
+    if loss_dict and not train_dict:
+        context = pytest.raises(
+            ValueError, match="If the provided `loss` is a dict, then the `train_dataset` must be a `DatasetDict`."
+        )
+    elif loss_dict and not eval_dict:
+        context = pytest.raises(
+            ValueError, match="If the provided `loss` is a dict, then the `eval_dataset` must be a `DatasetDict`."
+        )
+    elif streaming and train_dict:
+        context = pytest.raises(
+            ValueError,
+            match="Sentence Transformers is not compatible with a DatasetDict containing an IterableDataset.",
+        )
+
+    model = stsb_bert_tiny_model
+    original_model = deepcopy(model)
+    train_dataset = load_dataset("sentence-transformers/stsb", split="train[:10]")
+    eval_dataset = load_dataset("sentence-transformers/stsb", split="validation[:10]")
+    loss = losses.CosineSimilarityLoss(model=model)
+
+    if streaming:
+        train_dataset = train_dataset.to_iterable_dataset()
+        eval_dataset = eval_dataset.to_iterable_dataset()
+    if train_dict:
+        train_dataset = DatasetDict({"stsb-1": train_dataset, "stsb-2": train_dataset})
+    if eval_dict:
+        eval_dataset = DatasetDict({"stsb-1": eval_dataset, "stsb-2": eval_dataset})
+    if loss_dict:
+        loss = {
+            "stsb-1": loss,
+            "stsb-2": loss,
+        }
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        args = SentenceTransformerTrainingArguments(
+            output_dir=str(temp_dir),
+            max_steps=2,
+            eval_steps=2,
+            eval_strategy="steps",
+            per_device_train_batch_size=1,
+            per_device_eval_batch_size=1,
+        )
+        with context:
+            trainer = SentenceTransformerTrainer(
+                model=model,
+                args=args,
+                train_dataset=train_dataset,
+                eval_dataset=eval_dataset,
+                loss=loss,
+            )
+            trainer.train()
+
+    if isinstance(context, nullcontext):
+        original_embeddings = original_model.encode("The cat is on the mat.", convert_to_tensor=True)
+        new_embeddings = model.encode("The cat is on the the mat.", convert_to_tensor=True)
+        assert not torch.equal(original_embeddings, new_embeddings)


### PR DESCRIPTION
Resolves #2698

Hello!

## Pull Request overview
* Add support for streaming datasets
  * Update the model card generation: streaming datasets don't produce widget examples or dataset samples (sadly)
* Simplify `infer_datasets`: the method used for getting information (dataset name, id, number of samples, revision, etc.) from training datasets
* Don't put empty lists in the model card metadata (e.g. no `- widget: []`)
* Fix the test_dataloader accidentally using the training batch sizes.
* Add test cases for all dataset combinations

## Details
Note that a DatasetDict of streaming datasets is currently not supported. This is because training with multiple datasets at once is implemented via a ConcatDict, but this requires datasets with known lengths. Beyond that, we can't get training/evaluation samples to put in the model card from streaming datasets, because those samples won't "come back" after I've read them (but perhaps I can use the training/evaluation dataloader instead here? That one should be able to "reset" because otherwise you can't train multiple epochs/do multiple evaluations).

## Usage
You can use this in almost the same way as training with non-streaming datasets, with two exceptions:
* you should load the dataset with `streaming=True`: `train_dataset = load_dataset("sentence-transformers/gooaq", split="train", streaming=True)`
* you should specify the number of training steps so the scheduler can adapt the learning rate correctly: `num_examples = train_dataset.info.splits["train"].num_examples` and `max_steps=num_examples // train_batch_size` in the `SentenceTransformerTrainingArguments`.

This is a full training script with 3 million training samples:

```python
import logging
from datasets import load_dataset
from sentence_transformers import (
    SentenceTransformer,
    SentenceTransformerTrainer,
    SentenceTransformerTrainingArguments,
    SentenceTransformerModelCardData,
)
from sentence_transformers.losses import MultipleNegativesRankingLoss
from sentence_transformers.training_args import BatchSamplers

logging.basicConfig(
    format="%(asctime)s - %(message)s", datefmt="%Y-%m-%d %H:%M:%S", level=logging.INFO
)

# 1. Load a model to finetune with 2. (Optional) model card data
model = SentenceTransformer(
    "microsoft/mpnet-base",
    model_card_data=SentenceTransformerModelCardData(
        language="en",
        license="apache-2.0",
        model_name="MPNet base trained on GooAQ pairs",
    ),
)

streaming = True
name = "mpnet-base-gooaq"
if streaming:
    name += "-streaming"

# 2. Load a (streaming?) dataset to finetune on
train_dataset = load_dataset("sentence-transformers/gooaq", split="train", streaming=streaming)
num_examples = train_dataset.info.splits["train"].num_examples

# 3. Define a loss function
loss = MultipleNegativesRankingLoss(model)

# 4. (Optional) Specify training arguments
train_batch_size = 64
args = SentenceTransformerTrainingArguments(
    # Required parameter:
    output_dir=f"models/{name}",
    # Optional training parameters:
    num_train_epochs=1,
    per_device_train_batch_size=train_batch_size,
    learning_rate=2e-5,
    warmup_ratio=0.1,
    fp16=False,  # Set to False if you get an error that your GPU can't run on FP16
    bf16=True,  # Set to True if you have a GPU that supports BF16
    batch_sampler=BatchSamplers.NO_DUPLICATES,  # MultipleNegativesRankingLoss benefits from no duplicate samples in a batch
    # Optional tracking/debugging parameters:
    save_strategy="steps",
    save_steps=100,
    max_steps=num_examples // train_batch_size,
    save_total_limit=2,
    logging_steps=250,
    logging_first_step=True,
    run_name=name,  # Will be used in W&B if `wandb` is installed
)

# 5. Create a trainer & train
trainer = SentenceTransformerTrainer(
    model=model,
    args=args,
    train_dataset=train_dataset,
    loss=loss,
)
trainer.train()

# 6. Save the trained model
model.save_pretrained(f"models/{name}/final")

# 7. (Optional) Push it to the Hugging Face Hub
model.push_to_hub(name)
```

cc @david-waterworth @olivierr42 @ganeshkrishnan1 as you all expressed interested in streaming datasets.
If you find the time to experiment with this branch, I would appreciate it. You can install it with:
```
pip install git+https://github.com/tomaarsen/sentence-transformers.git@feat/streaming_datasets
```

- Tom Aarsen