### PR TITLE
Change eval dataloader to use eval_batch_size

### DIFF
--- a/sentence_transformers/trainer.py
+++ b/sentence_transformers/trainer.py
@@ -628,7 +628,7 @@ class SentenceTransformerTrainer(Trainer):
         else:
             batch_sampler = self.get_batch_sampler(
                 eval_dataset,
-                batch_size=self.args.train_batch_size,
+                batch_size=self.args.eval_batch_size,
                 drop_last=self.args.dataloader_drop_last,
                 valid_label_columns=data_collator.valid_label_columns,
                 generator=generator,


### PR DESCRIPTION
The evaluation dataloader is currently initialized using the train_batch_size which seems to be a bug. This PR fixes this.