### PR TITLE
[`fix`] Fix trainer.train(resume_from_checkpoint="...") with custom models (i.e. `trust_remote_code`)

### DIFF
--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -167,6 +167,7 @@ class SentenceTransformer(nn.Sequential, FitMixin):
         self.prompts = prompts or {}
         self.default_prompt_name = default_prompt_name
         self.similarity_fn_name = similarity_fn_name
+        self.trust_remote_code = trust_remote_code
         self.truncate_dim = truncate_dim
         self.model_card_data = model_card_data or SentenceTransformerModelCardData()
         self._model_card_vars = {}

--- a/sentence_transformers/trainer.py
+++ b/sentence_transformers/trainer.py
@@ -734,7 +734,7 @@ class SentenceTransformerTrainer(Trainer):
     def _load_from_checkpoint(self, checkpoint_path: str) -> None:
         from sentence_transformers import SentenceTransformer
 
-        loaded_model = SentenceTransformer(checkpoint_path)
+        loaded_model = SentenceTransformer(checkpoint_path, trust_remote_code=self.model.trust_remote_code)
         self.model.load_state_dict(loaded_model.state_dict())
 
     def create_model_card(


### PR DESCRIPTION
Resolves #2917

Hello!

## Pull Request overview
* Load checkpoint models with `trust_remote_code` if the original model was also loaded that way.

## Details
This solves the following scenario:
```python
...

model = SentenceTransformer("nomic-ai/nomic-embed-text-v1.5", trust_remote_code=True)

trainer = SentenceTransformerTrainer(
    model=model,
    ...
)
trainer.train(resume_from_checkpoint="checkpoints\checkpoint-50")
```

Which previously failed.

- Tom Aarsen