### PR TITLE
[`fix`] Safely continue if ProportionalBatchSampler sub-batch sampler throws StopIteration

### DIFF
--- a/sentence_transformers/sampler.py
+++ b/sentence_transformers/sampler.py
@@ -246,7 +246,10 @@ class ProportionalBatchSampler(SetEpochMixin, BatchSampler):
         batch_samplers = [iter(sampler) for sampler in self.batch_samplers]
         for dataset_idx in dataset_idx_sampler:
             sample_offset = sample_offsets[dataset_idx]
-            yield [idx + sample_offset for idx in next(batch_samplers[dataset_idx])]
+            try:
+                yield [idx + sample_offset for idx in next(batch_samplers[dataset_idx])]
+            except StopIteration:
+                continue
 
     def __len__(self) -> int:
         return sum([len(sampler) for sampler in self.batch_samplers])

--- a/tests/samplers/test_no_duplicates_batch_sampler.py
+++ b/tests/samplers/test_no_duplicates_batch_sampler.py
@@ -3,13 +3,15 @@ from __future__ import annotations
 import random
 
 import pytest
+import torch
 from datasets import Dataset
+from torch.utils.data import ConcatDataset
 
-from sentence_transformers.sampler import NoDuplicatesBatchSampler
+from sentence_transformers.sampler import NoDuplicatesBatchSampler, ProportionalBatchSampler
 
 
 @pytest.fixture
-def dummy_dataset():
+def dummy_dataset() -> Dataset:
     """
     Dummy dataset for testing purposes. The dataset looks as follows:
     {
@@ -25,7 +27,22 @@ def dummy_dataset():
     return Dataset.from_dict(data)
 
 
-def test_group_by_label_batch_sampler_label_a(dummy_dataset):
+@pytest.fixture
+def dummy_duplicates_dataset() -> Dataset:
+    """
+    Dummy dataset for testing purposes. The dataset looks as follows:
+    {
+        "anchor": ["anchor_1", "anchor_1", "anchor_1", ... "anchor_2", "anchor_2"],
+        "positive": ["positive_1", "positive_1", "positive_1", ... "positive_2", "positive_2"],
+    }
+    """
+    values = [{"anchor": "anchor_1", "positive": "positive_1"}] * 10 + [
+        {"anchor": "anchor_2", "positive": "positive_2"}
+    ] * 8
+    return Dataset.from_list(values)
+
+
+def test_group_by_label_batch_sampler_label_a(dummy_dataset: Dataset) -> None:
     batch_size = 10
 
     sampler = NoDuplicatesBatchSampler(
@@ -41,3 +58,36 @@ def test_group_by_label_batch_sampler_label_a(dummy_dataset):
     for batch in batches:
         batch_values = [dummy_dataset[i]["data"] for i in batch]
         assert len(batch_values) == len(set(batch_values)), f"Batch {batch} contains duplicate values: {batch_values}"
+
+
+@pytest.mark.parametrize("drop_last", [True, False])
+def test_proportional_no_duplicates(dummy_duplicates_dataset: Dataset, drop_last: bool) -> None:
+    batch_size = 2
+    sampler_1 = NoDuplicatesBatchSampler(
+        dataset=dummy_duplicates_dataset, batch_size=batch_size, drop_last=drop_last, valid_label_columns=["anchor"]
+    )
+    sampler_2 = NoDuplicatesBatchSampler(
+        dataset=dummy_duplicates_dataset, batch_size=batch_size, drop_last=drop_last, valid_label_columns=["positive"]
+    )
+
+    concat_dataset = ConcatDataset([dummy_duplicates_dataset, dummy_duplicates_dataset])
+
+    batch_sampler = ProportionalBatchSampler(
+        concat_dataset, [sampler_1, sampler_2], generator=torch.Generator(), seed=12
+    )
+    batches = list(iter(batch_sampler))
+
+    if drop_last:
+        # If we drop the last batch (i.e. incomplete batches), we should have 16 batches out of the 18 possible,
+        # because of the duplicates being skipped by the NoDuplicatesBatchSampler.
+        # Notably, we should not crash like reported in #2816.
+        assert len(batches) == 16
+        # All batches are the same size: 2
+        assert all(len(batch) == batch_size for batch in batches)
+        assert len(sum(batches, [])) == 32
+    else:
+        # If we don't drop incomplete batches, we should be able to do 18 batches, and get more data.
+        # Note: we don't get all data, because the NoDuplicatesBatchSampler will estimate the number of batches
+        # and it would require more (non-complete) batches to get all data.
+        assert len(batches) == 18
+        assert len(sum(batches, [])) == 34


### PR DESCRIPTION
Resolves #2816

## Pull Request overview
* Fix niche StopIteration with proportional multi-dataset sampler, no-duplicates batch sampler, and dataloader_drop_last=True

## Details
As reported in #2816, there was a bug in the following scenario:
* Multi-dataset training with the ProportionalBatchSampler
* batch_sampler set to NoDuplicatesBatchSampler
* dataloader_drop_last=True

The reasoning is that if `drop_last=True`, then the batch count that `NoDuplicatesBatchSampler` estimates might be higher than the true batch count that it returns. (If `drop_last=False`, then at the end we actually get multiple smaller batches, and the batch count estimate is actually *lower* than the true batch count).
This triggers a StopIteration if whatever code that iterates over the batch sampler samples 'batch count' values. Apparently, the default torch behaviour for a BatchSampler if `drop_last=True` is to try-except-break the batches from the underlying sampler: https://github.com/pytorch/pytorch/blob/a8f0979962f8a56ba01e8459bb91d9f7ac9f4e4d/torch/utils/data/sampler.py#L339-L343

This is different from what I implemented in `ProportionalBatchSampler`, which does not have this try-except-break. So, my solution is to add this try-except to avoid the crash. The result is that now if the `NoDuplicatesBatchSampler` overestimates the batch count, the training will just stop a bit earlier than expected, e.g. the final step will be step 16 out of e.g. 18 (in practice, it would stop at like step 3850 out of 3851 or 3852).

I've added a test which used to fail with a StopIteration.

Thanks @lanx7 for reporting this issue; it turns out to be a bit nicher of an issue than I expected, but I'm glad I found it and found a fix that best aligns with `torch`.

- Tom Aarsen