### PR TITLE
[feat] Added revision to push_to_hub argument.

### DIFF
--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -1314,7 +1314,9 @@ class SentenceTransformer(nn.Sequential, FitMixin):
                     train_datasets=train_datasets,
                     safe_serialization=safe_serialization,
                 )
-                folder_url = api.upload_folder(repo_id=repo_id, folder_path=tmp_dir, commit_message=commit_message, revision=revision)
+                folder_url = api.upload_folder(
+                    repo_id=repo_id, folder_path=tmp_dir, commit_message=commit_message, revision=revision
+                )
 
         refs = api.list_repo_refs(repo_id=repo_id)
         for branch in refs.branches:

--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -1269,6 +1269,7 @@ class SentenceTransformer(nn.Sequential, FitMixin):
         exist_ok: bool = False,
         replace_model_card: bool = False,
         train_datasets: list[str] | None = None,
+        revision: str | None = None,
     ) -> str:
         """
         Uploads all elements of this Sentence Transformer to a new HuggingFace Hub repository.
@@ -1283,6 +1284,7 @@ class SentenceTransformer(nn.Sequential, FitMixin):
             exist_ok (bool, optional): If true, saving to an existing repository is OK. If false, saving only to a new repository is possible
             replace_model_card (bool, optional): If true, replace an existing model card in the hub with the automatically created model card
             train_datasets (List[str], optional): Datasets used to train the model. If set, the datasets will be added to the model card in the Hub.
+            revision (str, optional): Branch to push the uploaded files to
 
         Returns:
             str: The url of the commit of your model in the repository on the Hugging Face Hub.
@@ -1296,9 +1298,11 @@ class SentenceTransformer(nn.Sequential, FitMixin):
         )
         repo_id = repo_url.repo_id  # Update the repo_id in case the old repo_id didn't contain a user or organization
         self.model_card_data.set_model_id(repo_id)
+        if revision is not None:
+            api.create_branch(repo_id=repo_id, branch=revision, exist_ok=True)
         if local_model_path:
             folder_url = api.upload_folder(
-                repo_id=repo_id, folder_path=local_model_path, commit_message=commit_message
+                repo_id=repo_id, folder_path=local_model_path, commit_message=commit_message, revision=revision
             )
         else:
             with tempfile.TemporaryDirectory() as tmp_dir:
@@ -1310,12 +1314,15 @@ class SentenceTransformer(nn.Sequential, FitMixin):
                     train_datasets=train_datasets,
                     safe_serialization=safe_serialization,
                 )
-                folder_url = api.upload_folder(repo_id=repo_id, folder_path=tmp_dir, commit_message=commit_message)
+                folder_url = api.upload_folder(repo_id=repo_id, folder_path=tmp_dir, commit_message=commit_message, revision=revision)
 
         refs = api.list_repo_refs(repo_id=repo_id)
         for branch in refs.branches:
-            if branch.name == "main":
+            if revision is None and branch.name == "main":
                 return f"https://huggingface.co/{repo_id}/commit/{branch.target_commit}"
+            elif branch.name == revision:
+                return f"https://huggingface.co/{repo_id}/commit/{branch.target_commit}"
+
         # This isn't expected to ever be reached.
         return folder_url
 

--- a/tests/test_sentence_transformer.py
+++ b/tests/test_sentence_transformer.py
@@ -234,6 +234,7 @@ def test_push_to_hub(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureF
             caplog.record_tuples[1][2]
             == 'Providing an `organization` to `save_to_hub` is deprecated, please use `repo_id="sentence-transformers-testing/stsb-bert-tiny-safetensors"` instead.'
         )
+    mock_upload_folder_kwargs.clear()
 
     url = model.push_to_hub("sentence-transformers-testing/stsb-bert-tiny-safetensors", revision="revision_test")
     assert mock_upload_folder_kwargs["repo_id"] == "sentence-transformers-testing/stsb-bert-tiny-safetensors"

--- a/tests/test_sentence_transformer.py
+++ b/tests/test_sentence_transformer.py
@@ -100,19 +100,25 @@ def test_push_to_hub(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureF
     def mock_list_repo_refs(self, repo_id=None, **kwargs):
         try:
             git_ref_info = GitRefInfo(name="main", ref="refs/heads/main", target_commit="123456")
+            git_ref_info2 = GitRefInfo(name="revision_test", ref="refs/heads/revision_test", target_commit="678901")
         except TypeError:
             git_ref_info = GitRefInfo(dict(name="main", ref="refs/heads/main", targetCommit="123456"))
+            git_ref_info2 = GitRefInfo(dict(name="revision_test", ref="refs/heads/revision_test", target_commit="678901"))
         # workaround for https://github.com/huggingface/huggingface_hub/issues/1956
-        git_ref_kwargs = {"branches": [git_ref_info], "converts": [], "tags": [], "pull_requests": None}
+        git_ref_kwargs = {"branches": [git_ref_info, git_ref_info2], "converts": [], "tags": [], "pull_requests": None}
         try:
             return GitRefs(**git_ref_kwargs)
         except TypeError:
             git_ref_kwargs.pop("pull_requests")
             return GitRefs(**git_ref_kwargs)
 
+    def mock_create_branch(self, repo_id, branch, revision=None, **kwargs):
+        return None
+
     monkeypatch.setattr(HfApi, "create_repo", mock_create_repo)
     monkeypatch.setattr(HfApi, "upload_folder", mock_upload_folder)
     monkeypatch.setattr(HfApi, "list_repo_refs", mock_list_repo_refs)
+    monkeypatch.setattr(HfApi, "create_branch", mock_create_branch)
 
     model = SentenceTransformer("sentence-transformers-testing/stsb-bert-tiny-safetensors")
 
@@ -226,6 +232,12 @@ def test_push_to_hub(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureF
             caplog.record_tuples[1][2]
             == 'Providing an `organization` to `save_to_hub` is deprecated, please use `repo_id="sentence-transformers-testing/stsb-bert-tiny-safetensors"` instead.'
         )
+
+    url = model.push_to_hub("sentence-transformers-testing/stsb-bert-tiny-safetensors", revision="revision_test")
+    assert mock_upload_folder_kwargs["repo_id"] == "sentence-transformers-testing/stsb-bert-tiny-safetensors"
+    assert mock_upload_folder_kwargs["revision"] == "revision_test"
+    assert url == "https://huggingface.co/sentence-transformers-testing/stsb-bert-tiny-safetensors/commit/678901"
+    mock_upload_folder_kwargs.clear()
 
 
 @pytest.mark.parametrize("safe_serialization", [True, False, None])

--- a/tests/test_sentence_transformer.py
+++ b/tests/test_sentence_transformer.py
@@ -103,7 +103,9 @@ def test_push_to_hub(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureF
             git_ref_info2 = GitRefInfo(name="revision_test", ref="refs/heads/revision_test", target_commit="678901")
         except TypeError:
             git_ref_info = GitRefInfo(dict(name="main", ref="refs/heads/main", targetCommit="123456"))
-            git_ref_info2 = GitRefInfo(dict(name="revision_test", ref="refs/heads/revision_test", target_commit="678901"))
+            git_ref_info2 = GitRefInfo(
+                dict(name="revision_test", ref="refs/heads/revision_test", target_commit="678901")
+            )
         # workaround for https://github.com/huggingface/huggingface_hub/issues/1956
         git_ref_kwargs = {"branches": [git_ref_info, git_ref_info2], "converts": [], "tags": [], "pull_requests": None}
         try:


### PR DESCRIPTION
## Issue

https://github.com/UKPLab/sentence-transformers/issues/2901

## Description
This pull request adds a new 'revision' parameter to the `push_to_hub` argument. This feature allows users to specify a particular revision when pushing to the Hugging Face Hub.

## Changes
- Added 'revision' parameter to `push_to_hub` function
- Updated relevant documentation to reflect the new parameter
- Added unit tests to ensure the new functionality works as expected

## Motivation
Adding the ability to specify a revision provides more control and flexibility when pushing models or other artifacts to the Hugging Face Hub. This can be particularly useful for version management and collaboration.

## Testing
- Unit tests have been added to cover the new functionality

```bash
$ pytest tests/test_sentence_transformer.py::test_push_to_hub
==================================================================================================================================================== test session starts =====================================================================================================================================================
platform darwin -- Python 3.8.19, pytest-8.3.2, pluggy-1.5.0
rootdir: /Users/pesuchin/sentence-transformers
configfile: pyproject.toml
collected 1 item                                                                                                                                                                                                                                                                                                             

tests/test_sentence_transformer.py . 
```

- Manual testing has been performed to ensure compatibility with existing workflows

```python
>>> from sentence_transformers import SentenceTransformer
>>> token = '[input your_token here]'
>>> model = SentenceTransformer("sentence-transformers-testing/stsb-bert-tiny-safetensors")
>>> url = model.push_to_hub("pesuchin/revision-test", token=token, revision="revision_test3", exist_ok=True)
>>> print(uri)
```

```
model.safetensors: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 438M/438M [00:23<00:00, 18.7MB/s]
https://huggingface.co/pesuchin/revision-test/commit/a855207445f8c10f5d4ae17b4882277e4020ae02
```

## Additional Notes
Please review and provide feedback. Let me know if any further changes or clarifications are needed.