### PR TITLE
[`chore`] Enable ruff's pypgrade (`UP`) ruleset

### DIFF
--- a/examples/applications/clustering/fast_clustering.py
+++ b/examples/applications/clustering/fast_clustering.py
@@ -57,11 +57,11 @@ start_time = time.time()
 # threshold: Consider sentence pairs with a cosine-similarity larger than threshold as similar
 clusters = util.community_detection(corpus_embeddings, min_community_size=25, threshold=0.75)
 
-print("Clustering done after {:.2f} sec".format(time.time() - start_time))
+print(f"Clustering done after {time.time() - start_time:.2f} sec")
 
 # Print for all clusters the top 3 and bottom 3 elements
 for i, cluster in enumerate(clusters):
-    print("\nCluster {}, #{} Elements ".format(i + 1, len(cluster)))
+    print(f"\nCluster {i + 1}, #{len(cluster)} Elements ")
     for sentence_id in cluster[0:3]:
         print("\t", corpus_sentences[sentence_id])
     print("\t", "...")

--- a/examples/applications/computing-embeddings/computing_embeddings_multi_gpu.py
+++ b/examples/applications/computing-embeddings/computing_embeddings_multi_gpu.py
@@ -15,7 +15,7 @@ logging.basicConfig(
 # Important, you need to shield your code with if __name__. Otherwise, CUDA runs into issues when spawning new processes.
 if __name__ == "__main__":
     # Create a large list of 100k sentences
-    sentences = ["This is sentence {}".format(i) for i in range(100000)]
+    sentences = [f"This is sentence {i}" for i in range(100000)]
 
     # Define the model
     model = SentenceTransformer("all-MiniLM-L6-v2")

--- a/examples/applications/cross-encoder/cross-encoder_reranking.py
+++ b/examples/applications/cross-encoder/cross-encoder_reranking.py
@@ -68,7 +68,7 @@ else:
         corpus_embeddings = cache_data["embeddings"][0:max_corpus_size]
 
 ###############################
-print("Corpus loaded with {} sentences / embeddings".format(len(corpus_sentences)))
+print(f"Corpus loaded with {len(corpus_sentences)} sentences / embeddings")
 
 while True:
     inp_question = input("Please enter a question: ")
@@ -80,7 +80,7 @@ while True:
     hits = util.semantic_search(question_embedding, corpus_embeddings, top_k=num_candidates)
     hits = hits[0]  # Get the hits for the first query
 
-    print("Cosine-Similarity search took {:.3f} seconds".format(time.time() - start_time))
+    print(f"Cosine-Similarity search took {time.time() - start_time:.3f} seconds")
     print("Top 5 hits with cosine-similarity:")
     for hit in hits[0:5]:
         print("\t{:.3f}\t{}".format(hit["score"], corpus_sentences[hit["corpus_id"]]))
@@ -95,7 +95,7 @@ while True:
 
     # Sort list by CrossEncoder scores
     hits = sorted(hits, key=lambda x: x["cross-encoder_score"], reverse=True)
-    print("\nRe-ranking with CrossEncoder took {:.3f} seconds".format(time.time() - start_time))
+    print(f"\nRe-ranking with CrossEncoder took {time.time() - start_time:.3f} seconds")
     print("Top 5 hits with CrossEncoder:")
     for hit in hits[0:5]:
         print("\t{:.3f}\t{}".format(hit["cross-encoder_score"], corpus_sentences[hit["corpus_id"]]))

--- a/examples/applications/parallel-sentence-mining/bitext_mining.py
+++ b/examples/applications/parallel-sentence-mining/bitext_mining.py
@@ -177,4 +177,4 @@ with gzip.open("parallel-sentences-out.tsv.gz", "wt", encoding="utf8") as fOut:
             )
             sentences_written += 1
 
-print("Done. {} sentences written".format(sentences_written))
+print(f"Done. {sentences_written} sentences written")

--- a/examples/applications/parallel-sentence-mining/bitext_mining_utils.py
+++ b/examples/applications/parallel-sentence-mining/bitext_mining_utils.py
@@ -45,7 +45,7 @@ def kNN(x, y, k, use_ann_search=False, ann_num_clusters=32768, ann_num_cluster_p
         idx.add(y)
         sim, ind = idx.search(x, k)
 
-    print("Done: {:.2f} sec".format(time.time() - start_time))
+    print(f"Done: {time.time() - start_time:.2f} sec")
     return sim, ind
 
 
@@ -56,4 +56,4 @@ def file_open(filepath):
     elif filepath.endswith("xz"):
         return lzma.open(filepath, "rt", encoding="utf8")
     else:
-        return open(filepath, "r", encoding="utf8")
+        return open(filepath, encoding="utf8")

--- a/examples/applications/parallel-sentence-mining/bucc2018.py
+++ b/examples/applications/parallel-sentence-mining/bucc2018.py
@@ -54,12 +54,8 @@ use_pca = False
 pca_dimensions = 128
 
 # We store the embeddings on disc, so that they can later be loaded from disc
-source_embedding_file = "{}_{}_{}.emb".format(
-    model_name, os.path.basename(source_file), pca_dimensions if use_pca else model.get_sentence_embedding_dimension()
-)
-target_embedding_file = "{}_{}_{}.emb".format(
-    model_name, os.path.basename(target_file), pca_dimensions if use_pca else model.get_sentence_embedding_dimension()
-)
+source_embedding_file = f"{model_name}_{os.path.basename(source_file)}_{pca_dimensions if use_pca else model.get_sentence_embedding_dimension()}.emb"
+target_embedding_file = f"{model_name}_{os.path.basename(target_file)}_{pca_dimensions if use_pca else model.get_sentence_embedding_dimension()}.emb"
 
 
 # Use PCA to reduce the dimensionality of the sentence embedding model

--- a/examples/applications/retrieve_rerank/in_document_search_crossencoder.py
+++ b/examples/applications/retrieve_rerank/in_document_search_crossencoder.py
@@ -88,7 +88,7 @@ for query in queries:
     results = sorted(results, key=lambda x: x["score"], reverse=True)
 
     print("Query:", query)
-    print("Search took {:.2f} seconds".format(time.time() - start_time))
+    print(f"Search took {time.time() - start_time:.2f} seconds")
     for hit in results[0:5]:
         print("Score: {:.2f}".format(hit["score"]), "\t", hit["input"][1])
 

--- a/examples/applications/semantic-search/semantic_search.py
+++ b/examples/applications/semantic-search/semantic_search.py
@@ -48,7 +48,7 @@ for query in queries:
     print("Top 5 most similar sentences in corpus:")
 
     for score, idx in zip(scores, indices):
-        print(corpus[idx], "(Score: {:.4f})".format(score))
+        print(corpus[idx], f"(Score: {score:.4f})")
 
     """
     # Alternatively, we can also use util.semantic_search to perform cosine similarty + topk

--- a/examples/applications/semantic-search/semantic_search_quora_annoy.py
+++ b/examples/applications/semantic-search/semantic_search_quora_annoy.py
@@ -90,7 +90,7 @@ else:
 
 if not os.path.exists(annoy_index_path):
     # Create Annoy Index
-    print("Create Annoy index with {} trees. This can take some time.".format(n_trees))
+    print(f"Create Annoy index with {n_trees} trees. This can take some time.")
     annoy_index = AnnoyIndex(embedding_size, "angular")
 
     for i in range(len(corpus_embeddings)):
@@ -108,7 +108,7 @@ corpus_embeddings = torch.from_numpy(corpus_embeddings)
 
 ######### Search in the index ###########
 
-print("Corpus loaded with {} sentences / embeddings".format(len(corpus_sentences)))
+print(f"Corpus loaded with {len(corpus_sentences)} sentences / embeddings")
 
 while True:
     inp_question = input("Please enter a question: ")
@@ -124,7 +124,7 @@ while True:
     end_time = time.time()
 
     print("Input question:", inp_question)
-    print("Results (after {:.3f} seconds):".format(end_time - start_time))
+    print(f"Results (after {end_time - start_time:.3f} seconds):")
     for hit in hits[0:top_k_hits]:
         print("\t{:.3f}\t{}".format(hit["score"], corpus_sentences[hit["corpus_id"]]))
 
@@ -139,7 +139,7 @@ while True:
         print("Approximate Nearest Neighbor returned a different number of results than expected")
 
     recall = len(ann_corpus_ids.intersection(correct_hits_ids)) / len(correct_hits_ids)
-    print("\nApproximate Nearest Neighbor Recall@{}: {:.2f}".format(top_k_hits, recall * 100))
+    print(f"\nApproximate Nearest Neighbor Recall@{top_k_hits}: {recall * 100:.2f}")
 
     if recall < 1:
         print("Missing results:")

--- a/examples/applications/semantic-search/semantic_search_quora_faiss.py
+++ b/examples/applications/semantic-search/semantic_search_quora_faiss.py
@@ -107,7 +107,7 @@ index.add(corpus_embeddings)
 ######### Search in the index ###########
 
 
-print("Corpus loaded with {} sentences / embeddings".format(len(corpus_sentences)))
+print(f"Corpus loaded with {len(corpus_sentences)} sentences / embeddings")
 
 while True:
     inp_question = input("Please enter a question: ")
@@ -128,7 +128,7 @@ while True:
     end_time = time.time()
 
     print("Input question:", inp_question)
-    print("Results (after {:.3f} seconds):".format(end_time - start_time))
+    print(f"Results (after {end_time - start_time:.3f} seconds):")
     for hit in hits[0:top_k_hits]:
         print("\t{:.3f}\t{}".format(hit["score"], corpus_sentences[hit["corpus_id"]]))
 
@@ -142,7 +142,7 @@ while True:
         print("Approximate Nearest Neighbor returned a different number of results than expected")
 
     recall = len(ann_corpus_ids.intersection(correct_hits_ids)) / len(correct_hits_ids)
-    print("\nApproximate Nearest Neighbor Recall@{}: {:.2f}".format(top_k_hits, recall * 100))
+    print(f"\nApproximate Nearest Neighbor Recall@{top_k_hits}: {recall * 100:.2f}")
 
     if recall < 1:
         print("Missing results:")

--- a/examples/applications/semantic-search/semantic_search_quora_hnswlib.py
+++ b/examples/applications/semantic-search/semantic_search_quora_hnswlib.py
@@ -102,7 +102,7 @@ index.set_ef(50)  # ef should always be > top_k_hits
 
 ######### Search in the index ###########
 
-print("Corpus loaded with {} sentences / embeddings".format(len(corpus_sentences)))
+print(f"Corpus loaded with {len(corpus_sentences)} sentences / embeddings")
 
 while True:
     inp_question = input("Please enter a question: ")
@@ -119,7 +119,7 @@ while True:
     end_time = time.time()
 
     print("Input question:", inp_question)
-    print("Results (after {:.3f} seconds):".format(end_time - start_time))
+    print(f"Results (after {end_time - start_time:.3f} seconds):")
     for hit in hits[0:top_k_hits]:
         print("\t{:.3f}\t{}".format(hit["score"], corpus_sentences[hit["corpus_id"]]))
 
@@ -133,7 +133,7 @@ while True:
         print("Approximate Nearest Neighbor returned a different number of results than expected")
 
     recall = len(ann_corpus_ids.intersection(correct_hits_ids)) / len(correct_hits_ids)
-    print("\nApproximate Nearest Neighbor Recall@{}: {:.2f}".format(top_k_hits, recall * 100))
+    print(f"\nApproximate Nearest Neighbor Recall@{top_k_hits}: {recall * 100:.2f}")
 
     if recall < 1:
         print("Missing results:")

--- a/examples/applications/semantic-search/semantic_search_quora_pytorch.py
+++ b/examples/applications/semantic-search/semantic_search_quora_pytorch.py
@@ -67,7 +67,7 @@ else:
         corpus_embeddings = cache_data["embeddings"][0:max_corpus_size]
 
 ###############################
-print("Corpus loaded with {} sentences / embeddings".format(len(corpus_sentences)))
+print(f"Corpus loaded with {len(corpus_sentences)} sentences / embeddings")
 
 # Move embeddings to the target device of the model
 corpus_embeddings = corpus_embeddings.to(model.device)
@@ -82,7 +82,7 @@ while True:
     hits = hits[0]  # Get the hits for the first query
 
     print("Input question:", inp_question)
-    print("Results (after {:.3f} seconds):".format(end_time - start_time))
+    print(f"Results (after {end_time - start_time:.3f} seconds):")
     for hit in hits[0:5]:
         print("\t{:.3f}\t{}".format(hit["score"], corpus_sentences[hit["corpus_id"]]))
 

--- a/examples/applications/semantic-search/semantic_search_wikipedia_qa.py
+++ b/examples/applications/semantic-search/semantic_search_wikipedia_qa.py
@@ -73,7 +73,7 @@ while True:
 
     # Output of top-k hits
     print("Input question:", query)
-    print("Results (after {:.3f} seconds):".format(end_time - start_time))
+    print(f"Results (after {end_time - start_time:.3f} seconds):")
     for hit in hits:
         print("\t{:.3f}\t{}".format(hit["score"], passages[hit["corpus_id"]]))
 

--- a/examples/evaluation/evaluation_inference_speed.py
+++ b/examples/evaluation/evaluation_inference_speed.py
@@ -37,6 +37,6 @@ for i in range(3):
     emb = model.encode(sentences, batch_size=32)
     end_time = time.time()
     diff_time = end_time - start_time
-    print("Done after {:.2f} seconds".format(diff_time))
-    print("Speed: {:.2f} sentences / second".format(len(sentences) / diff_time))
+    print(f"Done after {diff_time:.2f} seconds")
+    print(f"Speed: {len(sentences) / diff_time:.2f} sentences / second")
     print("=====")

--- a/examples/training/cross-encoder/training_nli.py
+++ b/examples/training/cross-encoder/training_nli.py
@@ -71,7 +71,7 @@ f1_evaluator = CEF1Evaluator.from_input_examples(dev_samples, name="AllNLI-dev")
 evaluator = SequentialEvaluator([accuracy_evaluator, f1_evaluator])
 
 warmup_steps = math.ceil(len(train_dataloader) * num_epochs * 0.1)  # 10% of train data for warm-up
-logger.info("Warmup-steps: {}".format(warmup_steps))
+logger.info(f"Warmup-steps: {warmup_steps}")
 
 
 # Train the model

--- a/examples/training/cross-encoder/training_quora_duplicate_questions.py
+++ b/examples/training/cross-encoder/training_quora_duplicate_questions.py
@@ -45,7 +45,7 @@ if not os.path.exists(dataset_path):
 # Read the quora dataset split for classification
 logger.info("Read train dataset")
 train_samples = []
-with open(os.path.join(dataset_path, "classification", "train_pairs.tsv"), "r", encoding="utf8") as fIn:
+with open(os.path.join(dataset_path, "classification", "train_pairs.tsv"), encoding="utf8") as fIn:
     reader = csv.DictReader(fIn, delimiter="\t", quoting=csv.QUOTE_NONE)
     for row in reader:
         train_samples.append(InputExample(texts=[row["question1"], row["question2"]], label=int(row["is_duplicate"])))
@@ -54,7 +54,7 @@ with open(os.path.join(dataset_path, "classification", "train_pairs.tsv"), "r", 
 
 logger.info("Read dev dataset")
 dev_samples = []
-with open(os.path.join(dataset_path, "classification", "dev_pairs.tsv"), "r", encoding="utf8") as fIn:
+with open(os.path.join(dataset_path, "classification", "dev_pairs.tsv"), encoding="utf8") as fIn:
     reader = csv.DictReader(fIn, delimiter="\t", quoting=csv.QUOTE_NONE)
     for row in reader:
         dev_samples.append(InputExample(texts=[row["question1"], row["question2"]], label=int(row["is_duplicate"])))
@@ -79,7 +79,7 @@ evaluator = CEBinaryClassificationEvaluator.from_input_examples(dev_samples, nam
 
 # Configure the training
 warmup_steps = math.ceil(len(train_dataloader) * num_epochs * 0.1)  # 10% of train data for warm-up
-logger.info("Warmup-steps: {}".format(warmup_steps))
+logger.info(f"Warmup-steps: {warmup_steps}")
 
 
 # Train the model

--- a/examples/training/cross-encoder/training_stsbenchmark.py
+++ b/examples/training/cross-encoder/training_stsbenchmark.py
@@ -76,7 +76,7 @@ evaluator = CECorrelationEvaluator.from_input_examples(dev_samples, name="sts-de
 
 # Configure the training
 warmup_steps = math.ceil(len(train_dataloader) * num_epochs * 0.1)  # 10% of train data for warm-up
-logger.info("Warmup-steps: {}".format(warmup_steps))
+logger.info(f"Warmup-steps: {warmup_steps}")
 
 
 # Train the model

--- a/examples/training/data_augmentation/train_sts_indomain_bm25.py
+++ b/examples/training/data_augmentation/train_sts_indomain_bm25.py
@@ -87,7 +87,7 @@ sentence_transformer.max_seq_length = max_seq_length
 #
 #####################################################################
 
-logging.info("Step 1: Train cross-encoder: ({}) with STSbenchmark".format(model_name))
+logging.info(f"Step 1: Train cross-encoder: ({model_name}) with STSbenchmark")
 
 # Load the STSB dataset: https://huggingface.co/datasets/sentence-transformers/stsb
 train_dataset = load_dataset("sentence-transformers/stsb", split="train")
@@ -113,7 +113,7 @@ evaluator = CECorrelationEvaluator(
 
 # Configure the training
 warmup_steps = math.ceil(len(train_dataloader) * num_epochs * 0.1)  # 10% of train data for warm-up
-logging.info("Warmup-steps: {}".format(warmup_steps))
+logging.info(f"Warmup-steps: {warmup_steps}")
 
 # Train the cross-encoder model
 cross_encoder.fit(
@@ -134,7 +134,7 @@ cross_encoder.fit(
 #### Larger the k, bigger the silver dataset ####
 
 index_name = "stsb"  # index-name should be in lowercase
-logging.info("Step 2.1: Generate STSbenchmark (silver dataset) using top-{} bm25 combinations".format(top_k))
+logging.info(f"Step 2.1: Generate STSbenchmark (silver dataset) using top-{top_k} bm25 combinations")
 
 unique_sentences = set()
 
@@ -148,7 +148,7 @@ duplicates = set(
 )  # not to include gold pairs of sentences again
 
 # Ignore 400 cause by IndexAlreadyExistsException when creating an index
-logging.info("Creating elastic-search index - {}".format(index_name))
+logging.info(f"Creating elastic-search index - {index_name}")
 es.indices.create(index=index_name, ignore=[400])
 
 # indexing all sentences
@@ -156,7 +156,7 @@ logging.info("Starting to index....")
 for sent in unique_sentences:
     response = es.index(index=index_name, id=sent2idx[sent], body={"sent": sent})
 
-logging.info("Indexing complete for {} unique sentences".format(len(unique_sentences)))
+logging.info(f"Indexing complete for {len(unique_sentences)} unique sentences")
 
 silver_data = []
 progress = tqdm.tqdm(unit="docs", total=len(sent2idx))
@@ -173,8 +173,8 @@ for sent, idx in sent2idx.items():
 progress.reset()
 progress.close()
 
-logging.info("Number of silver pairs generated for STSbenchmark: {}".format(len(silver_data)))
-logging.info("Step 2.2: Label STSbenchmark (silver dataset) with cross-encoder: {}".format(model_name))
+logging.info(f"Number of silver pairs generated for STSbenchmark: {len(silver_data)}")
+logging.info(f"Step 2.2: Label STSbenchmark (silver dataset) with cross-encoder: {model_name}")
 
 cross_encoder = CrossEncoder(cross_encoder_path)
 silver_scores = cross_encoder.predict(silver_data)
@@ -188,7 +188,7 @@ assert all(0.0 <= score <= 1.0 for score in silver_scores)
 #
 #################################################################################################
 
-logging.info("Step 3: Train bi-encoder: {} with STSbenchmark (gold + silver dataset)".format(model_name))
+logging.info(f"Step 3: Train bi-encoder: {model_name} with STSbenchmark (gold + silver dataset)")
 
 # Convert the dataset to a DataLoader ready for training
 logging.info("Read STSbenchmark gold and silver train dataset")

--- a/examples/training/data_augmentation/train_sts_indomain_nlpaug.py
+++ b/examples/training/data_augmentation/train_sts_indomain_nlpaug.py
@@ -111,7 +111,7 @@ silver_dataset = Dataset.from_dict(silver_samples)
 progress.reset()
 progress.close()
 logging.info("Textual augmentation completed....")
-logging.info("Number of silver pairs generated: {}".format(len(silver_samples)))
+logging.info(f"Number of silver pairs generated: {len(silver_samples)}")
 
 ###################################################################
 #

--- a/examples/training/data_augmentation/train_sts_qqp_crossdomain.py
+++ b/examples/training/data_augmentation/train_sts_qqp_crossdomain.py
@@ -82,13 +82,13 @@ bi_encoder_path = (
 
 ###### Cross-encoder (simpletransformers) ######
 
-logging.info("Loading cross-encoder model: {}".format(model_name))
+logging.info(f"Loading cross-encoder model: {model_name}")
 # Use Huggingface/transformers model (like BERT, RoBERTa, XLNet, XLM-R) for cross-encoder model
 cross_encoder = CrossEncoder(model_name, num_labels=1)
 
 ###### Bi-encoder (sentence-transformers) ######
 
-logging.info("Loading bi-encoder model: {}".format(model_name))
+logging.info(f"Loading bi-encoder model: {model_name}")
 
 # Use Huggingface/transformers model (like BERT, RoBERTa, XLNet, XLM-R) for mapping tokens to embeddings
 word_embedding_model = models.Transformer(model_name, max_seq_length=max_seq_length)
@@ -110,7 +110,7 @@ bi_encoder = SentenceTransformer(modules=[word_embedding_model, pooling_model])
 #
 #####################################################
 
-logging.info("Step 1: Train cross-encoder: {} with STSbenchmark (source dataset)".format(model_name))
+logging.info(f"Step 1: Train cross-encoder: {model_name} with STSbenchmark (source dataset)")
 
 gold_samples = []
 dev_samples = []
@@ -140,7 +140,7 @@ evaluator = CECorrelationEvaluator.from_input_examples(dev_samples, name="sts-de
 
 # Configure the training
 warmup_steps = math.ceil(len(train_dataloader) * num_epochs * 0.1)  # 10% of train data for warm-up
-logging.info("Warmup-steps: {}".format(warmup_steps))
+logging.info(f"Warmup-steps: {warmup_steps}")
 
 # Train the cross-encoder model
 cross_encoder.fit(
@@ -158,7 +158,7 @@ cross_encoder.fit(
 #
 ##################################################################
 
-logging.info("Step 2: Label QQP (target dataset) with cross-encoder: {}".format(model_name))
+logging.info(f"Step 2: Label QQP (target dataset) with cross-encoder: {model_name}")
 
 cross_encoder = CrossEncoder(cross_encoder_path)
 
@@ -183,7 +183,7 @@ binary_silver_scores = [1 if score >= 0.5 else 0 for score in silver_scores]
 #
 ###########################################################################
 
-logging.info("Step 3: Train bi-encoder: {} over labeled QQP (target dataset)".format(model_name))
+logging.info(f"Step 3: Train bi-encoder: {model_name} over labeled QQP (target dataset)")
 
 # Convert the dataset to a DataLoader ready for training
 logging.info("Loading BERT labeled QQP dataset")
@@ -216,7 +216,7 @@ evaluator = BinaryClassificationEvaluator(dev_sentences1, dev_sentences2, dev_la
 
 # Configure the training.
 warmup_steps = math.ceil(len(train_dataloader) * num_epochs * 0.1)  # 10% of train data for warm-up
-logging.info("Warmup-steps: {}".format(warmup_steps))
+logging.info(f"Warmup-steps: {warmup_steps}")
 
 # Train the bi-encoder model
 bi_encoder.fit(

--- a/examples/training/data_augmentation/train_sts_seed_optimization.py
+++ b/examples/training/data_augmentation/train_sts_seed_optimization.py
@@ -58,11 +58,11 @@ model_name = sys.argv[1] if len(sys.argv) > 1 else "bert-base-uncased"
 seed_count = int(sys.argv[2]) if len(sys.argv) > 2 else 10
 stop_after = float(sys.argv[3]) if len(sys.argv) > 3 else 0.3
 
-logging.info("Train and Evaluate: {} Random Seeds".format(seed_count))
+logging.info(f"Train and Evaluate: {seed_count} Random Seeds")
 
 for seed in range(seed_count):
     # Setting seed for all random initializations
-    logging.info("##### Seed {} #####".format(seed))
+    logging.info(f"##### Seed {seed} #####")
     random.seed(seed)
     np.random.seed(seed)
     torch.manual_seed(seed)
@@ -117,9 +117,9 @@ for seed in range(seed_count):
     # We find from (Dodge et al.) that 20-30% is often ideal for convergence of random seed
     steps_per_epoch = math.ceil(len(train_dataloader) * stop_after)
 
-    logging.info("Warmup-steps: {}".format(warmup_steps))
+    logging.info(f"Warmup-steps: {warmup_steps}")
 
-    logging.info("Early-stopping: {}% of the training-data".format(int(stop_after * 100)))
+    logging.info(f"Early-stopping: {int(stop_after * 100)}% of the training-data")
 
     # Train the model
     model.fit(

--- a/examples/training/distillation/dimensionality_reduction.py
+++ b/examples/training/distillation/dimensionality_reduction.py
@@ -77,7 +77,7 @@ dense.linear.weight = torch.nn.Parameter(torch.tensor(pca_comp))
 model.add_module("dense", dense)
 
 # Evaluate the model with the reduce embedding size
-logging.info("Model with {} dimensions:".format(new_dimension))
+logging.info(f"Model with {new_dimension} dimensions:")
 stsb_evaluator(model)
 
 

--- a/examples/training/distillation/model_distillation.py
+++ b/examples/training/distillation/model_distillation.py
@@ -147,7 +147,7 @@ if student_model.get_sentence_embedding_dimension() < teacher_model.get_sentence
     dense.linear.weight = torch.nn.Parameter(torch.tensor(pca.components_))
     teacher_model.add_module("dense", dense)
 
-    logging.info("Teacher Performance with {} dimensions:".format(teacher_model.get_sentence_embedding_dimension()))
+    logging.info(f"Teacher Performance with {teacher_model.get_sentence_embedding_dimension()} dimensions:")
     dev_evaluator_stsb(teacher_model)
 
 

--- a/examples/training/distillation/model_distillation_layer_reduction.py
+++ b/examples/training/distillation/model_distillation_layer_reduction.py
@@ -59,7 +59,7 @@ auto_model = student_model._first_module().auto_model
 # Keep every third layer:
 layers_to_keep = [0, 3, 6, 9, 12, 15, 18, 21]
 
-logging.info("Remove layers from student. Only keep these layers: {}".format(layers_to_keep))
+logging.info(f"Remove layers from student. Only keep these layers: {layers_to_keep}")
 new_layers = torch.nn.ModuleList(
     [layer_module for i, layer_module in enumerate(auto_model.encoder.layer) if i in layers_to_keep]
 )

--- a/examples/training/distillation/model_quantization.py
+++ b/examples/training/distillation/model_quantization.py
@@ -73,14 +73,14 @@ logging.info("Evaluating speed of unquantized model")
 start_time = time.time()
 emb = model.encode(sentences, show_progress_bar=True)
 diff_normal = time.time() - start_time
-logging.info("Done after {:.2f} sec. {:.2f} sentences / sec".format(diff_normal, len(sentences) / diff_normal))
+logging.info(f"Done after {diff_normal:.2f} sec. {len(sentences) / diff_normal:.2f} sentences / sec")
 
 logging.info("Evaluating speed of quantized model")
 start_time = time.time()
 emb = q_model.encode(sentences, show_progress_bar=True)
 diff_quantized = time.time() - start_time
-logging.info("Done after {:.2f} sec. {:.2f} sentences / sec".format(diff_quantized, len(sentences) / diff_quantized))
-logging.info("Speed-up: {:.2f}".format(diff_normal / diff_quantized))
+logging.info(f"Done after {diff_quantized:.2f} sec. {len(sentences) / diff_quantized:.2f} sentences / sec")
+logging.info(f"Speed-up: {diff_normal / diff_quantized:.2f}")
 #########
 
 evaluator = EmbeddingSimilarityEvaluator.from_input_examples(test_samples, name="sts-test")

--- a/examples/training/ms_marco/eval_cross-encoder-trec-dl.py
+++ b/examples/training/ms_marco/eval_cross-encoder-trec-dl.py
@@ -85,7 +85,7 @@ with gzip.open(passage_filepath, "rt", encoding="utf8") as fIn:
 
         passage_cand[qid].append([pid, passage])
 
-logging.info("Queries: {}".format(len(queries)))
+logging.info(f"Queries: {len(queries)}")
 
 queries_result_list = []
 run = {}

--- a/examples/training/ms_marco/eval_msmarco.py
+++ b/examples/training/ms_marco/eval_msmarco.py
@@ -96,8 +96,8 @@ with open(collection_filepath, encoding="utf8") as fIn:
 
 
 ## Run evaluator
-logging.info("Queries: {}".format(len(dev_queries)))
-logging.info("Corpus: {}".format(len(corpus)))
+logging.info(f"Queries: {len(dev_queries)}")
+logging.info(f"Corpus: {len(corpus)}")
 
 ir_evaluator = evaluation.InformationRetrievalEvaluator(
     dev_queries,

--- a/examples/training/ms_marco/multilingual/translate_queries.py
+++ b/examples/training/ms_marco/multilingual/translate_queries.py
@@ -27,14 +27,14 @@ target_lang = sys.argv[1]
 output_folder = "multilingual-data"
 data_folder = "../msmarco-data"
 
-output_filename = os.path.join(output_folder, "train_queries.en-{}.tsv".format(target_lang))
+output_filename = os.path.join(output_folder, f"train_queries.en-{target_lang}.tsv")
 os.makedirs(output_folder, exist_ok=True)
 
 
 ## Does the output file exists? If yes, read it so we can continue the translation
 translated_qids = set()
 if os.path.exists(output_filename):
-    with open(output_filename, "r", encoding="utf8") as fIn:
+    with open(output_filename, encoding="utf8") as fIn:
         for line in fIn:
             splits = line.strip().split("\t")
             translated_qids.add(splits[0])
@@ -66,7 +66,7 @@ if not os.path.exists(queries_filepath):
         tar.extractall(path=data_folder)
 
 
-with open(queries_filepath, "r", encoding="utf8") as fIn:
+with open(queries_filepath, encoding="utf8") as fIn:
     for line in fIn:
         qid, query = line.strip().split("\t")
         if qid in train_queries:
@@ -79,7 +79,7 @@ queries = [train_queries[qid] for qid in qids]
 # Define our translation model
 translation_model = EasyNMT("opus-mt")
 
-print("Start translation of {} queries.".format(len(queries)))
+print(f"Start translation of {len(queries)} queries.")
 print("This can take a while. But you can stop this script at any point")
 
 

--- a/examples/training/ms_marco/train_bi-encoder_margin-mse.py
+++ b/examples/training/ms_marco/train_bi-encoder_margin-mse.py
@@ -96,7 +96,7 @@ if not os.path.exists(collection_filepath):
         tar.extractall(path=data_folder)
 
 logging.info("Read corpus: collection.tsv")
-with open(collection_filepath, "r", encoding="utf8") as fIn:
+with open(collection_filepath, encoding="utf8") as fIn:
     for line in fIn:
         pid, passage = line.strip().split("\t")
         pid = int(pid)
@@ -116,7 +116,7 @@ if not os.path.exists(queries_filepath):
         tar.extractall(path=data_folder)
 
 
-with open(queries_filepath, "r", encoding="utf8") as fIn:
+with open(queries_filepath, encoding="utf8") as fIn:
     for line in fIn:
         qid, query = line.strip().split("\t")
         qid = int(qid)
@@ -189,7 +189,7 @@ with gzip.open(hard_negatives_filepath, "rt") as fIn:
                 "neg": neg_pids,
             }
 
-logging.info("Train queries: {}".format(len(train_queries)))
+logging.info(f"Train queries: {len(train_queries)}")
 
 
 # We create a custom MSMARCO dataset that returns triplets (query, positive, negative)

--- a/examples/training/ms_marco/train_bi-encoder_mnrl.py
+++ b/examples/training/ms_marco/train_bi-encoder_mnrl.py
@@ -106,7 +106,7 @@ if not os.path.exists(collection_filepath):
         tar.extractall(path=data_folder)
 
 logging.info("Read corpus: collection.tsv")
-with open(collection_filepath, "r", encoding="utf8") as fIn:
+with open(collection_filepath, encoding="utf8") as fIn:
     for line in fIn:
         pid, passage = line.strip().split("\t")
         pid = int(pid)
@@ -126,7 +126,7 @@ if not os.path.exists(queries_filepath):
         tar.extractall(path=data_folder)
 
 
-with open(queries_filepath, "r", encoding="utf8") as fIn:
+with open(queries_filepath, encoding="utf8") as fIn:
     for line in fIn:
         qid, query = line.strip().split("\t")
         qid = int(qid)
@@ -209,7 +209,7 @@ with gzip.open(hard_negatives_filepath, "rt") as fIn:
 
 del ce_scores
 
-logging.info("Train queries: {}".format(len(train_queries)))
+logging.info(f"Train queries: {len(train_queries)}")
 
 
 # We create a custom MSMARCO dataset that returns triplets (query, positive, negative)

--- a/examples/training/ms_marco/train_cross-encoder_kd.py
+++ b/examples/training/ms_marco/train_cross-encoder_kd.py
@@ -70,7 +70,7 @@ if not os.path.exists(collection_filepath):
     with tarfile.open(tar_filepath, "r:gz") as tar:
         tar.extractall(path=data_folder)
 
-with open(collection_filepath, "r", encoding="utf8") as fIn:
+with open(collection_filepath, encoding="utf8") as fIn:
     for line in fIn:
         pid, passage = line.strip().split("\t")
         corpus[pid] = passage
@@ -89,7 +89,7 @@ if not os.path.exists(queries_filepath):
         tar.extractall(path=data_folder)
 
 
-with open(queries_filepath, "r", encoding="utf8") as fIn:
+with open(queries_filepath, encoding="utf8") as fIn:
     for line in fIn:
         qid, query = line.strip().split("\t")
         queries[qid] = query
@@ -156,7 +156,7 @@ evaluator = CERerankingEvaluator(dev_samples, name="train-eval")
 
 # Configure the training
 warmup_steps = 5000
-logging.info("Warmup-steps: {}".format(warmup_steps))
+logging.info(f"Warmup-steps: {warmup_steps}")
 
 
 # Train the model

--- a/examples/training/ms_marco/train_cross-encoder_scratch.py
+++ b/examples/training/ms_marco/train_cross-encoder_scratch.py
@@ -77,7 +77,7 @@ if not os.path.exists(collection_filepath):
     with tarfile.open(tar_filepath, "r:gz") as tar:
         tar.extractall(path=data_folder)
 
-with open(collection_filepath, "r", encoding="utf8") as fIn:
+with open(collection_filepath, encoding="utf8") as fIn:
     for line in fIn:
         pid, passage = line.strip().split("\t")
         corpus[pid] = passage
@@ -96,7 +96,7 @@ if not os.path.exists(queries_filepath):
         tar.extractall(path=data_folder)
 
 
-with open(queries_filepath, "r", encoding="utf8") as fIn:
+with open(queries_filepath, encoding="utf8") as fIn:
     for line in fIn:
         qid, query = line.strip().split("\t")
         queries[qid] = query
@@ -170,7 +170,7 @@ evaluator = CERerankingEvaluator(dev_samples, name="train-eval")
 
 # Configure the training
 warmup_steps = 5000
-logging.info("Warmup-steps: {}".format(warmup_steps))
+logging.info(f"Warmup-steps: {warmup_steps}")
 
 
 # Train the model

--- a/examples/training/multilingual/get_parallel_data_opus.py
+++ b/examples/training/multilingual/get_parallel_data_opus.py
@@ -46,7 +46,7 @@ os.makedirs(output_folder, exist_ok=True)
 for corpus in corpora:
     for src_lang in source_languages:
         for trg_lang in target_languages:
-            output_filename = os.path.join(output_folder, "{}-{}-{}.tsv.gz".format(corpus, src_lang, trg_lang))
+            output_filename = os.path.join(output_folder, f"{corpus}-{src_lang}-{trg_lang}.tsv.gz")
             if not os.path.exists(output_filename):
                 print("Create:", output_filename)
                 try:

--- a/examples/training/multilingual/get_parallel_data_talks.py
+++ b/examples/training/multilingual/get_parallel_data_talks.py
@@ -44,11 +44,9 @@ files_to_create = []
 for source_lang in source_languages:
     for target_lang in target_languages:
         output_filename_train = os.path.join(
-            parallel_sentences_folder, "talks-{}-{}-train.tsv.gz".format(source_lang, target_lang)
+            parallel_sentences_folder, f"talks-{source_lang}-{target_lang}-train.tsv.gz"
         )
-        output_filename_dev = os.path.join(
-            parallel_sentences_folder, "talks-{}-{}-dev.tsv.gz".format(source_lang, target_lang)
-        )
+        output_filename_dev = os.path.join(parallel_sentences_folder, f"talks-{source_lang}-{target_lang}-dev.tsv.gz")
         train_files.append(output_filename_train)
         dev_files.append(output_filename_dev)
         if not os.path.exists(output_filename_train) or not os.path.exists(output_filename_dev):
@@ -82,7 +80,7 @@ if len(files_to_create) > 0:
                     else:
                         fOut = outfile["fTrain"]
 
-                    fOut.write("{}\t{}\n".format(src_text, trg_text))
+                    fOut.write(f"{src_text}\t{trg_text}\n")
 
     for outfile in files_to_create:
         outfile["fTrain"].close()

--- a/examples/training/multilingual/get_parallel_data_tatoeba.py
+++ b/examples/training/multilingual/get_parallel_data_tatoeba.py
@@ -91,10 +91,10 @@ for src_lang in source_languages:
         train_sentences = source_sentences[num_dev_sentences:]
         dev_sentences = source_sentences[0:num_dev_sentences]
 
-        print("{}-{} has {} sentences".format(src_lang, trg_lang, len(source_sentences)))
+        print(f"{src_lang}-{trg_lang} has {len(source_sentences)} sentences")
         if len(dev_sentences) > 0:
             with gzip.open(
-                os.path.join(output_folder, "Tatoeba-{}-{}-dev.tsv.gz".format(src_lang, trg_lang)),
+                os.path.join(output_folder, f"Tatoeba-{src_lang}-{trg_lang}-dev.tsv.gz"),
                 "wt",
                 encoding="utf8",
             ) as fOut:
@@ -104,7 +104,7 @@ for src_lang in source_languages:
 
         if len(train_sentences) > 0:
             with gzip.open(
-                os.path.join(output_folder, "Tatoeba-{}-{}-train.tsv.gz".format(src_lang, trg_lang)),
+                os.path.join(output_folder, f"Tatoeba-{src_lang}-{trg_lang}-train.tsv.gz"),
                 "wt",
                 encoding="utf8",
             ) as fOut:

--- a/examples/training/multilingual/get_parallel_data_wikimatrix.py
+++ b/examples/training/multilingual/get_parallel_data_wikimatrix.py
@@ -33,11 +33,9 @@ os.makedirs(parallel_sentences_folder, exist_ok=True)
 for source_lang in source_languages:
     for target_lang in target_languages:
         filename_train = os.path.join(
-            parallel_sentences_folder, "WikiMatrix-{}-{}-train.tsv.gz".format(source_lang, target_lang)
+            parallel_sentences_folder, f"WikiMatrix-{source_lang}-{target_lang}-train.tsv.gz"
         )
-        filename_dev = os.path.join(
-            parallel_sentences_folder, "WikiMatrix-{}-{}-dev.tsv.gz".format(source_lang, target_lang)
-        )
+        filename_dev = os.path.join(parallel_sentences_folder, f"WikiMatrix-{source_lang}-{target_lang}-dev.tsv.gz")
 
         if not os.path.exists(filename_train) and not os.path.exists(filename_dev):
             langs_ordered = sorted([source_lang, target_lang])

--- a/examples/training/quora_duplicate_questions/application_duplicate_questions_mining.py
+++ b/examples/training/quora_duplicate_questions/application_duplicate_questions_mining.py
@@ -39,4 +39,4 @@ pairs = util.paraphrase_mining(model, questions)
 
 # Output Top-20 pairs:
 for score, qid1, qid2 in pairs[0:20]:
-    print("{:.3f}\t{}\t\t\t{}".format(score, questions[qid1], questions[qid2]))
+    print(f"{score:.3f}\t{questions[qid1]}\t\t\t{questions[qid2]}")

--- a/examples/training/quora_duplicate_questions/create_splits.py
+++ b/examples/training/quora_duplicate_questions/create_splits.py
@@ -408,7 +408,7 @@ print("Test duplicates", len(test_duplicates))
 with open("quora-IR-dataset/graph/sentences.tsv", "w", encoding="utf8") as fOut:
     fOut.write("qid\tquestion\n")
     for id, question in sentences.items():
-        fOut.write("{}\t{}\n".format(id, question))
+        fOut.write(f"{id}\t{question}\n")
 
 duplicates_list = set()
 for a in duplicates:
@@ -424,7 +424,7 @@ print("\nWrite duplicate graph in pairwise format")
 with open("quora-IR-dataset/graph/duplicates-graph-pairwise.tsv", "w", encoding="utf8") as fOut:
     fOut.write("qid1\tqid2\n")
     for a, b in duplicates_list:
-        fOut.write("{}\t{}\n".format(a, b))
+        fOut.write(f"{a}\t{b}\n")
 
 
 print("Write duplicate graph in list format")
@@ -467,12 +467,12 @@ def write_mining_files(name, ids, dups):
     with open("quora-IR-dataset/duplicate-mining/" + name + "_corpus.tsv", "w", encoding="utf8") as fOut:
         fOut.write("qid\tquestion\n")
         for id in ids:
-            fOut.write("{}\t{}\n".format(id, sentences[id]))
+            fOut.write(f"{id}\t{sentences[id]}\n")
 
     with open("quora-IR-dataset/duplicate-mining/" + name + "_duplicates.tsv", "w", encoding="utf8") as fOut:
         fOut.write("qid1\tqid2\n")
         for a, b in dups:
-            fOut.write("{}\t{}\n".format(a, b))
+            fOut.write(f"{a}\t{b}\n")
 
 
 write_mining_files("train", train_ids, train_duplicates)
@@ -552,7 +552,7 @@ print("Test queries:", len(test_queries))
 with open("quora-IR-dataset/information-retrieval/corpus.tsv", "w", encoding="utf8") as fOut:
     fOut.write("qid\tquestion\n")
     for id in sorted(corpus_ids, key=lambda id: int(id)):
-        fOut.write("{}\t{}\n".format(id, sentences[id]))
+        fOut.write(f"{id}\t{sentences[id]}\n")
 
 with open("quora-IR-dataset/information-retrieval/dev-queries.tsv", "w", encoding="utf8") as fOut:
     fOut.write("qid\tquestion\tduplicate_qids\n")

--- a/examples/unsupervised_learning/CT/train_askubuntu_ct.py
+++ b/examples/unsupervised_learning/CT/train_askubuntu_ct.py
@@ -79,7 +79,7 @@ for id, sentence in corpus.items():
     if id not in dev_test_ids:
         train_sentences.append(sentence)
 
-logging.info("{} train sentences".format(len(train_sentences)))
+logging.info(f"{len(train_sentences)} train sentences")
 
 ################# Initialize an SBERT model #################
 

--- a/examples/unsupervised_learning/CT/train_ct_from_file.py
+++ b/examples/unsupervised_learning/CT/train_ct_from_file.py
@@ -33,7 +33,7 @@ max_seq_length = 75
 
 # Input file path (a text file, each line a sentence)
 if len(sys.argv) < 2:
-    print("Run this script with: python {} path/to/sentences.txt".format(sys.argv[0]))
+    print(f"Run this script with: python {sys.argv[0]} path/to/sentences.txt")
     exit()
 
 filepath = sys.argv[1]
@@ -64,7 +64,7 @@ with gzip.open(filepath, "rt", encoding="utf8") if filepath.endswith(".gz") else
             train_sentences.append(line)
 
 
-logging.info("Train sentences: {}".format(len(train_sentences)))
+logging.info(f"Train sentences: {len(train_sentences)}")
 
 # For ContrastiveTension we need a special data loader to construct batches with the desired properties
 train_dataloader = losses.ContrastiveTensionDataLoader(
@@ -76,7 +76,7 @@ train_loss = losses.ContrastiveTensionLoss(model)
 
 
 warmup_steps = math.ceil(len(train_dataloader) * num_epochs * 0.1)  # 10% of train data for warm-up
-logging.info("Warmup-steps: {}".format(warmup_steps))
+logging.info(f"Warmup-steps: {warmup_steps}")
 
 # Train the model
 model.fit(

--- a/examples/unsupervised_learning/CT/train_stsb_ct.py
+++ b/examples/unsupervised_learning/CT/train_stsb_ct.py
@@ -37,7 +37,7 @@ if not os.path.exists(wikipedia_dataset_path):
 
 # train_sentences are simply your list of sentences
 train_sentences = []
-with open(wikipedia_dataset_path, "r", encoding="utf8") as fIn:
+with open(wikipedia_dataset_path, encoding="utf8") as fIn:
     for line in fIn:
         line = line.strip()
         if len(line) >= 10:

--- a/examples/unsupervised_learning/CT_In-Batch_Negatives/train_askubuntu_ct-improved.py
+++ b/examples/unsupervised_learning/CT_In-Batch_Negatives/train_askubuntu_ct-improved.py
@@ -79,7 +79,7 @@ for id, sentence in corpus.items():
     if id not in dev_test_ids:
         train_sentences.append(InputExample(texts=[sentence, sentence]))
 
-logging.info("{} train sentences".format(len(train_sentences)))
+logging.info(f"{len(train_sentences)} train sentences")
 
 ################# Initialize an SBERT model #################
 

--- a/examples/unsupervised_learning/CT_In-Batch_Negatives/train_ct-improved_from_file.py
+++ b/examples/unsupervised_learning/CT_In-Batch_Negatives/train_ct-improved_from_file.py
@@ -33,7 +33,7 @@ max_seq_length = 75
 
 # Input file path (a text file, each line a sentence)
 if len(sys.argv) < 2:
-    print("Run this script with: python {} path/to/sentences.txt".format(sys.argv[0]))
+    print(f"Run this script with: python {sys.argv[0]} path/to/sentences.txt")
     exit()
 
 filepath = sys.argv[1]
@@ -64,7 +64,7 @@ with gzip.open(filepath, "rt", encoding="utf8") if filepath.endswith(".gz") else
             train_sentences.append(line)
 
 
-logging.info("Train sentences: {}".format(len(train_sentences)))
+logging.info(f"Train sentences: {len(train_sentences)}")
 
 # A regular torch DataLoader and as loss we use losses.ContrastiveTensionLossInBatchNegatives
 train_dataloader = DataLoader(train_sentences, batch_size=batch_size, shuffle=True, drop_last=True)
@@ -72,7 +72,7 @@ train_loss = losses.ContrastiveTensionLossInBatchNegatives(model)
 
 
 warmup_steps = math.ceil(len(train_dataloader) * num_epochs * 0.1)  # 10% of train data for warm-up
-logging.info("Warmup-steps: {}".format(warmup_steps))
+logging.info(f"Warmup-steps: {warmup_steps}")
 
 # Train the model
 model.fit(

--- a/examples/unsupervised_learning/CT_In-Batch_Negatives/train_stsb_ct-improved.py
+++ b/examples/unsupervised_learning/CT_In-Batch_Negatives/train_stsb_ct-improved.py
@@ -38,7 +38,7 @@ if not os.path.exists(wikipedia_dataset_path):
 
 # train_sentences are simply your list of sentences
 train_sentences = []
-with open(wikipedia_dataset_path, "r", encoding="utf8") as fIn:
+with open(wikipedia_dataset_path, encoding="utf8") as fIn:
     for line in fIn:
         train_sentences.append(InputExample(texts=[line.strip(), line.strip()]))
 

--- a/examples/unsupervised_learning/MLM/train_mlm.py
+++ b/examples/unsupervised_learning/MLM/train_mlm.py
@@ -49,7 +49,7 @@ print("Save checkpoints to:", output_dir)
 train_sentences = []
 train_path = sys.argv[2]
 with gzip.open(train_path, "rt", encoding="utf8") if train_path.endswith(".gz") else open(
-    train_path, "r", encoding="utf8"
+    train_path, encoding="utf8"
 ) as fIn:
     for line in fIn:
         line = line.strip()
@@ -62,7 +62,7 @@ dev_sentences = []
 if len(sys.argv) >= 4:
     dev_path = sys.argv[3]
     with gzip.open(dev_path, "rt", encoding="utf8") if dev_path.endswith(".gz") else open(
-        dev_path, "r", encoding="utf8"
+        dev_path, encoding="utf8"
     ) as fIn:
         for line in fIn:
             line = line.strip()

--- a/examples/unsupervised_learning/SimCSE/train_askubuntu_simcse.py
+++ b/examples/unsupervised_learning/SimCSE/train_askubuntu_simcse.py
@@ -78,7 +78,7 @@ for id, sentence in corpus.items():
     if id not in dev_test_ids:
         train_sentences.append(InputExample(texts=[sentence, sentence]))
 
-logging.info("{} train sentences".format(len(train_sentences)))
+logging.info(f"{len(train_sentences)} train sentences")
 
 ################# Initialize an SBERT model #################
 

--- a/examples/unsupervised_learning/SimCSE/train_simcse_from_file.py
+++ b/examples/unsupervised_learning/SimCSE/train_simcse_from_file.py
@@ -33,7 +33,7 @@ num_epochs = 1
 
 # Input file path (a text file, each line a sentence)
 if len(sys.argv) < 2:
-    print("Run this script with: python {} path/to/sentences.txt".format(sys.argv[0]))
+    print(f"Run this script with: python {sys.argv[0]} path/to/sentences.txt")
     exit()
 
 filepath = sys.argv[1]
@@ -64,14 +64,14 @@ with gzip.open(filepath, "rt", encoding="utf8") if filepath.endswith(".gz") else
             train_samples.append(InputExample(texts=[line, line]))
 
 
-logging.info("Train sentences: {}".format(len(train_samples)))
+logging.info(f"Train sentences: {len(train_samples)}")
 
 # We train our model using the MultipleNegativesRankingLoss
 train_dataloader = DataLoader(train_samples, shuffle=True, batch_size=train_batch_size, drop_last=True)
 train_loss = losses.MultipleNegativesRankingLoss(model)
 
 warmup_steps = math.ceil(len(train_dataloader) * num_epochs * 0.1)  # 10% of train data for warm-up
-logging.info("Warmup-steps: {}".format(warmup_steps))
+logging.info(f"Warmup-steps: {warmup_steps}")
 
 # Train the model
 model.fit(

--- a/examples/unsupervised_learning/SimCSE/train_stsb_simcse.py
+++ b/examples/unsupervised_learning/SimCSE/train_stsb_simcse.py
@@ -48,7 +48,7 @@ if not os.path.exists(wikipedia_dataset_path):
 
 # train_samples is a list of InputExample objects where we pass the same sentence twice to texts, i.e. texts=[sent, sent]
 train_samples = []
-with open(wikipedia_dataset_path, "r", encoding="utf8") as fIn:
+with open(wikipedia_dataset_path, encoding="utf8") as fIn:
     for line in fIn:
         line = line.strip()
         if len(line) >= 10:
@@ -81,8 +81,8 @@ train_loss = losses.MultipleNegativesRankingLoss(model)
 
 warmup_steps = math.ceil(len(train_dataloader) * num_epochs * 0.1)  # 10% of train data for warm-up
 evaluation_steps = int(len(train_dataloader) * 0.1)  # Evaluate every 10% of the data
-logging.info("Training sentences: {}".format(len(train_samples)))
-logging.info("Warmup-steps: {}".format(warmup_steps))
+logging.info(f"Training sentences: {len(train_samples)}")
+logging.info(f"Warmup-steps: {warmup_steps}")
 logging.info("Performance before training")
 dev_evaluator(model)
 

--- a/examples/unsupervised_learning/TSDAE/train_askubuntu_tsdae.py
+++ b/examples/unsupervised_learning/TSDAE/train_askubuntu_tsdae.py
@@ -72,7 +72,7 @@ for id, sentence in corpus.items():
         train_sentences.append(sentence)
 
 
-logging.info("{} train sentences".format(len(train_sentences)))
+logging.info(f"{len(train_sentences)} train sentences")
 
 ################# Initialize an SBERT model #################
 model_name = sys.argv[1] if len(sys.argv) >= 2 else "bert-base-uncased"

--- a/examples/unsupervised_learning/TSDAE/train_stsb_tsdae.py
+++ b/examples/unsupervised_learning/TSDAE/train_stsb_tsdae.py
@@ -48,7 +48,7 @@ if not os.path.exists(wikipedia_dataset_path):
 
 # train_samples is a list of InputExample objects where we pass the same sentence twice to texts, i.e. texts=[sent, sent]
 train_sentences = []
-with open(wikipedia_dataset_path, "r", encoding="utf8") as fIn:
+with open(wikipedia_dataset_path, encoding="utf8") as fIn:
     for line in fIn:
         line = line.strip()
         if len(line) >= 10:
@@ -82,7 +82,7 @@ train_loss = losses.DenoisingAutoEncoderLoss(model, decoder_name_or_path=model_n
 
 
 evaluation_steps = 1000
-logging.info("Training sentences: {}".format(len(train_sentences)))
+logging.info(f"Training sentences: {len(train_sentences)}")
 logging.info("Performance before training")
 dev_evaluator(model)
 

--- a/examples/unsupervised_learning/TSDAE/train_tsdae_from_file.py
+++ b/examples/unsupervised_learning/TSDAE/train_tsdae_from_file.py
@@ -30,7 +30,7 @@ batch_size = 8
 
 # Input file path (a text file, each line a sentence)
 if len(sys.argv) < 2:
-    print("Run this script with: python {} path/to/sentences.txt".format(sys.argv[0]))
+    print(f"Run this script with: python {sys.argv[0]} path/to/sentences.txt")
     exit()
 
 filepath = sys.argv[1]
@@ -54,7 +54,7 @@ with gzip.open(filepath, "rt", encoding="utf8") if filepath.endswith(".gz") else
             train_sentences.append(line)
 
 
-logging.info("{} train sentences".format(len(train_sentences)))
+logging.info(f"{len(train_sentences)} train sentences")
 
 ################# Initialize an SBERT model #################
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,9 +68,7 @@ ignore = [
     # LineTooLong
     "E501",
     # DoNotAssignLambda
-    "E731",
-    # SuperCallWithParameters
-    "UP008"
+    "E731"
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,13 +62,15 @@ line-length = 119
 fix = true
 
 [tool.ruff.lint]
-select = ["E", "F", "W", "I", "UP006", "UP007"]
+select = ["E", "F", "W", "I", "UP"]
 # Skip `E731` (do not assign a lambda expression, use a def)
 ignore = [
     # LineTooLong
     "E501",
     # DoNotAssignLambda
     "E731",
+    # SuperCallWithParameters
+    "UP008"
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -188,7 +188,7 @@ class SentenceTransformer(nn.Sequential, FitMixin):
 
         if device is None:
             device = get_device_name()
-            logger.info("Use pytorch device_name: {}".format(device))
+            logger.info(f"Use pytorch device_name: {device}")
 
         if device == "hpu" and importlib.util.find_spec("optimum") is not None:
             from optimum.habana.transformers.modeling_utils import adapt_transformers_to_gaudi
@@ -196,7 +196,7 @@ class SentenceTransformer(nn.Sequential, FitMixin):
             adapt_transformers_to_gaudi()
 
         if model_name_or_path is not None and model_name_or_path != "":
-            logger.info("Load pretrained SentenceTransformer: {}".format(model_name_or_path))
+            logger.info(f"Load pretrained SentenceTransformer: {model_name_or_path}")
 
             # Old models that don't belong to any organization
             basic_transformer_models = [
@@ -273,7 +273,7 @@ class SentenceTransformer(nn.Sequential, FitMixin):
             if not os.path.exists(model_name_or_path):
                 # Not a path, load from hub
                 if "\\" in model_name_or_path or model_name_or_path.count("/") > 1:
-                    raise ValueError("Path {} not found".format(model_name_or_path))
+                    raise ValueError(f"Path {model_name_or_path} not found")
 
                 if "/" not in model_name_or_path and model_name_or_path.lower() not in basic_transformer_models:
                     # A model from sentence-transformers
@@ -776,9 +776,9 @@ class SentenceTransformer(nn.Sequential, FitMixin):
         """
         if target_devices is None:
             if torch.cuda.is_available():
-                target_devices = ["cuda:{}".format(i) for i in range(torch.cuda.device_count())]
+                target_devices = [f"cuda:{i}" for i in range(torch.cuda.device_count())]
             elif is_torch_npu_available():
-                target_devices = ["npu:{}".format(i) for i in range(torch.npu.device_count())]
+                target_devices = [f"npu:{i}" for i in range(torch.npu.device_count())]
             else:
                 logger.info("CUDA/NPU is not available. Starting 4 CPU workers")
                 target_devices = ["cpu"] * 4
@@ -924,7 +924,7 @@ class SentenceTransformer(nn.Sequential, FitMixin):
 
     @staticmethod
     def _encode_multi_process_worker(
-        target_device: str, model: "SentenceTransformer", input_queue: Queue, results_queue: Queue
+        target_device: str, model: SentenceTransformer, input_queue: Queue, results_queue: Queue
     ) -> None:
         """
         Internal working process to encode sentences in multi-process setup
@@ -1078,7 +1078,7 @@ class SentenceTransformer(nn.Sequential, FitMixin):
 
         os.makedirs(path, exist_ok=True)
 
-        logger.info("Save model to {}".format(path))
+        logger.info(f"Save model to {path}")
         modules_config = []
 
         # Save some model info
@@ -1583,7 +1583,7 @@ class SentenceTransformer(nn.Sequential, FitMixin):
         return modules
 
     @staticmethod
-    def load(input_path) -> "SentenceTransformer":
+    def load(input_path) -> SentenceTransformer:
         return SentenceTransformer(input_path)
 
     @property

--- a/sentence_transformers/cross_encoder/CrossEncoder.py
+++ b/sentence_transformers/cross_encoder/CrossEncoder.py
@@ -109,7 +109,7 @@ class CrossEncoder(PushToHubMixin):
 
         if device is None:
             device = get_device_name()
-            logger.info("Use pytorch device: {}".format(device))
+            logger.info(f"Use pytorch device: {device}")
 
         self._target_device = torch.device(device)
 
@@ -118,9 +118,7 @@ class CrossEncoder(PushToHubMixin):
             try:
                 self.config.sbert_ce_default_activation_function = fullname(self.default_activation_function)
             except Exception as e:
-                logger.warning(
-                    "Was not able to update config about the default_activation_function: {}".format(str(e))
-                )
+                logger.warning(f"Was not able to update config about the default_activation_function: {str(e)}")
         elif (
             hasattr(self.config, "sbert_ce_default_activation_function")
             and self.config.sbert_ce_default_activation_function is not None
@@ -559,7 +557,7 @@ class CrossEncoder(PushToHubMixin):
         if path is None:
             return
 
-        logger.info("Save model to {}".format(path))
+        logger.info(f"Save model to {path}")
         self.model.save_pretrained(path, safe_serialization=safe_serialization, **kwargs)
         self.tokenizer.save_pretrained(path, **kwargs)
 

--- a/sentence_transformers/cross_encoder/evaluation/CEBinaryAccuracyEvaluator.py
+++ b/sentence_transformers/cross_encoder/evaluation/CEBinaryAccuracyEvaluator.py
@@ -51,9 +51,9 @@ class CEBinaryAccuracyEvaluator:
     def __call__(self, model, output_path: str = None, epoch: int = -1, steps: int = -1) -> float:
         if epoch != -1:
             if steps == -1:
-                out_txt = " after epoch {}:".format(epoch)
+                out_txt = f" after epoch {epoch}:"
             else:
-                out_txt = " in epoch {} after {} steps:".format(epoch, steps)
+                out_txt = f" in epoch {epoch} after {steps} steps:"
         else:
             out_txt = ":"
 
@@ -65,7 +65,7 @@ class CEBinaryAccuracyEvaluator:
 
         acc = np.sum(pred_labels == self.labels) / len(self.labels)
 
-        logger.info("Accuracy: {:.2f}".format(acc * 100))
+        logger.info(f"Accuracy: {acc * 100:.2f}")
 
         if output_path is not None and self.write_csv:
             csv_path = os.path.join(output_path, self.csv_file)

--- a/sentence_transformers/cross_encoder/evaluation/CEBinaryClassificationEvaluator.py
+++ b/sentence_transformers/cross_encoder/evaluation/CEBinaryClassificationEvaluator.py
@@ -68,9 +68,9 @@ class CEBinaryClassificationEvaluator:
     def __call__(self, model, output_path: str = None, epoch: int = -1, steps: int = -1) -> float:
         if epoch != -1:
             if steps == -1:
-                out_txt = " after epoch {}:".format(epoch)
+                out_txt = f" after epoch {epoch}:"
             else:
-                out_txt = " in epoch {} after {} steps:".format(epoch, steps)
+                out_txt = f" in epoch {epoch} after {steps} steps:"
         else:
             out_txt = ":"
 
@@ -85,11 +85,11 @@ class CEBinaryClassificationEvaluator:
         )
         ap = average_precision_score(self.labels, pred_scores)
 
-        logger.info("Accuracy:           {:.2f}\t(Threshold: {:.4f})".format(acc * 100, acc_threshold))
-        logger.info("F1:                 {:.2f}\t(Threshold: {:.4f})".format(f1 * 100, f1_threshold))
-        logger.info("Precision:          {:.2f}".format(precision * 100))
-        logger.info("Recall:             {:.2f}".format(recall * 100))
-        logger.info("Average Precision:  {:.2f}\n".format(ap * 100))
+        logger.info(f"Accuracy:           {acc * 100:.2f}\t(Threshold: {acc_threshold:.4f})")
+        logger.info(f"F1:                 {f1 * 100:.2f}\t(Threshold: {f1_threshold:.4f})")
+        logger.info(f"Precision:          {precision * 100:.2f}")
+        logger.info(f"Recall:             {recall * 100:.2f}")
+        logger.info(f"Average Precision:  {ap * 100:.2f}\n")
 
         if output_path is not None and self.write_csv:
             csv_path = os.path.join(output_path, self.csv_file)

--- a/sentence_transformers/cross_encoder/evaluation/CECorrelationEvaluator.py
+++ b/sentence_transformers/cross_encoder/evaluation/CECorrelationEvaluator.py
@@ -40,9 +40,9 @@ class CECorrelationEvaluator:
     def __call__(self, model, output_path: str = None, epoch: int = -1, steps: int = -1) -> float:
         if epoch != -1:
             if steps == -1:
-                out_txt = " after epoch {}:".format(epoch)
+                out_txt = f" after epoch {epoch}:"
             else:
-                out_txt = " in epoch {} after {} steps:".format(epoch, steps)
+                out_txt = f" in epoch {epoch} after {steps} steps:"
         else:
             out_txt = ":"
 
@@ -52,7 +52,7 @@ class CECorrelationEvaluator:
         eval_pearson, _ = pearsonr(self.scores, pred_scores)
         eval_spearman, _ = spearmanr(self.scores, pred_scores)
 
-        logger.info("Correlation:\tPearson: {:.4f}\tSpearman: {:.4f}".format(eval_pearson, eval_spearman))
+        logger.info(f"Correlation:\tPearson: {eval_pearson:.4f}\tSpearman: {eval_spearman:.4f}")
 
         if output_path is not None and self.write_csv:
             csv_path = os.path.join(output_path, self.csv_file)

--- a/sentence_transformers/cross_encoder/evaluation/CERerankingEvaluator.py
+++ b/sentence_transformers/cross_encoder/evaluation/CERerankingEvaluator.py
@@ -39,17 +39,17 @@ class CERerankingEvaluator:
         self.csv_headers = [
             "epoch",
             "steps",
-            "MRR@{}".format(self.at_k),
-            "NDCG@{}".format(self.at_k),
+            f"MRR@{self.at_k}",
+            f"NDCG@{self.at_k}",
         ]
         self.write_csv = write_csv
 
     def __call__(self, model, output_path: str = None, epoch: int = -1, steps: int = -1) -> float:
         if epoch != -1:
             if steps == -1:
-                out_txt = " after epoch {}:".format(epoch)
+                out_txt = f" after epoch {epoch}:"
             else:
-                out_txt = " in epoch {} after {} steps:".format(epoch, steps)
+                out_txt = f" in epoch {epoch} after {steps} steps:"
         else:
             out_txt = ":"
 
@@ -91,18 +91,10 @@ class CERerankingEvaluator:
         mean_ndcg = np.mean(all_ndcg_scores)
 
         logger.info(
-            "Queries: {} \t Positives: Min {:.1f}, Mean {:.1f}, Max {:.1f} \t Negatives: Min {:.1f}, Mean {:.1f}, Max {:.1f}".format(
-                num_queries,
-                np.min(num_positives),
-                np.mean(num_positives),
-                np.max(num_positives),
-                np.min(num_negatives),
-                np.mean(num_negatives),
-                np.max(num_negatives),
-            )
+            f"Queries: {num_queries} \t Positives: Min {np.min(num_positives):.1f}, Mean {np.mean(num_positives):.1f}, Max {np.max(num_positives):.1f} \t Negatives: Min {np.min(num_negatives):.1f}, Mean {np.mean(num_negatives):.1f}, Max {np.max(num_negatives):.1f}"
         )
-        logger.info("MRR@{}: {:.2f}".format(self.at_k, mean_mrr * 100))
-        logger.info("NDCG@{}: {:.2f}".format(self.at_k, mean_ndcg * 100))
+        logger.info(f"MRR@{self.at_k}: {mean_mrr * 100:.2f}")
+        logger.info(f"NDCG@{self.at_k}: {mean_ndcg * 100:.2f}")
 
         if output_path is not None and self.write_csv:
             csv_path = os.path.join(output_path, self.csv_file)

--- a/sentence_transformers/cross_encoder/evaluation/CESoftmaxAccuracyEvaluator.py
+++ b/sentence_transformers/cross_encoder/evaluation/CESoftmaxAccuracyEvaluator.py
@@ -41,9 +41,9 @@ class CESoftmaxAccuracyEvaluator:
     def __call__(self, model, output_path: str = None, epoch: int = -1, steps: int = -1) -> float:
         if epoch != -1:
             if steps == -1:
-                out_txt = " after epoch {}:".format(epoch)
+                out_txt = f" after epoch {epoch}:"
             else:
-                out_txt = " in epoch {} after {} steps:".format(epoch, steps)
+                out_txt = f" in epoch {epoch} after {steps} steps:"
         else:
             out_txt = ":"
 
@@ -55,7 +55,7 @@ class CESoftmaxAccuracyEvaluator:
 
         acc = np.sum(pred_labels == self.labels) / len(self.labels)
 
-        logger.info("Accuracy: {:.2f}".format(acc * 100))
+        logger.info(f"Accuracy: {acc * 100:.2f}")
 
         if output_path is not None and self.write_csv:
             csv_path = os.path.join(output_path, self.csv_file)

--- a/sentence_transformers/datasets/SentenceLabelDataset.py
+++ b/sentence_transformers/datasets/SentenceLabelDataset.py
@@ -65,9 +65,7 @@ class SentenceLabelDataset(IterableDataset):
         np.random.shuffle(self.label_range)
 
         logger.info(
-            "SentenceLabelDataset: {} examples, from which {} examples could be used (those labels appeared at least {} times). {} different labels found.".format(
-                len(examples), len(self.grouped_inputs), self.samples_per_label, num_labels
-            )
+            f"SentenceLabelDataset: {len(examples)} examples, from which {len(self.grouped_inputs)} examples could be used (those labels appeared at least {self.samples_per_label} times). {num_labels} different labels found."
         )
 
     def __iter__(self):

--- a/sentence_transformers/evaluation/BinaryClassificationEvaluator.py
+++ b/sentence_transformers/evaluation/BinaryClassificationEvaluator.py
@@ -154,7 +154,7 @@ class BinaryClassificationEvaluator(SentenceEvaluator):
         return cls(sentences1, sentences2, scores, **kwargs)
 
     def __call__(
-        self, model: "SentenceTransformer", output_path: str = None, epoch: int = -1, steps: int = -1
+        self, model: SentenceTransformer, output_path: str = None, epoch: int = -1, steps: int = -1
     ) -> dict[str, float]:
         """
         Compute the evaluation metrics for the given model.
@@ -260,13 +260,11 @@ class BinaryClassificationEvaluator(SentenceEvaluator):
             f1, precision, recall, f1_threshold = self.find_best_f1_and_threshold(scores, labels, reverse)
             ap = average_precision_score(labels, scores * (1 if reverse else -1))
 
-            logger.info(
-                "Accuracy with {}:           {:.2f}\t(Threshold: {:.4f})".format(name, acc * 100, acc_threshold)
-            )
-            logger.info("F1 with {}:                 {:.2f}\t(Threshold: {:.4f})".format(name, f1 * 100, f1_threshold))
-            logger.info("Precision with {}:          {:.2f}".format(name, precision * 100))
-            logger.info("Recall with {}:             {:.2f}".format(name, recall * 100))
-            logger.info("Average Precision with {}:  {:.2f}\n".format(name, ap * 100))
+            logger.info(f"Accuracy with {name}:           {acc * 100:.2f}\t(Threshold: {acc_threshold:.4f})")
+            logger.info(f"F1 with {name}:                 {f1 * 100:.2f}\t(Threshold: {f1_threshold:.4f})")
+            logger.info(f"Precision with {name}:          {precision * 100:.2f}")
+            logger.info(f"Recall with {name}:             {recall * 100:.2f}")
+            logger.info(f"Average Precision with {name}:  {ap * 100:.2f}\n")
 
             output_scores[short_name] = {
                 "accuracy": acc,

--- a/sentence_transformers/evaluation/EmbeddingSimilarityEvaluator.py
+++ b/sentence_transformers/evaluation/EmbeddingSimilarityEvaluator.py
@@ -143,7 +143,7 @@ class EmbeddingSimilarityEvaluator(SentenceEvaluator):
         return cls(sentences1, sentences2, scores, **kwargs)
 
     def __call__(
-        self, model: "SentenceTransformer", output_path: str = None, epoch: int = -1, steps: int = -1
+        self, model: SentenceTransformer, output_path: str = None, epoch: int = -1, steps: int = -1
     ) -> dict[str, float]:
         if epoch != -1:
             if steps == -1:
@@ -201,22 +201,14 @@ class EmbeddingSimilarityEvaluator(SentenceEvaluator):
         eval_pearson_dot, _ = pearsonr(labels, dot_products)
         eval_spearman_dot, _ = spearmanr(labels, dot_products)
 
+        logger.info(f"Cosine-Similarity :\tPearson: {eval_pearson_cosine:.4f}\tSpearman: {eval_spearman_cosine:.4f}")
         logger.info(
-            "Cosine-Similarity :\tPearson: {:.4f}\tSpearman: {:.4f}".format(eval_pearson_cosine, eval_spearman_cosine)
+            f"Manhattan-Distance:\tPearson: {eval_pearson_manhattan:.4f}\tSpearman: {eval_spearman_manhattan:.4f}"
         )
         logger.info(
-            "Manhattan-Distance:\tPearson: {:.4f}\tSpearman: {:.4f}".format(
-                eval_pearson_manhattan, eval_spearman_manhattan
-            )
+            f"Euclidean-Distance:\tPearson: {eval_pearson_euclidean:.4f}\tSpearman: {eval_spearman_euclidean:.4f}"
         )
-        logger.info(
-            "Euclidean-Distance:\tPearson: {:.4f}\tSpearman: {:.4f}".format(
-                eval_pearson_euclidean, eval_spearman_euclidean
-            )
-        )
-        logger.info(
-            "Dot-Product-Similarity:\tPearson: {:.4f}\tSpearman: {:.4f}".format(eval_pearson_dot, eval_spearman_dot)
-        )
+        logger.info(f"Dot-Product-Similarity:\tPearson: {eval_pearson_dot:.4f}\tSpearman: {eval_spearman_dot:.4f}")
 
         if output_path is not None and self.write_csv:
             csv_path = os.path.join(output_path, self.csv_file)

--- a/sentence_transformers/evaluation/InformationRetrievalEvaluator.py
+++ b/sentence_transformers/evaluation/InformationRetrievalEvaluator.py
@@ -191,23 +191,23 @@ class InformationRetrievalEvaluator(SentenceEvaluator):
 
         for score_name in self.score_function_names:
             for k in accuracy_at_k:
-                self.csv_headers.append("{}-Accuracy@{}".format(score_name, k))
+                self.csv_headers.append(f"{score_name}-Accuracy@{k}")
 
             for k in precision_recall_at_k:
-                self.csv_headers.append("{}-Precision@{}".format(score_name, k))
-                self.csv_headers.append("{}-Recall@{}".format(score_name, k))
+                self.csv_headers.append(f"{score_name}-Precision@{k}")
+                self.csv_headers.append(f"{score_name}-Recall@{k}")
 
             for k in mrr_at_k:
-                self.csv_headers.append("{}-MRR@{}".format(score_name, k))
+                self.csv_headers.append(f"{score_name}-MRR@{k}")
 
             for k in ndcg_at_k:
-                self.csv_headers.append("{}-NDCG@{}".format(score_name, k))
+                self.csv_headers.append(f"{score_name}-NDCG@{k}")
 
             for k in map_at_k:
-                self.csv_headers.append("{}-MAP@{}".format(score_name, k))
+                self.csv_headers.append(f"{score_name}-MAP@{k}")
 
     def __call__(
-        self, model: "SentenceTransformer", output_path: str = None, epoch: int = -1, steps: int = -1, *args, **kwargs
+        self, model: SentenceTransformer, output_path: str = None, epoch: int = -1, steps: int = -1, *args, **kwargs
     ) -> dict[str, float]:
         if epoch != -1:
             if steps == -1:
@@ -277,7 +277,7 @@ class InformationRetrievalEvaluator(SentenceEvaluator):
         return metrics
 
     def compute_metrices(
-        self, model: "SentenceTransformer", corpus_model=None, corpus_embeddings: Tensor = None
+        self, model: SentenceTransformer, corpus_model=None, corpus_embeddings: Tensor = None
     ) -> dict[str, float]:
         if corpus_model is None:
             corpus_model = model
@@ -352,15 +352,15 @@ class InformationRetrievalEvaluator(SentenceEvaluator):
                     score, corpus_id = queries_result_list[name][query_itr][doc_itr]
                     queries_result_list[name][query_itr][doc_itr] = {"corpus_id": corpus_id, "score": score}
 
-        logger.info("Queries: {}".format(len(self.queries)))
-        logger.info("Corpus: {}\n".format(len(self.corpus)))
+        logger.info(f"Queries: {len(self.queries)}")
+        logger.info(f"Corpus: {len(self.corpus)}\n")
 
         # Compute scores
         scores = {name: self.compute_metrics(queries_result_list[name]) for name in self.score_functions}
 
         # Output
         for name in self.score_function_names:
-            logger.info("Score-Function: {}".format(name))
+            logger.info(f"Score-Function: {name}")
             self.output_scores(scores[name])
 
         return scores

--- a/sentence_transformers/evaluation/LabelAccuracyEvaluator.py
+++ b/sentence_transformers/evaluation/LabelAccuracyEvaluator.py
@@ -47,7 +47,7 @@ class LabelAccuracyEvaluator(SentenceEvaluator):
         self.primary_metric = "accuracy"
 
     def __call__(
-        self, model: "SentenceTransformer", output_path: str = None, epoch: int = -1, steps: int = -1
+        self, model: SentenceTransformer, output_path: str = None, epoch: int = -1, steps: int = -1
     ) -> dict[str, float]:
         model.eval()
         total = 0
@@ -55,9 +55,9 @@ class LabelAccuracyEvaluator(SentenceEvaluator):
 
         if epoch != -1:
             if steps == -1:
-                out_txt = " after epoch {}:".format(epoch)
+                out_txt = f" after epoch {epoch}:"
             else:
-                out_txt = " in epoch {} after {} steps:".format(epoch, steps)
+                out_txt = f" in epoch {epoch} after {steps} steps:"
         else:
             out_txt = ":"
 
@@ -75,7 +75,7 @@ class LabelAccuracyEvaluator(SentenceEvaluator):
             correct += torch.argmax(prediction, dim=1).eq(label_ids).sum().item()
         accuracy = correct / total
 
-        logger.info("Accuracy: {:.4f} ({}/{})\n".format(accuracy, correct, total))
+        logger.info(f"Accuracy: {accuracy:.4f} ({correct}/{total})\n")
 
         if output_path is not None and self.write_csv:
             csv_path = os.path.join(output_path, self.csv_file)

--- a/sentence_transformers/evaluation/MSEEvaluator.py
+++ b/sentence_transformers/evaluation/MSEEvaluator.py
@@ -98,7 +98,7 @@ class MSEEvaluator(SentenceEvaluator):
         self.write_csv = write_csv
         self.primary_metric = "negative_mse"
 
-    def __call__(self, model: "SentenceTransformer", output_path: str = None, epoch=-1, steps=-1) -> dict[str, float]:
+    def __call__(self, model: SentenceTransformer, output_path: str = None, epoch=-1, steps=-1) -> dict[str, float]:
         if epoch != -1:
             if steps == -1:
                 out_txt = f" after epoch {epoch}"
@@ -121,7 +121,7 @@ class MSEEvaluator(SentenceEvaluator):
         mse *= 100
 
         logger.info(f"MSE evaluation (lower = better) on the {self.name} dataset{out_txt}:")
-        logger.info("MSE (*100):\t{:4f}".format(mse))
+        logger.info(f"MSE (*100):\t{mse:4f}")
 
         if output_path is not None and self.write_csv:
             csv_path = os.path.join(output_path, self.csv_file)

--- a/sentence_transformers/evaluation/MSEEvaluatorFromDataFrame.py
+++ b/sentence_transformers/evaluation/MSEEvaluatorFromDataFrame.py
@@ -41,7 +41,7 @@ class MSEEvaluatorFromDataFrame(SentenceEvaluator):
     def __init__(
         self,
         dataframe: list[dict[str, str]],
-        teacher_model: "SentenceTransformer",
+        teacher_model: SentenceTransformer,
         combinations: list[tuple[str, str]],
         batch_size: int = 8,
         name: str = "",
@@ -76,7 +76,7 @@ class MSEEvaluatorFromDataFrame(SentenceEvaluator):
                     trg_sentences.append(row[trg_lang])
 
             self.data[(src_lang, trg_lang)] = (src_sentences, trg_sentences)
-            self.csv_headers.append("{}-{}".format(src_lang, trg_lang))
+            self.csv_headers.append(f"{src_lang}-{trg_lang}")
 
         all_source_sentences = list(all_source_sentences)
         with nullcontext() if self.truncate_dim is None else teacher_model.truncate_sentence_embeddings(
@@ -86,7 +86,7 @@ class MSEEvaluatorFromDataFrame(SentenceEvaluator):
         self.teacher_embeddings = {sent: emb for sent, emb in zip(all_source_sentences, all_src_embeddings)}
 
     def __call__(
-        self, model: "SentenceTransformer", output_path: str = None, epoch: int = -1, steps: int = -1
+        self, model: SentenceTransformer, output_path: str = None, epoch: int = -1, steps: int = -1
     ) -> dict[str, float]:
         model.eval()
 
@@ -102,8 +102,8 @@ class MSEEvaluatorFromDataFrame(SentenceEvaluator):
             mse *= 100
             mse_scores.append(mse)
 
-            logger.info("MSE evaluation on {} dataset - {}-{}:".format(self.name, src_lang, trg_lang))
-            logger.info("MSE (*100):\t{:4f}".format(mse))
+            logger.info(f"MSE evaluation on {self.name} dataset - {src_lang}-{trg_lang}:")
+            logger.info(f"MSE (*100):\t{mse:4f}")
 
         if output_path is not None and self.write_csv:
             csv_path = os.path.join(output_path, self.csv_file)

--- a/sentence_transformers/evaluation/ParaphraseMiningEvaluator.py
+++ b/sentence_transformers/evaluation/ParaphraseMiningEvaluator.py
@@ -158,7 +158,7 @@ class ParaphraseMiningEvaluator(SentenceEvaluator):
         self.primary_metric = "average_precision"
 
     def __call__(
-        self, model: "SentenceTransformer", output_path: str = None, epoch: int = -1, steps: int = -1
+        self, model: SentenceTransformer, output_path: str = None, epoch: int = -1, steps: int = -1
     ) -> dict[str, float]:
         if epoch != -1:
             if steps == -1:
@@ -215,11 +215,11 @@ class ParaphraseMiningEvaluator(SentenceEvaluator):
 
         average_precision = average_precision / self.total_num_duplicates
 
-        logger.info("Average Precision: {:.2f}".format(average_precision * 100))
-        logger.info("Optimal threshold: {:.4f}".format(threshold))
-        logger.info("Precision: {:.2f}".format(best_precision * 100))
-        logger.info("Recall: {:.2f}".format(best_recall * 100))
-        logger.info("F1: {:.2f}\n".format(best_f1 * 100))
+        logger.info(f"Average Precision: {average_precision * 100:.2f}")
+        logger.info(f"Optimal threshold: {threshold:.4f}")
+        logger.info(f"Precision: {best_precision * 100:.2f}")
+        logger.info(f"Recall: {best_recall * 100:.2f}")
+        logger.info(f"F1: {best_f1 * 100:.2f}\n")
 
         if output_path is not None and self.write_csv:
             csv_path = os.path.join(output_path, self.csv_file)

--- a/sentence_transformers/evaluation/RerankingEvaluator.py
+++ b/sentence_transformers/evaluation/RerankingEvaluator.py
@@ -85,14 +85,14 @@ class RerankingEvaluator(SentenceEvaluator):
             "epoch",
             "steps",
             "MAP",
-            "MRR@{}".format(self.at_k),
-            "NDCG@{}".format(self.at_k),
+            f"MRR@{self.at_k}",
+            f"NDCG@{self.at_k}",
         ]
         self.write_csv = write_csv
         self.primary_metric = "map"
 
     def __call__(
-        self, model: "SentenceTransformer", output_path: str = None, epoch: int = -1, steps: int = -1
+        self, model: SentenceTransformer, output_path: str = None, epoch: int = -1, steps: int = -1
     ) -> dict[str, float]:
         """
         Evaluates the model on the dataset and returns the evaluation metrics.
@@ -128,19 +128,11 @@ class RerankingEvaluator(SentenceEvaluator):
         num_negatives = [len(sample["negative"]) for sample in self.samples]
 
         logger.info(
-            "Queries: {} \t Positives: Min {:.1f}, Mean {:.1f}, Max {:.1f} \t Negatives: Min {:.1f}, Mean {:.1f}, Max {:.1f}".format(
-                len(self.samples),
-                np.min(num_positives),
-                np.mean(num_positives),
-                np.max(num_positives),
-                np.min(num_negatives),
-                np.mean(num_negatives),
-                np.max(num_negatives),
-            )
+            f"Queries: {len(self.samples)} \t Positives: Min {np.min(num_positives):.1f}, Mean {np.mean(num_positives):.1f}, Max {np.max(num_positives):.1f} \t Negatives: Min {np.min(num_negatives):.1f}, Mean {np.mean(num_negatives):.1f}, Max {np.max(num_negatives):.1f}"
         )
-        logger.info("MAP: {:.2f}".format(mean_ap * 100))
-        logger.info("MRR@{}: {:.2f}".format(self.at_k, mean_mrr * 100))
-        logger.info("NDCG@{}: {:.2f}".format(self.at_k, mean_ndcg * 100))
+        logger.info(f"MAP: {mean_ap * 100:.2f}")
+        logger.info(f"MRR@{self.at_k}: {mean_mrr * 100:.2f}")
+        logger.info(f"NDCG@{self.at_k}: {mean_ndcg * 100:.2f}")
 
         #### Write results to disc
         if output_path is not None and self.write_csv:

--- a/sentence_transformers/evaluation/SentenceEvaluator.py
+++ b/sentence_transformers/evaluation/SentenceEvaluator.py
@@ -28,7 +28,7 @@ class SentenceEvaluator:
         self.primary_metric = None
 
     def __call__(
-        self, model: "SentenceTransformer", output_path: str = None, epoch: int = -1, steps: int = -1
+        self, model: SentenceTransformer, output_path: str = None, epoch: int = -1, steps: int = -1
     ) -> float | dict[str, float]:
         """
         This is called during training to evaluate the model.
@@ -62,7 +62,7 @@ class SentenceEvaluator:
             self.primary_metric = name + "_" + self.primary_metric
         return metrics
 
-    def store_metrics_in_model_card_data(self, model: "SentenceTransformer", metrics: dict[str, Any]) -> None:
+    def store_metrics_in_model_card_data(self, model: SentenceTransformer, metrics: dict[str, Any]) -> None:
         model.model_card_data.set_evaluation_metrics(self, metrics)
 
     @property

--- a/sentence_transformers/evaluation/SequentialEvaluator.py
+++ b/sentence_transformers/evaluation/SequentialEvaluator.py
@@ -38,7 +38,7 @@ class SequentialEvaluator(SentenceEvaluator):
         self.main_score_function = main_score_function
 
     def __call__(
-        self, model: "SentenceTransformer", output_path: str = None, epoch: int = -1, steps: int = -1
+        self, model: SentenceTransformer, output_path: str = None, epoch: int = -1, steps: int = -1
     ) -> dict[str, float]:
         evaluations = []
         scores = []

--- a/sentence_transformers/evaluation/TranslationEvaluator.py
+++ b/sentence_transformers/evaluation/TranslationEvaluator.py
@@ -102,7 +102,7 @@ class TranslationEvaluator(SentenceEvaluator):
         self.primary_metric = "mean_accuracy"
 
     def __call__(
-        self, model: "SentenceTransformer", output_path: str = None, epoch: int = -1, steps: int = -1
+        self, model: SentenceTransformer, output_path: str = None, epoch: int = -1, steps: int = -1
     ) -> dict[str, float]:
         if epoch != -1:
             if steps == -1:
@@ -164,8 +164,8 @@ class TranslationEvaluator(SentenceEvaluator):
         acc_src2trg = correct_src2trg / len(cos_sims)
         acc_trg2src = correct_trg2src / len(cos_sims)
 
-        logger.info("Accuracy src2trg: {:.2f}".format(acc_src2trg * 100))
-        logger.info("Accuracy trg2src: {:.2f}".format(acc_trg2src * 100))
+        logger.info(f"Accuracy src2trg: {acc_src2trg * 100:.2f}")
+        logger.info(f"Accuracy trg2src: {acc_trg2src * 100:.2f}")
 
         if output_path is not None and self.write_csv:
             csv_path = os.path.join(output_path, self.csv_file)

--- a/sentence_transformers/evaluation/TripletEvaluator.py
+++ b/sentence_transformers/evaluation/TripletEvaluator.py
@@ -123,7 +123,7 @@ class TripletEvaluator(SentenceEvaluator):
         return cls(anchors, positives, negatives, **kwargs)
 
     def __call__(
-        self, model: "SentenceTransformer", output_path: str = None, epoch: int = -1, steps: int = -1
+        self, model: SentenceTransformer, output_path: str = None, epoch: int = -1, steps: int = -1
     ) -> dict[str, float]:
         if epoch != -1:
             if steps == -1:
@@ -201,10 +201,10 @@ class TripletEvaluator(SentenceEvaluator):
         accuracy_manhattan = num_correct_manhattan_triplets / num_triplets
         accuracy_euclidean = num_correct_euclidean_triplets / num_triplets
 
-        logger.info("Accuracy Cosine Distance:   \t{:.2f}".format(accuracy_cos * 100))
-        logger.info("Accuracy Dot Product:       \t{:.2f}".format(accuracy_dot * 100))
-        logger.info("Accuracy Manhattan Distance:\t{:.2f}".format(accuracy_manhattan * 100))
-        logger.info("Accuracy Euclidean Distance:\t{:.2f}\n".format(accuracy_euclidean * 100))
+        logger.info(f"Accuracy Cosine Distance:   \t{accuracy_cos * 100:.2f}")
+        logger.info(f"Accuracy Dot Product:       \t{accuracy_dot * 100:.2f}")
+        logger.info(f"Accuracy Manhattan Distance:\t{accuracy_manhattan * 100:.2f}")
+        logger.info(f"Accuracy Euclidean Distance:\t{accuracy_euclidean * 100:.2f}\n")
 
         if output_path is not None and self.write_csv:
             csv_path = os.path.join(output_path, self.csv_file)

--- a/sentence_transformers/fit_mixin.py
+++ b/sentence_transformers/fit_mixin.py
@@ -69,7 +69,7 @@ class SaveModelCallback(TrainerCallback):
         state: TrainerState,
         control: TrainerControl,
         metrics: dict[str, Any],
-        model: "SentenceTransformer",
+        model: SentenceTransformer,
         **kwargs,
     ) -> None:
         if self.evaluator is not None and self.save_best_model:
@@ -85,7 +85,7 @@ class SaveModelCallback(TrainerCallback):
         args: SentenceTransformerTrainingArguments,
         state: TrainerState,
         control: TrainerControl,
-        model: "SentenceTransformer",
+        model: SentenceTransformer,
         **kwargs,
     ) -> None:
         if self.evaluator is None:
@@ -110,7 +110,7 @@ class EvaluatorCallback(TrainerCallback):
         args: SentenceTransformerTrainingArguments,
         state: TrainerState,
         control: TrainerControl,
-        model: "SentenceTransformer",
+        model: SentenceTransformer,
         **kwargs,
     ) -> None:
         evaluator_metrics = self.evaluator(model, epoch=state.epoch)
@@ -402,9 +402,9 @@ class FitMixin:
                 optimizer, num_warmup_steps=warmup_steps, num_training_steps=t_total
             )
         else:
-            raise ValueError("Unknown scheduler {}".format(scheduler))
+            raise ValueError(f"Unknown scheduler {scheduler}")
 
-    def smart_batching_collate(self, batch: list["InputExample"]) -> tuple[list[dict[str, Tensor]], Tensor]:
+    def smart_batching_collate(self, batch: list[InputExample]) -> tuple[list[dict[str, Tensor]], Tensor]:
         """
         Transforms a batch from a SmartBatchingDataset to a batch of tensors for the model
         Here, batch is a list of InputExample instances: [InputExample(...), ...]

--- a/sentence_transformers/losses/BatchAllTripletLoss.py
+++ b/sentence_transformers/losses/BatchAllTripletLoss.py
@@ -80,7 +80,7 @@ class BatchAllTripletLoss(nn.Module):
                 trainer.train()
 
         """
-        super(BatchAllTripletLoss, self).__init__()
+        super().__init__()
         self.sentence_embedder = model
         self.triplet_margin = margin
         self.distance_metric = distance_metric

--- a/sentence_transformers/losses/BatchHardSoftMarginTripletLoss.py
+++ b/sentence_transformers/losses/BatchHardSoftMarginTripletLoss.py
@@ -81,7 +81,7 @@ class BatchHardSoftMarginTripletLoss(BatchHardTripletLoss):
                 )
                 trainer.train()
         """
-        super(BatchHardSoftMarginTripletLoss, self).__init__(model)
+        super().__init__(model)
         self.sentence_embedder = model
         self.distance_metric = distance_metric
 

--- a/sentence_transformers/losses/BatchHardTripletLoss.py
+++ b/sentence_transformers/losses/BatchHardTripletLoss.py
@@ -134,7 +134,7 @@ class BatchHardTripletLoss(nn.Module):
                 )
                 trainer.train()
         """
-        super(BatchHardTripletLoss, self).__init__()
+        super().__init__()
         self.sentence_embedder = model
         self.triplet_margin = margin
         self.distance_metric = distance_metric

--- a/sentence_transformers/losses/BatchSemiHardTripletLoss.py
+++ b/sentence_transformers/losses/BatchSemiHardTripletLoss.py
@@ -90,7 +90,7 @@ class BatchSemiHardTripletLoss(nn.Module):
                 )
                 trainer.train()
         """
-        super(BatchSemiHardTripletLoss, self).__init__()
+        super().__init__()
         self.sentence_embedder = model
         self.margin = margin
         self.distance_metric = distance_metric

--- a/sentence_transformers/losses/CachedGISTEmbedLoss.py
+++ b/sentence_transformers/losses/CachedGISTEmbedLoss.py
@@ -132,7 +132,7 @@ class CachedGISTEmbedLoss(nn.Module):
                 )
                 trainer.train()
         """
-        super(CachedGISTEmbedLoss, self).__init__()
+        super().__init__()
         self.model = model
         self.guide = guide
         self.temperature = temperature

--- a/sentence_transformers/losses/CachedGISTEmbedLoss.py
+++ b/sentence_transformers/losses/CachedGISTEmbedLoss.py
@@ -226,7 +226,7 @@ class CachedGISTEmbedLoss(nn.Module):
             anchor, positive, negative = reps
             anchor_guide, positive_guide, negative_guide = reps_guided
         else:
-            raise ValueError("Expected 2 or 3 embeddings, got {}".format(len(reps)))
+            raise ValueError(f"Expected 2 or 3 embeddings, got {len(reps)}")
 
         anchor = torch.cat(anchor, dim=0)
         positive = torch.cat(positive, dim=0)
@@ -300,7 +300,7 @@ class CachedGISTEmbedLoss(nn.Module):
             anchor, positive, negative = reps
             anchor_guide, positive_guide, negative_guide = reps_guided
         else:
-            raise ValueError("Expected 2 or 3 embeddings, got {}".format(len(reps)))
+            raise ValueError(f"Expected 2 or 3 embeddings, got {len(reps)}")
 
         anchor = torch.cat(anchor, dim=0)
         positive = torch.cat(positive, dim=0)

--- a/sentence_transformers/losses/CachedMultipleNegativesRankingLoss.py
+++ b/sentence_transformers/losses/CachedMultipleNegativesRankingLoss.py
@@ -138,7 +138,7 @@ class CachedMultipleNegativesRankingLoss(nn.Module):
                 )
                 trainer.train()
         """
-        super(CachedMultipleNegativesRankingLoss, self).__init__()
+        super().__init__()
         self.model = model
         self.scale = scale
         self.similarity_fct = similarity_fct

--- a/sentence_transformers/losses/CoSENTLoss.py
+++ b/sentence_transformers/losses/CoSENTLoss.py
@@ -72,7 +72,7 @@ class CoSENTLoss(nn.Module):
                 )
                 trainer.train()
         """
-        super(CoSENTLoss, self).__init__()
+        super().__init__()
         self.model = model
         self.similarity_fct = similarity_fct
         self.scale = scale

--- a/sentence_transformers/losses/ContrastiveLoss.py
+++ b/sentence_transformers/losses/ContrastiveLoss.py
@@ -77,7 +77,7 @@ class ContrastiveLoss(nn.Module):
                 )
                 trainer.train()
         """
-        super(ContrastiveLoss, self).__init__()
+        super().__init__()
         self.distance_metric = distance_metric
         self.margin = margin
         self.model = model

--- a/sentence_transformers/losses/ContrastiveLoss.py
+++ b/sentence_transformers/losses/ContrastiveLoss.py
@@ -87,7 +87,7 @@ class ContrastiveLoss(nn.Module):
         distance_metric_name = self.distance_metric.__name__
         for name, value in vars(SiameseDistanceMetric).items():
             if value == self.distance_metric:
-                distance_metric_name = "SiameseDistanceMetric.{}".format(name)
+                distance_metric_name = f"SiameseDistanceMetric.{name}"
                 break
 
         return {"distance_metric": distance_metric_name, "margin": self.margin, "size_average": self.size_average}

--- a/sentence_transformers/losses/ContrastiveTensionLoss.py
+++ b/sentence_transformers/losses/ContrastiveTensionLoss.py
@@ -73,7 +73,7 @@ class ContrastiveTensionLoss(nn.Module):
     """
 
     def __init__(self, model: SentenceTransformer) -> None:
-        super(ContrastiveTensionLoss, self).__init__()
+        super().__init__()
         self.model2 = model  # This will be the final model used during the inference time.
         self.model1 = copy.deepcopy(model)
         self.criterion = nn.BCEWithLogitsLoss(reduction="sum")
@@ -165,7 +165,7 @@ class ContrastiveTensionLossInBatchNegatives(nn.Module):
                     epochs=10,
                 )
         """
-        super(ContrastiveTensionLossInBatchNegatives, self).__init__()
+        super().__init__()
         self.model2 = model  # This will be the final model used during the inference time.
         self.model1 = copy.deepcopy(model)
         self.similarity_fct = similarity_fct

--- a/sentence_transformers/losses/CosineSimilarityLoss.py
+++ b/sentence_transformers/losses/CosineSimilarityLoss.py
@@ -69,7 +69,7 @@ class CosineSimilarityLoss(nn.Module):
                 )
                 trainer.train()
         """
-        super(CosineSimilarityLoss, self).__init__()
+        super().__init__()
         self.model = model
         self.loss_fct = loss_fct
         self.cos_score_transformation = cos_score_transformation

--- a/sentence_transformers/losses/DenoisingAutoEncoderLoss.py
+++ b/sentence_transformers/losses/DenoisingAutoEncoderLoss.py
@@ -72,7 +72,7 @@ class DenoisingAutoEncoderLoss(nn.Module):
                     epochs=10,
                 )
         """
-        super(DenoisingAutoEncoderLoss, self).__init__()
+        super().__init__()
         self.encoder = model  # This will be the final model used during the inference time.
         self.tokenizer_encoder = model.tokenizer
 

--- a/sentence_transformers/losses/GISTEmbedLoss.py
+++ b/sentence_transformers/losses/GISTEmbedLoss.py
@@ -118,7 +118,7 @@ class GISTEmbedLoss(nn.Module):
             anchor, positive, negative = embeddings
             anchor_guide, positive_guide, negative_guide = guide_embeddings
         else:
-            raise ValueError("Expected 2 or 3 embeddings, got {}".format(len(embeddings)))
+            raise ValueError(f"Expected 2 or 3 embeddings, got {len(embeddings)}")
 
         # Compute the model's similarities
         ap_sim = self.sim_matrix(anchor, positive)

--- a/sentence_transformers/losses/GISTEmbedLoss.py
+++ b/sentence_transformers/losses/GISTEmbedLoss.py
@@ -72,7 +72,7 @@ class GISTEmbedLoss(nn.Module):
                 )
                 trainer.train()
         """
-        super(GISTEmbedLoss, self).__init__()
+        super().__init__()
         self.model = model
         self.guide = guide
         self.temperature = temperature

--- a/sentence_transformers/losses/MSELoss.py
+++ b/sentence_transformers/losses/MSELoss.py
@@ -68,7 +68,7 @@ class MSELoss(nn.Module):
                 )
                 trainer.train()
         """
-        super(MSELoss, self).__init__()
+        super().__init__()
         self.model = model
         self.loss_fct = nn.MSELoss()
 

--- a/sentence_transformers/losses/MarginMSELoss.py
+++ b/sentence_transformers/losses/MarginMSELoss.py
@@ -110,7 +110,7 @@ class MarginMSELoss(nn.Module):
                 )
                 trainer.train()
         """
-        super(MarginMSELoss, self).__init__()
+        super().__init__()
         self.model = model
         self.similarity_fct = similarity_fct
         self.loss_fct = nn.MSELoss()

--- a/sentence_transformers/losses/MegaBatchMarginLoss.py
+++ b/sentence_transformers/losses/MegaBatchMarginLoss.py
@@ -75,7 +75,7 @@ class MegaBatchMarginLoss(nn.Module):
                     epochs=10,
                 )
         """
-        super(MegaBatchMarginLoss, self).__init__()
+        super().__init__()
         self.model = model
         self.positive_margin = positive_margin
         self.negative_margin = negative_margin

--- a/sentence_transformers/losses/MultipleNegativesRankingLoss.py
+++ b/sentence_transformers/losses/MultipleNegativesRankingLoss.py
@@ -85,7 +85,7 @@ class MultipleNegativesRankingLoss(nn.Module):
                 )
                 trainer.train()
         """
-        super(MultipleNegativesRankingLoss, self).__init__()
+        super().__init__()
         self.model = model
         self.scale = scale
         self.similarity_fct = similarity_fct

--- a/sentence_transformers/losses/MultipleNegativesSymmetricRankingLoss.py
+++ b/sentence_transformers/losses/MultipleNegativesSymmetricRankingLoss.py
@@ -65,7 +65,7 @@ class MultipleNegativesSymmetricRankingLoss(nn.Module):
                 )
                 trainer.train()
         """
-        super(MultipleNegativesSymmetricRankingLoss, self).__init__()
+        super().__init__()
         self.model = model
         self.scale = scale
         self.similarity_fct = similarity_fct

--- a/sentence_transformers/losses/OnlineContrastiveLoss.py
+++ b/sentence_transformers/losses/OnlineContrastiveLoss.py
@@ -66,7 +66,7 @@ class OnlineContrastiveLoss(nn.Module):
                 )
                 trainer.train()
         """
-        super(OnlineContrastiveLoss, self).__init__()
+        super().__init__()
         self.model = model
         self.margin = margin
         self.distance_metric = distance_metric

--- a/sentence_transformers/losses/SoftmaxLoss.py
+++ b/sentence_transformers/losses/SoftmaxLoss.py
@@ -97,7 +97,7 @@ class SoftmaxLoss(nn.Module):
             num_vectors_concatenated += 1
         if concatenation_sent_multiplication:
             num_vectors_concatenated += 1
-        logger.info("Softmax loss: #Vectors concatenated: {}".format(num_vectors_concatenated))
+        logger.info(f"Softmax loss: #Vectors concatenated: {num_vectors_concatenated}")
         self.classifier = nn.Linear(
             num_vectors_concatenated * sentence_embedding_dimension, num_labels, device=model.device
         )

--- a/sentence_transformers/losses/SoftmaxLoss.py
+++ b/sentence_transformers/losses/SoftmaxLoss.py
@@ -83,7 +83,7 @@ class SoftmaxLoss(nn.Module):
                 )
                 trainer.train()
         """
-        super(SoftmaxLoss, self).__init__()
+        super().__init__()
         self.model = model
         self.num_labels = num_labels
         self.concatenation_sent_rep = concatenation_sent_rep

--- a/sentence_transformers/losses/TripletLoss.py
+++ b/sentence_transformers/losses/TripletLoss.py
@@ -72,7 +72,7 @@ class TripletLoss(nn.Module):
                 )
                 trainer.train()
         """
-        super(TripletLoss, self).__init__()
+        super().__init__()
         self.model = model
         self.distance_metric = distance_metric
         self.triplet_margin = triplet_margin

--- a/sentence_transformers/losses/TripletLoss.py
+++ b/sentence_transformers/losses/TripletLoss.py
@@ -91,7 +91,7 @@ class TripletLoss(nn.Module):
         distance_metric_name = self.distance_metric.__name__
         for name, value in vars(TripletDistanceMetric).items():
             if value == self.distance_metric:
-                distance_metric_name = "TripletDistanceMetric.{}".format(name)
+                distance_metric_name = f"TripletDistanceMetric.{name}"
                 break
 
         return {"distance_metric": distance_metric_name, "triplet_margin": self.triplet_margin}

--- a/sentence_transformers/model_card.py
+++ b/sentence_transformers/model_card.py
@@ -43,7 +43,7 @@ if TYPE_CHECKING:
 
 
 class ModelCardCallback(TrainerCallback):
-    def __init__(self, trainer: "SentenceTransformerTrainer", default_args_dict: dict[str, Any]) -> None:
+    def __init__(self, trainer: SentenceTransformerTrainer, default_args_dict: dict[str, Any]) -> None:
         super().__init__()
         self.trainer = trainer
         self.default_args_dict = default_args_dict
@@ -64,7 +64,7 @@ class ModelCardCallback(TrainerCallback):
         args: SentenceTransformerTrainingArguments,
         state: TrainerState,
         control: TrainerControl,
-        model: "SentenceTransformer",
+        model: SentenceTransformer,
         **kwargs,
     ) -> None:
         from sentence_transformers.losses import AdaptiveLayerLoss, Matryoshka2dLoss, MatryoshkaLoss
@@ -104,7 +104,7 @@ class ModelCardCallback(TrainerCallback):
         args: SentenceTransformerTrainingArguments,
         state: TrainerState,
         control: TrainerControl,
-        model: "SentenceTransformer",
+        model: SentenceTransformer,
         **kwargs,
     ) -> None:
         # model.model_card_data.hyperparameters = extract_hyperparameters_from_trainer(self.trainer)
@@ -147,7 +147,7 @@ class ModelCardCallback(TrainerCallback):
         args: SentenceTransformerTrainingArguments,
         state: TrainerState,
         control: TrainerControl,
-        model: "SentenceTransformer",
+        model: SentenceTransformer,
         metrics: dict[str, float],
         **kwargs,
     ) -> None:
@@ -171,7 +171,7 @@ class ModelCardCallback(TrainerCallback):
         args: SentenceTransformerTrainingArguments,
         state: TrainerState,
         control: TrainerControl,
-        model: "SentenceTransformer",
+        model: SentenceTransformer,
         logs: dict[str, float],
         **kwargs,
     ) -> None:
@@ -294,7 +294,7 @@ class SentenceTransformerModelCardData(CardData):
     base_model_revision: str | None = field(default=None, init=False)
     non_default_hyperparameters: dict[str, Any] = field(default_factory=dict, init=False)
     all_hyperparameters: dict[str, Any] = field(default_factory=dict, init=False)
-    eval_results_dict: dict["SentenceEvaluator", dict[str, Any]] | None = field(default_factory=dict, init=False)
+    eval_results_dict: dict[SentenceEvaluator, dict[str, Any]] | None = field(default_factory=dict, init=False)
     training_logs: list[dict[str, float]] = field(default_factory=list, init=False)
     widget: list[dict[str, str]] = field(default_factory=list, init=False)
     predict_example: str | None = field(default=None, init=False)
@@ -302,7 +302,7 @@ class SentenceTransformerModelCardData(CardData):
     code_carbon_callback: CodeCarbonCallback | None = field(default=None, init=False)
     citations: dict[str, str] = field(default_factory=dict, init=False)
     best_model_step: int | None = field(default=None, init=False)
-    trainer: "SentenceTransformerTrainer" | None = field(default=None, init=False, repr=False)
+    trainer: SentenceTransformerTrainer | None = field(default=None, init=False, repr=False)
     datasets: list[str] = field(default_factory=list, init=False, repr=False)
 
     # Utility fields
@@ -315,7 +315,7 @@ class SentenceTransformerModelCardData(CardData):
     version: dict[str, str] = field(default_factory=get_versions, init=False)
 
     # Passed via `register_model` only
-    model: "SentenceTransformer" | None = field(default=None, init=False, repr=False)
+    model: SentenceTransformer | None = field(default=None, init=False, repr=False)
 
     def __post_init__(self) -> None:
         # We don't want to save "ignore_metadata_errors" in our Model Card
@@ -401,7 +401,7 @@ class SentenceTransformerModelCardData(CardData):
     def set_best_model_step(self, step: int) -> None:
         self.best_model_step = step
 
-    def set_widget_examples(self, dataset: "Dataset" | "DatasetDict") -> None:
+    def set_widget_examples(self, dataset: Dataset | DatasetDict) -> None:
         if isinstance(dataset, Dataset):
             dataset = DatasetDict(dataset=dataset)
 
@@ -452,7 +452,7 @@ class SentenceTransformerModelCardData(CardData):
                 )
                 self.predict_example = sentences[:3]
 
-    def set_evaluation_metrics(self, evaluator: "SentenceEvaluator", metrics: dict[str, Any]) -> None:
+    def set_evaluation_metrics(self, evaluator: SentenceEvaluator, metrics: dict[str, Any]) -> None:
         from sentence_transformers.evaluation import SequentialEvaluator
 
         self.eval_results_dict[evaluator] = copy(metrics)
@@ -483,7 +483,7 @@ class SentenceTransformerModelCardData(CardData):
                     }
                 )
 
-    def set_label_examples(self, dataset: "Dataset") -> None:
+    def set_label_examples(self, dataset: Dataset) -> None:
         num_examples_per_label = 3
         examples = defaultdict(list)
         finished_labels = set()
@@ -504,9 +504,7 @@ class SentenceTransformerModelCardData(CardData):
             for label, example_set in examples.items()
         ]
 
-    def infer_datasets(
-        self, dataset: "Dataset" | "DatasetDict", dataset_name: str | None = None
-    ) -> list[dict[str, str]]:
+    def infer_datasets(self, dataset: Dataset | DatasetDict, dataset_name: str | None = None) -> list[dict[str, str]]:
         if isinstance(dataset, DatasetDict):
             return [
                 dataset
@@ -679,7 +677,7 @@ class SentenceTransformerModelCardData(CardData):
         return dataset_info
 
     def extract_dataset_metadata(
-        self, dataset: "Dataset" | "DatasetDict", dataset_metadata, dataset_type: Literal["train", "eval"]
+        self, dataset: Dataset | DatasetDict, dataset_metadata, dataset_type: Literal["train", "eval"]
     ) -> dict[str, Any]:
         if dataset:
             if dataset_metadata and (
@@ -717,7 +715,7 @@ class SentenceTransformerModelCardData(CardData):
 
         return self.validate_datasets(dataset_metadata)
 
-    def register_model(self, model: "SentenceTransformer") -> None:
+    def register_model(self, model: SentenceTransformer) -> None:
         self.model = model
 
     def set_model_id(self, model_id: str) -> None:
@@ -974,7 +972,7 @@ class SentenceTransformerModelCardData(CardData):
         ).strip()
 
 
-def generate_model_card(model: "SentenceTransformer") -> str:
+def generate_model_card(model: SentenceTransformer) -> str:
     template_path = Path(__file__).parent / "model_card_template.md"
     model_card = ModelCard.from_template(card_data=model.model_card_data, template_path=template_path, hf_emoji="🤗")
     return model_card.content

--- a/sentence_transformers/model_card_templates.py
+++ b/sentence_transformers/model_card_templates.py
@@ -169,17 +169,17 @@ def cls_pooling(model_output, attention_mask):
                 if hasattr(dataloader, "batch_sampler"):
                     loader_params["batch_sampler"] = fullname(dataloader.batch_sampler)
 
-            dataloader_str = """**DataLoader**:\n\n`{}` of length {} with parameters:
+            dataloader_str = f"""**DataLoader**:\n\n`{fullname(dataloader)}` of length {len(dataloader)} with parameters:
 ```
-{}
-```""".format(fullname(dataloader), len(dataloader), loader_params)
+{loader_params}
+```"""
 
             loss_str = "**Loss**:\n\n`{}` {}".format(
                 fullname(loss),
-                """with parameters:
+                f"""with parameters:
   ```
-  {}
-  ```""".format(loss.get_config_dict())
+  {loss.get_config_dict()}
+  ```"""
                 if hasattr(loss, "get_config_dict")
                 else "",
             )
@@ -187,5 +187,5 @@ def cls_pooling(model_output, attention_mask):
             return [dataloader_str, loss_str]
 
         except Exception as e:
-            logging.WARN("Exception when creating get_train_objective_info: {}".format(str(e)))
+            logging.WARN(f"Exception when creating get_train_objective_info: {str(e)}")
             return ""

--- a/sentence_transformers/models/Asym.py
+++ b/sentence_transformers/models/Asym.py
@@ -50,7 +50,7 @@ class Asym(nn.Sequential):
 
             for idx, model in enumerate(models):
                 ordered_dict[name + "-" + str(idx)] = model
-        super(Asym, self).__init__(ordered_dict)
+        super().__init__(ordered_dict)
 
     def forward(self, features: dict[str, Tensor]):
         if "text_keys" in features and len(features["text_keys"]) > 0:

--- a/sentence_transformers/models/BoW.py
+++ b/sentence_transformers/models/BoW.py
@@ -48,9 +48,7 @@ class BoW(nn.Module):
             self.weights.append(weight)
 
         logger.info(
-            "{} out of {} words without a weighting value. Set weight to {}".format(
-                num_unknown_words, len(vocab), unknown_word_weight
-            )
+            f"{num_unknown_words} out of {len(vocab)} words without a weighting value. Set weight to {unknown_word_weight}"
         )
 
         self.tokenizer = WhitespaceTokenizer(vocab, stop_words=set(), do_lower_case=False)

--- a/sentence_transformers/models/BoW.py
+++ b/sentence_transformers/models/BoW.py
@@ -26,7 +26,7 @@ class BoW(nn.Module):
         unknown_word_weight: float = 1,
         cumulative_term_frequency: bool = True,
     ):
-        super(BoW, self).__init__()
+        super().__init__()
         vocab = list(set(vocab))  # Ensure vocab is unique
         self.config_keys = ["vocab", "word_weights", "unknown_word_weight", "cumulative_term_frequency"]
         self.vocab = vocab

--- a/sentence_transformers/models/CLIPModel.py
+++ b/sentence_transformers/models/CLIPModel.py
@@ -84,5 +84,5 @@ class CLIPModel(nn.Module):
         self.processor.save_pretrained(output_path)
 
     @staticmethod
-    def load(input_path: str) -> "CLIPModel":
+    def load(input_path: str) -> CLIPModel:
         return CLIPModel(model_name=input_path)

--- a/sentence_transformers/models/CLIPModel.py
+++ b/sentence_transformers/models/CLIPModel.py
@@ -8,7 +8,7 @@ from torch import nn
 
 class CLIPModel(nn.Module):
     def __init__(self, model_name: str = "openai/clip-vit-base-patch32", processor_name=None) -> None:
-        super(CLIPModel, self).__init__()
+        super().__init__()
 
         if processor_name is None:
             processor_name = model_name

--- a/sentence_transformers/models/CNN.py
+++ b/sentence_transformers/models/CNN.py
@@ -73,7 +73,7 @@ class CNN(nn.Module):
 
     @staticmethod
     def load(input_path: str):
-        with open(os.path.join(input_path, "cnn_config.json"), "r") as fIn:
+        with open(os.path.join(input_path, "cnn_config.json")) as fIn:
             config = json.load(fIn)
 
         model = CNN(**config)

--- a/sentence_transformers/models/Dense.py
+++ b/sentence_transformers/models/Dense.py
@@ -74,7 +74,7 @@ class Dense(nn.Module):
             torch.save(self.state_dict(), os.path.join(output_path, "pytorch_model.bin"))
 
     def __repr__(self):
-        return "Dense({})".format(self.get_config_dict())
+        return f"Dense({self.get_config_dict()})"
 
     @staticmethod
     def load(input_path):

--- a/sentence_transformers/models/Dense.py
+++ b/sentence_transformers/models/Dense.py
@@ -36,7 +36,7 @@ class Dense(nn.Module):
         init_weight: Tensor = None,
         init_bias: Tensor = None,
     ):
-        super(Dense, self).__init__()
+        super().__init__()
         self.in_features = in_features
         self.out_features = out_features
         self.bias = bias

--- a/sentence_transformers/models/Dropout.py
+++ b/sentence_transformers/models/Dropout.py
@@ -14,7 +14,7 @@ class Dropout(nn.Module):
     """
 
     def __init__(self, dropout: float = 0.2):
-        super(Dropout, self).__init__()
+        super().__init__()
         self.dropout = dropout
         self.dropout_layer = nn.Dropout(self.dropout)
 

--- a/sentence_transformers/models/LSTM.py
+++ b/sentence_transformers/models/LSTM.py
@@ -75,7 +75,7 @@ class LSTM(nn.Module):
 
     @staticmethod
     def load(input_path: str):
-        with open(os.path.join(input_path, "lstm_config.json"), "r") as fIn:
+        with open(os.path.join(input_path, "lstm_config.json")) as fIn:
             config = json.load(fIn)
 
         model = LSTM(**config)

--- a/sentence_transformers/models/LayerNorm.py
+++ b/sentence_transformers/models/LayerNorm.py
@@ -11,7 +11,7 @@ from torch import Tensor, nn
 
 class LayerNorm(nn.Module):
     def __init__(self, dimension: int):
-        super(LayerNorm, self).__init__()
+        super().__init__()
         self.dimension = dimension
         self.norm = nn.LayerNorm(dimension)
 

--- a/sentence_transformers/models/Normalize.py
+++ b/sentence_transformers/models/Normalize.py
@@ -8,7 +8,7 @@ class Normalize(nn.Module):
     """This layer normalizes embeddings to unit length"""
 
     def __init__(self) -> None:
-        super(Normalize, self).__init__()
+        super().__init__()
 
     def forward(self, features: dict[str, Tensor]) -> dict[str, Tensor]:
         features.update({"sentence_embedding": F.normalize(features["sentence_embedding"], p=2, dim=1)})

--- a/sentence_transformers/models/Normalize.py
+++ b/sentence_transformers/models/Normalize.py
@@ -18,5 +18,5 @@ class Normalize(nn.Module):
         pass
 
     @staticmethod
-    def load(input_path) -> "Normalize":
+    def load(input_path) -> Normalize:
         return Normalize()

--- a/sentence_transformers/models/Pooling.py
+++ b/sentence_transformers/models/Pooling.py
@@ -110,7 +110,7 @@ class Pooling(nn.Module):
         self.pooling_output_dimension = pooling_mode_multiplier * word_embedding_dimension
 
     def __repr__(self) -> str:
-        return "Pooling({})".format(self.get_config_dict())
+        return f"Pooling({self.get_config_dict()})"
 
     def get_pooling_mode_str(self) -> str:
         """Returns the pooling mode as string"""
@@ -236,7 +236,7 @@ class Pooling(nn.Module):
             json.dump(self.get_config_dict(), fOut, indent=2)
 
     @staticmethod
-    def load(input_path) -> "Pooling":
+    def load(input_path) -> Pooling:
         with open(os.path.join(input_path, "config.json")) as fIn:
             config = json.load(fIn)
 

--- a/sentence_transformers/models/Pooling.py
+++ b/sentence_transformers/models/Pooling.py
@@ -59,7 +59,7 @@ class Pooling(nn.Module):
         pooling_mode_lasttoken: bool = False,
         include_prompt=True,
     ) -> None:
-        super(Pooling, self).__init__()
+        super().__init__()
 
         self.config_keys = [
             "word_embedding_dimension",

--- a/sentence_transformers/models/Transformer.py
+++ b/sentence_transformers/models/Transformer.py
@@ -42,7 +42,7 @@ class Transformer(nn.Module):
         do_lower_case: bool = False,
         tokenizer_name_or_path: str = None,
     ) -> None:
-        super(Transformer, self).__init__()
+        super().__init__()
         self.config_keys = ["max_seq_length", "do_lower_case"]
         self.do_lower_case = do_lower_case
         if model_args is None:

--- a/sentence_transformers/models/Transformer.py
+++ b/sentence_transformers/models/Transformer.py
@@ -107,9 +107,7 @@ class Transformer(nn.Module):
         )
 
     def __repr__(self) -> str:
-        return "Transformer({}) with Transformer model: {} ".format(
-            self.get_config_dict(), self.auto_model.__class__.__name__
-        )
+        return f"Transformer({self.get_config_dict()}) with Transformer model: {self.auto_model.__class__.__name__} "
 
     def forward(self, features: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
         """Returns token_embeddings, cls_token"""
@@ -186,7 +184,7 @@ class Transformer(nn.Module):
             json.dump(self.get_config_dict(), fOut, indent=2)
 
     @classmethod
-    def load(cls, input_path: str) -> "Transformer":
+    def load(cls, input_path: str) -> Transformer:
         # Old classes used other config names than 'sentence_bert_config.json'
         for config_name in [
             "sentence_bert_config.json",

--- a/sentence_transformers/models/WeightedLayerPooling.py
+++ b/sentence_transformers/models/WeightedLayerPooling.py
@@ -15,7 +15,7 @@ class WeightedLayerPooling(nn.Module):
     def __init__(
         self, word_embedding_dimension, num_hidden_layers: int = 12, layer_start: int = 4, layer_weights=None
     ):
-        super(WeightedLayerPooling, self).__init__()
+        super().__init__()
         self.config_keys = ["word_embedding_dimension", "layer_start", "num_hidden_layers"]
         self.word_embedding_dimension = word_embedding_dimension
         self.layer_start = layer_start

--- a/sentence_transformers/models/WordEmbeddings.py
+++ b/sentence_transformers/models/WordEmbeddings.py
@@ -97,7 +97,7 @@ class WordEmbeddings(nn.Module):
 
     @staticmethod
     def load(input_path: str):
-        with open(os.path.join(input_path, "wordembedding_config.json"), "r") as fIn:
+        with open(os.path.join(input_path, "wordembedding_config.json")) as fIn:
             config = json.load(fIn)
 
         tokenizer_class = import_from_string(config["tokenizer_class"])
@@ -120,13 +120,13 @@ class WordEmbeddings(nn.Module):
         tokenizer=WhitespaceTokenizer(),
         max_vocab_size: int = None,
     ):
-        logger.info("Read in embeddings file {}".format(embeddings_file_path))
+        logger.info(f"Read in embeddings file {embeddings_file_path}")
 
         if not os.path.exists(embeddings_file_path):
-            logger.info("{} does not exist, try to download from server".format(embeddings_file_path))
+            logger.info(f"{embeddings_file_path} does not exist, try to download from server")
 
             if "/" in embeddings_file_path or "\\" in embeddings_file_path:
-                raise ValueError("Embeddings file not found: {}".format(embeddings_file_path))
+                raise ValueError(f"Embeddings file not found: {embeddings_file_path}")
 
             url = "https://public.ukp.informatik.tu-darmstadt.de/reimers/embeddings/" + embeddings_file_path
             http_get(url, embeddings_file_path)

--- a/sentence_transformers/models/WordWeights.py
+++ b/sentence_transformers/models/WordWeights.py
@@ -24,7 +24,7 @@ class WordWeights(nn.Module):
             unknown_word_weight (float, optional): Weight for words in vocab that do not appear in the word_weights lookup.
                 These can be, for example, rare words in the vocab where no weight exists. Defaults to 1.
         """
-        super(WordWeights, self).__init__()
+        super().__init__()
         self.config_keys = ["vocab", "word_weights", "unknown_word_weight"]
         self.vocab = vocab
         self.word_weights = word_weights

--- a/sentence_transformers/models/WordWeights.py
+++ b/sentence_transformers/models/WordWeights.py
@@ -43,9 +43,7 @@ class WordWeights(nn.Module):
             weights.append(weight)
 
         logger.info(
-            "{} of {} words without a weighting value. Set weight to {}".format(
-                num_unknown_words, len(vocab), unknown_word_weight
-            )
+            f"{num_unknown_words} of {len(vocab)} words without a weighting value. Set weight to {unknown_word_weight}"
         )
 
         self.emb_layer = nn.Embedding(len(vocab), 1)

--- a/sentence_transformers/models/tokenizer/PhraseTokenizer.py
+++ b/sentence_transformers/models/tokenizer/PhraseTokenizer.py
@@ -57,8 +57,8 @@ class PhraseTokenizer(WordTokenizer):
                     self.ngram_lengths.add(ngram_count)
 
         if len(vocab) > 0:
-            logger.info("PhraseTokenizer - Phrase ngram lengths: {}".format(self.ngram_lengths))
-            logger.info("PhraseTokenizer - Num phrases: {}".format(len(self.ngram_lookup)))
+            logger.info(f"PhraseTokenizer - Phrase ngram lengths: {self.ngram_lengths}")
+            logger.info(f"PhraseTokenizer - Num phrases: {len(self.ngram_lookup)}")
 
     def tokenize(self, text: str, **kwargs) -> list[int]:
         from nltk import word_tokenize
@@ -116,7 +116,7 @@ class PhraseTokenizer(WordTokenizer):
 
     @staticmethod
     def load(input_path: str):
-        with open(os.path.join(input_path, "phrasetokenizer_config.json"), "r") as fIn:
+        with open(os.path.join(input_path, "phrasetokenizer_config.json")) as fIn:
             config = json.load(fIn)
 
         return PhraseTokenizer(**config)

--- a/sentence_transformers/models/tokenizer/WhitespaceTokenizer.py
+++ b/sentence_transformers/models/tokenizer/WhitespaceTokenizer.py
@@ -72,7 +72,7 @@ class WhitespaceTokenizer(WordTokenizer):
 
     @staticmethod
     def load(input_path: str):
-        with open(os.path.join(input_path, "whitespacetokenizer_config.json"), "r") as fIn:
+        with open(os.path.join(input_path, "whitespacetokenizer_config.json")) as fIn:
             config = json.load(fIn)
 
         return WhitespaceTokenizer(**config)

--- a/sentence_transformers/quantization.py
+++ b/sentence_transformers/quantization.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 def semantic_search_faiss(
     query_embeddings: np.ndarray,
     corpus_embeddings: np.ndarray | None = None,
-    corpus_index: "faiss.Index" | None = None,
+    corpus_index: faiss.Index | None = None,
     corpus_precision: Literal["float32", "uint8", "ubinary"] = "float32",
     top_k: int = 10,
     ranges: np.ndarray | None = None,
@@ -27,7 +27,7 @@ def semantic_search_faiss(
     rescore_multiplier: int = 2,
     exact: bool = True,
     output_index: bool = False,
-) -> tuple[list[list[dict[str, int | float]]], float, "faiss.Index"]:
+) -> tuple[list[list[dict[str, int | float]]], float, faiss.Index]:
     """
     Performs semantic search using the FAISS library.
 
@@ -185,7 +185,7 @@ def semantic_search_faiss(
 def semantic_search_usearch(
     query_embeddings: np.ndarray,
     corpus_embeddings: np.ndarray | None = None,
-    corpus_index: "usearch.index.Index" | None = None,
+    corpus_index: usearch.index.Index | None = None,
     corpus_precision: Literal["float32", "int8", "binary"] = "float32",
     top_k: int = 10,
     ranges: np.ndarray | None = None,
@@ -194,7 +194,7 @@ def semantic_search_usearch(
     rescore_multiplier: int = 2,
     exact: bool = True,
     output_index: bool = False,
-) -> tuple[list[list[dict[str, int | float]]], float, "usearch.index.Index"]:
+) -> tuple[list[list[dict[str, int | float]]], float, usearch.index.Index]:
     """
     Performs semantic search using the usearch library.
 

--- a/sentence_transformers/readers/NLIDataReader.py
+++ b/sentence_transformers/readers/NLIDataReader.py
@@ -6,7 +6,7 @@ import os
 from . import InputExample
 
 
-class NLIDataReader(object):
+class NLIDataReader:
     """Reads in the Stanford NLI dataset and the MultiGenre NLI dataset"""
 
     def __init__(self, dataset_folder):

--- a/sentence_transformers/readers/PairedFilesReader.py
+++ b/sentence_transformers/readers/PairedFilesReader.py
@@ -5,7 +5,7 @@ import gzip
 from . import InputExample
 
 
-class PairedFilesReader(object):
+class PairedFilesReader:
     """Reads in the a Pair Dataset, split in two files"""
 
     def __init__(self, filepaths):

--- a/sentence_transformers/readers/TripletReader.py
+++ b/sentence_transformers/readers/TripletReader.py
@@ -6,7 +6,7 @@ import os
 from . import InputExample
 
 
-class TripletReader(object):
+class TripletReader:
     """Reads in the a Triplet Dataset: Each line contains (at least) 3 columns, one anchor column (s1),
     one positive example (s2) and one negative example (s3)
     """

--- a/sentence_transformers/sampler.py
+++ b/sentence_transformers/sampler.py
@@ -57,7 +57,7 @@ class GroupByLabelBatchSampler(SetEpochMixin, BatchSampler):
 
     def __init__(
         self,
-        dataset: "Dataset",
+        dataset: Dataset,
         batch_size: int,
         drop_last: bool,
         valid_label_columns: list[str] = None,
@@ -86,7 +86,7 @@ class GroupByLabelBatchSampler(SetEpochMixin, BatchSampler):
         }
 
     @staticmethod
-    def _determine_labels_to_use(dataset: "Dataset", valid_label_columns: list[str]) -> list[Any]:
+    def _determine_labels_to_use(dataset: Dataset, valid_label_columns: list[str]) -> list[Any]:
         for column_name in valid_label_columns or []:
             if column_name in dataset.column_names:
                 return dataset[column_name]
@@ -116,7 +116,7 @@ class GroupByLabelBatchSampler(SetEpochMixin, BatchSampler):
 class NoDuplicatesBatchSampler(SetEpochMixin, BatchSampler):
     def __init__(
         self,
-        dataset: "Dataset",
+        dataset: Dataset,
         batch_size: int,
         drop_last: bool,
         valid_label_columns: list[str] = [],

--- a/sentence_transformers/similarity_functions.py
+++ b/sentence_transformers/similarity_functions.py
@@ -36,7 +36,7 @@ class SimilarityFunction(Enum):
 
     @staticmethod
     def to_similarity_fn(
-        similarity_function: str | "SimilarityFunction",
+        similarity_function: str | SimilarityFunction,
     ) -> Callable[[Tensor | ndarray, Tensor | ndarray], Tensor]:
         """
         Converts a similarity function name or enum value to the corresponding similarity function.
@@ -69,14 +69,12 @@ class SimilarityFunction(Enum):
             return euclidean_sim
 
         raise ValueError(
-            "The provided function {} is not supported. Use one of the supported values: {}.".format(
-                similarity_function, SimilarityFunction.possible_values()
-            )
+            f"The provided function {similarity_function} is not supported. Use one of the supported values: {SimilarityFunction.possible_values()}."
         )
 
     @staticmethod
     def to_similarity_pairwise_fn(
-        similarity_function: str | "SimilarityFunction",
+        similarity_function: str | SimilarityFunction,
     ) -> Callable[[Tensor | ndarray, Tensor | ndarray], Tensor]:
         """
         Converts a similarity function into a pairwise similarity function.
@@ -112,9 +110,7 @@ class SimilarityFunction(Enum):
             return pairwise_euclidean_sim
 
         raise ValueError(
-            "The provided function {} is not supported. Use one of the supported values: {}.".format(
-                similarity_function, SimilarityFunction.possible_values()
-            )
+            f"The provided function {similarity_function} is not supported. Use one of the supported values: {SimilarityFunction.possible_values()}."
         )
 
     @staticmethod

--- a/sentence_transformers/util.py
+++ b/sentence_transformers/util.py
@@ -517,9 +517,9 @@ def semantic_search(
 
 
 def mine_hard_negatives(
-    dataset: "Dataset",
-    model: "SentenceTransformer",
-    cross_encoder: "CrossEncoder" | None = None,
+    dataset: Dataset,
+    model: SentenceTransformer,
+    cross_encoder: CrossEncoder | None = None,
     range_min: int = 0,
     range_max: int | None = None,
     max_score: float | None = None,
@@ -530,7 +530,7 @@ def mine_hard_negatives(
     batch_size=32,
     use_faiss: bool = False,
     verbose: bool = True,
-) -> "Dataset":
+) -> Dataset:
     """
     Add hard negatives to a dataset of (anchor, positive) pairs to create (anchor, positive, negative) triplets or
     (anchor, positive, negative_1, ..., negative_n) tuples.
@@ -893,7 +893,7 @@ def http_get(url: str, path: str) -> None:
 
     req = requests.get(url, stream=True)
     if req.status_code != 200:
-        print("Exception when trying to download {}. Response {}".format(url, req.status_code), file=sys.stderr)
+        print(f"Exception when trying to download {url}. Response {req.status_code}", file=sys.stderr)
         req.raise_for_status()
         return
 
@@ -977,7 +977,7 @@ def import_from_string(dotted_path: str) -> type:
     try:
         module_path, class_name = dotted_path.rsplit(".", 1)
     except ValueError:
-        msg = "%s doesn't look like a module path" % dotted_path
+        msg = f"{dotted_path} doesn't look like a module path"
         raise ImportError(msg)
 
     try:
@@ -988,7 +988,7 @@ def import_from_string(dotted_path: str) -> type:
     try:
         return getattr(module, class_name)
     except AttributeError:
-        msg = 'Module "%s" does not define a "%s" attribute/class' % (module_path, class_name)
+        msg = f'Module "{module_path}" does not define a "{class_name}" attribute/class'
         raise ImportError(msg)
 
 

--- a/sentence_transformers/util.py
+++ b/sentence_transformers/util.py
@@ -24,6 +24,8 @@ logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from datasets import Dataset
+    from sentence_transformers.cross_encoder.CrossEncoder import CrossEncoder
+    from sentence_transformers.SentenceTransformer import SentenceTransformer
 
     from sentence_transformers.cross_encoder.CrossEncoder import CrossEncoder
     from sentence_transformers.SentenceTransformer import SentenceTransformer

--- a/sentence_transformers/util.py
+++ b/sentence_transformers/util.py
@@ -28,9 +28,6 @@ if TYPE_CHECKING:
     from sentence_transformers.cross_encoder.CrossEncoder import CrossEncoder
     from sentence_transformers.SentenceTransformer import SentenceTransformer
 
-    from sentence_transformers.cross_encoder.CrossEncoder import CrossEncoder
-    from sentence_transformers.SentenceTransformer import SentenceTransformer
-
 
 def _convert_to_tensor(a: list | np.ndarray | Tensor) -> Tensor:
     """

--- a/sentence_transformers/util.py
+++ b/sentence_transformers/util.py
@@ -24,6 +24,7 @@ logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from datasets import Dataset
+
     from sentence_transformers.cross_encoder.CrossEncoder import CrossEncoder
     from sentence_transformers.SentenceTransformer import SentenceTransformer
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,7 +48,7 @@ def distilbert_base_uncased_model() -> SentenceTransformer:
 
 
 @pytest.fixture(scope="session")
-def stsb_dataset_dict() -> "DatasetDict":
+def stsb_dataset_dict() -> DatasetDict:
     return load_dataset("mteb/stsbenchmark-sts")
 
 

--- a/tests/samplers/test_group_by_label_batch_sampler.py
+++ b/tests/samplers/test_group_by_label_batch_sampler.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections import Counter
 
 import pytest
+
 from datasets import Dataset
 
 from sentence_transformers.sampler import GroupByLabelBatchSampler

--- a/tests/samplers/test_group_by_label_batch_sampler.py
+++ b/tests/samplers/test_group_by_label_batch_sampler.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from collections import Counter
 
 import pytest
-
 from datasets import Dataset
 
 from sentence_transformers.sampler import GroupByLabelBatchSampler

--- a/tests/samplers/test_no_duplicates_batch_sampler.py
+++ b/tests/samplers/test_no_duplicates_batch_sampler.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import random
 
 import pytest
-
 from datasets import Dataset
 
 from sentence_transformers.sampler import NoDuplicatesBatchSampler

--- a/tests/samplers/test_no_duplicates_batch_sampler.py
+++ b/tests/samplers/test_no_duplicates_batch_sampler.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import random
 
 import pytest
+
 from datasets import Dataset
 
 from sentence_transformers.sampler import NoDuplicatesBatchSampler

--- a/tests/samplers/test_round_robin_batch_sampler.py
+++ b/tests/samplers/test_round_robin_batch_sampler.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
 import pytest
-from torch.utils.data import BatchSampler, ConcatDataset, SequentialSampler
-
 from datasets import Dataset
 from torch.utils.data import BatchSampler, ConcatDataset, SequentialSampler
 

--- a/tests/samplers/test_round_robin_batch_sampler.py
+++ b/tests/samplers/test_round_robin_batch_sampler.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import pytest
+from torch.utils.data import BatchSampler, ConcatDataset, SequentialSampler
+
 from datasets import Dataset
 from torch.utils.data import BatchSampler, ConcatDataset, SequentialSampler
 

--- a/tests/test_cross_encoder.py
+++ b/tests/test_cross_encoder.py
@@ -51,7 +51,7 @@ def evaluate_stsb_test(
     model = distilroberta_base_ce_model
     evaluator = CECorrelationEvaluator.from_input_examples(test_samples[:num_test_samples], name="sts-test")
     score = evaluator(model) * 100
-    print("STS-Test Performance: {:.2f} vs. exp: {:.2f}".format(score, expected_score))
+    print(f"STS-Test Performance: {score:.2f} vs. exp: {expected_score:.2f}")
     assert score > expected_score or abs(score - expected_score) < 0.1
 
 

--- a/tests/test_multi_process.py
+++ b/tests/test_multi_process.py
@@ -17,7 +17,7 @@ def test_encode_multi_process(
 ) -> None:
     model = stsb_bert_tiny_model
     model.prompts = {"retrieval": "Represent this sentence for searching relevant passages: "}
-    sentences = ["This is sentence {}".format(i) for i in range(40)]
+    sentences = [f"This is sentence {i}" for i in range(40)]
 
     # Start the multi-process pool on e.g. two CPU devices & compute the embeddings using the pool
     pool = model.start_multi_process_pool(["cpu", "cpu"])

--- a/tests/test_pretrained_stsb.py
+++ b/tests/test_pretrained_stsb.py
@@ -40,7 +40,7 @@ def pretrained_model_score(
 
     scores = model.evaluate(evaluator)
     score = scores[evaluator.primary_metric] * 100
-    print(model_name, "{:.2f} vs. exp: {:.2f}".format(score, expected_score))
+    print(model_name, f"{score:.2f} vs. exp: {expected_score:.2f}")
     assert score > expected_score or abs(score - expected_score) < 0.1
 
 

--- a/tests/test_sentence_transformer.py
+++ b/tests/test_sentence_transformer.py
@@ -341,7 +341,7 @@ def test_save_load_prompts() -> None:
         model.save(str(model_path))
         config_path = model_path / "config_sentence_transformers.json"
         assert config_path.exists()
-        with open(config_path, "r", encoding="utf8") as f:
+        with open(config_path, encoding="utf8") as f:
             saved_config = json.load(f)
         assert saved_config["prompts"] == {"query": "query: "}
         assert saved_config["default_prompt_name"] == "query"
@@ -584,7 +584,7 @@ def test_model_card_save_update_model_id(stsb_bert_tiny_model: SentenceTransform
     model._model_card_text = ""
     with tempfile.TemporaryDirectory() as tmp_folder:
         model.save(tmp_folder)
-        with open(Path(tmp_folder) / "README.md", "r", encoding="utf8") as f:
+        with open(Path(tmp_folder) / "README.md", encoding="utf8") as f:
             model_card_text = f.read()
             assert 'model = SentenceTransformer("sentence_transformers_model_id"' in model_card_text
 
@@ -595,7 +595,7 @@ def test_model_card_save_update_model_id(stsb_bert_tiny_model: SentenceTransform
     with tempfile.TemporaryDirectory() as tmp_folder:
         loaded_model.save(tmp_folder, model_name="test_user/test_model")
 
-        with open(Path(tmp_folder) / "README.md", "r", encoding="utf8") as f:
+        with open(Path(tmp_folder) / "README.md", encoding="utf8") as f:
             model_card_text = f.read()
             assert 'model = SentenceTransformer("test_user/test_model"' in model_card_text
 

--- a/tests/test_train_stsb.py
+++ b/tests/test_train_stsb.py
@@ -69,7 +69,7 @@ def evaluate_stsb_test(model, expected_score, test_samples) -> None:
     evaluator = EmbeddingSimilarityEvaluator.from_input_examples(test_samples, name="sts-test")
     scores = model.evaluate(evaluator)
     score = scores[evaluator.primary_metric] * 100
-    print("STS-Test Performance: {:.2f} vs. exp: {:.2f}".format(score, expected_score))
+    print(f"STS-Test Performance: {score:.2f} vs. exp: {expected_score:.2f}")
     assert score > expected_score or abs(score - expected_score) < 0.1
 
 

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -18,7 +18,7 @@ if is_datasets_available():
     reason='Sentence Transformers was not installed with the `["train"]` extra.',
 )
 def test_trainer_multi_dataset_errors(
-    stsb_bert_tiny_model: SentenceTransformer, stsb_dataset_dict: "DatasetDict"
+    stsb_bert_tiny_model: SentenceTransformer, stsb_dataset_dict: DatasetDict
 ) -> None:
     train_dataset = stsb_dataset_dict["train"]
     loss = {
@@ -87,7 +87,7 @@ def test_trainer_multi_dataset_errors(
     reason='Sentence Transformers was not installed with the `["train"]` extra.',
 )
 def test_trainer_invalid_column_names(
-    stsb_bert_tiny_model: SentenceTransformer, stsb_dataset_dict: "DatasetDict"
+    stsb_bert_tiny_model: SentenceTransformer, stsb_dataset_dict: DatasetDict
 ) -> None:
     train_dataset = stsb_dataset_dict["train"]
     for column_name in ("return_loss", "dataset_name"):
@@ -130,7 +130,7 @@ def test_model_card_reuse(stsb_bert_tiny_model: SentenceTransformer):
         model_path = Path(tmp_folder) / "tiny_model_local"
         stsb_bert_tiny_model.save(str(model_path))
 
-        with open(model_path / "README.md", "r") as f:
+        with open(model_path / "README.md") as f:
             model_card_text = f.read()
         assert model_card_text == stsb_bert_tiny_model._model_card_text
 
@@ -141,6 +141,6 @@ def test_model_card_reuse(stsb_bert_tiny_model: SentenceTransformer):
         model_path = Path(tmp_folder) / "tiny_model_local"
         stsb_bert_tiny_model.save(str(model_path))
 
-        with open(model_path / "README.md", "r") as f:
+        with open(model_path / "README.md") as f:
             model_card_text = f.read()
         assert model_card_text != stsb_bert_tiny_model._model_card_text


### PR DESCRIPTION
This PR builds on top of [the previous PR](https://github.com/UKPLab/sentence-transformers/pull/2830), which served as a stepping stone; now we can easily enable the full pyupgrade (`UP`) ruleset.

The most common changes are:

## [UP008](https://docs.astral.sh/ruff/rules/super-call-with-parameters/)

Checks for super calls that pass redundant arguments.

e.g. replace

```py
super(Dense, self).__init__()
```

with

```py
super().__init__()
```

## [UP032](https://docs.astral.sh/ruff/rules/f-string/)

Checks for str.format calls that can be replaced with f-strings.

e.g. replace

```py
print("\nCluster {}, #{} Elements ".format(i + 1, len(cluster)))
```

with

```py
print(f"\nCluster {i + 1}, #{len(cluster)} Elements ")
```

## [UP037](https://docs.astral.sh/ruff/rules/quoted-annotation/)

Checks for the presence of unnecessary quotes in type annotations.

e.g. replace

```py
self, model: "SentenceTransformer", output_path: str = None, epoch: int = -1, steps: int = -1

```

with

```py
self, model: SentenceTransformer, output_path: str = None, epoch: int = -1, steps: int = -1
```
