### PR TITLE
[`chore`] Enable ruff rules `UP006` and `UP007` to improve type hints.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ line-length = 119
 fix = true
 
 [tool.ruff.lint]
-select = ["E", "F", "W", "I"]
+select = ["E", "F", "W", "I", "UP006", "UP007"]
 # Skip `E731` (do not assign a lambda expression, use a def)
 ignore = [
     # LineTooLong
@@ -72,11 +72,21 @@ ignore = [
 ]
 
 [tool.ruff.lint.per-file-ignores]
-# Ignore `E402` (import violations) in all examples
-"examples/**" = ["E402"]
+"examples/**" = [
+    # Ignore `E402` (import violations) in all examples
+    "E402", 
+    # Ignore missing required imports
+    "I002"
+    ]
+"docs/**" = [
+    # Ignore missing required imports
+    "I002"
+    ]
 
 [tool.ruff.lint.isort]
 known-third-party = ["datasets"]
+required-imports = ["from __future__ import annotations"]
+
 
 [tool.pytest.ini_options]
 testpaths = [

--- a/sentence_transformers/LoggingHandler.py
+++ b/sentence_transformers/LoggingHandler.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 
 import tqdm

--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import copy
 import importlib
 import json
@@ -12,7 +14,7 @@ from collections import OrderedDict
 from contextlib import contextmanager
 from multiprocessing import Queue
 from pathlib import Path
-from typing import Any, Callable, Dict, Iterable, Iterator, List, Literal, Optional, Tuple, Union, overload
+from typing import Any, Callable, Iterable, Iterator, Literal, overload
 
 import numpy as np
 import torch
@@ -143,23 +145,23 @@ class SentenceTransformer(nn.Sequential, FitMixin):
 
     def __init__(
         self,
-        model_name_or_path: Optional[str] = None,
-        modules: Optional[Iterable[nn.Module]] = None,
-        device: Optional[str] = None,
-        prompts: Optional[Dict[str, str]] = None,
-        default_prompt_name: Optional[str] = None,
-        similarity_fn_name: Optional[Union[str, SimilarityFunction]] = None,
-        cache_folder: Optional[str] = None,
+        model_name_or_path: str | None = None,
+        modules: Iterable[nn.Module] | None = None,
+        device: str | None = None,
+        prompts: dict[str, str] | None = None,
+        default_prompt_name: str | None = None,
+        similarity_fn_name: str | SimilarityFunction | None = None,
+        cache_folder: str | None = None,
         trust_remote_code: bool = False,
-        revision: Optional[str] = None,
+        revision: str | None = None,
         local_files_only: bool = False,
-        token: Optional[Union[bool, str]] = None,
-        use_auth_token: Optional[Union[bool, str]] = None,
-        truncate_dim: Optional[int] = None,
-        model_kwargs: Optional[Dict[str, Any]] = None,
-        tokenizer_kwargs: Optional[Dict[str, Any]] = None,
-        config_kwargs: Optional[Dict[str, Any]] = None,
-        model_card_data: Optional[SentenceTransformerModelCardData] = None,
+        token: bool | str | None = None,
+        use_auth_token: bool | str | None = None,
+        truncate_dim: int | None = None,
+        model_kwargs: dict[str, Any] | None = None,
+        tokenizer_kwargs: dict[str, Any] | None = None,
+        config_kwargs: dict[str, Any] | None = None,
+        model_card_data: SentenceTransformerModelCardData | None = None,
     ) -> None:
         # Note: self._load_sbert_model can also update `self.prompts` and `self.default_prompt_name`
         self.prompts = prompts or {}
@@ -355,11 +357,11 @@ class SentenceTransformer(nn.Sequential, FitMixin):
     def encode(
         self,
         sentences: str,
-        prompt_name: Optional[str] = ...,
-        prompt: Optional[str] = ...,
+        prompt_name: str | None = ...,
+        prompt: str | None = ...,
         batch_size: int = ...,
-        show_progress_bar: Optional[bool] = ...,
-        output_value: Optional[Literal["sentence_embedding", "token_embeddings"]] = ...,
+        show_progress_bar: bool | None = ...,
+        output_value: Literal["sentence_embedding", "token_embeddings"] | None = ...,
         precision: Literal["float32", "int8", "uint8", "binary", "ubinary"] = ...,
         convert_to_numpy: Literal[False] = ...,
         convert_to_tensor: Literal[False] = ...,
@@ -370,12 +372,12 @@ class SentenceTransformer(nn.Sequential, FitMixin):
     @overload
     def encode(
         self,
-        sentences: Union[str, List[str]],
-        prompt_name: Optional[str] = ...,
-        prompt: Optional[str] = ...,
+        sentences: str | list[str],
+        prompt_name: str | None = ...,
+        prompt: str | None = ...,
         batch_size: int = ...,
-        show_progress_bar: Optional[bool] = ...,
-        output_value: Optional[Literal["sentence_embedding", "token_embeddings"]] = ...,
+        show_progress_bar: bool | None = ...,
+        output_value: Literal["sentence_embedding", "token_embeddings"] | None = ...,
         precision: Literal["float32", "int8", "uint8", "binary", "ubinary"] = ...,
         convert_to_numpy: Literal[True] = ...,
         convert_to_tensor: Literal[False] = ...,
@@ -386,12 +388,12 @@ class SentenceTransformer(nn.Sequential, FitMixin):
     @overload
     def encode(
         self,
-        sentences: Union[str, List[str]],
-        prompt_name: Optional[str] = ...,
-        prompt: Optional[str] = ...,
+        sentences: str | list[str],
+        prompt_name: str | None = ...,
+        prompt: str | None = ...,
         batch_size: int = ...,
-        show_progress_bar: Optional[bool] = ...,
-        output_value: Optional[Literal["sentence_embedding", "token_embeddings"]] = ...,
+        show_progress_bar: bool | None = ...,
+        output_value: Literal["sentence_embedding", "token_embeddings"] | None = ...,
         precision: Literal["float32", "int8", "uint8", "binary", "ubinary"] = ...,
         convert_to_numpy: bool = ...,
         convert_to_tensor: Literal[True] = ...,
@@ -402,33 +404,33 @@ class SentenceTransformer(nn.Sequential, FitMixin):
     @overload
     def encode(
         self,
-        sentences: Union[List[str], np.ndarray],
-        prompt_name: Optional[str] = ...,
-        prompt: Optional[str] = ...,
+        sentences: list[str] | np.ndarray,
+        prompt_name: str | None = ...,
+        prompt: str | None = ...,
         batch_size: int = ...,
-        show_progress_bar: Optional[bool] = ...,
-        output_value: Optional[Literal["sentence_embedding", "token_embeddings"]] = ...,
+        show_progress_bar: bool | None = ...,
+        output_value: Literal["sentence_embedding", "token_embeddings"] | None = ...,
         precision: Literal["float32", "int8", "uint8", "binary", "ubinary"] = ...,
         convert_to_numpy: Literal[False] = ...,
         convert_to_tensor: Literal[False] = ...,
         device: str = ...,
         normalize_embeddings: bool = ...,
-    ) -> List[Tensor]: ...
+    ) -> list[Tensor]: ...
 
     def encode(
         self,
-        sentences: Union[str, List[str]],
-        prompt_name: Optional[str] = None,
-        prompt: Optional[str] = None,
+        sentences: str | list[str],
+        prompt_name: str | None = None,
+        prompt: str | None = None,
         batch_size: int = 32,
-        show_progress_bar: Optional[bool] = None,
-        output_value: Optional[Literal["sentence_embedding", "token_embeddings"]] = "sentence_embedding",
+        show_progress_bar: bool | None = None,
+        output_value: Literal["sentence_embedding", "token_embeddings"] | None = "sentence_embedding",
         precision: Literal["float32", "int8", "uint8", "binary", "ubinary"] = "float32",
         convert_to_numpy: bool = True,
         convert_to_tensor: bool = False,
         device: str = None,
         normalize_embeddings: bool = False,
-    ) -> Union[List[Tensor], np.ndarray, Tensor]:
+    ) -> list[Tensor] | np.ndarray | Tensor:
         """
         Computes sentence embeddings.
 
@@ -637,7 +639,7 @@ class SentenceTransformer(nn.Sequential, FitMixin):
         return all_embeddings
 
     @property
-    def similarity_fn_name(self) -> Optional[str]:
+    def similarity_fn_name(self) -> str | None:
         """Return the name of the similarity function used by :meth:`SentenceTransformer.similarity` and :meth:`SentenceTransformer.similarity_pairwise`.
 
         Returns:
@@ -652,7 +654,7 @@ class SentenceTransformer(nn.Sequential, FitMixin):
         return self._similarity_fn_name
 
     @similarity_fn_name.setter
-    def similarity_fn_name(self, value: Union[str, SimilarityFunction]) -> None:
+    def similarity_fn_name(self, value: str | SimilarityFunction) -> None:
         if isinstance(value, SimilarityFunction):
             value = value.value
         self._similarity_fn_name = value
@@ -668,7 +670,7 @@ class SentenceTransformer(nn.Sequential, FitMixin):
     def similarity(self, embeddings1: ndarray, embeddings2: ndarray) -> Tensor: ...
 
     @property
-    def similarity(self) -> Callable[[Union[Tensor, ndarray], Union[Tensor, ndarray]], Tensor]:
+    def similarity(self) -> Callable[[Tensor | ndarray, Tensor | ndarray], Tensor]:
         """
         Compute the similarity between two collections of embeddings. The output will be a matrix with the similarity
         scores between all embeddings from the first parameter and all embeddings from the second parameter. This
@@ -717,7 +719,7 @@ class SentenceTransformer(nn.Sequential, FitMixin):
     def similarity_pairwise(self, embeddings1: ndarray, embeddings2: ndarray) -> Tensor: ...
 
     @property
-    def similarity_pairwise(self) -> Callable[[Union[Tensor, ndarray], Union[Tensor, ndarray]], Tensor]:
+    def similarity_pairwise(self) -> Callable[[Tensor | ndarray, Tensor | ndarray], Tensor]:
         """
         Compute the similarity between two collections of embeddings. The output will be a vector with the similarity
         scores between each pair of embeddings.
@@ -753,8 +755,8 @@ class SentenceTransformer(nn.Sequential, FitMixin):
         return self._similarity_pairwise
 
     def start_multi_process_pool(
-        self, target_devices: List[str] = None
-    ) -> Dict[Literal["input", "output", "processes"], Any]:
+        self, target_devices: list[str] = None
+    ) -> dict[Literal["input", "output", "processes"], Any]:
         """
         Starts a multi-process pool to process the encoding with several independent processes
         via :meth:`SentenceTransformer.encode_multi_process <sentence_transformers.SentenceTransformer.encode_multi_process>`.
@@ -802,7 +804,7 @@ class SentenceTransformer(nn.Sequential, FitMixin):
         return {"input": input_queue, "output": output_queue, "processes": processes}
 
     @staticmethod
-    def stop_multi_process_pool(pool: Dict[Literal["input", "output", "processes"], Any]) -> None:
+    def stop_multi_process_pool(pool: dict[Literal["input", "output", "processes"], Any]) -> None:
         """
         Stops all processes started with start_multi_process_pool.
 
@@ -824,13 +826,13 @@ class SentenceTransformer(nn.Sequential, FitMixin):
 
     def encode_multi_process(
         self,
-        sentences: List[str],
-        pool: Dict[Literal["input", "output", "processes"], Any],
-        prompt_name: Optional[str] = None,
-        prompt: Optional[str] = None,
+        sentences: list[str],
+        pool: dict[Literal["input", "output", "processes"], Any],
+        prompt_name: str | None = None,
+        prompt: str | None = None,
         batch_size: int = 32,
         chunk_size: int = None,
-        show_progress_bar: Optional[bool] = None,
+        show_progress_bar: bool | None = None,
         precision: Literal["float32", "int8", "uint8", "binary", "ubinary"] = "float32",
         normalize_embeddings: bool = False,
     ) -> np.ndarray:
@@ -966,7 +968,7 @@ class SentenceTransformer(nn.Sequential, FitMixin):
                 module.include_prompt = include_prompt
                 break
 
-    def get_max_seq_length(self) -> Optional[int]:
+    def get_max_seq_length(self) -> int | None:
         """
         Returns the maximal sequence length that the model accepts. Longer inputs will be truncated.
 
@@ -978,7 +980,7 @@ class SentenceTransformer(nn.Sequential, FitMixin):
 
         return None
 
-    def tokenize(self, texts: Union[List[str], List[Dict], List[Tuple[str, str]]]) -> Dict[str, Tensor]:
+    def tokenize(self, texts: list[str] | list[dict] | list[tuple[str, str]]) -> dict[str, Tensor]:
         """
         Tokenizes the texts.
 
@@ -991,10 +993,10 @@ class SentenceTransformer(nn.Sequential, FitMixin):
         """
         return self._first_module().tokenize(texts)
 
-    def get_sentence_features(self, *features) -> Dict[Literal["sentence_embedding"], torch.Tensor]:
+    def get_sentence_features(self, *features) -> dict[Literal["sentence_embedding"], torch.Tensor]:
         return self._first_module().get_sentence_features(*features)
 
-    def get_sentence_embedding_dimension(self) -> Optional[int]:
+    def get_sentence_embedding_dimension(self) -> int | None:
         """
         Returns the number of dimensions in the output of :meth:`SentenceTransformer.encode <sentence_transformers.SentenceTransformer.encode>`.
 
@@ -1014,7 +1016,7 @@ class SentenceTransformer(nn.Sequential, FitMixin):
         return output_dim
 
     @contextmanager
-    def truncate_sentence_embeddings(self, truncate_dim: Optional[int]) -> Iterator[None]:
+    def truncate_sentence_embeddings(self, truncate_dim: int | None) -> Iterator[None]:
         """
         In this context, :meth:`SentenceTransformer.encode <sentence_transformers.SentenceTransformer.encode>` outputs
         sentence embeddings truncated at dimension ``truncate_dim``.
@@ -1054,9 +1056,9 @@ class SentenceTransformer(nn.Sequential, FitMixin):
     def save(
         self,
         path: str,
-        model_name: Optional[str] = None,
+        model_name: str | None = None,
         create_model_card: bool = True,
-        train_datasets: Optional[List[str]] = None,
+        train_datasets: list[str] | None = None,
         safe_serialization: bool = True,
     ) -> None:
         """
@@ -1122,9 +1124,9 @@ class SentenceTransformer(nn.Sequential, FitMixin):
     def save_pretrained(
         self,
         path: str,
-        model_name: Optional[str] = None,
+        model_name: str | None = None,
         create_model_card: bool = True,
-        train_datasets: Optional[List[str]] = None,
+        train_datasets: list[str] | None = None,
         safe_serialization: bool = True,
     ) -> None:
         """
@@ -1148,7 +1150,7 @@ class SentenceTransformer(nn.Sequential, FitMixin):
         )
 
     def _create_model_card(
-        self, path: str, model_name: Optional[str] = None, train_datasets: Optional[List[str]] = "deprecated"
+        self, path: str, model_name: str | None = None, train_datasets: list[str] | None = "deprecated"
     ) -> None:
         """
         Create an automatic model and stores it in the specified path. If no training was done and the loaded model
@@ -1195,15 +1197,15 @@ class SentenceTransformer(nn.Sequential, FitMixin):
     def save_to_hub(
         self,
         repo_id: str,
-        organization: Optional[str] = None,
-        token: Optional[str] = None,
-        private: Optional[bool] = None,
+        organization: str | None = None,
+        token: str | None = None,
+        private: bool | None = None,
         safe_serialization: bool = True,
         commit_message: str = "Add new SentenceTransformer model.",
-        local_model_path: Optional[str] = None,
+        local_model_path: str | None = None,
         exist_ok: bool = False,
         replace_model_card: bool = False,
-        train_datasets: Optional[List[str]] = None,
+        train_datasets: list[str] | None = None,
     ) -> str:
         """
         DEPRECATED, use `push_to_hub` instead.
@@ -1259,14 +1261,14 @@ class SentenceTransformer(nn.Sequential, FitMixin):
     def push_to_hub(
         self,
         repo_id: str,
-        token: Optional[str] = None,
-        private: Optional[bool] = None,
+        token: str | None = None,
+        private: bool | None = None,
         safe_serialization: bool = True,
         commit_message: str = "Add new SentenceTransformer model.",
-        local_model_path: Optional[str] = None,
+        local_model_path: str | None = None,
         exist_ok: bool = False,
         replace_model_card: bool = False,
-        train_datasets: Optional[List[str]] = None,
+        train_datasets: list[str] | None = None,
     ) -> str:
         """
         Uploads all elements of this Sentence Transformer to a new HuggingFace Hub repository.
@@ -1317,7 +1319,7 @@ class SentenceTransformer(nn.Sequential, FitMixin):
         # This isn't expected to ever be reached.
         return folder_url
 
-    def _text_length(self, text: Union[List[int], List[List[int]]]) -> int:
+    def _text_length(self, text: list[int] | list[list[int]]) -> int:
         """
         Help function to get the length for the input text. Text can be either
         a list of ints (which means a single text as input), or a tuple of list of ints
@@ -1333,7 +1335,7 @@ class SentenceTransformer(nn.Sequential, FitMixin):
         else:
             return sum([len(t) for t in text])  # Sum of length of individual strings
 
-    def evaluate(self, evaluator: SentenceEvaluator, output_path: str = None) -> Union[Dict[str, float], float]:
+    def evaluate(self, evaluator: SentenceEvaluator, output_path: str = None) -> dict[str, float] | float:
         """
         Evaluate the model based on an evaluator
 
@@ -1351,15 +1353,15 @@ class SentenceTransformer(nn.Sequential, FitMixin):
     def _load_auto_model(
         self,
         model_name_or_path: str,
-        token: Optional[Union[bool, str]],
-        cache_folder: Optional[str],
-        revision: Optional[str] = None,
+        token: bool | str | None,
+        cache_folder: str | None,
+        revision: str | None = None,
         trust_remote_code: bool = False,
         local_files_only: bool = False,
-        model_kwargs: Optional[Dict[str, Any]] = None,
-        tokenizer_kwargs: Optional[Dict[str, Any]] = None,
-        config_kwargs: Optional[Dict[str, Any]] = None,
-    ) -> List[nn.Module]:
+        model_kwargs: dict[str, Any] | None = None,
+        tokenizer_kwargs: dict[str, Any] | None = None,
+        config_kwargs: dict[str, Any] | None = None,
+    ) -> list[nn.Module]:
         """
         Creates a simple Transformer + Mean Pooling model and returns the modules
 
@@ -1405,15 +1407,15 @@ class SentenceTransformer(nn.Sequential, FitMixin):
     def _load_sbert_model(
         self,
         model_name_or_path: str,
-        token: Optional[Union[bool, str]],
-        cache_folder: Optional[str],
-        revision: Optional[str] = None,
+        token: bool | str | None,
+        cache_folder: str | None,
+        revision: str | None = None,
         trust_remote_code: bool = False,
         local_files_only: bool = False,
-        model_kwargs: Optional[Dict[str, Any]] = None,
-        tokenizer_kwargs: Optional[Dict[str, Any]] = None,
-        config_kwargs: Optional[Dict[str, Any]] = None,
-    ) -> Dict[str, nn.Module]:
+        model_kwargs: dict[str, Any] | None = None,
+        tokenizer_kwargs: dict[str, Any] | None = None,
+        config_kwargs: dict[str, Any] | None = None,
+    ) -> dict[str, nn.Module]:
         """
         Loads a full SentenceTransformer model using the modules.json file.
 
@@ -1595,7 +1597,7 @@ class SentenceTransformer(nn.Sequential, FitMixin):
         except StopIteration:
             # For nn.DataParallel compatibility in PyTorch 1.5
 
-            def find_tensor_attributes(module: nn.Module) -> List[Tuple[str, Tensor]]:
+            def find_tensor_attributes(module: nn.Module) -> list[tuple[str, Tensor]]:
                 tuples = [(k, v) for k, v in module.__dict__.items() if torch.is_tensor(v)]
                 return tuples
 
@@ -1654,18 +1656,18 @@ class SentenceTransformer(nn.Sequential, FitMixin):
         return self.device
 
     @_target_device.setter
-    def _target_device(self, device: Optional[Union[int, str, torch.device]] = None) -> None:
+    def _target_device(self, device: int | str | torch.device | None = None) -> None:
         self.to(device)
 
     @property
-    def _no_split_modules(self) -> List[str]:
+    def _no_split_modules(self) -> list[str]:
         try:
             return self._first_module()._no_split_modules
         except AttributeError:
             return []
 
     @property
-    def _keys_to_ignore_on_save(self) -> List[str]:
+    def _keys_to_ignore_on_save(self) -> list[str]:
         try:
             return self._first_module()._keys_to_ignore_on_save
         except AttributeError:

--- a/sentence_transformers/__init__.py
+++ b/sentence_transformers/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 __version__ = "3.1.0.dev0"
 __MODEL_HUB_ORGANIZATION__ = "sentence-transformers"
 

--- a/sentence_transformers/cross_encoder/CrossEncoder.py
+++ b/sentence_transformers/cross_encoder/CrossEncoder.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import logging
 import os
 from functools import wraps
-from typing import Callable, Dict, List, Literal, Optional, Tuple, Type, Union, overload
+from typing import Callable, Literal, overload
 
 import numpy as np
 import torch
@@ -58,11 +60,11 @@ class CrossEncoder(PushToHubMixin):
         model_name: str,
         num_labels: int = None,
         max_length: int = None,
-        device: Optional[str] = None,
-        tokenizer_args: Dict = None,
-        automodel_args: Dict = None,
+        device: str | None = None,
+        tokenizer_args: dict = None,
+        automodel_args: dict = None,
         trust_remote_code: bool = False,
-        revision: Optional[str] = None,
+        revision: str | None = None,
         local_files_only: bool = False,
         default_activation_function=None,
         classifier_dropout: float = None,
@@ -127,7 +129,7 @@ class CrossEncoder(PushToHubMixin):
         else:
             self.default_activation_function = nn.Sigmoid() if self.config.num_labels == 1 else nn.Identity()
 
-    def smart_batching_collate(self, batch: List[InputExample]) -> Tuple[BatchEncoding, Tensor]:
+    def smart_batching_collate(self, batch: list[InputExample]) -> tuple[BatchEncoding, Tensor]:
         texts = [[] for _ in range(len(batch[0].texts))]
         labels = []
 
@@ -149,7 +151,7 @@ class CrossEncoder(PushToHubMixin):
 
         return tokenized, labels
 
-    def smart_batching_collate_text_only(self, batch: List[InputExample]) -> BatchEncoding:
+    def smart_batching_collate_text_only(self, batch: list[InputExample]) -> BatchEncoding:
         texts = [[] for _ in range(len(batch[0]))]
 
         for example in batch:
@@ -174,8 +176,8 @@ class CrossEncoder(PushToHubMixin):
         activation_fct=nn.Identity(),
         scheduler: str = "WarmupLinear",
         warmup_steps: int = 10000,
-        optimizer_class: Type[Optimizer] = torch.optim.AdamW,
-        optimizer_params: Dict[str, object] = {"lr": 2e-5},
+        optimizer_class: type[Optimizer] = torch.optim.AdamW,
+        optimizer_params: dict[str, object] = {"lr": 2e-5},
         weight_decay: float = 0.01,
         evaluation_steps: int = 0,
         output_path: str = None,
@@ -305,12 +307,12 @@ class CrossEncoder(PushToHubMixin):
     @overload
     def predict(
         self,
-        sentences: Union[Tuple[str, str], List[str]],
+        sentences: tuple[str, str] | list[str],
         batch_size: int = ...,
-        show_progress_bar: Optional[bool] = ...,
+        show_progress_bar: bool | None = ...,
         num_workers: int = ...,
-        activation_fct: Optional[Callable] = ...,
-        apply_softmax: Optional[bool] = ...,
+        activation_fct: Callable | None = ...,
+        apply_softmax: bool | None = ...,
         convert_to_numpy: Literal[False] = ...,
         convert_to_tensor: Literal[False] = ...,
     ) -> torch.Tensor: ...
@@ -318,12 +320,12 @@ class CrossEncoder(PushToHubMixin):
     @overload
     def predict(
         self,
-        sentences: Union[List[Tuple[str, str]], List[List[str]], Tuple[str, str], List[str]],
+        sentences: list[tuple[str, str]] | list[list[str]] | tuple[str, str] | list[str],
         batch_size: int = ...,
-        show_progress_bar: Optional[bool] = ...,
+        show_progress_bar: bool | None = ...,
         num_workers: int = ...,
-        activation_fct: Optional[Callable] = ...,
-        apply_softmax: Optional[bool] = ...,
+        activation_fct: Callable | None = ...,
+        apply_softmax: bool | None = ...,
         convert_to_numpy: Literal[True] = True,
         convert_to_tensor: Literal[False] = False,
     ) -> np.ndarray: ...
@@ -331,12 +333,12 @@ class CrossEncoder(PushToHubMixin):
     @overload
     def predict(
         self,
-        sentences: Union[List[Tuple[str, str]], List[List[str]], Tuple[str, str], List[str]],
+        sentences: list[tuple[str, str]] | list[list[str]] | tuple[str, str] | list[str],
         batch_size: int = ...,
-        show_progress_bar: Optional[bool] = ...,
+        show_progress_bar: bool | None = ...,
         num_workers: int = ...,
-        activation_fct: Optional[Callable] = ...,
-        apply_softmax: Optional[bool] = ...,
+        activation_fct: Callable | None = ...,
+        apply_softmax: bool | None = ...,
         convert_to_numpy: bool = ...,
         convert_to_tensor: Literal[True] = ...,
     ) -> torch.Tensor: ...
@@ -344,27 +346,27 @@ class CrossEncoder(PushToHubMixin):
     @overload
     def predict(
         self,
-        sentences: Union[List[Tuple[str, str]], List[List[str]]],
+        sentences: list[tuple[str, str]] | list[list[str]],
         batch_size: int = ...,
-        show_progress_bar: Optional[bool] = ...,
+        show_progress_bar: bool | None = ...,
         num_workers: int = ...,
-        activation_fct: Optional[Callable] = ...,
-        apply_softmax: Optional[bool] = ...,
+        activation_fct: Callable | None = ...,
+        apply_softmax: bool | None = ...,
         convert_to_numpy: Literal[False] = ...,
         convert_to_tensor: Literal[False] = ...,
-    ) -> List[torch.Tensor]: ...
+    ) -> list[torch.Tensor]: ...
 
     def predict(
         self,
-        sentences: Union[List[Tuple[str, str]], List[List[str]], Tuple[str, str], List[str]],
+        sentences: list[tuple[str, str]] | list[list[str]] | tuple[str, str] | list[str],
         batch_size: int = 32,
-        show_progress_bar: Optional[bool] = None,
+        show_progress_bar: bool | None = None,
         num_workers: int = 0,
-        activation_fct: Optional[Callable] = None,
-        apply_softmax: Optional[bool] = False,
+        activation_fct: Callable | None = None,
+        apply_softmax: bool | None = False,
         convert_to_numpy: bool = True,
         convert_to_tensor: bool = False,
-    ) -> Union[List[torch.Tensor], np.ndarray, torch.Tensor]:
+    ) -> list[torch.Tensor] | np.ndarray | torch.Tensor:
         """
         Performs predictions with the CrossEncoder on the given sentence pairs.
 
@@ -451,8 +453,8 @@ class CrossEncoder(PushToHubMixin):
     def rank(
         self,
         query: str,
-        documents: List[str],
-        top_k: Optional[int] = None,
+        documents: list[str],
+        top_k: int | None = None,
         return_documents: bool = False,
         batch_size: int = 32,
         show_progress_bar: bool = None,
@@ -461,7 +463,7 @@ class CrossEncoder(PushToHubMixin):
         apply_softmax=False,
         convert_to_numpy: bool = True,
         convert_to_tensor: bool = False,
-    ) -> List[Dict[Literal["corpus_id", "score", "text"], Union[int, float, str]]]:
+    ) -> list[dict[Literal["corpus_id", "score", "text"], int | float | str]]:
         """
         Performs ranking with the CrossEncoder on the given query and documents. Returns a sorted list with the document indices and scores.
 
@@ -572,10 +574,10 @@ class CrossEncoder(PushToHubMixin):
         self,
         repo_id: str,
         *,
-        commit_message: Optional[str] = None,
-        private: Optional[bool] = None,
+        commit_message: str | None = None,
+        private: bool | None = None,
         safe_serialization: bool = True,
-        tags: Optional[List[str]] = None,
+        tags: list[str] | None = None,
         **kwargs,
     ) -> str:
         if isinstance(tags, str):

--- a/sentence_transformers/cross_encoder/__init__.py
+++ b/sentence_transformers/cross_encoder/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from .CrossEncoder import CrossEncoder
 
 __all__ = ["CrossEncoder"]

--- a/sentence_transformers/cross_encoder/evaluation/CEBinaryAccuracyEvaluator.py
+++ b/sentence_transformers/cross_encoder/evaluation/CEBinaryAccuracyEvaluator.py
@@ -1,7 +1,8 @@
+from __future__ import annotations
+
 import csv
 import logging
 import os
-from typing import List
 
 import numpy as np
 
@@ -22,8 +23,8 @@ class CEBinaryAccuracyEvaluator:
 
     def __init__(
         self,
-        sentence_pairs: List[List[str]],
-        labels: List[int],
+        sentence_pairs: list[list[str]],
+        labels: list[int],
         name: str = "",
         threshold: float = 0.5,
         write_csv: bool = True,
@@ -38,7 +39,7 @@ class CEBinaryAccuracyEvaluator:
         self.write_csv = write_csv
 
     @classmethod
-    def from_input_examples(cls, examples: List[InputExample], **kwargs):
+    def from_input_examples(cls, examples: list[InputExample], **kwargs):
         sentence_pairs = []
         labels = []
 

--- a/sentence_transformers/cross_encoder/evaluation/CEBinaryClassificationEvaluator.py
+++ b/sentence_transformers/cross_encoder/evaluation/CEBinaryClassificationEvaluator.py
@@ -1,7 +1,8 @@
+from __future__ import annotations
+
 import csv
 import logging
 import os
-from typing import List
 
 import numpy as np
 from sklearn.metrics import average_precision_score
@@ -20,8 +21,8 @@ class CEBinaryClassificationEvaluator:
 
     def __init__(
         self,
-        sentence_pairs: List[List[str]],
-        labels: List[int],
+        sentence_pairs: list[list[str]],
+        labels: list[int],
         name: str = "",
         show_progress_bar: bool = False,
         write_csv: bool = True,
@@ -55,7 +56,7 @@ class CEBinaryClassificationEvaluator:
         self.write_csv = write_csv
 
     @classmethod
-    def from_input_examples(cls, examples: List[InputExample], **kwargs):
+    def from_input_examples(cls, examples: list[InputExample], **kwargs):
         sentence_pairs = []
         labels = []
 

--- a/sentence_transformers/cross_encoder/evaluation/CECorrelationEvaluator.py
+++ b/sentence_transformers/cross_encoder/evaluation/CECorrelationEvaluator.py
@@ -1,7 +1,8 @@
+from __future__ import annotations
+
 import csv
 import logging
 import os
-from typing import List
 
 from scipy.stats import pearsonr, spearmanr
 
@@ -17,7 +18,7 @@ class CECorrelationEvaluator:
     and the gold score.
     """
 
-    def __init__(self, sentence_pairs: List[List[str]], scores: List[float], name: str = "", write_csv: bool = True):
+    def __init__(self, sentence_pairs: list[list[str]], scores: list[float], name: str = "", write_csv: bool = True):
         self.sentence_pairs = sentence_pairs
         self.scores = scores
         self.name = name
@@ -27,7 +28,7 @@ class CECorrelationEvaluator:
         self.write_csv = write_csv
 
     @classmethod
-    def from_input_examples(cls, examples: List[InputExample], **kwargs):
+    def from_input_examples(cls, examples: list[InputExample], **kwargs):
         sentence_pairs = []
         scores = []
 

--- a/sentence_transformers/cross_encoder/evaluation/CEF1Evaluator.py
+++ b/sentence_transformers/cross_encoder/evaluation/CEF1Evaluator.py
@@ -1,7 +1,8 @@
+from __future__ import annotations
+
 import csv
 import logging
 import os
-from typing import List
 
 import numpy as np
 from sklearn.metrics import f1_score
@@ -31,8 +32,8 @@ class CEF1Evaluator:
 
     def __init__(
         self,
-        sentence_pairs: List[List[str]],
-        labels: List[int],
+        sentence_pairs: list[list[str]],
+        labels: list[int],
         *,
         batch_size: int = 32,
         show_progress_bar: bool = False,
@@ -67,7 +68,7 @@ class CEF1Evaluator:
         self.csv_headers = ["epoch", "steps"] + [metric_name for metric_name, _ in self.f1_callables]
 
     @classmethod
-    def from_input_examples(cls, examples: List[InputExample], **kwargs):
+    def from_input_examples(cls, examples: list[InputExample], **kwargs):
         """
         Create an instance of CEF1Evaluator from a list of InputExample objects.
 

--- a/sentence_transformers/cross_encoder/evaluation/CERerankingEvaluator.py
+++ b/sentence_transformers/cross_encoder/evaluation/CERerankingEvaluator.py
@@ -1,7 +1,8 @@
+from __future__ import annotations
+
 import csv
 import logging
 import os
-from typing import Optional
 
 import numpy as np
 from sklearn.metrics import ndcg_score
@@ -22,9 +23,7 @@ class CERerankingEvaluator:
             of positive (relevant) documents, negative is a list of negative (irrelevant) documents.
     """
 
-    def __init__(
-        self, samples, at_k: int = 10, name: str = "", write_csv: bool = True, mrr_at_k: Optional[int] = None
-    ):
+    def __init__(self, samples, at_k: int = 10, name: str = "", write_csv: bool = True, mrr_at_k: int | None = None):
         self.samples = samples
         self.name = name
         if mrr_at_k is not None:

--- a/sentence_transformers/cross_encoder/evaluation/CESoftmaxAccuracyEvaluator.py
+++ b/sentence_transformers/cross_encoder/evaluation/CESoftmaxAccuracyEvaluator.py
@@ -1,7 +1,8 @@
+from __future__ import annotations
+
 import csv
 import logging
 import os
-from typing import List
 
 import numpy as np
 
@@ -18,7 +19,7 @@ class CESoftmaxAccuracyEvaluator:
     accuracy of the predict class vs. the gold labels.
     """
 
-    def __init__(self, sentence_pairs: List[List[str]], labels: List[int], name: str = "", write_csv: bool = True):
+    def __init__(self, sentence_pairs: list[list[str]], labels: list[int], name: str = "", write_csv: bool = True):
         self.sentence_pairs = sentence_pairs
         self.labels = labels
         self.name = name
@@ -28,7 +29,7 @@ class CESoftmaxAccuracyEvaluator:
         self.write_csv = write_csv
 
     @classmethod
-    def from_input_examples(cls, examples: List[InputExample], **kwargs):
+    def from_input_examples(cls, examples: list[InputExample], **kwargs):
         sentence_pairs = []
         labels = []
 

--- a/sentence_transformers/cross_encoder/evaluation/__init__.py
+++ b/sentence_transformers/cross_encoder/evaluation/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from .CEBinaryAccuracyEvaluator import CEBinaryAccuracyEvaluator
 from .CEBinaryClassificationEvaluator import CEBinaryClassificationEvaluator
 from .CECorrelationEvaluator import CECorrelationEvaluator

--- a/sentence_transformers/data_collator.py
+++ b/sentence_transformers/data_collator.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 from dataclasses import dataclass, field
-from typing import Any, Callable, Dict, List
+from typing import Any, Callable
 
 import torch
 
@@ -13,9 +15,9 @@ class SentenceTransformerDataCollator:
     """
 
     tokenize_fn: Callable
-    valid_label_columns: List[str] = field(default_factory=lambda: ["label", "score"])
+    valid_label_columns: list[str] = field(default_factory=lambda: ["label", "score"])
 
-    def __call__(self, features: List[Dict[str, Any]]) -> Dict[str, torch.Tensor]:
+    def __call__(self, features: list[dict[str, Any]]) -> dict[str, torch.Tensor]:
         columns = list(features[0].keys())
 
         # We should always be able to return a loss, label or not:

--- a/sentence_transformers/datasets/DenoisingAutoEncoderDataset.py
+++ b/sentence_transformers/datasets/DenoisingAutoEncoderDataset.py
@@ -1,4 +1,4 @@
-from typing import List
+from __future__ import annotations
 
 import numpy as np
 from torch.utils.data import Dataset
@@ -19,7 +19,7 @@ class DenoisingAutoEncoderDataset(Dataset):
             with noise, e.g. deleted words
     """
 
-    def __init__(self, sentences: List[str], noise_fn=lambda s: DenoisingAutoEncoderDataset.delete(s)):
+    def __init__(self, sentences: list[str], noise_fn=lambda s: DenoisingAutoEncoderDataset.delete(s)):
         if not is_nltk_available():
             raise ImportError(NLTK_IMPORT_ERROR.format(self.__class__.__name__))
 

--- a/sentence_transformers/datasets/NoDuplicatesDataLoader.py
+++ b/sentence_transformers/datasets/NoDuplicatesDataLoader.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import math
 import random
 

--- a/sentence_transformers/datasets/ParallelSentencesDataset.py
+++ b/sentence_transformers/datasets/ParallelSentencesDataset.py
@@ -1,7 +1,8 @@
+from __future__ import annotations
+
 import gzip
 import logging
 import random
-from typing import List
 
 from torch.utils.data import Dataset
 
@@ -99,7 +100,7 @@ class ParallelSentencesDataset(Dataset):
 
     def add_dataset(
         self,
-        parallel_sentences: List[List[str]],
+        parallel_sentences: list[list[str]],
         weight: int = 100,
         max_sentences: int = None,
         max_sentence_length: int = 128,

--- a/sentence_transformers/datasets/SentenceLabelDataset.py
+++ b/sentence_transformers/datasets/SentenceLabelDataset.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 import logging
-from typing import List
 
 import numpy as np
 from torch.utils.data import IterableDataset
@@ -23,7 +24,7 @@ class SentenceLabelDataset(IterableDataset):
     by the samples drawn per label.
     """
 
-    def __init__(self, examples: List[InputExample], samples_per_label: int = 2, with_replacement: bool = False):
+    def __init__(self, examples: list[InputExample], samples_per_label: int = 2, with_replacement: bool = False):
         """
         Creates a LabelSampler for a SentenceLabelDataset.
 

--- a/sentence_transformers/datasets/SentencesDataset.py
+++ b/sentence_transformers/datasets/SentencesDataset.py
@@ -1,4 +1,4 @@
-from typing import List
+from __future__ import annotations
 
 from torch.utils.data import Dataset
 
@@ -12,7 +12,7 @@ class SentencesDataset(Dataset):
     and then passing it to the DataLoader, you can pass the list of InputExamples directly to the dataset loader.
     """
 
-    def __init__(self, examples: List[InputExample], model: SentenceTransformer):
+    def __init__(self, examples: list[InputExample], model: SentenceTransformer):
         self.examples = examples
 
     def __getitem__(self, item):

--- a/sentence_transformers/datasets/__init__.py
+++ b/sentence_transformers/datasets/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from .DenoisingAutoEncoderDataset import DenoisingAutoEncoderDataset
 from .NoDuplicatesDataLoader import NoDuplicatesDataLoader
 from .ParallelSentencesDataset import ParallelSentencesDataset

--- a/sentence_transformers/evaluation/BinaryClassificationEvaluator.py
+++ b/sentence_transformers/evaluation/BinaryClassificationEvaluator.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 import csv
 import logging
 import os
 from contextlib import nullcontext
-from typing import TYPE_CHECKING, Dict, List, Optional
+from typing import TYPE_CHECKING
 
 import numpy as np
 from sklearn.metrics import average_precision_score
@@ -94,14 +96,14 @@ class BinaryClassificationEvaluator(SentenceEvaluator):
 
     def __init__(
         self,
-        sentences1: List[str],
-        sentences2: List[str],
-        labels: List[int],
+        sentences1: list[str],
+        sentences2: list[str],
+        labels: list[int],
         name: str = "",
         batch_size: int = 32,
         show_progress_bar: bool = False,
         write_csv: bool = True,
-        truncate_dim: Optional[int] = None,
+        truncate_dim: int | None = None,
     ):
         self.sentences1 = sentences1
         self.sentences2 = sentences2
@@ -140,7 +142,7 @@ class BinaryClassificationEvaluator(SentenceEvaluator):
                 self.csv_headers.append(f"{v}_{m}")
 
     @classmethod
-    def from_input_examples(cls, examples: List[InputExample], **kwargs):
+    def from_input_examples(cls, examples: list[InputExample], **kwargs):
         sentences1 = []
         sentences2 = []
         scores = []
@@ -153,7 +155,7 @@ class BinaryClassificationEvaluator(SentenceEvaluator):
 
     def __call__(
         self, model: "SentenceTransformer", output_path: str = None, epoch: int = -1, steps: int = -1
-    ) -> Dict[str, float]:
+    ) -> dict[str, float]:
         """
         Compute the evaluation metrics for the given model.
 

--- a/sentence_transformers/evaluation/EmbeddingSimilarityEvaluator.py
+++ b/sentence_transformers/evaluation/EmbeddingSimilarityEvaluator.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 import csv
 import logging
 import os
 from contextlib import nullcontext
-from typing import TYPE_CHECKING, Dict, List, Literal, Optional, Union
+from typing import TYPE_CHECKING, Literal
 
 import numpy as np
 from scipy.stats import pearsonr, spearmanr
@@ -59,16 +61,16 @@ class EmbeddingSimilarityEvaluator(SentenceEvaluator):
 
     def __init__(
         self,
-        sentences1: List[str],
-        sentences2: List[str],
-        scores: List[float],
+        sentences1: list[str],
+        sentences2: list[str],
+        scores: list[float],
         batch_size: int = 16,
-        main_similarity: Optional[Union[str, SimilarityFunction]] = None,
+        main_similarity: str | SimilarityFunction | None = None,
         name: str = "",
         show_progress_bar: bool = False,
         write_csv: bool = True,
-        precision: Optional[Literal["float32", "int8", "uint8", "binary", "ubinary"]] = None,
-        truncate_dim: Optional[int] = None,
+        precision: Literal["float32", "int8", "uint8", "binary", "ubinary"] | None = None,
+        truncate_dim: int | None = None,
     ):
         """
         Constructs an evaluator based for the dataset.
@@ -129,7 +131,7 @@ class EmbeddingSimilarityEvaluator(SentenceEvaluator):
         ]
 
     @classmethod
-    def from_input_examples(cls, examples: List[InputExample], **kwargs):
+    def from_input_examples(cls, examples: list[InputExample], **kwargs):
         sentences1 = []
         sentences2 = []
         scores = []
@@ -142,7 +144,7 @@ class EmbeddingSimilarityEvaluator(SentenceEvaluator):
 
     def __call__(
         self, model: "SentenceTransformer", output_path: str = None, epoch: int = -1, steps: int = -1
-    ) -> Dict[str, float]:
+    ) -> dict[str, float]:
         if epoch != -1:
             if steps == -1:
                 out_txt = f" after epoch {epoch}"

--- a/sentence_transformers/evaluation/InformationRetrievalEvaluator.py
+++ b/sentence_transformers/evaluation/InformationRetrievalEvaluator.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 import heapq
 import logging
 import os
 from contextlib import nullcontext
-from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Set, Union
+from typing import TYPE_CHECKING, Callable
 
 import numpy as np
 import torch
@@ -112,25 +114,25 @@ class InformationRetrievalEvaluator(SentenceEvaluator):
 
     def __init__(
         self,
-        queries: Dict[str, str],  # qid => query
-        corpus: Dict[str, str],  # cid => doc
-        relevant_docs: Dict[str, Set[str]],  # qid => Set[cid]
+        queries: dict[str, str],  # qid => query
+        corpus: dict[str, str],  # cid => doc
+        relevant_docs: dict[str, set[str]],  # qid => Set[cid]
         corpus_chunk_size: int = 50000,
-        mrr_at_k: List[int] = [10],
-        ndcg_at_k: List[int] = [10],
-        accuracy_at_k: List[int] = [1, 3, 5, 10],
-        precision_recall_at_k: List[int] = [1, 3, 5, 10],
-        map_at_k: List[int] = [100],
+        mrr_at_k: list[int] = [10],
+        ndcg_at_k: list[int] = [10],
+        accuracy_at_k: list[int] = [1, 3, 5, 10],
+        precision_recall_at_k: list[int] = [1, 3, 5, 10],
+        map_at_k: list[int] = [100],
         show_progress_bar: bool = False,
         batch_size: int = 32,
         name: str = "",
         write_csv: bool = True,
-        truncate_dim: Optional[int] = None,
-        score_functions: Dict[str, Callable[[Tensor, Tensor], Tensor]] = {
+        truncate_dim: int | None = None,
+        score_functions: dict[str, Callable[[Tensor, Tensor], Tensor]] = {
             SimilarityFunction.COSINE.value: cos_sim,
             SimilarityFunction.DOT_PRODUCT.value: dot_score,
         },  # Score function, higher=more similar
-        main_score_function: Optional[Union[str, SimilarityFunction]] = None,
+        main_score_function: str | SimilarityFunction | None = None,
     ) -> None:
         """
         Initializes the InformationRetrievalEvaluator.
@@ -206,7 +208,7 @@ class InformationRetrievalEvaluator(SentenceEvaluator):
 
     def __call__(
         self, model: "SentenceTransformer", output_path: str = None, epoch: int = -1, steps: int = -1, *args, **kwargs
-    ) -> Dict[str, float]:
+    ) -> dict[str, float]:
         if epoch != -1:
             if steps == -1:
                 out_txt = f" after epoch {epoch}"
@@ -276,7 +278,7 @@ class InformationRetrievalEvaluator(SentenceEvaluator):
 
     def compute_metrices(
         self, model: "SentenceTransformer", corpus_model=None, corpus_embeddings: Tensor = None
-    ) -> Dict[str, float]:
+    ) -> dict[str, float]:
         if corpus_model is None:
             corpus_model = model
 
@@ -363,7 +365,7 @@ class InformationRetrievalEvaluator(SentenceEvaluator):
 
         return scores
 
-    def compute_metrics(self, queries_result_list: List[object]):
+    def compute_metrics(self, queries_result_list: list[object]):
         # Init score computation values
         num_hits_at_k = {k: 0 for k in self.accuracy_at_k}
         precisions_at_k = {k: [] for k in self.precision_recall_at_k}

--- a/sentence_transformers/evaluation/LabelAccuracyEvaluator.py
+++ b/sentence_transformers/evaluation/LabelAccuracyEvaluator.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import csv
 import logging
 import os
-from typing import TYPE_CHECKING, Dict
+from typing import TYPE_CHECKING
 
 import torch
 from torch.utils.data import DataLoader
@@ -46,7 +48,7 @@ class LabelAccuracyEvaluator(SentenceEvaluator):
 
     def __call__(
         self, model: "SentenceTransformer", output_path: str = None, epoch: int = -1, steps: int = -1
-    ) -> Dict[str, float]:
+    ) -> dict[str, float]:
         model.eval()
         total = 0
         correct = 0

--- a/sentence_transformers/evaluation/MSEEvaluator.py
+++ b/sentence_transformers/evaluation/MSEEvaluator.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 import csv
 import logging
 import os
 from contextlib import nullcontext
-from typing import TYPE_CHECKING, Dict, List, Optional
+from typing import TYPE_CHECKING
 
 from sentence_transformers.evaluation.SentenceEvaluator import SentenceEvaluator
 
@@ -68,14 +70,14 @@ class MSEEvaluator(SentenceEvaluator):
 
     def __init__(
         self,
-        source_sentences: List[str],
-        target_sentences: List[str],
+        source_sentences: list[str],
+        target_sentences: list[str],
         teacher_model=None,
         show_progress_bar: bool = False,
         batch_size: int = 32,
         name: str = "",
         write_csv: bool = True,
-        truncate_dim: Optional[int] = None,
+        truncate_dim: int | None = None,
     ):
         super().__init__()
         self.truncate_dim = truncate_dim
@@ -96,7 +98,7 @@ class MSEEvaluator(SentenceEvaluator):
         self.write_csv = write_csv
         self.primary_metric = "negative_mse"
 
-    def __call__(self, model: "SentenceTransformer", output_path: str = None, epoch=-1, steps=-1) -> Dict[str, float]:
+    def __call__(self, model: "SentenceTransformer", output_path: str = None, epoch=-1, steps=-1) -> dict[str, float]:
         if epoch != -1:
             if steps == -1:
                 out_txt = f" after epoch {epoch}"

--- a/sentence_transformers/evaluation/MSEEvaluatorFromDataFrame.py
+++ b/sentence_transformers/evaluation/MSEEvaluatorFromDataFrame.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 import csv
 import logging
 import os
 from contextlib import nullcontext
-from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING
 
 import numpy as np
 
@@ -38,13 +40,13 @@ class MSEEvaluatorFromDataFrame(SentenceEvaluator):
 
     def __init__(
         self,
-        dataframe: List[Dict[str, str]],
+        dataframe: list[dict[str, str]],
         teacher_model: "SentenceTransformer",
-        combinations: List[Tuple[str, str]],
+        combinations: list[tuple[str, str]],
         batch_size: int = 8,
         name: str = "",
         write_csv: bool = True,
-        truncate_dim: Optional[int] = None,
+        truncate_dim: int | None = None,
     ):
         super().__init__()
         self.combinations = combinations
@@ -85,7 +87,7 @@ class MSEEvaluatorFromDataFrame(SentenceEvaluator):
 
     def __call__(
         self, model: "SentenceTransformer", output_path: str = None, epoch: int = -1, steps: int = -1
-    ) -> Dict[str, float]:
+    ) -> dict[str, float]:
         model.eval()
 
         mse_scores = []

--- a/sentence_transformers/evaluation/ParaphraseMiningEvaluator.py
+++ b/sentence_transformers/evaluation/ParaphraseMiningEvaluator.py
@@ -1,9 +1,11 @@
+from __future__ import annotations
+
 import csv
 import logging
 import os
 from collections import defaultdict
 from contextlib import nullcontext
-from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING
 
 from sentence_transformers.evaluation.SentenceEvaluator import SentenceEvaluator
 from sentence_transformers.util import paraphrase_mining
@@ -62,9 +64,9 @@ class ParaphraseMiningEvaluator(SentenceEvaluator):
 
     def __init__(
         self,
-        sentences_map: Dict[str, str],
-        duplicates_list: List[Tuple[str, str]] = None,
-        duplicates_dict: Dict[str, Dict[str, bool]] = None,
+        sentences_map: dict[str, str],
+        duplicates_list: list[tuple[str, str]] = None,
+        duplicates_dict: dict[str, dict[str, bool]] = None,
         add_transitive_closure: bool = False,
         query_chunk_size: int = 5000,
         corpus_chunk_size: int = 100000,
@@ -74,7 +76,7 @@ class ParaphraseMiningEvaluator(SentenceEvaluator):
         batch_size: int = 16,
         name: str = "",
         write_csv: bool = True,
-        truncate_dim: Optional[int] = None,
+        truncate_dim: int | None = None,
     ):
         """
         Initializes the ParaphraseMiningEvaluator.
@@ -157,7 +159,7 @@ class ParaphraseMiningEvaluator(SentenceEvaluator):
 
     def __call__(
         self, model: "SentenceTransformer", output_path: str = None, epoch: int = -1, steps: int = -1
-    ) -> Dict[str, float]:
+    ) -> dict[str, float]:
         if epoch != -1:
             if steps == -1:
                 out_txt = f" after epoch {epoch}"

--- a/sentence_transformers/evaluation/RerankingEvaluator.py
+++ b/sentence_transformers/evaluation/RerankingEvaluator.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 import csv
 import logging
 import os
 from contextlib import nullcontext
-from typing import TYPE_CHECKING, Callable, Dict, Optional
+from typing import TYPE_CHECKING, Callable
 
 import numpy as np
 import torch
@@ -51,8 +53,8 @@ class RerankingEvaluator(SentenceEvaluator):
         batch_size: int = 64,
         show_progress_bar: bool = False,
         use_batched_encoding: bool = True,
-        truncate_dim: Optional[int] = None,
-        mrr_at_k: Optional[int] = None,
+        truncate_dim: int | None = None,
+        mrr_at_k: int | None = None,
     ):
         super().__init__()
         self.samples = samples
@@ -91,7 +93,7 @@ class RerankingEvaluator(SentenceEvaluator):
 
     def __call__(
         self, model: "SentenceTransformer", output_path: str = None, epoch: int = -1, steps: int = -1
-    ) -> Dict[str, float]:
+    ) -> dict[str, float]:
         """
         Evaluates the model on the dataset and returns the evaluation metrics.
 

--- a/sentence_transformers/evaluation/SentenceEvaluator.py
+++ b/sentence_transformers/evaluation/SentenceEvaluator.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import re
-from typing import TYPE_CHECKING, Any, Dict, Union
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from sentence_transformers.SentenceTransformer import SentenceTransformer
@@ -27,7 +29,7 @@ class SentenceEvaluator:
 
     def __call__(
         self, model: "SentenceTransformer", output_path: str = None, epoch: int = -1, steps: int = -1
-    ) -> Union[float, Dict[str, float]]:
+    ) -> float | dict[str, float]:
         """
         This is called during training to evaluate the model.
         It returns a score for the evaluation with a higher score indicating a better result.
@@ -52,7 +54,7 @@ class SentenceEvaluator:
         """
         pass
 
-    def prefix_name_to_metrics(self, metrics: Dict[str, float], name: str) -> Dict[str, float]:
+    def prefix_name_to_metrics(self, metrics: dict[str, float], name: str) -> dict[str, float]:
         if not name:
             return metrics
         metrics = {name + "_" + key: value for key, value in metrics.items()}
@@ -60,7 +62,7 @@ class SentenceEvaluator:
             self.primary_metric = name + "_" + self.primary_metric
         return metrics
 
-    def store_metrics_in_model_card_data(self, model: "SentenceTransformer", metrics: Dict[str, Any]) -> None:
+    def store_metrics_in_model_card_data(self, model: "SentenceTransformer", metrics: dict[str, Any]) -> None:
         model.model_card_data.set_evaluation_metrics(self, metrics)
 
     @property

--- a/sentence_transformers/evaluation/SequentialEvaluator.py
+++ b/sentence_transformers/evaluation/SequentialEvaluator.py
@@ -1,4 +1,6 @@
-from typing import TYPE_CHECKING, Dict, Iterable
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Iterable
 
 from sentence_transformers.evaluation.SentenceEvaluator import SentenceEvaluator
 
@@ -37,7 +39,7 @@ class SequentialEvaluator(SentenceEvaluator):
 
     def __call__(
         self, model: "SentenceTransformer", output_path: str = None, epoch: int = -1, steps: int = -1
-    ) -> Dict[str, float]:
+    ) -> dict[str, float]:
         evaluations = []
         scores = []
         for evaluator_idx, evaluator in enumerate(self.evaluators):

--- a/sentence_transformers/evaluation/SimilarityFunction.py
+++ b/sentence_transformers/evaluation/SimilarityFunction.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from sentence_transformers.similarity_functions import SimilarityFunction
 
 __all__ = ["SimilarityFunction"]

--- a/sentence_transformers/evaluation/TranslationEvaluator.py
+++ b/sentence_transformers/evaluation/TranslationEvaluator.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 import csv
 import logging
 import os
 from contextlib import nullcontext
-from typing import TYPE_CHECKING, Dict, List, Optional
+from typing import TYPE_CHECKING
 
 import numpy as np
 import torch
@@ -55,14 +57,14 @@ class TranslationEvaluator(SentenceEvaluator):
 
     def __init__(
         self,
-        source_sentences: List[str],
-        target_sentences: List[str],
+        source_sentences: list[str],
+        target_sentences: list[str],
         show_progress_bar: bool = False,
         batch_size: int = 16,
         name: str = "",
         print_wrong_matches: bool = False,
         write_csv: bool = True,
-        truncate_dim: Optional[int] = None,
+        truncate_dim: int | None = None,
     ):
         """
         Constructs an evaluator based for the dataset
@@ -101,7 +103,7 @@ class TranslationEvaluator(SentenceEvaluator):
 
     def __call__(
         self, model: "SentenceTransformer", output_path: str = None, epoch: int = -1, steps: int = -1
-    ) -> Dict[str, float]:
+    ) -> dict[str, float]:
         if epoch != -1:
             if steps == -1:
                 out_txt = f" after epoch {epoch}"

--- a/sentence_transformers/evaluation/TripletEvaluator.py
+++ b/sentence_transformers/evaluation/TripletEvaluator.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 import csv
 import logging
 import os
 from contextlib import nullcontext
-from typing import TYPE_CHECKING, Dict, List, Optional, Union
+from typing import TYPE_CHECKING
 
 import numpy as np
 from sklearn.metrics.pairwise import paired_cosine_distances, paired_euclidean_distances, paired_manhattan_distances
@@ -58,15 +60,15 @@ class TripletEvaluator(SentenceEvaluator):
 
     def __init__(
         self,
-        anchors: List[str],
-        positives: List[str],
-        negatives: List[str],
-        main_distance_function: Optional[Union[str, SimilarityFunction]] = None,
+        anchors: list[str],
+        positives: list[str],
+        negatives: list[str],
+        main_distance_function: str | SimilarityFunction | None = None,
         name: str = "",
         batch_size: int = 16,
         show_progress_bar: bool = False,
         write_csv: bool = True,
-        truncate_dim: Optional[int] = None,
+        truncate_dim: int | None = None,
     ):
         """
         Initializes a TripletEvaluator object.
@@ -109,7 +111,7 @@ class TripletEvaluator(SentenceEvaluator):
         self.write_csv = write_csv
 
     @classmethod
-    def from_input_examples(cls, examples: List[InputExample], **kwargs):
+    def from_input_examples(cls, examples: list[InputExample], **kwargs):
         anchors = []
         positives = []
         negatives = []
@@ -122,7 +124,7 @@ class TripletEvaluator(SentenceEvaluator):
 
     def __call__(
         self, model: "SentenceTransformer", output_path: str = None, epoch: int = -1, steps: int = -1
-    ) -> Dict[str, float]:
+    ) -> dict[str, float]:
         if epoch != -1:
             if steps == -1:
                 out_txt = f" after epoch {epoch}"

--- a/sentence_transformers/evaluation/__init__.py
+++ b/sentence_transformers/evaluation/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from .BinaryClassificationEvaluator import BinaryClassificationEvaluator
 from .EmbeddingSimilarityEvaluator import EmbeddingSimilarityEvaluator
 from .InformationRetrievalEvaluator import InformationRetrievalEvaluator

--- a/sentence_transformers/fit_mixin.py
+++ b/sentence_transformers/fit_mixin.py
@@ -1,9 +1,11 @@
+from __future__ import annotations
+
 import json
 import logging
 import os
 import shutil
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, List, Optional, Tuple, Type
+from typing import TYPE_CHECKING, Any, Callable, Iterable
 
 import numpy as np
 import torch
@@ -49,7 +51,7 @@ class SaveModelCallback(TrainerCallback):
         We save after the model has been trained.
     """
 
-    def __init__(self, output_dir: str, evaluator: Optional[SentenceEvaluator], save_best_model: bool) -> None:
+    def __init__(self, output_dir: str, evaluator: SentenceEvaluator | None, save_best_model: bool) -> None:
         super().__init__()
         self.output_dir = output_dir
         self.evaluator = evaluator
@@ -66,7 +68,7 @@ class SaveModelCallback(TrainerCallback):
         args: SentenceTransformerTrainingArguments,
         state: TrainerState,
         control: TrainerControl,
-        metrics: Dict[str, Any],
+        metrics: dict[str, Any],
         model: "SentenceTransformer",
         **kwargs,
     ) -> None:
@@ -140,7 +142,7 @@ class OriginalCallback(TrainerCallback):
         args: transformers.TrainingArguments,
         state: TrainerState,
         control: TrainerControl,
-        metrics: Dict[str, Any],
+        metrics: dict[str, Any],
         **kwargs,
     ) -> None:
         metric_key = getattr(self.evaluator, "primary_metric", "evaluator")
@@ -154,14 +156,14 @@ class FitMixin:
 
     def fit(
         self,
-        train_objectives: Iterable[Tuple[DataLoader, nn.Module]],
+        train_objectives: Iterable[tuple[DataLoader, nn.Module]],
         evaluator: SentenceEvaluator = None,
         epochs: int = 1,
         steps_per_epoch=None,
         scheduler: str = "WarmupLinear",
         warmup_steps: int = 10000,
-        optimizer_class: Type[Optimizer] = torch.optim.AdamW,
-        optimizer_params: Dict[str, object] = {"lr": 2e-5},
+        optimizer_class: type[Optimizer] = torch.optim.AdamW,
+        optimizer_params: dict[str, object] = {"lr": 2e-5},
         weight_decay: float = 0.01,
         evaluation_steps: int = 0,
         output_path: str = None,
@@ -402,7 +404,7 @@ class FitMixin:
         else:
             raise ValueError("Unknown scheduler {}".format(scheduler))
 
-    def smart_batching_collate(self, batch: List["InputExample"]) -> Tuple[List[Dict[str, Tensor]], Tensor]:
+    def smart_batching_collate(self, batch: list["InputExample"]) -> tuple[list[dict[str, Tensor]], Tensor]:
         """
         Transforms a batch from a SmartBatchingDataset to a batch of tensors for the model
         Here, batch is a list of InputExample instances: [InputExample(...), ...]
@@ -432,14 +434,14 @@ class FitMixin:
 
     def old_fit(
         self,
-        train_objectives: Iterable[Tuple[DataLoader, nn.Module]],
+        train_objectives: Iterable[tuple[DataLoader, nn.Module]],
         evaluator: SentenceEvaluator = None,
         epochs: int = 1,
         steps_per_epoch=None,
         scheduler: str = "WarmupLinear",
         warmup_steps: int = 10000,
-        optimizer_class: Type[Optimizer] = torch.optim.AdamW,
-        optimizer_params: Dict[str, object] = {"lr": 2e-5},
+        optimizer_class: type[Optimizer] = torch.optim.AdamW,
+        optimizer_params: dict[str, object] = {"lr": 2e-5},
         weight_decay: float = 0.01,
         evaluation_steps: int = 0,
         output_path: str = None,

--- a/sentence_transformers/losses/AnglELoss.py
+++ b/sentence_transformers/losses/AnglELoss.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from sentence_transformers import SentenceTransformer, losses, util
 
 

--- a/sentence_transformers/losses/BatchAllTripletLoss.py
+++ b/sentence_transformers/losses/BatchAllTripletLoss.py
@@ -1,4 +1,6 @@
-from typing import Dict, Iterable
+from __future__ import annotations
+
+from typing import Iterable
 
 from torch import Tensor, nn
 
@@ -83,7 +85,7 @@ class BatchAllTripletLoss(nn.Module):
         self.triplet_margin = margin
         self.distance_metric = distance_metric
 
-    def forward(self, sentence_features: Iterable[Dict[str, Tensor]], labels: Tensor) -> Tensor:
+    def forward(self, sentence_features: Iterable[dict[str, Tensor]], labels: Tensor) -> Tensor:
         rep = self.sentence_embedder(sentence_features[0])["sentence_embedding"]
         return self.batch_all_triplet_loss(labels, rep)
 

--- a/sentence_transformers/losses/BatchHardSoftMarginTripletLoss.py
+++ b/sentence_transformers/losses/BatchHardSoftMarginTripletLoss.py
@@ -1,4 +1,6 @@
-from typing import Dict, Iterable
+from __future__ import annotations
+
+from typing import Iterable
 
 import torch
 from torch import Tensor
@@ -83,7 +85,7 @@ class BatchHardSoftMarginTripletLoss(BatchHardTripletLoss):
         self.sentence_embedder = model
         self.distance_metric = distance_metric
 
-    def forward(self, sentence_features: Iterable[Dict[str, Tensor]], labels: Tensor) -> Tensor:
+    def forward(self, sentence_features: Iterable[dict[str, Tensor]], labels: Tensor) -> Tensor:
         rep = self.sentence_embedder(sentence_features[0])["sentence_embedding"]
         return self.batch_hard_triplet_soft_margin_loss(labels, rep)
 

--- a/sentence_transformers/losses/BatchHardTripletLoss.py
+++ b/sentence_transformers/losses/BatchHardTripletLoss.py
@@ -1,4 +1,6 @@
-from typing import Dict, Iterable
+from __future__ import annotations
+
+from typing import Iterable
 
 import torch
 from torch import Tensor, nn
@@ -137,7 +139,7 @@ class BatchHardTripletLoss(nn.Module):
         self.triplet_margin = margin
         self.distance_metric = distance_metric
 
-    def forward(self, sentence_features: Iterable[Dict[str, Tensor]], labels: Tensor):
+    def forward(self, sentence_features: Iterable[dict[str, Tensor]], labels: Tensor):
         rep = self.sentence_embedder(sentence_features[0])["sentence_embedding"]
         return self.batch_hard_triplet_loss(labels, rep)
 

--- a/sentence_transformers/losses/BatchSemiHardTripletLoss.py
+++ b/sentence_transformers/losses/BatchSemiHardTripletLoss.py
@@ -1,4 +1,6 @@
-from typing import Dict, Iterable
+from __future__ import annotations
+
+from typing import Iterable
 
 import torch
 from torch import Tensor, nn
@@ -93,7 +95,7 @@ class BatchSemiHardTripletLoss(nn.Module):
         self.margin = margin
         self.distance_metric = distance_metric
 
-    def forward(self, sentence_features: Iterable[Dict[str, Tensor]], labels: Tensor) -> Tensor:
+    def forward(self, sentence_features: Iterable[dict[str, Tensor]], labels: Tensor) -> Tensor:
         rep = self.sentence_embedder(sentence_features[0])["sentence_embedding"]
         return self.batch_semi_hard_triplet_loss(labels, rep)
 

--- a/sentence_transformers/losses/CachedGISTEmbedLoss.py
+++ b/sentence_transformers/losses/CachedGISTEmbedLoss.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from contextlib import nullcontext
 from functools import partial
-from typing import Any, Dict, Iterable, Iterator, List, Optional, Tuple
+from typing import Any, Iterable, Iterator
 
 import torch
 import tqdm
@@ -38,7 +38,7 @@ class RandContext:
 
 def _backward_hook(
     grad_output: Tensor,
-    sentence_features: Iterable[Dict[str, Tensor]],
+    sentence_features: Iterable[dict[str, Tensor]],
     loss_obj: CachedGISTEmbedLoss,
 ) -> None:
     """A backward hook to backpropagate the cached gradients mini-batch by mini-batch."""
@@ -143,8 +143,8 @@ class CachedGISTEmbedLoss(nn.Module):
             )
         self.cross_entropy_loss = nn.CrossEntropyLoss()
         self.mini_batch_size = mini_batch_size
-        self.cache: Optional[List[List[Tensor]]] = None
-        self.random_states: Optional[List[List[RandContext]]] = None
+        self.cache: list[list[Tensor]] | None = None
+        self.random_states: list[list[RandContext]] | None = None
         self.show_progress_bar = show_progress_bar
         self.must_retokenize = (
             model.tokenizer.vocab != guide.tokenizer.vocab or guide.max_seq_length < model.max_seq_length
@@ -157,13 +157,13 @@ class CachedGISTEmbedLoss(nn.Module):
 
     def embed_minibatch(
         self,
-        sentence_feature: Dict[str, Tensor],
+        sentence_feature: dict[str, Tensor],
         begin: int,
         end: int,
         with_grad: bool,
         copy_random_state: bool,
-        random_state: Optional[RandContext] = None,
-    ) -> Tuple[Tensor, Optional[RandContext]]:
+        random_state: RandContext | None = None,
+    ) -> tuple[Tensor, RandContext | None]:
         """Do forward pass on a minibatch of the input features and return corresponding embeddings."""
         grad_context = nullcontext if with_grad else torch.no_grad
         random_state_context = nullcontext() if random_state is None else random_state
@@ -187,11 +187,11 @@ class CachedGISTEmbedLoss(nn.Module):
 
     def embed_minibatch_iter(
         self,
-        sentence_feature: Dict[str, Tensor],
+        sentence_feature: dict[str, Tensor],
         with_grad: bool,
         copy_random_state: bool,
-        random_states: Optional[List[RandContext]] = None,
-    ) -> Iterator[Tuple[Tensor, Optional[RandContext]]]:
+        random_states: list[RandContext] | None = None,
+    ) -> Iterator[tuple[Tensor, RandContext | None]]:
         """Do forward pass on all the minibatches of the input features and yield corresponding embeddings."""
         input_ids: Tensor = sentence_feature["input_ids"]
         bsz, _ = input_ids.shape
@@ -215,7 +215,7 @@ class CachedGISTEmbedLoss(nn.Module):
             )
             yield reps, guide_reps, random_state  # reps: (mbsz, hdim)
 
-    def calculate_loss_and_cache_gradients(self, reps: List[List[Tensor]], reps_guided: List[List[Tensor]]) -> Tensor:
+    def calculate_loss_and_cache_gradients(self, reps: list[list[Tensor]], reps_guided: list[list[Tensor]]) -> Tensor:
         """Calculate the cross-entropy loss and cache the gradients wrt. the embeddings."""
         if len(reps) == 2:
             anchor, positive = reps
@@ -240,7 +240,7 @@ class CachedGISTEmbedLoss(nn.Module):
         labels = torch.arange(anchor.size(0)).long().to(anchor.device)
         batch_size = anchor.shape[0]
 
-        losses: List[torch.Tensor] = []
+        losses: list[torch.Tensor] = []
         for b in tqdm.trange(
             0,
             batch_size,
@@ -289,7 +289,7 @@ class CachedGISTEmbedLoss(nn.Module):
 
         return loss
 
-    def calculate_loss(self, reps: List[List[Tensor]], reps_guided: List[List[Tensor]]) -> Tensor:
+    def calculate_loss(self, reps: list[list[Tensor]], reps_guided: list[list[Tensor]]) -> Tensor:
         """Calculate the cross-entropy loss. No need to cache the gradients."""
         if len(reps) == 2:
             anchor, positive = reps
@@ -314,7 +314,7 @@ class CachedGISTEmbedLoss(nn.Module):
         labels = torch.arange(anchor.size(0)).long().to(anchor.device)
         batch_size = anchor.shape[0]
 
-        losses: List[torch.Tensor] = []
+        losses: list[torch.Tensor] = []
         for b in tqdm.trange(
             0,
             batch_size,
@@ -359,7 +359,7 @@ class CachedGISTEmbedLoss(nn.Module):
         loss = sum(losses)
         return loss
 
-    def forward(self, sentence_features: Iterable[Dict[str, Tensor]], labels: Tensor) -> Tensor:
+    def forward(self, sentence_features: Iterable[dict[str, Tensor]], labels: Tensor) -> Tensor:
         # Step (1): A quick embedding step without gradients/computation graphs to get all the embeddings
         reps = []
         reps_guided = []
@@ -391,7 +391,7 @@ class CachedGISTEmbedLoss(nn.Module):
             loss = self.calculate_loss(reps, reps_guided)
         return loss
 
-    def get_config_dict(self) -> Dict[str, Any]:
+    def get_config_dict(self) -> dict[str, Any]:
         return {
             "guide": self.guide,
             "temperature": self.temperature,

--- a/sentence_transformers/losses/CoSENTLoss.py
+++ b/sentence_transformers/losses/CoSENTLoss.py
@@ -1,4 +1,6 @@
-from typing import Any, Dict, Iterable
+from __future__ import annotations
+
+from typing import Any, Iterable
 
 import torch
 from torch import Tensor, nn
@@ -75,7 +77,7 @@ class CoSENTLoss(nn.Module):
         self.similarity_fct = similarity_fct
         self.scale = scale
 
-    def forward(self, sentence_features: Iterable[Dict[str, Tensor]], labels: Tensor) -> Tensor:
+    def forward(self, sentence_features: Iterable[dict[str, Tensor]], labels: Tensor) -> Tensor:
         embeddings = [self.model(sentence_feature)["sentence_embedding"] for sentence_feature in sentence_features]
 
         scores = self.similarity_fct(embeddings[0], embeddings[1])
@@ -95,7 +97,7 @@ class CoSENTLoss(nn.Module):
 
         return loss
 
-    def get_config_dict(self) -> Dict[str, Any]:
+    def get_config_dict(self) -> dict[str, Any]:
         return {"scale": self.scale, "similarity_fct": self.similarity_fct.__name__}
 
     @property

--- a/sentence_transformers/losses/ContrastiveLoss.py
+++ b/sentence_transformers/losses/ContrastiveLoss.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 from enum import Enum
-from typing import Any, Dict, Iterable
+from typing import Any, Iterable
 
 import torch.nn.functional as F
 from torch import Tensor, nn
@@ -81,7 +83,7 @@ class ContrastiveLoss(nn.Module):
         self.model = model
         self.size_average = size_average
 
-    def get_config_dict(self) -> Dict[str, Any]:
+    def get_config_dict(self) -> dict[str, Any]:
         distance_metric_name = self.distance_metric.__name__
         for name, value in vars(SiameseDistanceMetric).items():
             if value == self.distance_metric:
@@ -90,7 +92,7 @@ class ContrastiveLoss(nn.Module):
 
         return {"distance_metric": distance_metric_name, "margin": self.margin, "size_average": self.size_average}
 
-    def forward(self, sentence_features: Iterable[Dict[str, Tensor]], labels: Tensor) -> Tensor:
+    def forward(self, sentence_features: Iterable[dict[str, Tensor]], labels: Tensor) -> Tensor:
         reps = [self.model(sentence_feature)["sentence_embedding"] for sentence_feature in sentence_features]
         assert len(reps) == 2
         rep_anchor, rep_other = reps

--- a/sentence_transformers/losses/ContrastiveTensionLoss.py
+++ b/sentence_transformers/losses/ContrastiveTensionLoss.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import copy
 import math
 import random
-from typing import Dict, Iterable
+from typing import Iterable
 
 import numpy as np
 import torch
@@ -76,7 +78,7 @@ class ContrastiveTensionLoss(nn.Module):
         self.model1 = copy.deepcopy(model)
         self.criterion = nn.BCEWithLogitsLoss(reduction="sum")
 
-    def forward(self, sentence_features: Iterable[Dict[str, Tensor]], labels: Tensor) -> Tensor:
+    def forward(self, sentence_features: Iterable[dict[str, Tensor]], labels: Tensor) -> Tensor:
         sentence_features1, sentence_features2 = tuple(sentence_features)
         reps_1 = self.model1(sentence_features1)["sentence_embedding"]  # (bsz, hdim)
         reps_2 = self.model2(sentence_features2)["sentence_embedding"]
@@ -170,7 +172,7 @@ class ContrastiveTensionLossInBatchNegatives(nn.Module):
         self.cross_entropy_loss = nn.CrossEntropyLoss()
         self.logit_scale = nn.Parameter(torch.ones([]) * np.log(scale))
 
-    def forward(self, sentence_features: Iterable[Dict[str, Tensor]], labels: Tensor) -> Tensor:
+    def forward(self, sentence_features: Iterable[dict[str, Tensor]], labels: Tensor) -> Tensor:
         sentence_features1, sentence_features2 = tuple(sentence_features)
         embeddings_a = self.model1(sentence_features1)["sentence_embedding"]  # (bsz, hdim)
         embeddings_b = self.model2(sentence_features2)["sentence_embedding"]

--- a/sentence_transformers/losses/CosineSimilarityLoss.py
+++ b/sentence_transformers/losses/CosineSimilarityLoss.py
@@ -1,4 +1,6 @@
-from typing import Any, Dict, Iterable
+from __future__ import annotations
+
+from typing import Any, Iterable
 
 import torch
 from torch import Tensor, nn
@@ -72,10 +74,10 @@ class CosineSimilarityLoss(nn.Module):
         self.loss_fct = loss_fct
         self.cos_score_transformation = cos_score_transformation
 
-    def forward(self, sentence_features: Iterable[Dict[str, Tensor]], labels: Tensor) -> Tensor:
+    def forward(self, sentence_features: Iterable[dict[str, Tensor]], labels: Tensor) -> Tensor:
         embeddings = [self.model(sentence_feature)["sentence_embedding"] for sentence_feature in sentence_features]
         output = self.cos_score_transformation(torch.cosine_similarity(embeddings[0], embeddings[1]))
         return self.loss_fct(output, labels.float().view(-1))
 
-    def get_config_dict(self) -> Dict[str, Any]:
+    def get_config_dict(self) -> dict[str, Any]:
         return {"loss_fct": fullname(self.loss_fct)}

--- a/sentence_transformers/losses/DenoisingAutoEncoderLoss.py
+++ b/sentence_transformers/losses/DenoisingAutoEncoderLoss.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import logging
-from typing import Dict, Iterable, Optional
+from typing import Iterable
 
 from torch import Tensor, nn
 from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer, PreTrainedModel
@@ -11,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 class DenoisingAutoEncoderLoss(nn.Module):
     def __init__(
-        self, model: SentenceTransformer, decoder_name_or_path: Optional[str] = None, tie_encoder_decoder: bool = True
+        self, model: SentenceTransformer, decoder_name_or_path: str | None = None, tie_encoder_decoder: bool = True
     ) -> None:
         r"""
         This loss expects as input a pairs of damaged sentences and the corresponding original ones.
@@ -134,7 +136,7 @@ class DenoisingAutoEncoderLoss(nn.Module):
                     encoder_name_or_path,
                 )
 
-    def retokenize(self, sentence_features: Dict[str, Tensor]) -> Dict[str, Tensor]:
+    def retokenize(self, sentence_features: dict[str, Tensor]) -> dict[str, Tensor]:
         input_ids = sentence_features["input_ids"]
         device = input_ids.device
         sentences_decoded = self.tokenizer_encoder.batch_decode(
@@ -145,7 +147,7 @@ class DenoisingAutoEncoderLoss(nn.Module):
         ).to(device)
         return retokenized
 
-    def forward(self, sentence_features: Iterable[Dict[str, Tensor]], labels: Tensor) -> Tensor:
+    def forward(self, sentence_features: Iterable[dict[str, Tensor]], labels: Tensor) -> Tensor:
         source_features, target_features = tuple(sentence_features)
         if self.need_retokenization:
             # since the sentence_features here are all tokenized by encoder's tokenizer,

--- a/sentence_transformers/losses/GISTEmbedLoss.py
+++ b/sentence_transformers/losses/GISTEmbedLoss.py
@@ -1,4 +1,6 @@
-from typing import Any, Dict, Iterable
+from __future__ import annotations
+
+from typing import Any, Iterable
 
 import torch
 from torch import Tensor, nn
@@ -88,7 +90,7 @@ class GISTEmbedLoss(nn.Module):
     def sim_matrix(self, embed1: Tensor, embed2: Tensor) -> Tensor:
         return self.similarity_fct(embed1.unsqueeze(1), embed2.unsqueeze(0))
 
-    def forward(self, sentence_features: Iterable[Dict[str, Tensor]], labels: Tensor) -> Tensor:
+    def forward(self, sentence_features: Iterable[dict[str, Tensor]], labels: Tensor) -> Tensor:
         embeddings = [self.model(sentence_feature)["sentence_embedding"] for sentence_feature in sentence_features]
         with torch.no_grad():
             if self.must_retokenize:
@@ -157,7 +159,7 @@ class GISTEmbedLoss(nn.Module):
 
         return nn.CrossEntropyLoss()(scores, labels)
 
-    def get_config_dict(self) -> Dict[str, Any]:
+    def get_config_dict(self) -> dict[str, Any]:
         return {
             "guide": self.guide,
             "temperature": self.temperature,

--- a/sentence_transformers/losses/MSELoss.py
+++ b/sentence_transformers/losses/MSELoss.py
@@ -1,4 +1,6 @@
-from typing import Dict, Iterable
+from __future__ import annotations
+
+from typing import Iterable
 
 import torch
 from torch import Tensor, nn
@@ -70,7 +72,7 @@ class MSELoss(nn.Module):
         self.model = model
         self.loss_fct = nn.MSELoss()
 
-    def forward(self, sentence_features: Iterable[Dict[str, Tensor]], labels: Tensor) -> Tensor:
+    def forward(self, sentence_features: Iterable[dict[str, Tensor]], labels: Tensor) -> Tensor:
         # Concatenate multiple inputs on the batch dimension
         if len(sentence_features) > 1:
             embeddings = torch.cat([self.model(inputs)["sentence_embedding"] for inputs in sentence_features], dim=0)

--- a/sentence_transformers/losses/MarginMSELoss.py
+++ b/sentence_transformers/losses/MarginMSELoss.py
@@ -1,4 +1,6 @@
-from typing import Dict, Iterable
+from __future__ import annotations
+
+from typing import Iterable
 
 from torch import Tensor, nn
 
@@ -113,7 +115,7 @@ class MarginMSELoss(nn.Module):
         self.similarity_fct = similarity_fct
         self.loss_fct = nn.MSELoss()
 
-    def forward(self, sentence_features: Iterable[Dict[str, Tensor]], labels: Tensor) -> Tensor:
+    def forward(self, sentence_features: Iterable[dict[str, Tensor]], labels: Tensor) -> Tensor:
         # sentence_features: query, positive passage, negative passage
         reps = [self.model(sentence_feature)["sentence_embedding"] for sentence_feature in sentence_features]
         embeddings_query = reps[0]

--- a/sentence_transformers/losses/Matryoshka2dLoss.py
+++ b/sentence_transformers/losses/Matryoshka2dLoss.py
@@ -1,4 +1,6 @@
-from typing import Any, Dict, List, Optional, Union
+from __future__ import annotations
+
+from typing import Any
 
 from torch.nn import Module
 
@@ -11,8 +13,8 @@ class Matryoshka2dLoss(AdaptiveLayerLoss):
         self,
         model: SentenceTransformer,
         loss: Module,
-        matryoshka_dims: List[int],
-        matryoshka_weights: Optional[List[Union[float, int]]] = None,
+        matryoshka_dims: list[int],
+        matryoshka_weights: list[float | int] | None = None,
         n_layers_per_step: int = 1,
         n_dims_per_step: int = 1,
         last_layer_weight: float = 1.0,
@@ -124,7 +126,7 @@ class Matryoshka2dLoss(AdaptiveLayerLoss):
             kl_temperature=kl_temperature,
         )
 
-    def get_config_dict(self) -> Dict[str, Any]:
+    def get_config_dict(self) -> dict[str, Any]:
         return {
             **super().get_config_dict(),
             **self.loss.get_config_dict(),

--- a/sentence_transformers/losses/MatryoshkaLoss.py
+++ b/sentence_transformers/losses/MatryoshkaLoss.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 import random
 import warnings
-from typing import Any, Dict, Iterable, List, Optional, Union
+from typing import Any, Iterable
 
 import torch.nn.functional as F
 from torch import Tensor, nn
@@ -33,7 +35,7 @@ class ForwardDecorator:
         tensor = F.normalize(tensor, p=2, dim=-1)
         return tensor
 
-    def __call__(self, features: Dict[str, Tensor]) -> Dict[str, Tensor]:
+    def __call__(self, features: dict[str, Tensor]) -> dict[str, Tensor]:
         # Growing cache:
         if self.cache_dim is None or self.cache_dim == self.dim:
             output = self.fn(features)
@@ -53,8 +55,8 @@ class MatryoshkaLoss(nn.Module):
         self,
         model: SentenceTransformer,
         loss: nn.Module,
-        matryoshka_dims: List[int],
-        matryoshka_weights: Optional[List[Union[float, int]]] = None,
+        matryoshka_dims: list[int],
+        matryoshka_weights: list[float | int] | None = None,
         n_dims_per_step: int = -1,
     ) -> None:
         """
@@ -129,7 +131,7 @@ class MatryoshkaLoss(nn.Module):
         self.matryoshka_dims, self.matryoshka_weights = zip(*sorted(dims_weights, key=lambda x: x[0], reverse=True))
         self.n_dims_per_step = n_dims_per_step
 
-    def forward(self, sentence_features: Iterable[Dict[str, Tensor]], labels: Tensor) -> Tensor:
+    def forward(self, sentence_features: Iterable[dict[str, Tensor]], labels: Tensor) -> Tensor:
         original_forward = self.model.forward
         try:
             decorated_forward = ForwardDecorator(original_forward)
@@ -149,7 +151,7 @@ class MatryoshkaLoss(nn.Module):
             self.model.forward = original_forward
         return loss
 
-    def get_config_dict(self) -> Dict[str, Any]:
+    def get_config_dict(self) -> dict[str, Any]:
         return {
             "loss": self.loss.__class__.__name__,
             "matryoshka_dims": self.matryoshka_dims,

--- a/sentence_transformers/losses/MegaBatchMarginLoss.py
+++ b/sentence_transformers/losses/MegaBatchMarginLoss.py
@@ -1,4 +1,6 @@
-from typing import Dict, Iterable
+from __future__ import annotations
+
+from typing import Iterable
 
 import torch
 import torch.nn.functional as F
@@ -80,7 +82,7 @@ class MegaBatchMarginLoss(nn.Module):
         self.mini_batch_size = mini_batch_size
         self.forward = self.forward_mini_batched if use_mini_batched_version else self.forward_non_mini_batched
 
-    def forward_mini_batched(self, sentence_features: Iterable[Dict[str, Tensor]], labels: Tensor) -> Tensor:
+    def forward_mini_batched(self, sentence_features: Iterable[dict[str, Tensor]], labels: Tensor) -> Tensor:
         anchor, positive = sentence_features
         feature_names = list(anchor.keys())
 
@@ -137,7 +139,7 @@ class MegaBatchMarginLoss(nn.Module):
         return losses
 
     ##### Non mini-batched version ###
-    def forward_non_mini_batched(self, sentence_features: Iterable[Dict[str, Tensor]], labels: Tensor) -> Tensor:
+    def forward_non_mini_batched(self, sentence_features: Iterable[dict[str, Tensor]], labels: Tensor) -> Tensor:
         reps = [self.model(sentence_feature)["sentence_embedding"] for sentence_feature in sentence_features]
         embeddings_a, embeddings_b = reps
 

--- a/sentence_transformers/losses/MultipleNegativesRankingLoss.py
+++ b/sentence_transformers/losses/MultipleNegativesRankingLoss.py
@@ -1,4 +1,6 @@
-from typing import Any, Dict, Iterable
+from __future__ import annotations
+
+from typing import Any, Iterable
 
 import torch
 from torch import Tensor, nn
@@ -89,7 +91,7 @@ class MultipleNegativesRankingLoss(nn.Module):
         self.similarity_fct = similarity_fct
         self.cross_entropy_loss = nn.CrossEntropyLoss()
 
-    def forward(self, sentence_features: Iterable[Dict[str, Tensor]], labels: Tensor) -> Tensor:
+    def forward(self, sentence_features: Iterable[dict[str, Tensor]], labels: Tensor) -> Tensor:
         reps = [self.model(sentence_feature)["sentence_embedding"] for sentence_feature in sentence_features]
         embeddings_a = reps[0]
         embeddings_b = torch.cat(reps[1:])
@@ -99,7 +101,7 @@ class MultipleNegativesRankingLoss(nn.Module):
         range_labels = torch.arange(0, scores.size(0), device=scores.device)
         return self.cross_entropy_loss(scores, range_labels)
 
-    def get_config_dict(self) -> Dict[str, Any]:
+    def get_config_dict(self) -> dict[str, Any]:
         return {"scale": self.scale, "similarity_fct": self.similarity_fct.__name__}
 
     @property

--- a/sentence_transformers/losses/MultipleNegativesSymmetricRankingLoss.py
+++ b/sentence_transformers/losses/MultipleNegativesSymmetricRankingLoss.py
@@ -1,4 +1,6 @@
-from typing import Any, Dict, Iterable
+from __future__ import annotations
+
+from typing import Any, Iterable
 
 import torch
 from torch import Tensor, nn
@@ -69,7 +71,7 @@ class MultipleNegativesSymmetricRankingLoss(nn.Module):
         self.similarity_fct = similarity_fct
         self.cross_entropy_loss = nn.CrossEntropyLoss()
 
-    def forward(self, sentence_features: Iterable[Dict[str, Tensor]], labels: Tensor) -> Tensor:
+    def forward(self, sentence_features: Iterable[dict[str, Tensor]], labels: Tensor) -> Tensor:
         reps = [self.model(sentence_feature)["sentence_embedding"] for sentence_feature in sentence_features]
         anchor = reps[0]
         candidates = torch.cat(reps[1:])
@@ -84,5 +86,5 @@ class MultipleNegativesSymmetricRankingLoss(nn.Module):
         backward_loss = self.cross_entropy_loss(anchor_positive_scores.transpose(0, 1), labels)
         return (forward_loss + backward_loss) / 2
 
-    def get_config_dict(self) -> Dict[str, Any]:
+    def get_config_dict(self) -> dict[str, Any]:
         return {"scale": self.scale, "similarity_fct": self.similarity_fct.__name__}

--- a/sentence_transformers/losses/OnlineContrastiveLoss.py
+++ b/sentence_transformers/losses/OnlineContrastiveLoss.py
@@ -1,4 +1,6 @@
-from typing import Dict, Iterable
+from __future__ import annotations
+
+from typing import Iterable
 
 import torch.nn.functional as F
 from torch import Tensor, nn
@@ -69,7 +71,7 @@ class OnlineContrastiveLoss(nn.Module):
         self.margin = margin
         self.distance_metric = distance_metric
 
-    def forward(self, sentence_features: Iterable[Dict[str, Tensor]], labels: Tensor, size_average=False) -> Tensor:
+    def forward(self, sentence_features: Iterable[dict[str, Tensor]], labels: Tensor, size_average=False) -> Tensor:
         embeddings = [self.model(sentence_feature)["sentence_embedding"] for sentence_feature in sentence_features]
 
         distance_matrix = self.distance_metric(embeddings[0], embeddings[1])

--- a/sentence_transformers/losses/SoftmaxLoss.py
+++ b/sentence_transformers/losses/SoftmaxLoss.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import logging
-from typing import Callable, Dict, Iterable, Tuple, Union
+from typing import Callable, Iterable
 
 import torch
 from torch import Tensor, nn
@@ -102,8 +104,8 @@ class SoftmaxLoss(nn.Module):
         self.loss_fct = loss_fct
 
     def forward(
-        self, sentence_features: Iterable[Dict[str, Tensor]], labels: Tensor
-    ) -> Union[Tensor, Tuple[Tensor, Tensor]]:
+        self, sentence_features: Iterable[dict[str, Tensor]], labels: Tensor
+    ) -> Tensor | tuple[Tensor, Tensor]:
         reps = [self.model(sentence_feature)["sentence_embedding"] for sentence_feature in sentence_features]
         rep_a, rep_b = reps
 

--- a/sentence_transformers/losses/TripletLoss.py
+++ b/sentence_transformers/losses/TripletLoss.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 from enum import Enum
-from typing import Any, Dict, Iterable
+from typing import Any, Iterable
 
 import torch.nn.functional as F
 from torch import Tensor, nn
@@ -75,7 +77,7 @@ class TripletLoss(nn.Module):
         self.distance_metric = distance_metric
         self.triplet_margin = triplet_margin
 
-    def forward(self, sentence_features: Iterable[Dict[str, Tensor]], labels: Tensor) -> Tensor:
+    def forward(self, sentence_features: Iterable[dict[str, Tensor]], labels: Tensor) -> Tensor:
         reps = [self.model(sentence_feature)["sentence_embedding"] for sentence_feature in sentence_features]
 
         rep_anchor, rep_pos, rep_neg = reps
@@ -85,7 +87,7 @@ class TripletLoss(nn.Module):
         losses = F.relu(distance_pos - distance_neg + self.triplet_margin)
         return losses.mean()
 
-    def get_config_dict(self) -> Dict[str, Any]:
+    def get_config_dict(self) -> dict[str, Any]:
         distance_metric_name = self.distance_metric.__name__
         for name, value in vars(TripletDistanceMetric).items():
             if value == self.distance_metric:

--- a/sentence_transformers/losses/__init__.py
+++ b/sentence_transformers/losses/__init__.py
@@ -1,4 +1,6 @@
 # CoSENTLoss must be imported before AnglELoss
+from __future__ import annotations
+
 from .CoSENTLoss import CoSENTLoss  # isort: skip
 
 from .AdaptiveLayerLoss import AdaptiveLayerLoss

--- a/sentence_transformers/model_card.py
+++ b/sentence_transformers/model_card.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import logging
 import random
@@ -8,7 +10,7 @@ from dataclasses import dataclass, field, fields
 from pathlib import Path
 from platform import python_version
 from textwrap import indent
-from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Literal
 
 import torch
 import transformers
@@ -41,7 +43,7 @@ if TYPE_CHECKING:
 
 
 class ModelCardCallback(TrainerCallback):
-    def __init__(self, trainer: "SentenceTransformerTrainer", default_args_dict: Dict[str, Any]) -> None:
+    def __init__(self, trainer: "SentenceTransformerTrainer", default_args_dict: dict[str, Any]) -> None:
         super().__init__()
         self.trainer = trainer
         self.default_args_dict = default_args_dict
@@ -146,7 +148,7 @@ class ModelCardCallback(TrainerCallback):
         state: TrainerState,
         control: TrainerControl,
         model: "SentenceTransformer",
-        metrics: Dict[str, float],
+        metrics: dict[str, float],
         **kwargs,
     ) -> None:
         loss_dict = {" ".join(key.split("_")[1:]): metrics[key] for key in metrics if key.endswith("_loss")}
@@ -170,7 +172,7 @@ class ModelCardCallback(TrainerCallback):
         state: TrainerState,
         control: TrainerControl,
         model: "SentenceTransformer",
-        logs: Dict[str, float],
+        logs: dict[str, float],
         **kwargs,
     ) -> None:
         keys = {"loss"} & set(logs)
@@ -206,7 +208,7 @@ YAML_FIELDS = [
 IGNORED_FIELDS = ["model", "trainer", "eval_results_dict"]
 
 
-def get_versions() -> Dict[str, Any]:
+def get_versions() -> dict[str, Any]:
     versions = {
         "python": python_version(),
         "sentence_transformers": sentence_transformers_version,
@@ -269,16 +271,16 @@ class SentenceTransformerModelCardData(CardData):
     """
 
     # Potentially provided by the user
-    language: Optional[Union[str, List[str]]] = field(default_factory=list)
-    license: Optional[str] = None
-    model_name: Optional[str] = None
-    model_id: Optional[str] = None
-    train_datasets: List[Dict[str, str]] = field(default_factory=list)
-    eval_datasets: List[Dict[str, str]] = field(default_factory=list)
+    language: str | list[str] | None = field(default_factory=list)
+    license: str | None = None
+    model_name: str | None = None
+    model_id: str | None = None
+    train_datasets: list[dict[str, str]] = field(default_factory=list)
+    eval_datasets: list[dict[str, str]] = field(default_factory=list)
     task_name: str = (
         "semantic textual similarity, semantic search, paraphrase mining, text classification, clustering, and more"
     )
-    tags: Optional[List[str]] = field(
+    tags: list[str] | None = field(
         default_factory=lambda: [
             "sentence-transformers",
             "sentence-similarity",
@@ -288,20 +290,20 @@ class SentenceTransformerModelCardData(CardData):
     generate_widget_examples: Literal["deprecated"] = "deprecated"
 
     # Automatically filled by `ModelCardCallback` and the Trainer directly
-    base_model: Optional[str] = field(default=None, init=False)
-    base_model_revision: Optional[str] = field(default=None, init=False)
-    non_default_hyperparameters: Dict[str, Any] = field(default_factory=dict, init=False)
-    all_hyperparameters: Dict[str, Any] = field(default_factory=dict, init=False)
-    eval_results_dict: Optional[Dict["SentenceEvaluator", Dict[str, Any]]] = field(default_factory=dict, init=False)
-    training_logs: List[Dict[str, float]] = field(default_factory=list, init=False)
-    widget: List[Dict[str, str]] = field(default_factory=list, init=False)
-    predict_example: Optional[str] = field(default=None, init=False)
-    label_example_list: List[Dict[str, str]] = field(default_factory=list, init=False)
-    code_carbon_callback: Optional[CodeCarbonCallback] = field(default=None, init=False)
-    citations: Dict[str, str] = field(default_factory=dict, init=False)
-    best_model_step: Optional[int] = field(default=None, init=False)
-    trainer: Optional["SentenceTransformerTrainer"] = field(default=None, init=False, repr=False)
-    datasets: List[str] = field(default_factory=list, init=False, repr=False)
+    base_model: str | None = field(default=None, init=False)
+    base_model_revision: str | None = field(default=None, init=False)
+    non_default_hyperparameters: dict[str, Any] = field(default_factory=dict, init=False)
+    all_hyperparameters: dict[str, Any] = field(default_factory=dict, init=False)
+    eval_results_dict: dict["SentenceEvaluator", dict[str, Any]] | None = field(default_factory=dict, init=False)
+    training_logs: list[dict[str, float]] = field(default_factory=list, init=False)
+    widget: list[dict[str, str]] = field(default_factory=list, init=False)
+    predict_example: str | None = field(default=None, init=False)
+    label_example_list: list[dict[str, str]] = field(default_factory=list, init=False)
+    code_carbon_callback: CodeCarbonCallback | None = field(default=None, init=False)
+    citations: dict[str, str] = field(default_factory=dict, init=False)
+    best_model_step: int | None = field(default=None, init=False)
+    trainer: "SentenceTransformerTrainer" | None = field(default=None, init=False, repr=False)
+    datasets: list[str] = field(default_factory=list, init=False, repr=False)
 
     # Utility fields
     first_save: bool = field(default=True, init=False)
@@ -310,10 +312,10 @@ class SentenceTransformerModelCardData(CardData):
     # Computed once, always unchanged
     pipeline_tag: str = field(default="sentence-similarity", init=False)
     library_name: str = field(default="sentence-transformers", init=False)
-    version: Dict[str, str] = field(default_factory=get_versions, init=False)
+    version: dict[str, str] = field(default_factory=get_versions, init=False)
 
     # Passed via `register_model` only
-    model: Optional["SentenceTransformer"] = field(default=None, init=False, repr=False)
+    model: "SentenceTransformer" | None = field(default=None, init=False, repr=False)
 
     def __post_init__(self) -> None:
         # We don't want to save "ignore_metadata_errors" in our Model Card
@@ -365,7 +367,7 @@ class SentenceTransformerModelCardData(CardData):
             output_dataset_list.append(dataset)
         return output_dataset_list
 
-    def set_losses(self, losses: List[nn.Module]) -> None:
+    def set_losses(self, losses: list[nn.Module]) -> None:
         citations = {
             "Sentence Transformers": """
 @inproceedings{reimers-2019-sentence-bert,
@@ -388,7 +390,7 @@ class SentenceTransformerModelCardData(CardData):
         for loss, citation in citations.items():
             inverted_citations[citation].append(loss)
 
-        def join_list(losses: List[str]) -> str:
+        def join_list(losses: list[str]) -> str:
             if len(losses) > 1:
                 return ", ".join(losses[:-1]) + " and " + losses[-1]
             return losses[0]
@@ -399,7 +401,7 @@ class SentenceTransformerModelCardData(CardData):
     def set_best_model_step(self, step: int) -> None:
         self.best_model_step = step
 
-    def set_widget_examples(self, dataset: Union["Dataset", "DatasetDict"]) -> None:
+    def set_widget_examples(self, dataset: "Dataset" | "DatasetDict") -> None:
         if isinstance(dataset, Dataset):
             dataset = DatasetDict(dataset=dataset)
 
@@ -450,7 +452,7 @@ class SentenceTransformerModelCardData(CardData):
                 )
                 self.predict_example = sentences[:3]
 
-    def set_evaluation_metrics(self, evaluator: "SentenceEvaluator", metrics: Dict[str, Any]) -> None:
+    def set_evaluation_metrics(self, evaluator: "SentenceEvaluator", metrics: dict[str, Any]) -> None:
         from sentence_transformers.evaluation import SequentialEvaluator
 
         self.eval_results_dict[evaluator] = copy(metrics)
@@ -503,8 +505,8 @@ class SentenceTransformerModelCardData(CardData):
         ]
 
     def infer_datasets(
-        self, dataset: Union["Dataset", "DatasetDict"], dataset_name: Optional[str] = None
-    ) -> List[Dict[str, str]]:
+        self, dataset: "Dataset" | "DatasetDict", dataset_name: str | None = None
+    ) -> list[dict[str, str]]:
         if isinstance(dataset, DatasetDict):
             return [
                 dataset
@@ -512,7 +514,7 @@ class SentenceTransformerModelCardData(CardData):
                 for dataset in self.infer_datasets(sub_dataset, dataset_name=dataset_name)
             ]
 
-        def subtuple_finder(tuple: Tuple[str], subtuple: Tuple[str]) -> int:
+        def subtuple_finder(tuple: tuple[str], subtuple: tuple[str]) -> int:
             for i, element in enumerate(tuple):
                 if element == subtuple[0] and tuple[i : i + len(subtuple)] == subtuple:
                     return i
@@ -558,10 +560,10 @@ class SentenceTransformerModelCardData(CardData):
 
     def compute_dataset_metrics(
         self,
-        dataset: Dict[str, str],
-        dataset_info: Dict[str, Any],
-        loss: Optional[Union[Dict[str, nn.Module], nn.Module]],
-    ) -> Dict[str, str]:
+        dataset: dict[str, str],
+        dataset_info: dict[str, Any],
+        loss: dict[str, nn.Module] | nn.Module | None,
+    ) -> dict[str, str]:
         """
         Given a dataset, compute the following:
         * Dataset Size
@@ -677,8 +679,8 @@ class SentenceTransformerModelCardData(CardData):
         return dataset_info
 
     def extract_dataset_metadata(
-        self, dataset: Union["Dataset", "DatasetDict"], dataset_metadata, dataset_type: Literal["train", "eval"]
-    ) -> Dict[str, Any]:
+        self, dataset: "Dataset" | "DatasetDict", dataset_metadata, dataset_type: Literal["train", "eval"]
+    ) -> dict[str, Any]:
         if dataset:
             if dataset_metadata and (
                 (isinstance(dataset, DatasetDict) and len(dataset_metadata) != len(dataset))
@@ -721,7 +723,7 @@ class SentenceTransformerModelCardData(CardData):
     def set_model_id(self, model_id: str) -> None:
         self.model_id = model_id
 
-    def set_base_model(self, model_id: str, revision: Optional[str] = None) -> None:
+    def set_base_model(self, model_id: str, revision: str | None = None) -> None:
         try:
             model_info = get_model_info(model_id)
         except Exception:
@@ -733,7 +735,7 @@ class SentenceTransformerModelCardData(CardData):
         self.base_model_revision = revision
         return True
 
-    def set_language(self, language: Union[str, List[str]]) -> None:
+    def set_language(self, language: str | list[str]) -> None:
         if isinstance(language, str):
             language = [language]
         self.language = language
@@ -741,7 +743,7 @@ class SentenceTransformerModelCardData(CardData):
     def set_license(self, license: str) -> None:
         self.license = license
 
-    def add_tags(self, tags: Union[str, List[str]]) -> None:
+    def add_tags(self, tags: str | list[str]) -> None:
         if isinstance(tags, str):
             tags = [tags]
         for tag in tags:
@@ -767,7 +769,7 @@ class SentenceTransformerModelCardData(CardData):
                 if self.set_base_model(model_id):
                     break
 
-    def format_eval_metrics(self) -> Dict[str, Any]:
+    def format_eval_metrics(self) -> dict[str, Any]:
         """Format the evaluation metrics for the model card.
 
         The following keys will be returned:
@@ -875,7 +877,7 @@ class SentenceTransformerModelCardData(CardData):
             "explain_bold_in_eval": "**" in eval_lines,
         }
 
-    def get_codecarbon_data(self) -> Dict[Literal["co2_eq_emissions"], Dict[str, Any]]:
+    def get_codecarbon_data(self) -> dict[Literal["co2_eq_emissions"], dict[str, Any]]:
         emissions_data = self.code_carbon_callback.tracker._prepare_emissions_data()
         results = {
             "co2_eq_emissions": {
@@ -894,7 +896,7 @@ class SentenceTransformerModelCardData(CardData):
             results["co2_eq_emissions"]["hardware_used"] = emissions_data.gpu_model
         return results
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         # Extract some meaningful examples from the evaluation or training dataset to showcase the performance
         if (
             not self.widget

--- a/sentence_transformers/model_card_templates.py
+++ b/sentence_transformers/model_card_templates.py
@@ -3,6 +3,8 @@ This file contains the templating for model cards prior to the v3.0 release. It 
 SentenceTransformer.old_fit for backwards compatibility, but will be removed in a future release.
 """
 
+from __future__ import annotations
+
 import logging
 
 from .util import fullname

--- a/sentence_transformers/models/Asym.py
+++ b/sentence_transformers/models/Asym.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import json
 import os
 from collections import OrderedDict
-from typing import Dict, List, Tuple, Union
+from typing import List
 
 from torch import Tensor, nn
 
@@ -9,7 +11,7 @@ from sentence_transformers.util import import_from_string
 
 
 class Asym(nn.Sequential):
-    def __init__(self, sub_modules: Dict[str, List[nn.Module]], allow_empty_key: bool = True):
+    def __init__(self, sub_modules: dict[str, list[nn.Module]], allow_empty_key: bool = True):
         """
         This model allows to create asymmetric SentenceTransformer models, that apply different models depending on the specified input key.
 
@@ -50,7 +52,7 @@ class Asym(nn.Sequential):
                 ordered_dict[name + "-" + str(idx)] = model
         super(Asym, self).__init__(ordered_dict)
 
-    def forward(self, features: Dict[str, Tensor]):
+    def forward(self, features: dict[str, Tensor]):
         if "text_keys" in features and len(features["text_keys"]) > 0:
             text_key = features["text_keys"][0]
             for model in self.sub_modules[text_key]:
@@ -95,7 +97,7 @@ class Asym(nn.Sequential):
                 indent=2,
             )
 
-    def tokenize(self, texts: Union[List[str], List[Tuple[str, str]]], **kwargs):
+    def tokenize(self, texts: list[str] | list[tuple[str, str]], **kwargs):
         """Tokenizes a text and maps tokens to token-ids"""
         if not isinstance(texts[0], dict):
             raise AttributeError("Asym. model requires that texts are passed as dicts: {'key': 'text'}")

--- a/sentence_transformers/models/BoW.py
+++ b/sentence_transformers/models/BoW.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import json
 import logging
 import os
-from typing import Dict, List, Literal
+from typing import Literal
 
 import torch
 from torch import Tensor, nn
@@ -19,8 +21,8 @@ class BoW(nn.Module):
 
     def __init__(
         self,
-        vocab: List[str],
-        word_weights: Dict[str, float] = {},
+        vocab: list[str],
+        word_weights: dict[str, float] = {},
         unknown_word_weight: float = 1,
         cumulative_term_frequency: bool = True,
     ):
@@ -54,11 +56,11 @@ class BoW(nn.Module):
         self.tokenizer = WhitespaceTokenizer(vocab, stop_words=set(), do_lower_case=False)
         self.sentence_embedding_dimension = len(vocab)
 
-    def forward(self, features: Dict[str, Tensor]):
+    def forward(self, features: dict[str, Tensor]):
         # Nothing to do, everything is done in get_sentence_features
         return features
 
-    def tokenize(self, texts: List[str], **kwargs) -> List[int]:
+    def tokenize(self, texts: list[str], **kwargs) -> list[int]:
         tokenized = [self.tokenizer.tokenize(text, **kwargs) for text in texts]
         return self.get_sentence_features(tokenized)
 
@@ -66,8 +68,8 @@ class BoW(nn.Module):
         return self.sentence_embedding_dimension
 
     def get_sentence_features(
-        self, tokenized_texts: List[List[int]], pad_seq_length: int = 0
-    ) -> Dict[Literal["sentence_embedding"], torch.Tensor]:
+        self, tokenized_texts: list[list[int]], pad_seq_length: int = 0
+    ) -> dict[Literal["sentence_embedding"], torch.Tensor]:
         vectors = []
 
         for tokens in tokenized_texts:

--- a/sentence_transformers/models/CLIPModel.py
+++ b/sentence_transformers/models/CLIPModel.py
@@ -1,4 +1,4 @@
-from typing import Dict, Union
+from __future__ import annotations
 
 import torch
 import transformers
@@ -19,7 +19,7 @@ class CLIPModel(nn.Module):
     def __repr__(self) -> str:
         return "CLIPModel()"
 
-    def forward(self, features: Dict[str, torch.Tensor]) -> Dict[str, torch.Tensor]:
+    def forward(self, features: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
         image_embeds = []
         text_embeds = []
 
@@ -51,7 +51,7 @@ class CLIPModel(nn.Module):
 
         return features
 
-    def tokenize(self, texts, padding: Union[str, bool] = True) -> Dict[str, torch.Tensor]:
+    def tokenize(self, texts, padding: str | bool = True) -> dict[str, torch.Tensor]:
         images = []
         texts_values = []
         image_text_info = []

--- a/sentence_transformers/models/CNN.py
+++ b/sentence_transformers/models/CNN.py
@@ -1,6 +1,7 @@
+from __future__ import annotations
+
 import json
 import os
-from typing import List
 
 import torch
 from safetensors.torch import load_model as load_safetensors_model
@@ -15,8 +16,8 @@ class CNN(nn.Module):
         self,
         in_word_embedding_dimension: int,
         out_channels: int = 256,
-        kernel_sizes: List[int] = [1, 3, 5],
-        stride_sizes: List[int] = None,
+        kernel_sizes: list[int] = [1, 3, 5],
+        stride_sizes: list[int] = None,
     ):
         nn.Module.__init__(self)
         self.config_keys = ["in_word_embedding_dimension", "out_channels", "kernel_sizes"]
@@ -55,7 +56,7 @@ class CNN(nn.Module):
     def get_word_embedding_dimension(self) -> int:
         return self.embeddings_dimension
 
-    def tokenize(self, text: str, **kwargs) -> List[int]:
+    def tokenize(self, text: str, **kwargs) -> list[int]:
         raise NotImplementedError()
 
     def save(self, output_path: str, safe_serialization: bool = True):

--- a/sentence_transformers/models/Dense.py
+++ b/sentence_transformers/models/Dense.py
@@ -1,6 +1,7 @@
+from __future__ import annotations
+
 import json
 import os
-from typing import Dict
 
 import torch
 from safetensors.torch import load_model as load_safetensors_model
@@ -48,7 +49,7 @@ class Dense(nn.Module):
         if init_bias is not None:
             self.linear.bias = nn.Parameter(init_bias)
 
-    def forward(self, features: Dict[str, Tensor]):
+    def forward(self, features: dict[str, Tensor]):
         features.update({"sentence_embedding": self.activation_function(self.linear(features["sentence_embedding"]))})
         return features
 

--- a/sentence_transformers/models/Dropout.py
+++ b/sentence_transformers/models/Dropout.py
@@ -1,6 +1,7 @@
+from __future__ import annotations
+
 import json
 import os
-from typing import Dict
 
 from torch import Tensor, nn
 
@@ -17,7 +18,7 @@ class Dropout(nn.Module):
         self.dropout = dropout
         self.dropout_layer = nn.Dropout(self.dropout)
 
-    def forward(self, features: Dict[str, Tensor]):
+    def forward(self, features: dict[str, Tensor]):
         features.update({"sentence_embedding": self.dropout_layer(features["sentence_embedding"])})
         return features
 

--- a/sentence_transformers/models/LSTM.py
+++ b/sentence_transformers/models/LSTM.py
@@ -1,6 +1,7 @@
+from __future__ import annotations
+
 import json
 import os
-from typing import List
 
 import torch
 from safetensors.torch import load_model as load_safetensors_model
@@ -55,7 +56,7 @@ class LSTM(nn.Module):
     def get_word_embedding_dimension(self) -> int:
         return self.embeddings_dimension
 
-    def tokenize(self, text: str, **kwargs) -> List[int]:
+    def tokenize(self, text: str, **kwargs) -> list[int]:
         raise NotImplementedError()
 
     def save(self, output_path: str, safe_serialization: bool = True):

--- a/sentence_transformers/models/LayerNorm.py
+++ b/sentence_transformers/models/LayerNorm.py
@@ -1,6 +1,7 @@
+from __future__ import annotations
+
 import json
 import os
-from typing import Dict
 
 import torch
 from safetensors.torch import load_model as load_safetensors_model
@@ -14,7 +15,7 @@ class LayerNorm(nn.Module):
         self.dimension = dimension
         self.norm = nn.LayerNorm(dimension)
 
-    def forward(self, features: Dict[str, Tensor]):
+    def forward(self, features: dict[str, Tensor]):
         features["sentence_embedding"] = self.norm(features["sentence_embedding"])
         return features
 

--- a/sentence_transformers/models/Normalize.py
+++ b/sentence_transformers/models/Normalize.py
@@ -1,4 +1,4 @@
-from typing import Dict
+from __future__ import annotations
 
 import torch.nn.functional as F
 from torch import Tensor, nn
@@ -10,7 +10,7 @@ class Normalize(nn.Module):
     def __init__(self) -> None:
         super(Normalize, self).__init__()
 
-    def forward(self, features: Dict[str, Tensor]) -> Dict[str, Tensor]:
+    def forward(self, features: dict[str, Tensor]) -> dict[str, Tensor]:
         features.update({"sentence_embedding": F.normalize(features["sentence_embedding"], p=2, dim=1)})
         return features
 

--- a/sentence_transformers/models/Pooling.py
+++ b/sentence_transformers/models/Pooling.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 import json
 import os
-from typing import Any, Dict
+from typing import Any
 
 import torch
 from torch import Tensor, nn
@@ -128,7 +130,7 @@ class Pooling(nn.Module):
 
         return "+".join(modes)
 
-    def forward(self, features: Dict[str, Tensor]) -> Dict[str, Tensor]:
+    def forward(self, features: dict[str, Tensor]) -> dict[str, Tensor]:
         token_embeddings = features["token_embeddings"]
         attention_mask = features["attention_mask"]
         if not self.include_prompt and "prompt_length" in features:
@@ -226,7 +228,7 @@ class Pooling(nn.Module):
     def get_sentence_embedding_dimension(self) -> int:
         return self.pooling_output_dimension
 
-    def get_config_dict(self) -> Dict[str, Any]:
+    def get_config_dict(self) -> dict[str, Any]:
         return {key: self.__dict__[key] for key in self.config_keys}
 
     def save(self, output_path) -> None:

--- a/sentence_transformers/models/Transformer.py
+++ b/sentence_transformers/models/Transformer.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 import json
 import os
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any
 
 import torch
 from torch import nn
@@ -32,11 +34,11 @@ class Transformer(nn.Module):
     def __init__(
         self,
         model_name_or_path: str,
-        max_seq_length: Optional[int] = None,
-        model_args: Optional[Dict[str, Any]] = None,
-        tokenizer_args: Optional[Dict[str, Any]] = None,
-        config_args: Optional[Dict[str, Any]] = None,
-        cache_dir: Optional[str] = None,
+        max_seq_length: int | None = None,
+        model_args: dict[str, Any] | None = None,
+        tokenizer_args: dict[str, Any] | None = None,
+        config_args: dict[str, Any] | None = None,
+        cache_dir: str | None = None,
         do_lower_case: bool = False,
         tokenizer_name_or_path: str = None,
     ) -> None:
@@ -109,7 +111,7 @@ class Transformer(nn.Module):
             self.get_config_dict(), self.auto_model.__class__.__name__
         )
 
-    def forward(self, features: Dict[str, torch.Tensor]) -> Dict[str, torch.Tensor]:
+    def forward(self, features: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
         """Returns token_embeddings, cls_token"""
         trans_features = {"input_ids": features["input_ids"], "attention_mask": features["attention_mask"]}
         if "token_type_ids" in features:
@@ -134,8 +136,8 @@ class Transformer(nn.Module):
         return self.auto_model.config.hidden_size
 
     def tokenize(
-        self, texts: Union[List[str], List[Dict], List[Tuple[str, str]]], padding: Union[str, bool] = True
-    ) -> Dict[str, torch.Tensor]:
+        self, texts: list[str] | list[dict] | list[tuple[str, str]], padding: str | bool = True
+    ) -> dict[str, torch.Tensor]:
         """Tokenizes a text and maps tokens to token-ids"""
         output = {}
         if isinstance(texts[0], str):
@@ -173,7 +175,7 @@ class Transformer(nn.Module):
         )
         return output
 
-    def get_config_dict(self) -> Dict[str, Any]:
+    def get_config_dict(self) -> dict[str, Any]:
         return {key: self.__dict__[key] for key in self.config_keys}
 
     def save(self, output_path: str, safe_serialization: bool = True) -> None:

--- a/sentence_transformers/models/WeightedLayerPooling.py
+++ b/sentence_transformers/models/WeightedLayerPooling.py
@@ -1,6 +1,7 @@
+from __future__ import annotations
+
 import json
 import os
-from typing import Dict
 
 import torch
 from safetensors.torch import load_model as load_safetensors_model
@@ -25,7 +26,7 @@ class WeightedLayerPooling(nn.Module):
             else nn.Parameter(torch.tensor([1] * (num_hidden_layers + 1 - layer_start), dtype=torch.float))
         )
 
-    def forward(self, features: Dict[str, Tensor]):
+    def forward(self, features: dict[str, Tensor]):
         ft_all_layers = features["all_layer_embeddings"]
 
         all_layer_embedding = torch.stack(ft_all_layers)

--- a/sentence_transformers/models/WordEmbeddings.py
+++ b/sentence_transformers/models/WordEmbeddings.py
@@ -1,8 +1,9 @@
+from __future__ import annotations
+
 import gzip
 import json
 import logging
 import os
-from typing import List
 
 import numpy as np
 import torch
@@ -54,7 +55,7 @@ class WordEmbeddings(nn.Module):
         )
         return features
 
-    def tokenize(self, texts: List[str], **kwargs):
+    def tokenize(self, texts: list[str], **kwargs):
         tokenized_texts = [self.tokenizer.tokenize(text, **kwargs) for text in texts]
         sentence_lengths = [len(tokens) for tokens in tokenized_texts]
         max_len = max(sentence_lengths)

--- a/sentence_transformers/models/WordWeights.py
+++ b/sentence_transformers/models/WordWeights.py
@@ -1,7 +1,8 @@
+from __future__ import annotations
+
 import json
 import logging
 import os
-from typing import Dict, List
 
 import torch
 from torch import Tensor, nn
@@ -12,7 +13,7 @@ logger = logging.getLogger(__name__)
 class WordWeights(nn.Module):
     """This model can weight word embeddings, for example, with idf-values."""
 
-    def __init__(self, vocab: List[str], word_weights: Dict[str, float], unknown_word_weight: float = 1):
+    def __init__(self, vocab: list[str], word_weights: dict[str, float], unknown_word_weight: float = 1):
         """
         Initializes the WordWeights class.
 
@@ -50,7 +51,7 @@ class WordWeights(nn.Module):
         self.emb_layer = nn.Embedding(len(vocab), 1)
         self.emb_layer.load_state_dict({"weight": torch.FloatTensor(weights).unsqueeze(1)})
 
-    def forward(self, features: Dict[str, Tensor]):
+    def forward(self, features: dict[str, Tensor]):
         attention_mask = features["attention_mask"]
         token_embeddings = features["token_embeddings"]
 

--- a/sentence_transformers/models/__init__.py
+++ b/sentence_transformers/models/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from .Asym import Asym
 from .BoW import BoW
 from .CLIPModel import CLIPModel

--- a/sentence_transformers/models/tokenizer/PhraseTokenizer.py
+++ b/sentence_transformers/models/tokenizer/PhraseTokenizer.py
@@ -1,9 +1,11 @@
+from __future__ import annotations
+
 import collections
 import json
 import logging
 import os
 import string
-from typing import Iterable, List
+from typing import Iterable
 
 from transformers.utils.import_utils import NLTK_IMPORT_ERROR, is_nltk_available
 
@@ -58,7 +60,7 @@ class PhraseTokenizer(WordTokenizer):
             logger.info("PhraseTokenizer - Phrase ngram lengths: {}".format(self.ngram_lengths))
             logger.info("PhraseTokenizer - Num phrases: {}".format(len(self.ngram_lookup)))
 
-    def tokenize(self, text: str, **kwargs) -> List[int]:
+    def tokenize(self, text: str, **kwargs) -> list[int]:
         from nltk import word_tokenize
 
         tokens = word_tokenize(text, preserve_line=True)

--- a/sentence_transformers/models/tokenizer/WhitespaceTokenizer.py
+++ b/sentence_transformers/models/tokenizer/WhitespaceTokenizer.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 import collections
 import json
 import os
 import string
-from typing import Iterable, List
+from typing import Iterable
 
 from .WordTokenizer import ENGLISH_STOP_WORDS, WordTokenizer
 
@@ -27,7 +29,7 @@ class WhitespaceTokenizer(WordTokenizer):
         self.vocab = vocab
         self.word2idx = collections.OrderedDict([(word, idx) for idx, word in enumerate(vocab)])
 
-    def tokenize(self, text: str, **kwargs) -> List[int]:
+    def tokenize(self, text: str, **kwargs) -> list[int]:
         if self.do_lower_case:
             text = text.lower()
 

--- a/sentence_transformers/models/tokenizer/WordTokenizer.py
+++ b/sentence_transformers/models/tokenizer/WordTokenizer.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
-from typing import Iterable, List
+from typing import Iterable
 
 ENGLISH_STOP_WORDS = [
     "!",
@@ -401,7 +403,7 @@ class WordTokenizer(ABC):
         pass
 
     @abstractmethod
-    def tokenize(self, text: str, **kwargs) -> List[int]:
+    def tokenize(self, text: str, **kwargs) -> list[int]:
         pass
 
     @abstractmethod

--- a/sentence_transformers/models/tokenizer/__init__.py
+++ b/sentence_transformers/models/tokenizer/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from .PhraseTokenizer import PhraseTokenizer
 from .WhitespaceTokenizer import WhitespaceTokenizer
 from .WordTokenizer import ENGLISH_STOP_WORDS, WordTokenizer

--- a/sentence_transformers/quantization.py
+++ b/sentence_transformers/quantization.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 import logging
 import time
-from typing import TYPE_CHECKING, Dict, List, Literal, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Literal
 
 import numpy as np
 from torch import Tensor
@@ -15,17 +17,17 @@ if TYPE_CHECKING:
 
 def semantic_search_faiss(
     query_embeddings: np.ndarray,
-    corpus_embeddings: Optional[np.ndarray] = None,
-    corpus_index: Optional["faiss.Index"] = None,
+    corpus_embeddings: np.ndarray | None = None,
+    corpus_index: "faiss.Index" | None = None,
     corpus_precision: Literal["float32", "uint8", "ubinary"] = "float32",
     top_k: int = 10,
-    ranges: Optional[np.ndarray] = None,
-    calibration_embeddings: Optional[np.ndarray] = None,
+    ranges: np.ndarray | None = None,
+    calibration_embeddings: np.ndarray | None = None,
     rescore: bool = True,
     rescore_multiplier: int = 2,
     exact: bool = True,
     output_index: bool = False,
-) -> Tuple[List[List[Dict[str, Union[int, float]]]], float, "faiss.Index"]:
+) -> tuple[list[list[dict[str, int | float]]], float, "faiss.Index"]:
     """
     Performs semantic search using the FAISS library.
 
@@ -182,17 +184,17 @@ def semantic_search_faiss(
 
 def semantic_search_usearch(
     query_embeddings: np.ndarray,
-    corpus_embeddings: Optional[np.ndarray] = None,
-    corpus_index: Optional["usearch.index.Index"] = None,
+    corpus_embeddings: np.ndarray | None = None,
+    corpus_index: "usearch.index.Index" | None = None,
     corpus_precision: Literal["float32", "int8", "binary"] = "float32",
     top_k: int = 10,
-    ranges: Optional[np.ndarray] = None,
-    calibration_embeddings: Optional[np.ndarray] = None,
+    ranges: np.ndarray | None = None,
+    calibration_embeddings: np.ndarray | None = None,
     rescore: bool = True,
     rescore_multiplier: int = 2,
     exact: bool = True,
     output_index: bool = False,
-) -> Tuple[List[List[Dict[str, Union[int, float]]]], float, "usearch.index.Index"]:
+) -> tuple[list[list[dict[str, int | float]]], float, "usearch.index.Index"]:
     """
     Performs semantic search using the usearch library.
 
@@ -361,10 +363,10 @@ def semantic_search_usearch(
 
 
 def quantize_embeddings(
-    embeddings: Union[Tensor, np.ndarray],
+    embeddings: Tensor | np.ndarray,
     precision: Literal["float32", "int8", "uint8", "binary", "ubinary"],
-    ranges: Optional[np.ndarray] = None,
-    calibration_embeddings: Optional[np.ndarray] = None,
+    ranges: np.ndarray | None = None,
+    calibration_embeddings: np.ndarray | None = None,
 ) -> np.ndarray:
     """
     Quantizes embeddings to a lower precision. This can be used to reduce the memory footprint and increase the

--- a/sentence_transformers/readers/InputExample.py
+++ b/sentence_transformers/readers/InputExample.py
@@ -1,10 +1,10 @@
-from typing import List, Union
+from __future__ import annotations
 
 
 class InputExample:
     """Structure for one input example with texts, the label and a unique id"""
 
-    def __init__(self, guid: str = "", texts: List[str] = None, label: Union[int, float] = 0):
+    def __init__(self, guid: str = "", texts: list[str] = None, label: int | float = 0):
         """
         Creates one InputExample with the given texts, guid and label
 

--- a/sentence_transformers/readers/LabelSentenceReader.py
+++ b/sentence_transformers/readers/LabelSentenceReader.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 
 from . import InputExample

--- a/sentence_transformers/readers/NLIDataReader.py
+++ b/sentence_transformers/readers/NLIDataReader.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gzip
 import os
 

--- a/sentence_transformers/readers/PairedFilesReader.py
+++ b/sentence_transformers/readers/PairedFilesReader.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gzip
 
 from . import InputExample

--- a/sentence_transformers/readers/STSDataReader.py
+++ b/sentence_transformers/readers/STSDataReader.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import csv
 import gzip
 import os

--- a/sentence_transformers/readers/TripletReader.py
+++ b/sentence_transformers/readers/TripletReader.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import csv
 import os
 

--- a/sentence_transformers/readers/__init__.py
+++ b/sentence_transformers/readers/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from .InputExample import InputExample
 from .LabelSentenceReader import LabelSentenceReader
 from .NLIDataReader import NLIDataReader

--- a/sentence_transformers/sampler.py
+++ b/sentence_transformers/sampler.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import logging
 from collections import defaultdict
 from itertools import accumulate, cycle
-from typing import Any, Iterator, List
+from typing import Any, Iterator
 
 import torch
 from torch.utils.data import BatchSampler, ConcatDataset, SubsetRandomSampler
@@ -58,7 +60,7 @@ class GroupByLabelBatchSampler(SetEpochMixin, BatchSampler):
         dataset: "Dataset",
         batch_size: int,
         drop_last: bool,
-        valid_label_columns: List[str] = None,
+        valid_label_columns: list[str] = None,
         generator: torch.Generator = None,
         seed: int = 0,
     ) -> None:
@@ -84,7 +86,7 @@ class GroupByLabelBatchSampler(SetEpochMixin, BatchSampler):
         }
 
     @staticmethod
-    def _determine_labels_to_use(dataset: "Dataset", valid_label_columns: List[str]) -> List[Any]:
+    def _determine_labels_to_use(dataset: "Dataset", valid_label_columns: list[str]) -> list[Any]:
         for column_name in valid_label_columns or []:
             if column_name in dataset.column_names:
                 return dataset[column_name]
@@ -93,7 +95,7 @@ class GroupByLabelBatchSampler(SetEpochMixin, BatchSampler):
             f"which only has these columns: {dataset.column_names}."
         )
 
-    def __iter__(self) -> Iterator[List[int]]:
+    def __iter__(self) -> Iterator[list[int]]:
         if self.generator and self.seed:
             self.generator.manual_seed(self.seed + self.epoch)
 
@@ -117,7 +119,7 @@ class NoDuplicatesBatchSampler(SetEpochMixin, BatchSampler):
         dataset: "Dataset",
         batch_size: int,
         drop_last: bool,
-        valid_label_columns: List[str] = [],
+        valid_label_columns: list[str] = [],
         generator: torch.Generator = None,
         seed: int = 0,
     ) -> None:
@@ -130,7 +132,7 @@ class NoDuplicatesBatchSampler(SetEpochMixin, BatchSampler):
         self.generator = generator
         self.seed = seed
 
-    def __iter__(self) -> Iterator[List[int]]:
+    def __iter__(self) -> Iterator[list[int]]:
         """
         Iterate over the remaining non-yielded indices. For each index, check if the sample values are already in the
         batch. If not, add the sample values to the batch keep going until the batch is full. If the batch is full, yield
@@ -185,7 +187,7 @@ class RoundRobinBatchSampler(SetEpochMixin, BatchSampler):
     def __init__(
         self,
         dataset: ConcatDataset,
-        batch_samplers: List[BatchSampler],
+        batch_samplers: list[BatchSampler],
         generator: torch.Generator = None,
         seed: int = None,
     ) -> None:
@@ -197,7 +199,7 @@ class RoundRobinBatchSampler(SetEpochMixin, BatchSampler):
         self.generator = generator
         self.seed = seed
 
-    def __iter__(self) -> Iterator[List[int]]:
+    def __iter__(self) -> Iterator[list[int]]:
         if self.generator and self.seed:
             self.generator.manual_seed(self.seed + self.epoch)
 
@@ -221,7 +223,7 @@ class ProportionalBatchSampler(SetEpochMixin, BatchSampler):
     def __init__(
         self,
         dataset: ConcatDataset,
-        batch_samplers: List[BatchSampler],
+        batch_samplers: list[BatchSampler],
         generator: torch.Generator,
         seed: int,
     ) -> None:
@@ -231,7 +233,7 @@ class ProportionalBatchSampler(SetEpochMixin, BatchSampler):
         self.generator = generator
         self.seed = seed
 
-    def __iter__(self) -> Iterator[List[int]]:
+    def __iter__(self) -> Iterator[list[int]]:
         self.generator.manual_seed(self.seed + self.epoch)
 
         num_samples = [len(dataset) for dataset in self.dataset.datasets]

--- a/sentence_transformers/similarity_functions.py
+++ b/sentence_transformers/similarity_functions.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 from enum import Enum
-from typing import Callable, List, Union
+from typing import Callable
 
 from numpy import ndarray
 from torch import Tensor
@@ -34,8 +36,8 @@ class SimilarityFunction(Enum):
 
     @staticmethod
     def to_similarity_fn(
-        similarity_function: Union[str, "SimilarityFunction"],
-    ) -> Callable[[Union[Tensor, ndarray], Union[Tensor, ndarray]], Tensor]:
+        similarity_function: str | "SimilarityFunction",
+    ) -> Callable[[Tensor | ndarray, Tensor | ndarray], Tensor]:
         """
         Converts a similarity function name or enum value to the corresponding similarity function.
 
@@ -74,8 +76,8 @@ class SimilarityFunction(Enum):
 
     @staticmethod
     def to_similarity_pairwise_fn(
-        similarity_function: Union[str, "SimilarityFunction"],
-    ) -> Callable[[Union[Tensor, ndarray], Union[Tensor, ndarray]], Tensor]:
+        similarity_function: str | "SimilarityFunction",
+    ) -> Callable[[Tensor | ndarray, Tensor | ndarray], Tensor]:
         """
         Converts a similarity function into a pairwise similarity function.
 
@@ -116,7 +118,7 @@ class SimilarityFunction(Enum):
         )
 
     @staticmethod
-    def possible_values() -> List[str]:
+    def possible_values() -> list[str]:
         """
         Returns a list of possible values for the SimilarityFunction enum.
 

--- a/sentence_transformers/training_args.py
+++ b/sentence_transformers/training_args.py
@@ -1,6 +1,7 @@
+from __future__ import annotations
+
 import logging
 from dataclasses import dataclass, field
-from typing import Union
 
 from transformers import TrainingArguments as TransformersTrainingArguments
 from transformers.training_args import ParallelMode
@@ -62,10 +63,10 @@ class SentenceTransformerTrainingArguments(TransformersTrainingArguments):
             for valid options. Defaults to ``MultiDatasetBatchSamplers.PROPORTIONAL``.
     """
 
-    batch_sampler: Union[BatchSamplers, str] = field(
+    batch_sampler: BatchSamplers | str = field(
         default=BatchSamplers.BATCH_SAMPLER, metadata={"help": "The batch sampler to use."}
     )
-    multi_dataset_batch_sampler: Union[MultiDatasetBatchSamplers, str] = field(
+    multi_dataset_batch_sampler: MultiDatasetBatchSamplers | str = field(
         default=MultiDatasetBatchSamplers.PROPORTIONAL, metadata={"help": "The multi-dataset batch sampler to use."}
     )
 

--- a/sentence_transformers/util.py
+++ b/sentence_transformers/util.py
@@ -22,6 +22,8 @@ logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from datasets import Dataset
+    from sentence_transformers.cross_encoder.CrossEncoder import CrossEncoder
+    from sentence_transformers.SentenceTransformer import SentenceTransformer
 
     from sentence_transformers.cross_encoder.CrossEncoder import CrossEncoder
     from sentence_transformers.SentenceTransformer import SentenceTransformer

--- a/sentence_transformers/util.py
+++ b/sentence_transformers/util.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import functools
 import heapq
 import importlib
@@ -7,7 +9,7 @@ import queue
 import random
 import sys
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Literal, Optional, Type, Union, overload
+from typing import TYPE_CHECKING, Any, Callable, Literal, overload
 
 import numpy as np
 import requests
@@ -30,7 +32,7 @@ if TYPE_CHECKING:
     from sentence_transformers.SentenceTransformer import SentenceTransformer
 
 
-def _convert_to_tensor(a: Union[list, np.ndarray, Tensor]) -> Tensor:
+def _convert_to_tensor(a: list | np.ndarray | Tensor) -> Tensor:
     """
     Converts the input `a` to a PyTorch tensor if it is not already a tensor.
 
@@ -60,7 +62,7 @@ def _convert_to_batch(a: Tensor) -> Tensor:
     return a
 
 
-def _convert_to_batch_tensor(a: Union[list, np.ndarray, Tensor]) -> Tensor:
+def _convert_to_batch_tensor(a: list | np.ndarray | Tensor) -> Tensor:
     """
     Converts the input data to a tensor with a batch dimension.
 
@@ -89,7 +91,7 @@ def pytorch_cos_sim(a: Tensor, b: Tensor) -> Tensor:
     return cos_sim(a, b)
 
 
-def cos_sim(a: Union[list, np.ndarray, Tensor], b: Union[list, np.ndarray, Tensor]) -> Tensor:
+def cos_sim(a: list | np.ndarray | Tensor, b: list | np.ndarray | Tensor) -> Tensor:
     """
     Computes the cosine similarity between two tensors.
 
@@ -125,7 +127,7 @@ def pairwise_cos_sim(a: Tensor, b: Tensor) -> Tensor:
     return pairwise_dot_score(normalize_embeddings(a), normalize_embeddings(b))
 
 
-def dot_score(a: Union[list, np.ndarray, Tensor], b: Union[list, np.ndarray, Tensor]) -> Tensor:
+def dot_score(a: list | np.ndarray | Tensor, b: list | np.ndarray | Tensor) -> Tensor:
     """
     Computes the dot-product dot_prod(a[i], b[j]) for all i and j.
 
@@ -159,7 +161,7 @@ def pairwise_dot_score(a: Tensor, b: Tensor) -> Tensor:
     return (a * b).sum(dim=-1)
 
 
-def manhattan_sim(a: Union[list, np.ndarray, Tensor], b: Union[list, np.ndarray, Tensor]) -> Tensor:
+def manhattan_sim(a: list | np.ndarray | Tensor, b: list | np.ndarray | Tensor) -> Tensor:
     """
     Computes the manhattan similarity (i.e., negative distance) between two tensors.
 
@@ -176,7 +178,7 @@ def manhattan_sim(a: Union[list, np.ndarray, Tensor], b: Union[list, np.ndarray,
     return -torch.cdist(a, b, p=1.0)
 
 
-def pairwise_manhattan_sim(a: Union[list, np.ndarray, Tensor], b: Union[list, np.ndarray, Tensor]):
+def pairwise_manhattan_sim(a: list | np.ndarray | Tensor, b: list | np.ndarray | Tensor):
     """
     Computes the manhattan similarity (i.e., negative distance) between pairs of tensors.
 
@@ -193,7 +195,7 @@ def pairwise_manhattan_sim(a: Union[list, np.ndarray, Tensor], b: Union[list, np
     return -torch.sum(torch.abs(a - b), dim=-1)
 
 
-def euclidean_sim(a: Union[list, np.ndarray, Tensor], b: Union[list, np.ndarray, Tensor]) -> Tensor:
+def euclidean_sim(a: list | np.ndarray | Tensor, b: list | np.ndarray | Tensor) -> Tensor:
     """
     Computes the euclidean similarity (i.e., negative distance) between two tensors.
 
@@ -210,7 +212,7 @@ def euclidean_sim(a: Union[list, np.ndarray, Tensor], b: Union[list, np.ndarray,
     return -torch.cdist(a, b, p=2.0)
 
 
-def pairwise_euclidean_sim(a: Union[list, np.ndarray, Tensor], b: Union[list, np.ndarray, Tensor]):
+def pairwise_euclidean_sim(a: list | np.ndarray | Tensor, b: list | np.ndarray | Tensor):
     """
     Computes the euclidean distance (i.e., negative distance) between pairs of tensors.
 
@@ -275,16 +277,14 @@ def normalize_embeddings(embeddings: Tensor) -> Tensor:
 
 
 @overload
-def truncate_embeddings(embeddings: np.ndarray, truncate_dim: Optional[int]) -> np.ndarray: ...
+def truncate_embeddings(embeddings: np.ndarray, truncate_dim: int | None) -> np.ndarray: ...
 
 
 @overload
-def truncate_embeddings(embeddings: torch.Tensor, truncate_dim: Optional[int]) -> torch.Tensor: ...
+def truncate_embeddings(embeddings: torch.Tensor, truncate_dim: int | None) -> torch.Tensor: ...
 
 
-def truncate_embeddings(
-    embeddings: Union[np.ndarray, torch.Tensor], truncate_dim: Optional[int]
-) -> Union[np.ndarray, torch.Tensor]:
+def truncate_embeddings(embeddings: np.ndarray | torch.Tensor, truncate_dim: int | None) -> np.ndarray | torch.Tensor:
     """
     Truncates the embeddings matrix.
 
@@ -318,7 +318,7 @@ def truncate_embeddings(
 
 def paraphrase_mining(
     model,
-    sentences: List[str],
+    sentences: list[str],
     show_progress_bar: bool = False,
     batch_size: int = 32,
     query_chunk_size: int = 5000,
@@ -326,7 +326,7 @@ def paraphrase_mining(
     max_pairs: int = 500000,
     top_k: int = 100,
     score_function: Callable[[Tensor, Tensor], Tensor] = cos_sim,
-) -> List[List[Union[float, int]]]:
+) -> list[list[float | int]]:
     """
     Given a list of sentences / texts, this function performs paraphrase mining. It compares all sentences against all
     other sentences and returns a list with the pairs that have the highest cosine similarity score.
@@ -368,7 +368,7 @@ def paraphrase_mining_embeddings(
     max_pairs: int = 500000,
     top_k: int = 100,
     score_function: Callable[[Tensor, Tensor], Tensor] = cos_sim,
-) -> List[List[Union[float, int]]]:
+) -> list[list[float | int]]:
     """
     Given a list of sentences / texts, this function performs paraphrase mining. It compares all sentences against all
     other sentences and returns a list with the pairs that have the highest cosine similarity score.
@@ -434,7 +434,7 @@ def paraphrase_mining_embeddings(
     return pairs_list
 
 
-def information_retrieval(*args, **kwargs) -> List[List[Dict[str, Union[int, float]]]]:
+def information_retrieval(*args, **kwargs) -> list[list[dict[str, int | float]]]:
     """This function is deprecated. Use semantic_search instead"""
     return semantic_search(*args, **kwargs)
 
@@ -446,7 +446,7 @@ def semantic_search(
     corpus_chunk_size: int = 500000,
     top_k: int = 10,
     score_function: Callable[[Tensor, Tensor], Tensor] = cos_sim,
-) -> List[List[Dict[str, Union[int, float]]]]:
+) -> list[list[dict[str, int | float]]]:
     """
     This function performs a cosine similarity search between a list of query embeddings  and a list of corpus embeddings.
     It can be used for Information Retrieval / Semantic Search for corpora up to about 1 Million entries.
@@ -522,11 +522,11 @@ def semantic_search(
 def mine_hard_negatives(
     dataset: "Dataset",
     model: "SentenceTransformer",
-    cross_encoder: Optional["CrossEncoder"] = None,
+    cross_encoder: "CrossEncoder" | None = None,
     range_min: int = 0,
-    range_max: Optional[int] = None,
-    max_score: Optional[float] = None,
-    margin: Optional[float] = None,
+    range_max: int | None = None,
+    max_score: float | None = None,
+    margin: float | None = None,
     num_negatives: int = 3,
     sampling_strategy: Literal["random", "top"] = "top",
     as_triplets: bool = True,
@@ -914,7 +914,7 @@ def http_get(url: str, path: str) -> None:
     progress.close()
 
 
-def batch_to_device(batch: Dict[str, Any], target_device: device) -> Dict[str, Any]:
+def batch_to_device(batch: dict[str, Any], target_device: device) -> dict[str, Any]:
     """
     Send a PyTorch batch (i.e., a dictionary of string keys to Tensors) to a device (e.g. "cpu", "cuda", "mps").
 
@@ -959,7 +959,7 @@ def fullname(o) -> str:
         return module + "." + o.__class__.__name__
 
 
-def import_from_string(dotted_path: str) -> Type:
+def import_from_string(dotted_path: str) -> type:
     """
     Import a dotted module path and return the attribute/class designated by the
     last name in the path. Raise ImportError if the import failed.
@@ -996,12 +996,12 @@ def import_from_string(dotted_path: str) -> Type:
 
 
 def community_detection(
-    embeddings: Union[torch.Tensor, np.ndarray],
+    embeddings: torch.Tensor | np.ndarray,
     threshold: float = 0.75,
     min_community_size: int = 10,
     batch_size: int = 1024,
     show_progress_bar: bool = False,
-) -> List[List[int]]:
+) -> list[list[int]]:
     """
     Function for Fast Community Detection.
 
@@ -1144,9 +1144,9 @@ def disable_logging(highest_level=logging.CRITICAL):
 
 def is_sentence_transformer_model(
     model_name_or_path: str,
-    token: Optional[Union[bool, str]] = None,
-    cache_folder: Optional[str] = None,
-    revision: Optional[str] = None,
+    token: bool | str | None = None,
+    cache_folder: str | None = None,
+    revision: str | None = None,
     local_files_only: bool = False,
 ) -> bool:
     """
@@ -1177,11 +1177,11 @@ def is_sentence_transformer_model(
 def load_file_path(
     model_name_or_path: str,
     filename: str,
-    token: Optional[Union[bool, str]],
-    cache_folder: Optional[str],
-    revision: Optional[str] = None,
+    token: bool | str | None,
+    cache_folder: str | None,
+    revision: str | None = None,
     local_files_only: bool = False,
-) -> Optional[str]:
+) -> str | None:
     """
     Loads a file from a local or remote location.
 
@@ -1219,11 +1219,11 @@ def load_file_path(
 def load_dir_path(
     model_name_or_path: str,
     directory: str,
-    token: Optional[Union[bool, str]],
-    cache_folder: Optional[str],
-    revision: Optional[str] = None,
+    token: bool | str | None,
+    cache_folder: str | None,
+    revision: str | None = None,
     local_files_only: bool = False,
-) -> Optional[str]:
+) -> str | None:
     """
     Loads the directory path for a given model name or path.
 

--- a/sentence_transformers/util.py
+++ b/sentence_transformers/util.py
@@ -28,9 +28,6 @@ if TYPE_CHECKING:
     from sentence_transformers.cross_encoder.CrossEncoder import CrossEncoder
     from sentence_transformers.SentenceTransformer import SentenceTransformer
 
-    from sentence_transformers.cross_encoder.CrossEncoder import CrossEncoder
-    from sentence_transformers.SentenceTransformer import SentenceTransformer
-
 
 def _convert_to_tensor(a: list | np.ndarray | Tensor) -> Tensor:
     """

--- a/sentence_transformers/util.py
+++ b/sentence_transformers/util.py
@@ -22,6 +22,7 @@ logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from datasets import Dataset
+
     from sentence_transformers.cross_encoder.CrossEncoder import CrossEncoder
     from sentence_transformers.SentenceTransformer import SentenceTransformer
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import platform
 import tempfile

--- a/tests/samplers/test_group_by_label_batch_sampler.py
+++ b/tests/samplers/test_group_by_label_batch_sampler.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections import Counter
 
 import pytest

--- a/tests/samplers/test_group_by_label_batch_sampler.py
+++ b/tests/samplers/test_group_by_label_batch_sampler.py
@@ -1,7 +1,6 @@
 from collections import Counter
 
 import pytest
-
 from datasets import Dataset
 
 from sentence_transformers.sampler import GroupByLabelBatchSampler

--- a/tests/samplers/test_group_by_label_batch_sampler.py
+++ b/tests/samplers/test_group_by_label_batch_sampler.py
@@ -1,6 +1,7 @@
 from collections import Counter
 
 import pytest
+
 from datasets import Dataset
 
 from sentence_transformers.sampler import GroupByLabelBatchSampler

--- a/tests/samplers/test_no_duplicates_batch_sampler.py
+++ b/tests/samplers/test_no_duplicates_batch_sampler.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import random
 
 import pytest

--- a/tests/samplers/test_no_duplicates_batch_sampler.py
+++ b/tests/samplers/test_no_duplicates_batch_sampler.py
@@ -1,6 +1,7 @@
 import random
 
 import pytest
+
 from datasets import Dataset
 
 from sentence_transformers.sampler import NoDuplicatesBatchSampler

--- a/tests/samplers/test_no_duplicates_batch_sampler.py
+++ b/tests/samplers/test_no_duplicates_batch_sampler.py
@@ -1,7 +1,6 @@
 import random
 
 import pytest
-
 from datasets import Dataset
 
 from sentence_transformers.sampler import NoDuplicatesBatchSampler

--- a/tests/samplers/test_round_robin_batch_sampler.py
+++ b/tests/samplers/test_round_robin_batch_sampler.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 from datasets import Dataset
 from torch.utils.data import BatchSampler, ConcatDataset, SequentialSampler

--- a/tests/samplers/test_round_robin_batch_sampler.py
+++ b/tests/samplers/test_round_robin_batch_sampler.py
@@ -1,4 +1,6 @@
 import pytest
+from torch.utils.data import BatchSampler, ConcatDataset, SequentialSampler
+
 from datasets import Dataset
 from torch.utils.data import BatchSampler, ConcatDataset, SequentialSampler
 

--- a/tests/samplers/test_round_robin_batch_sampler.py
+++ b/tests/samplers/test_round_robin_batch_sampler.py
@@ -1,6 +1,4 @@
 import pytest
-from torch.utils.data import BatchSampler, ConcatDataset, SequentialSampler
-
 from datasets import Dataset
 from torch.utils.data import BatchSampler, ConcatDataset, SequentialSampler
 

--- a/tests/test_cmnrl.py
+++ b/tests/test_cmnrl.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 from contextlib import nullcontext
-from typing import List
 
 import pytest
 import torch
@@ -79,8 +80,8 @@ from sentence_transformers import InputExample, SentenceTransformer, losses
     ],
 )
 def test_cmnrl_same_grad(
-    train_samples_mnrl: List[InputExample],
-    train_samples_cmnrl: List[InputExample],
+    train_samples_mnrl: list[InputExample],
+    train_samples_cmnrl: list[InputExample],
     same_grad: bool,
     scaler: float,
     precision: float,

--- a/tests/test_compute_embeddings.py
+++ b/tests/test_compute_embeddings.py
@@ -2,6 +2,8 @@
 Computes embeddings
 """
 
+from __future__ import annotations
+
 import numpy as np
 
 from sentence_transformers import SentenceTransformer

--- a/tests/test_cross_encoder.py
+++ b/tests/test_cross_encoder.py
@@ -2,12 +2,14 @@
 Tests that the pretrained models produce the correct scores on the STSbenchmark dataset
 """
 
+from __future__ import annotations
+
 import csv
 import gzip
 import os
 import tempfile
 from pathlib import Path
-from typing import Generator, List, Tuple
+from typing import Generator
 
 import numpy as np
 import pytest
@@ -20,7 +22,7 @@ from sentence_transformers.readers import InputExample
 
 
 @pytest.fixture()
-def sts_resource() -> Generator[Tuple[List[InputExample], List[InputExample]], None, None]:
+def sts_resource() -> Generator[tuple[list[InputExample], list[InputExample]], None, None]:
     sts_dataset_path = "datasets/stsbenchmark.tsv.gz"
     if not os.path.exists(sts_dataset_path):
         util.http_get("https://sbert.net/datasets/stsbenchmark.tsv.gz", sts_dataset_path)
@@ -43,7 +45,7 @@ def sts_resource() -> Generator[Tuple[List[InputExample], List[InputExample]], N
 def evaluate_stsb_test(
     distilroberta_base_ce_model: CrossEncoder,
     expected_score: float,
-    test_samples: List[InputExample],
+    test_samples: list[InputExample],
     num_test_samples: int = -1,
 ) -> None:
     model = distilroberta_base_ce_model
@@ -53,7 +55,7 @@ def evaluate_stsb_test(
     assert score > expected_score or abs(score - expected_score) < 0.1
 
 
-def test_pretrained_stsb(sts_resource: Tuple[List[InputExample], List[InputExample]]):
+def test_pretrained_stsb(sts_resource: tuple[list[InputExample], list[InputExample]]):
     _, sts_test_samples = sts_resource
     model = CrossEncoder("cross-encoder/stsb-distilroberta-base")
     evaluate_stsb_test(model, 87.92, sts_test_samples)
@@ -61,7 +63,7 @@ def test_pretrained_stsb(sts_resource: Tuple[List[InputExample], List[InputExamp
 
 @pytest.mark.slow
 def test_train_stsb_slow(
-    distilroberta_base_ce_model: CrossEncoder, sts_resource: Tuple[List[InputExample], List[InputExample]]
+    distilroberta_base_ce_model: CrossEncoder, sts_resource: tuple[list[InputExample], list[InputExample]]
 ) -> None:
     model = distilroberta_base_ce_model
     sts_train_samples, sts_test_samples = sts_resource
@@ -75,7 +77,7 @@ def test_train_stsb_slow(
 
 
 def test_train_stsb(
-    distilroberta_base_ce_model: CrossEncoder, sts_resource: Tuple[List[InputExample], List[InputExample]]
+    distilroberta_base_ce_model: CrossEncoder, sts_resource: tuple[list[InputExample], list[InputExample]]
 ) -> None:
     model = distilroberta_base_ce_model
     sts_train_samples, sts_test_samples = sts_resource

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -2,6 +2,8 @@
 Tests the correct computation of evaluation scores from BinaryClassificationEvaluator
 """
 
+from __future__ import annotations
+
 import csv
 import gzip
 import os

--- a/tests/test_image_embeddings.py
+++ b/tests/test_image_embeddings.py
@@ -2,6 +2,8 @@
 Compute image embeddings
 """
 
+from __future__ import annotations
+
 import os
 
 from PIL import Image

--- a/tests/test_model_card_data.py
+++ b/tests/test_model_card_data.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from sentence_transformers import SentenceTransformer, SentenceTransformerTrainer

--- a/tests/test_multi_process.py
+++ b/tests/test_multi_process.py
@@ -2,7 +2,7 @@
 Computes embeddings
 """
 
-from typing import Optional
+from __future__ import annotations
 
 import numpy as np
 import pytest
@@ -13,7 +13,7 @@ from sentence_transformers import SentenceTransformer
 @pytest.mark.parametrize("normalize_embeddings", (False, True))
 @pytest.mark.parametrize("prompt_name", (None, "retrieval"))
 def test_encode_multi_process(
-    stsb_bert_tiny_model: SentenceTransformer, normalize_embeddings: bool, prompt_name: Optional[str]
+    stsb_bert_tiny_model: SentenceTransformer, normalize_embeddings: bool, prompt_name: str | None
 ) -> None:
     model = stsb_bert_tiny_model
     model.prompts = {"retrieval": "Represent this sentence for searching relevant passages: "}

--- a/tests/test_pretrained_stsb.py
+++ b/tests/test_pretrained_stsb.py
@@ -2,11 +2,12 @@
 Tests that the pretrained models produce the correct scores on the STSbenchmark dataset
 """
 
+from __future__ import annotations
+
 import csv
 import gzip
 import os
 from functools import partial
-from typing import Optional
 
 import pytest
 
@@ -15,7 +16,7 @@ from sentence_transformers.evaluation import EmbeddingSimilarityEvaluator
 
 
 def pretrained_model_score(
-    model_name, expected_score: float, max_test_samples: int = 100, cache_dir: Optional[str] = None
+    model_name, expected_score: float, max_test_samples: int = 100, cache_dir: str | None = None
 ) -> None:
     model = SentenceTransformer(model_name, cache_folder=cache_dir)
     sts_dataset_path = "datasets/stsbenchmark.tsv.gz"

--- a/tests/test_sentence_transformer.py
+++ b/tests/test_sentence_transformer.py
@@ -2,6 +2,8 @@
 Tests general behaviour of the SentenceTransformer class
 """
 
+from __future__ import annotations
+
 import json
 import logging
 import os
@@ -9,7 +11,7 @@ import re
 import tempfile
 from functools import partial
 from pathlib import Path
-from typing import Dict, List, Literal, Optional, Union, cast
+from typing import Dict, List, Literal, cast
 
 import numpy as np
 import pytest
@@ -444,11 +446,11 @@ def test_encode_quantization(
 @pytest.mark.parametrize("normalize_embeddings", [True, False])
 @pytest.mark.parametrize("output_value", ["sentence_embedding", None])
 def test_encode_truncate(
-    sentences: Union[str, List[str]],
+    sentences: str | list[str],
     convert_to_tensor: bool,
     convert_to_numpy: bool,
     normalize_embeddings: bool,
-    output_value: Optional[Literal["sentence_embedding"]],
+    output_value: Literal["sentence_embedding"] | None,
 ) -> None:
     model = SentenceTransformer("sentence-transformers-testing/stsb-bert-tiny-safetensors")
     embeddings_full_unnormalized: torch.Tensor = model.encode(
@@ -636,7 +638,7 @@ def test_override_config_versions(stsb_bert_tiny_model: SentenceTransformer) -> 
         SentenceTransformer("sentence-transformers/average_word_embeddings_levy_dependency"),
     ],
 )
-def test_safetensors(modules: Union[List[nn.Module], SentenceTransformer]) -> None:
+def test_safetensors(modules: list[nn.Module] | SentenceTransformer) -> None:
     if isinstance(modules, SentenceTransformer):
         model = modules
     else:

--- a/tests/test_train_stsb.py
+++ b/tests/test_train_stsb.py
@@ -2,10 +2,12 @@
 Tests that the pretrained models produce the correct scores on the STSbenchmark dataset
 """
 
+from __future__ import annotations
+
 import csv
 import gzip
 import os
-from typing import Generator, List, Tuple
+from typing import Generator
 
 import pytest
 import torch
@@ -23,7 +25,7 @@ from sentence_transformers.util import is_training_available
 
 
 @pytest.fixture()
-def sts_resource() -> Generator[Tuple[List[InputExample], List[InputExample]], None, None]:
+def sts_resource() -> Generator[tuple[list[InputExample], list[InputExample]], None, None]:
     sts_dataset_path = "datasets/stsbenchmark.tsv.gz"
     if not os.path.exists(sts_dataset_path):
         util.http_get("https://sbert.net/datasets/stsbenchmark.tsv.gz", sts_dataset_path)
@@ -44,7 +46,7 @@ def sts_resource() -> Generator[Tuple[List[InputExample], List[InputExample]], N
 
 
 @pytest.fixture()
-def nli_resource() -> Generator[List[InputExample], None, None]:
+def nli_resource() -> Generator[list[InputExample], None, None]:
     nli_dataset_path = "datasets/AllNLI.tsv.gz"
     if not os.path.exists(nli_dataset_path):
         util.http_get("https://sbert.net/datasets/AllNLI.tsv.gz", nli_dataset_path)
@@ -77,7 +79,7 @@ def evaluate_stsb_test(model, expected_score, test_samples) -> None:
     reason='Sentence Transformers was not installed with the `["train"]` extra.',
 )
 def test_train_stsb_slow(
-    distilbert_base_uncased_model: SentenceTransformer, sts_resource: Tuple[List[InputExample], List[InputExample]]
+    distilbert_base_uncased_model: SentenceTransformer, sts_resource: tuple[list[InputExample], list[InputExample]]
 ) -> None:
     model = distilbert_base_uncased_model
     sts_train_samples, sts_test_samples = sts_resource
@@ -102,7 +104,7 @@ def test_train_stsb_slow(
     reason='Sentence Transformers was not installed with the `["train"]` extra.',
 )
 def test_train_stsb(
-    distilbert_base_uncased_model: SentenceTransformer, sts_resource: Tuple[List[InputExample], List[InputExample]]
+    distilbert_base_uncased_model: SentenceTransformer, sts_resource: tuple[list[InputExample], list[InputExample]]
 ) -> None:
     model = distilbert_base_uncased_model
     sts_train_samples, sts_test_samples = sts_resource
@@ -128,8 +130,8 @@ def test_train_stsb(
 )
 def test_train_nli_slow(
     distilbert_base_uncased_model: SentenceTransformer,
-    nli_resource: List[InputExample],
-    sts_resource: Tuple[List[InputExample], List[InputExample]],
+    nli_resource: list[InputExample],
+    sts_resource: tuple[list[InputExample], list[InputExample]],
 ):
     model = distilbert_base_uncased_model
     _, sts_test_samples = sts_resource
@@ -158,8 +160,8 @@ def test_train_nli_slow(
 )
 def test_train_nli(
     distilbert_base_uncased_model: SentenceTransformer,
-    nli_resource: List[InputExample],
-    sts_resource: Tuple[List[InputExample], List[InputExample]],
+    nli_resource: list[InputExample],
+    sts_resource: tuple[list[InputExample], list[InputExample]],
 ):
     model = distilbert_base_uncased_model
     _, sts_test_samples = sts_resource

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import re
 import tempfile
 from pathlib import Path

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 import sklearn
 import torch


### PR DESCRIPTION
This PR proposes to enable the following rules in `ruff`:

- [UP006](https://docs.astral.sh/ruff/rules/non-pep585-annotation/)
- [UP007](https://docs.astral.sh/ruff/rules/non-pep604-annotation/)

This implements changes as proposed by [PEP585](https://peps.python.org/pep-0585/) and [PEP604](https://peps.python.org/pep-0604/). For example, this changes

```py
from typing import List

def foo(
        documents: List[str],
        top_k: Optional[int] = None,
        ...
)
```

to

```py
def foo(
        documents: list[str],
        top_k: int | None = None,
        ...
)
```

Steps to create this PR were simply updating the `pyproject.toml` and then running `ruff check --unsafe-fixes`.