### PR TITLE
[chore] Add test for RoundrobinBatchSampler

### DIFF
--- a/sentence_transformers/sampler.py
+++ b/sentence_transformers/sampler.py
@@ -149,7 +149,9 @@ class NoDuplicatesBatchSampler(SetEpochMixin, BatchSampler):
 
 class RoundRobinBatchSampler(SetEpochMixin, BatchSampler):
     """
-    Batch sampler that yields batches in a round-robin fashion from multiple batch samplers.
+    Batch sampler that yields batches in a round-robin fashion from multiple batch samplers, until one is exhausted.
+    With this sampler, it's unlikely that all samples from each dataset are used, but we do ensure that each dataset
+    is sampled from equally.
 
     Args:
         dataset (ConcatDataset): A concatenation of multiple datasets.

--- a/sentence_transformers/sampler.py
+++ b/sentence_transformers/sampler.py
@@ -152,8 +152,8 @@ class RoundRobinBatchSampler(SetEpochMixin, BatchSampler):
         self,
         dataset: ConcatDataset,
         batch_samplers: List[BatchSampler],
-        generator: torch.Generator,
-        seed: int,
+        generator: torch.Generator = None,
+        seed: int = None,
     ) -> None:
         super().__init__(dataset, batch_samplers[0].batch_size, batch_samplers[0].drop_last)
         self.dataset = dataset
@@ -162,7 +162,8 @@ class RoundRobinBatchSampler(SetEpochMixin, BatchSampler):
         self.seed = seed
 
     def __iter__(self) -> Iterator[List[int]]:
-        self.generator.manual_seed(self.seed + self.epoch)
+        if self.generator and self.seed:
+            self.generator.manual_seed(self.seed + self.epoch)
 
         num_samples = [len(dataset) for dataset in self.dataset.datasets]
         sample_offsets = [0] + list(accumulate(num_samples))

--- a/tests/samplers/test_round_robin_batch_sampler.py
+++ b/tests/samplers/test_round_robin_batch_sampler.py
@@ -1,0 +1,37 @@
+import pytest
+from datasets import Dataset
+from sentence_transformers.sampler import RoundRobinBatchSampler
+
+from torch.utils.data import BatchSampler, SequentialSampler, ConcatDataset
+
+
+@pytest.fixture
+def dummy_dataset() -> ConcatDataset:
+    """
+    Dummy dataset for testing purposes. The dataset looks as follows:
+    {
+        "data": [0, 1, 2, ... , 23, 24, 100, 101, ..., 123, 124],
+        "label": [0, 1, 0, 1, ..., 0, 1],
+    }
+    """
+
+    values_1 = list(range(25))
+    labels = [x % 2 for x in values_1]
+    dataset_1 = Dataset.from_dict({"data": values_1, "label": labels})
+
+    values_2 = [x + 100 for x in values_1]
+    dataset_2 = Dataset.from_dict({"data": values_2, "label": labels})
+
+    return ConcatDataset([dataset_1, dataset_2])
+
+
+def test_round_robin_batch_sampler(dummy_dataset):
+    batch_sampler_1 = BatchSampler(SequentialSampler(range(len(dummy_dataset))), batch_size=4, drop_last=True)
+    batch_sampler_2 = BatchSampler(SequentialSampler(range(len(dummy_dataset))), batch_size=4, drop_last=True)
+    sampler = RoundRobinBatchSampler(dataset=dummy_dataset, batch_samplers=[batch_sampler_1, batch_sampler_2])
+
+    batches = list(iter(sampler))
+
+    for batch in batches:
+        for idx in batch:
+            print(dummy_dataset[idx])

--- a/tests/samplers/test_round_robin_batch_sampler.py
+++ b/tests/samplers/test_round_robin_batch_sampler.py
@@ -4,6 +4,8 @@ from sentence_transformers.sampler import RoundRobinBatchSampler
 
 from torch.utils.data import BatchSampler, SequentialSampler, ConcatDataset
 
+DATASET_LENGTH = 25
+
 
 @pytest.fixture
 def dummy_dataset() -> ConcatDataset:
@@ -14,8 +16,7 @@ def dummy_dataset() -> ConcatDataset:
         "label": [0, 1, 0, 1, ..., 0, 1],
     }
     """
-
-    values_1 = list(range(25))
+    values_1 = list(range(DATASET_LENGTH))
     labels = [x % 2 for x in values_1]
     dataset_1 = Dataset.from_dict({"data": values_1, "label": labels})
 
@@ -26,12 +27,25 @@ def dummy_dataset() -> ConcatDataset:
 
 
 def test_round_robin_batch_sampler(dummy_dataset):
-    batch_sampler_1 = BatchSampler(SequentialSampler(range(len(dummy_dataset))), batch_size=4, drop_last=True)
-    batch_sampler_2 = BatchSampler(SequentialSampler(range(len(dummy_dataset))), batch_size=4, drop_last=True)
-    sampler = RoundRobinBatchSampler(dataset=dummy_dataset, batch_samplers=[batch_sampler_1, batch_sampler_2])
+    batch_size = 4
+    batch_sampler_1 = BatchSampler(SequentialSampler(range(DATASET_LENGTH)), batch_size=batch_size, drop_last=True)
+    batch_sampler_2 = BatchSampler(SequentialSampler(range(DATASET_LENGTH)), batch_size=batch_size, drop_last=True)
 
+    sampler = RoundRobinBatchSampler(dataset=dummy_dataset, batch_samplers=[batch_sampler_1, batch_sampler_2])
     batches = list(iter(sampler))
 
-    for batch in batches:
-        for idx in batch:
-            print(dummy_dataset[idx])
+    assert len(batches) == 2 * DATASET_LENGTH // batch_size
+
+    # Assert that batches are produced in a round-robin fashion
+    for i in range(0, len(batches), 2):
+        # Batch from the first part of the dataset
+        batch_1 = batches[i]
+        assert all(
+            dummy_dataset[idx]["data"] < 100 for idx in batch_1
+        ), f"Batch {i} contains data from the second part of the dataset: {[dummy_dataset[idx]['data'] for idx in batch_1]}"
+
+        # Batch from the second part of the dataset
+        batch_2 = batches[i + 1]
+        assert all(
+            dummy_dataset[idx]["data"] >= 100 for idx in batch_2
+        ), f"Batch {i+1} contains data from the first part of the dataset: {[dummy_dataset[idx]['data'] for idx in batch_2]}"

--- a/tests/samplers/test_round_robin_batch_sampler.py
+++ b/tests/samplers/test_round_robin_batch_sampler.py
@@ -49,3 +49,17 @@ def test_round_robin_batch_sampler(dummy_dataset):
         assert all(
             dummy_dataset[idx]["data"] >= 100 for idx in batch_2
         ), f"Batch {i+1} contains data from the first part of the dataset: {[dummy_dataset[idx]['data'] for idx in batch_2]}"
+
+
+def test_round_robin_batch_sampler_value_error(dummy_dataset):
+    batch_size = 4
+    batch_sampler_1 = BatchSampler(SequentialSampler(range(DATASET_LENGTH)), batch_size=batch_size, drop_last=True)
+    batch_sampler_2 = BatchSampler(SequentialSampler(range(DATASET_LENGTH)), batch_size=batch_size, drop_last=True)
+    batch_sampler_3 = BatchSampler(SequentialSampler(range(DATASET_LENGTH)), batch_size=batch_size, drop_last=True)
+
+    with pytest.raises(
+        ValueError, match="The number of batch samplers must match the number of datasets in the ConcatDataset"
+    ):
+        RoundRobinBatchSampler(
+            dataset=dummy_dataset, batch_samplers=[batch_sampler_1, batch_sampler_2, batch_sampler_3]
+        )

--- a/tests/samplers/test_round_robin_batch_sampler.py
+++ b/tests/samplers/test_round_robin_batch_sampler.py
@@ -8,7 +8,7 @@ DATASET_LENGTH = 25
 
 
 @pytest.fixture
-def dummy_dataset() -> ConcatDataset:
+def dummy_concat_dataset() -> ConcatDataset:
     """
     Dummy dataset for testing purposes. The dataset looks as follows:
     {
@@ -20,38 +20,45 @@ def dummy_dataset() -> ConcatDataset:
     labels = [x % 2 for x in values_1]
     dataset_1 = Dataset.from_dict({"data": values_1, "label": labels})
 
-    values_2 = [x + 100 for x in values_1]
-    dataset_2 = Dataset.from_dict({"data": values_2, "label": labels})
+    values_2 = [x + 100 for x in values_1] + [x + 200 for x in values_1]
+    dataset_2 = Dataset.from_dict({"data": values_2, "label": labels + labels})
 
     return ConcatDataset([dataset_1, dataset_2])
 
 
-def test_round_robin_batch_sampler(dummy_dataset):
+def test_round_robin_batch_sampler(dummy_concat_dataset: ConcatDataset) -> None:
     batch_size = 4
-    batch_sampler_1 = BatchSampler(SequentialSampler(range(DATASET_LENGTH)), batch_size=batch_size, drop_last=True)
-    batch_sampler_2 = BatchSampler(SequentialSampler(range(DATASET_LENGTH)), batch_size=batch_size, drop_last=True)
+    batch_sampler_1 = BatchSampler(
+        SequentialSampler(range(len(dummy_concat_dataset.datasets[0]))), batch_size=batch_size, drop_last=True
+    )
+    batch_sampler_2 = BatchSampler(
+        SequentialSampler(range(len(dummy_concat_dataset.datasets[1]))), batch_size=batch_size, drop_last=True
+    )
 
-    sampler = RoundRobinBatchSampler(dataset=dummy_dataset, batch_samplers=[batch_sampler_1, batch_sampler_2])
+    sampler = RoundRobinBatchSampler(dataset=dummy_concat_dataset, batch_samplers=[batch_sampler_1, batch_sampler_2])
     batches = list(iter(sampler))
 
+    # Despite the second dataset being larger (2 * DATASET_LENGTH), we still only sample DATASET_LENGTH // batch_size batches from each dataset
+    # because the RoundRobinBatchSampler should stop sampling once it has sampled all elements from one dataset
     assert len(batches) == 2 * DATASET_LENGTH // batch_size
+    assert len(sampler) == len(batches)
 
     # Assert that batches are produced in a round-robin fashion
     for i in range(0, len(batches), 2):
         # Batch from the first part of the dataset
         batch_1 = batches[i]
         assert all(
-            dummy_dataset[idx]["data"] < 100 for idx in batch_1
-        ), f"Batch {i} contains data from the second part of the dataset: {[dummy_dataset[idx]['data'] for idx in batch_1]}"
+            dummy_concat_dataset[idx]["data"] < 100 for idx in batch_1
+        ), f"Batch {i} contains data from the second part of the dataset: {[dummy_concat_dataset[idx]['data'] for idx in batch_1]}"
 
         # Batch from the second part of the dataset
         batch_2 = batches[i + 1]
         assert all(
-            dummy_dataset[idx]["data"] >= 100 for idx in batch_2
-        ), f"Batch {i+1} contains data from the first part of the dataset: {[dummy_dataset[idx]['data'] for idx in batch_2]}"
+            dummy_concat_dataset[idx]["data"] >= 100 for idx in batch_2
+        ), f"Batch {i+1} contains data from the first part of the dataset: {[dummy_concat_dataset[idx]['data'] for idx in batch_2]}"
 
 
-def test_round_robin_batch_sampler_value_error(dummy_dataset):
+def test_round_robin_batch_sampler_value_error(dummy_concat_dataset: ConcatDataset) -> None:
     batch_size = 4
     batch_sampler_1 = BatchSampler(SequentialSampler(range(DATASET_LENGTH)), batch_size=batch_size, drop_last=True)
     batch_sampler_2 = BatchSampler(SequentialSampler(range(DATASET_LENGTH)), batch_size=batch_size, drop_last=True)
@@ -61,5 +68,5 @@ def test_round_robin_batch_sampler_value_error(dummy_dataset):
         ValueError, match="The number of batch samplers must match the number of datasets in the ConcatDataset"
     ):
         RoundRobinBatchSampler(
-            dataset=dummy_dataset, batch_samplers=[batch_sampler_1, batch_sampler_2, batch_sampler_3]
+            dataset=dummy_concat_dataset, batch_samplers=[batch_sampler_1, batch_sampler_2, batch_sampler_3]
         )


### PR DESCRIPTION
This PR

- Makes the `seed` and `generator` arguments optional
- Adds unit tests for the `RoundRobinBatchSampler`.
- Have the class return a ValueError if the length of the `ConcaDataset` does not match the length of the list of `BatchSamplers`. 

The reason for the last point above, is that I ran into an issue while creating the unit tests. Initially I tried:

```py
import pytest
from datasets import Dataset
from sentence_transformers.sampler import RoundRobinBatchSampler

from torch.utils.data import BatchSampler, SequentialSampler, ConcatDataset


@pytest.fixture
def dummy_dataset() -> ConcatDataset:
    """
    Dummy dataset for testing purposes. The dataset looks as follows:
    {
        "data": [0, 1, 2, ... , 23, 24, 100, 101, ..., 123, 124],
        "label": [0, 1, 0, 1, ..., 0, 1],
    }
    """

    values_1 = list(range(25))
    labels = [x % 2 for x in values_1]
    dataset_1 = Dataset.from_dict({"data": values_1, "label": labels})

    values_2 = [x + 100 for x in values_1]
    dataset_2 = Dataset.from_dict({"data": values_2, "label": labels})

    return ConcatDataset([dataset_1, dataset_2])


def test_round_robin_batch_sampler(dummy_dataset):
    batch_sampler_1 = BatchSampler(SequentialSampler(range(len(dummy_dataset))), batch_size=4, drop_last=True)
    batch_sampler_2 = BatchSampler(SequentialSampler(range(len(dummy_dataset))), batch_size=4, drop_last=True)
    sampler = RoundRobinBatchSampler(dataset=dummy_dataset, batch_samplers=[batch_sampler_1, batch_sampler_2])

    batches = list(iter(sampler))

    for batch in batches:
        for idx in batch:
            print(dummy_dataset[idx])
```

But that failed with a `IndexError: list index out of range`. Since the sampler takes both a `ConcatDataset`and a list of `BatchSamplers`, I am assuming the intended way to use this class is to have a sampler for each dataset in the `ConcatDataset`, so I added that as a check in the class. But maybe my assumption here is wrong; if so please let me know.