### PR TITLE
Update "def text_length"

### DIFF
--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -1319,16 +1319,19 @@ class SentenceTransformer(nn.Sequential, FitMixin):
         # This isn't expected to ever be reached.
         return folder_url
 
-    def _text_length(self, text: list[int] | list[list[int]]) -> int:
+    # def text_length(self, text: Union[List[int], List[List[int]]]) -> int:
+    def text_length(self, text: Union[str, List[str], List[int], List[List[int]]]):
         """
         Help function to get the length for the input text. Text can be either
-        a list of ints (which means a single text as input), or a tuple of list of ints
-        (representing several text inputs to the model).
+        a string, a list of strings, a list of ints (which means a single text as input),
+        or a tuple of list of ints (representing several text inputs to the model).
         """
-
-        if isinstance(text, dict):  # {key: value} case
+        # if isinstance(text, dict):  # {key: value} case
+        if isinstance(text, str):
+            return len(text)
+        elif isinstance(text, dict):  # {key: value} case
             return len(next(iter(text.values())))
-        elif not hasattr(text, "__len__"):  # Object has no len() method
+        elif not hasattr(text, "_len_"):  # Object has no len() method
             return 1
         elif len(text) == 0 or isinstance(text[0], int):  # Empty string or list of ints
             return len(text)


### PR DESCRIPTION
This change enhances the text_length function to support a wider range of input types, particularly adding support for strings and lists of strings.  Specifically...

Initially Supported:

1. List of integers (List[int])
2. List of lists of integers (List[List[int]])
3. Dictionary (dict) - handled as a special case

Now Supports:

1. String (str)
2. List of strings (List[str])
3. List of integers (List[int])
4. List of lists of integers (List[List[int]])
5. Dictionary (dict) - handled as before

The impetus for this pull was the fact that some programs provide a different format in order to work properly...And under the current implementation, it was breaking the program.  I tried multiple times to fix this but was unsuccessful and this was the only solution that worked.

Please note, the commented out portions represent the deleted text so it's a little redundant with how Github does the comparison.  Apologies for that; that's just want way it was modified in my script and the comments can obviously be deleted.