### PR TITLE
[`chore`] Add some additional commands to the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,18 @@
+.PHONY: venv
+venv: ## Create virtual environment and install development dependencies
+	@echo "Creating virtual environment..."
+	@python -m venv .venv
+	@echo "Activating virtual environment..."
+ifeq ($(OS), Windows_NT)
+	.venv\Scripts\activate
+else
+	. .venv/bin/activate
+endif
+	@echo "Installing development dependencies..."
+	@pip install '.[dev]'
 
 .PHONY: check
-check: ## Run code quality tools.
+check: ## Run code quality tools
 	@echo "Linting code via pre-commit"
 	@pre-commit run -a
 
@@ -12,8 +24,14 @@ test: ## Run unit tests
 test-cov: ## Run unit tests and generate a coverage report
 	@pytest --cov-report term --cov-report=html --cov=sentence_transformers
 
+.PHONY: build
+build: ## Build the wheel file
+	@echo "Building the wheel file..."
+	@pip install build
+	@python -m build
+
 .PHONY: help
-help: ## Show help for the commands.
+help: ## Show help for the commands
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
 
 .DEFAULT_GOAL := help


### PR DESCRIPTION
Proposal to add two commands to the `Makefile` to make developer's life a bit easier.

```     
> make help

venv                 Create virtual environment and install development dependencies
check                Run code quality tools
test                 Run unit tests
test-cov             Run unit tests and generate a coverage report
build                Build the wheel file
help                 Show help for the commands
```