### PR TITLE
[`fix`] Handle out of range values in scalar quantization

### DIFF
--- a/sentence_transformers/quantization.py
+++ b/sentence_transformers/quantization.py
@@ -423,9 +423,12 @@ def quantize_embeddings(
         steps = (ranges[1, :] - ranges[0, :]) / 255
 
         if precision == "uint8":
-            return ((embeddings - starts) / steps).astype(np.uint8)
+            q_vals = np.floor((embeddings - starts) / steps)
+            return np.clip(q_vals, 0, 255).astype(np.uint8)
         elif precision == "int8":
-            return ((embeddings - starts) / steps - 128).astype(np.int8)
+            q_vals = np.floor((embeddings - starts) / steps)
+            q_vals = np.clip(q_vals, 0, 255)
+            return (q_vals - 128).astype(np.int8)
 
     if precision == "binary":
         return (np.packbits(embeddings > 0).reshape(embeddings.shape[0], -1) - 128).astype(np.int8)


### PR DESCRIPTION
### Issue description
This PR addresses an issue with **out-of-range values** during scalar quantization. Previously, when quantizing data, values outside the calibration range could result in incorrect quantization. 

### Solution
The PR fixes this issue by introducing a **clip operation** in the quantization process. This operation ensures that quantized values are correctly bounded within the expected range,  thus preventing out-of-range values from producing incorrect results.

### Example
```
calibration_set = np.array([[1,20,-3], [4,5,-60]], dtype=np.float32)
dataset = np.array([[-1,15,1]], dtype=np.float32). 
sq_embeddings = quantize_embeddings(
    dataset,
    precision="int8",
    calibration_embeddings=my_np_array,
)
print("quantizing dataset = ", sq_embeddings)
```
**Result:**
 incorrect quantized values for the first and third entries, respectively, which are outside the calibration range.
```
quantizing dataset =  [[ -42   42 -112]]
```

**After the PR:**
The quantized values are correctly bounded and thus match the expected output.
```
quantizing dataset =  [[-128   42  127]]
```




