### PR TITLE
Move `pytest` config to `pyproject.toml` and remove `pytest.ini`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,3 +72,12 @@ ignore = [
 [tool.ruff.lint.per-file-ignores]
 # Ignore `E402` (import violations) in all examples
 "examples/**" = ["E402"]
+
+[tool.pytest.ini_options]
+testpaths = [
+    "tests"
+]
+addopts = "--strict-markers -m 'not slow'"
+markers = [
+    "slow: marks tests as slow"
+]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,0 @@
-[pytest]
-testpaths =
-    tests
-addopts = --strict-markers -m "not slow"
-markers =
-    slow: marks tests as slow


### PR DESCRIPTION
Now that the project uses `pyproject.toml`, we can also consider moving the `pytest` configuration to `pyproject.toml` under [[tool.pytest.ini_options]](https://docs.pytest.org/en/stable/reference/customize.html#pyproject-toml) and remove the `pytest.ini` file. 