### PR TITLE
[`chore`] Enable `isort` with `ruff`

### DIFF
--- a/examples/applications/computing-embeddings/computing_embeddings_streaming.py
+++ b/examples/applications/computing-embeddings/computing_embeddings_streaming.py
@@ -10,10 +10,10 @@ https://huggingface.co/docs/datasets/stream
 
 import logging
 
+from datasets import load_dataset
 from torch.utils.data import DataLoader
 from tqdm import tqdm
 
-from datasets import load_dataset
 from sentence_transformers import LoggingHandler, SentenceTransformer
 
 logging.basicConfig(

--- a/examples/applications/embedding-quantization/semantic_search_faiss.py
+++ b/examples/applications/embedding-quantization/semantic_search_faiss.py
@@ -1,6 +1,7 @@
 import time
 
 from datasets import load_dataset
+
 from sentence_transformers import SentenceTransformer
 from sentence_transformers.quantization import quantize_embeddings, semantic_search_faiss
 

--- a/examples/applications/embedding-quantization/semantic_search_faiss_benchmark.py
+++ b/examples/applications/embedding-quantization/semantic_search_faiss_benchmark.py
@@ -1,4 +1,5 @@
 from datasets import load_dataset
+
 from sentence_transformers import SentenceTransformer
 from sentence_transformers.quantization import quantize_embeddings, semantic_search_faiss
 

--- a/examples/applications/embedding-quantization/semantic_search_recommended.py
+++ b/examples/applications/embedding-quantization/semantic_search_recommended.py
@@ -10,9 +10,9 @@ import time
 
 import faiss
 import numpy as np
+from datasets import load_dataset
 from usearch.index import Index
 
-from datasets import load_dataset
 from sentence_transformers import SentenceTransformer
 from sentence_transformers.quantization import quantize_embeddings
 

--- a/examples/applications/embedding-quantization/semantic_search_usearch.py
+++ b/examples/applications/embedding-quantization/semantic_search_usearch.py
@@ -1,6 +1,7 @@
 import time
 
 from datasets import load_dataset
+
 from sentence_transformers import SentenceTransformer
 from sentence_transformers.quantization import quantize_embeddings, semantic_search_usearch
 

--- a/examples/applications/embedding-quantization/semantic_search_usearch_benchmark.py
+++ b/examples/applications/embedding-quantization/semantic_search_usearch_benchmark.py
@@ -1,4 +1,5 @@
 from datasets import load_dataset
+
 from sentence_transformers import SentenceTransformer
 from sentence_transformers.quantization import quantize_embeddings, semantic_search_usearch
 

--- a/examples/evaluation/evaluation_inference_speed.py
+++ b/examples/evaluation/evaluation_inference_speed.py
@@ -11,8 +11,8 @@ import sys
 import time
 
 import torch
-
 from datasets import load_dataset
+
 from sentence_transformers import SentenceTransformer
 
 # Limit torch to 4 threads

--- a/examples/evaluation/evaluation_stsbenchmark.py
+++ b/examples/evaluation/evaluation_stsbenchmark.py
@@ -12,8 +12,8 @@ import os
 import sys
 
 import torch
-
 from datasets import load_dataset
+
 from sentence_transformers import SentenceTransformer
 from sentence_transformers.evaluation import EmbeddingSimilarityEvaluator
 from sentence_transformers.similarity_functions import SimilarityFunction

--- a/examples/evaluation/evaluation_translation_matching.py
+++ b/examples/evaluation/evaluation_translation_matching.py
@@ -23,6 +23,7 @@ import logging
 import sys
 
 from datasets import load_dataset
+
 from sentence_transformers import SentenceTransformer, evaluation
 
 # Set the log level to INFO to get more information

--- a/examples/training/adaptive_layer/adaptive_layer_nli.py
+++ b/examples/training/adaptive_layer/adaptive_layer_nli.py
@@ -16,6 +16,7 @@ import traceback
 from datetime import datetime
 
 from datasets import load_dataset
+
 from sentence_transformers import (
     SentenceTransformer,
     SentenceTransformerTrainer,

--- a/examples/training/adaptive_layer/adaptive_layer_sts.py
+++ b/examples/training/adaptive_layer/adaptive_layer_sts.py
@@ -16,6 +16,7 @@ import traceback
 from datetime import datetime
 
 from datasets import load_dataset
+
 from sentence_transformers import (
     SentenceTransformer,
     SentenceTransformerTrainer,

--- a/examples/training/avg_word_embeddings/training_stsbenchmark_avg_word_embeddings.py
+++ b/examples/training/avg_word_embeddings/training_stsbenchmark_avg_word_embeddings.py
@@ -12,6 +12,7 @@ import traceback
 from datetime import datetime
 
 from datasets import load_dataset
+
 from sentence_transformers import SentenceTransformer, losses, models
 from sentence_transformers.evaluation import EmbeddingSimilarityEvaluator
 from sentence_transformers.similarity_functions import SimilarityFunction

--- a/examples/training/avg_word_embeddings/training_stsbenchmark_bilstm.py
+++ b/examples/training/avg_word_embeddings/training_stsbenchmark_bilstm.py
@@ -10,6 +10,7 @@ import traceback
 from datetime import datetime
 
 from datasets import load_dataset
+
 from sentence_transformers import SentenceTransformer, losses, models
 from sentence_transformers.evaluation import EmbeddingSimilarityEvaluator
 from sentence_transformers.similarity_functions import SimilarityFunction

--- a/examples/training/avg_word_embeddings/training_stsbenchmark_bow.py
+++ b/examples/training/avg_word_embeddings/training_stsbenchmark_bow.py
@@ -12,6 +12,7 @@ import traceback
 from datetime import datetime
 
 from datasets import load_dataset
+
 from sentence_transformers import SentenceTransformer, losses, models, util
 from sentence_transformers.evaluation import EmbeddingSimilarityEvaluator
 from sentence_transformers.models.tokenizer.WordTokenizer import ENGLISH_STOP_WORDS

--- a/examples/training/avg_word_embeddings/training_stsbenchmark_cnn.py
+++ b/examples/training/avg_word_embeddings/training_stsbenchmark_cnn.py
@@ -11,6 +11,7 @@ import traceback
 from datetime import datetime
 
 from datasets import load_dataset
+
 from sentence_transformers import SentenceTransformer, losses, models
 from sentence_transformers.evaluation import EmbeddingSimilarityEvaluator
 from sentence_transformers.similarity_functions import SimilarityFunction

--- a/examples/training/avg_word_embeddings/training_stsbenchmark_tf-idf_word_embeddings.py
+++ b/examples/training/avg_word_embeddings/training_stsbenchmark_tf-idf_word_embeddings.py
@@ -16,6 +16,7 @@ import traceback
 from datetime import datetime
 
 from datasets import load_dataset
+
 from sentence_transformers import SentenceTransformer, losses, models, util
 from sentence_transformers.evaluation import EmbeddingSimilarityEvaluator
 from sentence_transformers.similarity_functions import SimilarityFunction

--- a/examples/training/data_augmentation/train_sts_indomain_bm25.py
+++ b/examples/training/data_augmentation/train_sts_indomain_bm25.py
@@ -33,10 +33,10 @@ import traceback
 from datetime import datetime
 
 import tqdm
+from datasets import Dataset, concatenate_datasets, load_dataset
 from elasticsearch import Elasticsearch
 from torch.utils.data import DataLoader
 
-from datasets import Dataset, concatenate_datasets, load_dataset
 from sentence_transformers import SentenceTransformer, losses
 from sentence_transformers.cross_encoder import CrossEncoder
 from sentence_transformers.cross_encoder.evaluation import CECorrelationEvaluator

--- a/examples/training/data_augmentation/train_sts_indomain_nlpaug.py
+++ b/examples/training/data_augmentation/train_sts_indomain_nlpaug.py
@@ -37,8 +37,8 @@ from datetime import datetime
 import nlpaug.augmenter.word as naw
 import torch
 import tqdm
-
 from datasets import Dataset, concatenate_datasets, load_dataset
+
 from sentence_transformers import SentenceTransformer, losses
 from sentence_transformers.evaluation import EmbeddingSimilarityEvaluator
 from sentence_transformers.similarity_functions import SimilarityFunction

--- a/examples/training/distillation/dimensionality_reduction.py
+++ b/examples/training/distillation/dimensionality_reduction.py
@@ -20,9 +20,9 @@ import random
 
 import numpy as np
 import torch
+from datasets import load_dataset
 from sklearn.decomposition import PCA
 
-from datasets import load_dataset
 from sentence_transformers import SentenceTransformer, models
 from sentence_transformers.evaluation import EmbeddingSimilarityEvaluator
 

--- a/examples/training/distillation/model_distillation.py
+++ b/examples/training/distillation/model_distillation.py
@@ -26,9 +26,9 @@ from datetime import datetime
 
 import pandas as pd
 import torch
+from datasets import Dataset, concatenate_datasets, load_dataset
 from sklearn.decomposition import PCA
 
-from datasets import Dataset, concatenate_datasets, load_dataset
 from sentence_transformers import LoggingHandler, SentenceTransformer, evaluation, losses, models
 from sentence_transformers.evaluation import EmbeddingSimilarityEvaluator
 from sentence_transformers.similarity_functions import SimilarityFunction

--- a/examples/training/distillation/model_distillation_layer_reduction.py
+++ b/examples/training/distillation/model_distillation_layer_reduction.py
@@ -26,8 +26,8 @@ from datetime import datetime
 
 import pandas as pd
 import torch
-
 from datasets import Dataset, concatenate_datasets, load_dataset
+
 from sentence_transformers import SentenceTransformer, evaluation, losses
 from sentence_transformers.evaluation import EmbeddingSimilarityEvaluator
 from sentence_transformers.similarity_functions import SimilarityFunction

--- a/examples/training/hpo/hpo_nli.py
+++ b/examples/training/hpo/hpo_nli.py
@@ -1,4 +1,5 @@
 from datasets import load_dataset
+
 from sentence_transformers import (
     SentenceTransformer,
     SentenceTransformerTrainer,

--- a/examples/training/matryoshka/2d_matryoshka_nli.py
+++ b/examples/training/matryoshka/2d_matryoshka_nli.py
@@ -17,6 +17,7 @@ import traceback
 from datetime import datetime
 
 from datasets import load_dataset
+
 from sentence_transformers import (
     SentenceTransformer,
     SentenceTransformerTrainer,

--- a/examples/training/matryoshka/2d_matryoshka_sts.py
+++ b/examples/training/matryoshka/2d_matryoshka_sts.py
@@ -16,6 +16,7 @@ import traceback
 from datetime import datetime
 
 from datasets import load_dataset
+
 from sentence_transformers import (
     SentenceTransformer,
     SentenceTransformerTrainer,

--- a/examples/training/matryoshka/matryoshka_eval_stsb.py
+++ b/examples/training/matryoshka/matryoshka_eval_stsb.py
@@ -9,9 +9,9 @@ from typing import Dict, List, Optional, Tuple, cast
 
 import matplotlib.pyplot as plt
 import numpy as np
+from datasets import load_dataset
 from tqdm.auto import tqdm
 
-from datasets import load_dataset
 from sentence_transformers import SentenceTransformer
 from sentence_transformers.evaluation import (
     EmbeddingSimilarityEvaluator,

--- a/examples/training/matryoshka/matryoshka_nli.py
+++ b/examples/training/matryoshka/matryoshka_nli.py
@@ -17,6 +17,7 @@ import traceback
 from datetime import datetime
 
 from datasets import load_dataset
+
 from sentence_transformers import (
     SentenceTransformer,
     SentenceTransformerTrainer,

--- a/examples/training/matryoshka/matryoshka_nli_reduced_dim.py
+++ b/examples/training/matryoshka/matryoshka_nli_reduced_dim.py
@@ -21,6 +21,7 @@ import traceback
 from datetime import datetime
 
 from datasets import load_dataset
+
 from sentence_transformers import (
     SentenceTransformer,
     SentenceTransformerTrainer,

--- a/examples/training/matryoshka/matryoshka_sts.py
+++ b/examples/training/matryoshka/matryoshka_sts.py
@@ -16,6 +16,7 @@ import traceback
 from datetime import datetime
 
 from datasets import load_dataset
+
 from sentence_transformers import (
     SentenceTransformer,
     SentenceTransformerTrainer,

--- a/examples/training/multilingual/make_multilingual.py
+++ b/examples/training/multilingual/make_multilingual.py
@@ -22,8 +22,8 @@ import traceback
 from datetime import datetime
 
 import numpy as np
-
 from datasets import DatasetDict, load_dataset
+
 from sentence_transformers import LoggingHandler, SentenceTransformer
 from sentence_transformers.evaluation import (
     EmbeddingSimilarityEvaluator,

--- a/examples/training/nli/training_nli.py
+++ b/examples/training/nli/training_nli.py
@@ -16,6 +16,7 @@ import traceback
 from datetime import datetime
 
 from datasets import load_dataset
+
 from sentence_transformers import SentenceTransformer, losses
 from sentence_transformers.evaluation import EmbeddingSimilarityEvaluator
 from sentence_transformers.similarity_functions import SimilarityFunction

--- a/examples/training/nli/training_nli_v2.py
+++ b/examples/training/nli/training_nli_v2.py
@@ -16,6 +16,7 @@ import traceback
 from datetime import datetime
 
 from datasets import load_dataset
+
 from sentence_transformers import SentenceTransformer, losses
 from sentence_transformers.evaluation import EmbeddingSimilarityEvaluator
 from sentence_transformers.similarity_functions import SimilarityFunction

--- a/examples/training/nli/training_nli_v3.py
+++ b/examples/training/nli/training_nli_v3.py
@@ -16,6 +16,7 @@ import traceback
 from datetime import datetime
 
 from datasets import load_dataset
+
 from sentence_transformers import SentenceTransformer, losses
 from sentence_transformers.evaluation import EmbeddingSimilarityEvaluator
 from sentence_transformers.similarity_functions import SimilarityFunction

--- a/examples/training/other/training_multi-task.py
+++ b/examples/training/other/training_multi-task.py
@@ -9,6 +9,7 @@ import traceback
 from datetime import datetime
 
 from datasets import load_dataset
+
 from sentence_transformers import SentenceTransformer
 from sentence_transformers.evaluation import EmbeddingSimilarityEvaluator
 from sentence_transformers.losses import CosineSimilarityLoss, SoftmaxLoss

--- a/examples/training/other/training_wikipedia_sections.py
+++ b/examples/training/other/training_wikipedia_sections.py
@@ -9,6 +9,7 @@ import traceback
 from datetime import datetime
 
 from datasets import load_dataset
+
 from sentence_transformers import SentenceTransformer
 from sentence_transformers.evaluation import TripletEvaluator
 from sentence_transformers.losses import TripletLoss

--- a/examples/training/paraphrases/training.py
+++ b/examples/training/paraphrases/training.py
@@ -8,6 +8,7 @@ import traceback
 from datetime import datetime
 
 from datasets import load_dataset
+
 from sentence_transformers import SentenceTransformer
 from sentence_transformers.evaluation import EmbeddingSimilarityEvaluator
 from sentence_transformers.losses import MultipleNegativesRankingLoss

--- a/examples/training/quora_duplicate_questions/training_MultipleNegativesRankingLoss.py
+++ b/examples/training/quora_duplicate_questions/training_MultipleNegativesRankingLoss.py
@@ -17,6 +17,7 @@ import traceback
 from datetime import datetime
 
 from datasets import load_dataset
+
 from sentence_transformers import SentenceTransformer
 from sentence_transformers.evaluation import (
     BinaryClassificationEvaluator,

--- a/examples/training/quora_duplicate_questions/training_OnlineContrastiveLoss.py
+++ b/examples/training/quora_duplicate_questions/training_OnlineContrastiveLoss.py
@@ -15,6 +15,7 @@ import traceback
 from datetime import datetime
 
 from datasets import load_dataset
+
 from sentence_transformers import SentenceTransformer
 from sentence_transformers.evaluation import (
     BinaryClassificationEvaluator,

--- a/examples/training/quora_duplicate_questions/training_multi-task-learning.py
+++ b/examples/training/quora_duplicate_questions/training_multi-task-learning.py
@@ -17,6 +17,7 @@ import traceback
 from datetime import datetime
 
 from datasets import load_dataset
+
 from sentence_transformers import SentenceTransformer
 from sentence_transformers.evaluation import (
     BinaryClassificationEvaluator,

--- a/examples/training/sts/training_stsbenchmark.py
+++ b/examples/training/sts/training_stsbenchmark.py
@@ -15,6 +15,7 @@ import traceback
 from datetime import datetime
 
 from datasets import load_dataset
+
 from sentence_transformers import SentenceTransformer, losses
 from sentence_transformers.evaluation import EmbeddingSimilarityEvaluator
 from sentence_transformers.similarity_functions import SimilarityFunction

--- a/examples/training/sts/training_stsbenchmark_continue_training.py
+++ b/examples/training/sts/training_stsbenchmark_continue_training.py
@@ -12,6 +12,7 @@ import traceback
 from datetime import datetime
 
 from datasets import load_dataset
+
 from sentence_transformers import SentenceTransformer, losses
 from sentence_transformers.evaluation import EmbeddingSimilarityEvaluator
 from sentence_transformers.similarity_functions import SimilarityFunction

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ line-length = 119
 fix = true
 
 [tool.ruff.lint]
-select = ["E", "F", "W"]
+select = ["E", "F", "W", "I"]
 # Skip `E731` (do not assign a lambda expression, use a def)
 ignore = [
     # LineTooLong
@@ -74,6 +74,9 @@ ignore = [
 [tool.ruff.lint.per-file-ignores]
 # Ignore `E402` (import violations) in all examples
 "examples/**" = ["E402"]
+
+[tool.ruff.lint.isort]
+known-first-party = ["datasets"]
 
 [tool.pytest.ini_options]
 testpaths = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ ignore = [
 "examples/**" = ["E402"]
 
 [tool.ruff.lint.isort]
-known-first-party = ["datasets"]
+known-third-party = ["datasets"]
 
 [tool.pytest.ini_options]
 testpaths = [

--- a/sentence_transformers/sampler.py
+++ b/sentence_transformers/sampler.py
@@ -1,7 +1,7 @@
 import logging
 from collections import defaultdict
 from itertools import accumulate, cycle
-from typing import Iterator, List, Any
+from typing import Any, Iterator, List
 
 import torch
 from torch.utils.data import BatchSampler, ConcatDataset, SubsetRandomSampler

--- a/sentence_transformers/util.py
+++ b/sentence_transformers/util.py
@@ -21,9 +21,9 @@ from transformers import is_torch_npu_available
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
-    from sentence_transformers.SentenceTransformer import SentenceTransformer
-    from sentence_transformers.cross_encoder.CrossEncoder import CrossEncoder
     from datasets import Dataset
+    from sentence_transformers.cross_encoder.CrossEncoder import CrossEncoder
+    from sentence_transformers.SentenceTransformer import SentenceTransformer
 
 
 def _convert_to_tensor(a: Union[list, np.ndarray, Tensor]) -> Tensor:

--- a/sentence_transformers/util.py
+++ b/sentence_transformers/util.py
@@ -22,6 +22,7 @@ logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from datasets import Dataset
+
     from sentence_transformers.cross_encoder.CrossEncoder import CrossEncoder
     from sentence_transformers.SentenceTransformer import SentenceTransformer
 

--- a/tests/samplers/test_group_by_label_batch_sampler.py
+++ b/tests/samplers/test_group_by_label_batch_sampler.py
@@ -1,7 +1,9 @@
+from collections import Counter
+
 import pytest
+
 from datasets import Dataset
 from sentence_transformers.sampler import GroupByLabelBatchSampler
-from collections import Counter
 
 
 @pytest.fixture

--- a/tests/samplers/test_group_by_label_batch_sampler.py
+++ b/tests/samplers/test_group_by_label_batch_sampler.py
@@ -1,8 +1,8 @@
 from collections import Counter
 
 import pytest
-
 from datasets import Dataset
+
 from sentence_transformers.sampler import GroupByLabelBatchSampler
 
 

--- a/tests/samplers/test_no_duplicates_batch_sampler.py
+++ b/tests/samplers/test_no_duplicates_batch_sampler.py
@@ -1,8 +1,8 @@
 import random
 
 import pytest
-
 from datasets import Dataset
+
 from sentence_transformers.sampler import NoDuplicatesBatchSampler
 
 

--- a/tests/samplers/test_no_duplicates_batch_sampler.py
+++ b/tests/samplers/test_no_duplicates_batch_sampler.py
@@ -1,7 +1,9 @@
+import random
+
 import pytest
+
 from datasets import Dataset
 from sentence_transformers.sampler import NoDuplicatesBatchSampler
-import random
 
 
 @pytest.fixture

--- a/tests/samplers/test_round_robin_batch_sampler.py
+++ b/tests/samplers/test_round_robin_batch_sampler.py
@@ -1,7 +1,7 @@
 import pytest
+from datasets import Dataset
 from torch.utils.data import BatchSampler, ConcatDataset, SequentialSampler
 
-from datasets import Dataset
 from sentence_transformers.sampler import RoundRobinBatchSampler
 
 DATASET_LENGTH = 25

--- a/tests/samplers/test_round_robin_batch_sampler.py
+++ b/tests/samplers/test_round_robin_batch_sampler.py
@@ -1,8 +1,8 @@
 import pytest
+from torch.utils.data import BatchSampler, ConcatDataset, SequentialSampler
+
 from datasets import Dataset
 from sentence_transformers.sampler import RoundRobinBatchSampler
-
-from torch.utils.data import BatchSampler, SequentialSampler, ConcatDataset
 
 DATASET_LENGTH = 25
 


### PR DESCRIPTION
This PR proposes to enable `isort` in the project. Earlier there seemed to be [an issue](https://github.com/UKPLab/sentence-transformers/pull/2790#issuecomment-2196674153) with enabling `isort` causing inconsistent behavior between running `ruff` locally vs in the CI/CD pipeline. I believe this issue can be resolved using the [known-third-party](https://docs.astral.sh/ruff/settings/#lint_isort_known-third-party) setting.



