### PR TITLE
Perform additional check for owner string in `is_<library>_available` functions

### DIFF
--- a/sentence_transformers/util.py
+++ b/sentence_transformers/util.py
@@ -1304,7 +1304,7 @@ def get_device_name() -> Literal["mps", "cuda", "npu", "hpu", "cpu"]:
     return "cpu"
 
 
-def check_package_availability(package_name: str, owner: str) -> None:
+def check_package_availability(package_name: str, owner: str) -> bool:
     """
     Checks if a package is available from the correct owner.
     """

--- a/sentence_transformers/util.py
+++ b/sentence_transformers/util.py
@@ -9,6 +9,7 @@ import queue
 import random
 import sys
 from contextlib import contextmanager
+from importlib.metadata import PackageNotFoundError, metadata
 from typing import TYPE_CHECKING, Any, Callable, Literal, overload
 
 import numpy as np
@@ -1308,10 +1309,11 @@ def check_package_availability(package_name: str, owner: str) -> bool:
     """
     Checks if a package is available from the correct owner.
     """
-    spec = importlib.util.find_spec(package_name)
-    if spec and owner in spec.origin:
-        return True
-    return False
+    try:
+        meta = metadata(package_name)
+        return meta["Name"] == package_name and owner in meta["Home-page"]
+    except PackageNotFoundError:
+        return False
 
 
 def is_accelerate_available() -> bool:
@@ -1326,3 +1328,11 @@ def is_datasets_available() -> bool:
     Returns True if the Huggingface datasets library is available.
     """
     return check_package_availability("datasets", "huggingface")
+
+
+def is_training_available() -> bool:
+    """
+    Returns True if we have the required dependencies for training Sentence
+    Transformers models, i.e. Huggingface datasets and Huggingface accelerate.
+    """
+    return is_accelerate_available() and is_datasets_available()

--- a/sentence_transformers/util.py
+++ b/sentence_transformers/util.py
@@ -1304,22 +1304,25 @@ def get_device_name() -> Literal["mps", "cuda", "npu", "hpu", "cpu"]:
     return "cpu"
 
 
+def check_package_availability(package_name: str, owner: str) -> None:
+    """
+    Checks if a package is available from the correct owner.
+    """
+    spec = importlib.util.find_spec(package_name)
+    if spec and owner in spec.origin:
+        return True
+    return False
+
+
 def is_accelerate_available() -> bool:
     """
-    Returns True if the accelerate library is available.
+    Returns True if the Huggingface accelerate library is available.
     """
-    return importlib.util.find_spec("accelerate") is not None
+    return check_package_availability("accelerate", "huggingface")
 
 
 def is_datasets_available() -> bool:
     """
-    Returns True if the datasets library is available.
+    Returns True if the Huggingface datasets library is available.
     """
-    return importlib.util.find_spec("datasets") is not None
-
-
-def is_training_available() -> bool:
-    """
-    Returns True if we have the required dependencies for training Sentence Transformer models
-    """
-    return is_accelerate_available() and is_datasets_available()
+    return check_package_availability("datasets", "huggingface")


### PR DESCRIPTION
Currently if you have a `datasets` module in your `sys.path`, the `is_datasets_available` function will return `True`, even if it's not the one from Huggingface.

Here we add a slightly smarter logic to check the origin string of the `importlib` spec, and match it against the expected owner. This makes it possible for users who also have an unrelated module in their `sys.path` called `datasets` to do imports like

```py
from sentence_transformers import SentenceTransformer
```

while leaving all other functionality untouched.

Closes #2858 