### PR TITLE
[`fix`] Fix SoftmaxLoss by initializing the optimizer over the loss(es) rather than the model

### DIFF
--- a/sentence_transformers/losses/SoftmaxLoss.py
+++ b/sentence_transformers/losses/SoftmaxLoss.py
@@ -4,6 +4,8 @@ import logging
 from typing import Callable, Iterable
 
 import torch
+import transformers
+from packaging import version
 from torch import Tensor, nn
 
 from sentence_transformers.SentenceTransformer import SentenceTransformer
@@ -102,6 +104,13 @@ class SoftmaxLoss(nn.Module):
             num_vectors_concatenated * sentence_embedding_dimension, num_labels, device=model.device
         )
         self.loss_fct = loss_fct
+
+        if version.parse(transformers.__version__) < version.parse("4.43.0"):
+            logger.warning(
+                "SoftmaxLoss requires transformers >= 4.43.0 to work correctly. "
+                "Otherwise, the classifier layer that maps embeddings to the labels cannot be updated. "
+                "Consider updating transformers with `pip install transformers>=4.43.0`."
+            )
 
     def forward(
         self, sentence_features: Iterable[dict[str, Tensor]], labels: Tensor


### PR DESCRIPTION
Resolves #2872

Hello!

## Pull Request overview
* Initialize the optimizer using the weights across all losses, rather than just the model weights: This fixes SoftmaxLoss
* Note: you need `transformers` >= 4.43.0 for this fix to work

## Details
Prior to this fix, running this training script:
```python
from datasets import load_dataset
from sentence_transformers import SentenceTransformer, SentenceTransformerTrainer
from sentence_transformers.evaluation import TripletEvaluator
from sentence_transformers.losses import SoftmaxLoss

all_nli_pair_class_train = load_dataset(
    "sentence-transformers/all-nli",
    "pair-class",
    split="train[:1000]",
)
# Load a dataset with (anchor, positive, negative) triplets
all_nli_pair_class_eval = load_dataset("sentence-transformers/all-nli", "triplet", split="dev")

# Initialize the TripletEvaluator using anchors, positives, and negatives
triplet_evaluator = TripletEvaluator(
    anchors=all_nli_pair_class_eval[:1000]["anchor"],
    positives=all_nli_pair_class_eval[:1000]["positive"],
    negatives=all_nli_pair_class_eval[:1000]["negative"],
    name="all-nli-dev",
)

model = SentenceTransformer("all-MiniLM-L6-v2")
train_dataset = {
    "all-nli-pair-class": all_nli_pair_class_train,
}
softmax_loss = SoftmaxLoss(model, 384, 3)

trainer = SentenceTransformerTrainer(
    model=model,
    train_dataset=train_dataset,
    eval_dataset=all_nli_pair_class_eval,
    loss=softmax_loss,
)
trainer.train()
results = triplet_evaluator(model)
print(results)
```
gave:
```
{'all-nli-dev_cosine_accuracy': 0.541, 'all-nli-dev_dot_accuracy': 0.459, 'all-nli-dev_manhattan_accuracy': 0.547, 'all-nli-dev_euclidean_accuracy': 0.541, 'all-nli-dev_max_accuracy': 0.547}
```
After this PR it gives:
```
{'all-nli-dev_cosine_accuracy': 0.7, 'all-nli-dev_dot_accuracy': 0.3, 'all-nli-dev_manhattan_accuracy': 0.694, 'all-nli-dev_euclidean_accuracy': 0.7, 'all-nli-dev_max_accuracy': 0.7}
```

## Source
This bug originated in the v3.0 release, where I moved to using the transformers Trainer. This Trainer by default relies on the `model` to initialize its weights, whereas the original code in Sentence Transformers created the optimizer based on the loss model instead (which I didn't realise).

Since transformers 4.43.0, we can subclass the `get_optimizer_cls_and_kwargs` method, which allows us to initialize the optimizer based on the loss model (or loss models). If you're using SoftmaxLoss without `transformers` 4.43.0, then you'll be given a warning.

Big thanks to @hjc3613 for discovering this bug and @ir2718 for verifying that it's indeed a bug.

- Tom Aarsen