### PR TITLE
Fix 'module object is not callable' error in Matryoshka2dLoss

### DIFF
--- a/sentence_transformers/losses/Matryoshka2dLoss.py
+++ b/sentence_transformers/losses/Matryoshka2dLoss.py
@@ -4,9 +4,10 @@ from typing import Any
 
 from torch.nn import Module
 
+from sentence_transformers import SentenceTransformer
+
 from .AdaptiveLayerLoss import AdaptiveLayerLoss
 from .MatryoshkaLoss import MatryoshkaLoss
-from sentence_transformers import SentenceTransformer
 
 
 class Matryoshka2dLoss(AdaptiveLayerLoss):

--- a/sentence_transformers/losses/Matryoshka2dLoss.py
+++ b/sentence_transformers/losses/Matryoshka2dLoss.py
@@ -4,8 +4,9 @@ from typing import Any
 
 from torch.nn import Module
 
-from sentence_transformers.losses import AdaptiveLayerLoss, MatryoshkaLoss
-from sentence_transformers.SentenceTransformer import SentenceTransformer
+from .AdaptiveLayerLoss import AdaptiveLayerLoss
+from .MatryoshkaLoss import MatryoshkaLoss
+from sentence_transformers import SentenceTransformer
 
 
 class Matryoshka2dLoss(AdaptiveLayerLoss):


### PR DESCRIPTION
## Issue

https://github.com/UKPLab/sentence-transformers/issues/2841

## Problem
A 'module object is not callable' error was occurring when using the Matryoshka2dLoss class.

## Solution
I changed the absolute imports to relative imports in the Matryoshka2dLoss.py file, as shown in the following code:
https://github.com/UKPLab/sentence-transformers/blob/master/sentence_transformers/losses/BatchSemiHardTripletLoss.py#L10

Specifically:
- Before: 
```python
from sentence_transformers.losses import AdaptiveLayerLoss, MatryoshkaLoss
from sentence_transformers.SentenceTransformer import SentenceTransformer
```
- After:
```python
from .AdaptiveLayerLoss import AdaptiveLayerLoss
from .MatryoshkaLoss import MatryoshkaLoss
```

## Verification

Tested the changes in a local environment and confirmed that this modification resolves the aforementioned error. The following code was used for verification:

```python
from sentence_transformers import SentenceTransformer, losses

model = SentenceTransformer("microsoft/mpnet-base")
train_loss = losses.MultipleNegativesRankingLoss(model=model)
train_loss = losses.Matryoshka2dLoss(model, train_loss, [768, 512, 256, 128, 64])
```

## Review Notes
Please pay attention to:
- The appropriateness of the import changes
- Any potential side effects on other parts of the codebase

Your review and feedback are greatly appreciated.