### PR TITLE
Fix `ruff` pre-commit hook.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ namespaces = false
 
 [tool.ruff]
 line-length = 119
+fix = true
 
 [tool.ruff.lint]
 select = ["E", "F", "W"]


### PR DESCRIPTION
Currently the pre-commit hooks do not automatically fix issues that ruff can autofix, due to a recent change by me. This PR fixes that problem.