### PR TITLE
improve ruff config

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -22,14 +22,13 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Setup Python environment
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
-          python-version: 3.9
-      - name: Install dependencies
+          python-version: "3.10"
+      - name: Install pre-commit
         run: |
           python -m pip install --upgrade pip
-          python -m pip install .
-          python -m pip install ruff
+          python -m pip install pre-commit
       - name: Code quality
         run: |
-          make quality
+          make check

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ checkpoints
 tmp
 .venv
 venv
+.DS_Store

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,7 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    # Ruff version.
-    rev: v0.3.5
+    rev: v0.5.0
     hooks:
-      # These hooks are equivalent to running `make quality`
       - id: ruff
+        args: [--exit-non-zero-on-fix]
       - id: ruff-format
-        args: [ --check ]

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,11 @@
-quality:
-	ruff check
-	ruff format --check
 
-style:
-	ruff check --fix
-	ruff format
+.PHONY: check
+check: ## Run code quality tools.
+	@echo "🚀 Linting code: Running pre-commit"
+	@pre-commit run -a
+
+.PHONY: help
+help: ## Show help for the commands.
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
+
+.DEFAULT_GOAL := help

--- a/ruff.toml
+++ b/ruff.toml
@@ -2,10 +2,14 @@
 line-length = 119
 
 [lint]
-# Skip `E731` (do not assign a lambda expression, use a def)
-ignore = ["E731"]
+ignore = [
+    # LineTooLong
+    "E501",
+    # DoNotAssignLambda
+    "E731",
+]
 
-select = ["E4", "E7", "E9", "F", "W"]
+select = ["E", "F", "W"]
 
 [lint.per-file-ignores]
 # Ignore `E402` (import violations) in all examples

--- a/setup.py
+++ b/setup.py
@@ -33,13 +33,7 @@ setup(
             "datasets",
             "accelerate>=0.20.3",
         ],
-        "dev": [
-            "datasets",
-            "accelerate>=0.20.3",
-            "pre-commit",
-            "pytest",
-            "ruff>=0.3.0",
-        ],
+        "dev": ["datasets", "accelerate>=0.20.3", "pre-commit", "pytest"],
     },
     classifiers=[
         "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
This PR does a few small things:

- Improve the ruff configuration; just enable all `E` rules except `E501`.
- Remove `ruff` from the project's development dependencies, since it is already used in the pre-commit hooks. This also reduces the risk of using two different versions of `ruff` in the project.
- Remove the `make style` and `make quality` commands and replace them with `make check`, which simply runs the pre-commit hooks.
- Improve the `Makefile`. Running just `make` now displays:
  ```
  check                Run code quality tools.
  help                 Show help for the commands.
  ```
  
  If either of the ruff commands fails in the pre-commit hook, a error code of 1 is returned and the CI/CD pipeline fails. An example run can be found [here](https://github.com/fpgmaas/sentence-transformers/actions/runs/9715709557/job/26817721044)