### PR TITLE
[`docs`] Heavily extend sampler documentation

### DIFF
--- a/docs/package_reference/sentence_transformer/index.rst
+++ b/docs/package_reference/sentence_transformer/index.rst
@@ -7,6 +7,7 @@ Sentence Transformer
    SentenceTransformer
    trainer
    training_args
+   sampler
    losses
    evaluation
    datasets

--- a/docs/package_reference/sentence_transformer/sampler.md
+++ b/docs/package_reference/sentence_transformer/sampler.md
@@ -1,0 +1,39 @@
+
+# Samplers
+
+## BatchSamplers
+```eval_rst
+.. autoclass:: sentence_transformers.training_args.BatchSamplers
+    :members:
+```
+
+```eval_rst
+.. autoclass:: sentence_transformers.sampler.DefaultBatchSampler
+    :members:
+```
+
+```eval_rst
+.. autoclass:: sentence_transformers.sampler.NoDuplicatesBatchSampler
+    :members:
+```
+
+```eval_rst
+.. autoclass:: sentence_transformers.sampler.GroupByLabelBatchSampler
+    :members:
+```
+
+## MultiDatasetBatchSamplers
+```eval_rst
+.. autoclass:: sentence_transformers.training_args.MultiDatasetBatchSamplers
+    :members:
+```
+
+```eval_rst
+.. autoclass:: sentence_transformers.sampler.RoundRobinBatchSampler
+    :members:
+```
+
+```eval_rst
+.. autoclass:: sentence_transformers.sampler.ProportionalBatchSampler
+    :members:
+```

--- a/docs/package_reference/sentence_transformer/training_args.md
+++ b/docs/package_reference/sentence_transformer/training_args.md
@@ -7,15 +7,3 @@
     :members:
     :inherited-members:
 ```
-
-## BatchSamplers
-```eval_rst
-.. autoclass:: sentence_transformers.training_args.BatchSamplers
-    :members:
-```
-
-## MultiDatasetBatchSamplers
-```eval_rst
-.. autoclass:: sentence_transformers.training_args.MultiDatasetBatchSamplers
-    :members:
-```

--- a/sentence_transformers/losses/AdaptiveLayerLoss.py
+++ b/sentence_transformers/losses/AdaptiveLayerLoss.py
@@ -150,16 +150,16 @@ class AdaptiveLayerLoss(nn.Module):
         Requirements:
             1. The base loss cannot be :class:`CachedMultipleNegativesRankingLoss` or :class:`CachedGISTEmbedLoss`.
 
-        Relations:
-            - :class:`Matryoshka2dLoss` uses this loss in combination with :class:`MatryoshkaLoss` which allows for
-                output dimensionality reduction for faster downstream tasks (e.g. retrieval).
-
-        Input:
+        Inputs:
             +---------------------------------------+--------+
             | Texts                                 | Labels |
             +=======================================+========+
             | any                                   | any    |
             +---------------------------------------+--------+
+
+        Relations:
+            - :class:`Matryoshka2dLoss` uses this loss in combination with :class:`MatryoshkaLoss` which allows for
+                output dimensionality reduction for faster downstream tasks (e.g. retrieval).
 
         Example:
             ::

--- a/sentence_transformers/losses/AnglELoss.py
+++ b/sentence_transformers/losses/AnglELoss.py
@@ -33,16 +33,16 @@ class AnglELoss(losses.CoSENTLoss):
         Requirements:
             - Sentence pairs with corresponding similarity scores in range of the similarity function. Default is [-1,1].
 
-        Relations:
-            - :class:`CoSENTLoss` is AnglELoss with ``pairwise_cos_sim`` as the metric, rather than ``pairwise_angle_sim``.
-            - :class:`CosineSimilarityLoss` seems to produce a weaker training signal than ``CoSENTLoss`` or ``AnglELoss``.
-
         Inputs:
             +--------------------------------+------------------------+
             | Texts                          | Labels                 |
             +================================+========================+
             | (sentence_A, sentence_B) pairs | float similarity score |
             +--------------------------------+------------------------+
+
+        Relations:
+            - :class:`CoSENTLoss` is AnglELoss with ``pairwise_cos_sim`` as the metric, rather than ``pairwise_angle_sim``.
+            - :class:`CosineSimilarityLoss` seems to produce a weaker training signal than ``CoSENTLoss`` or ``AnglELoss``.
 
         Example:
             ::

--- a/sentence_transformers/losses/BatchAllTripletLoss.py
+++ b/sentence_transformers/losses/BatchAllTripletLoss.py
@@ -39,18 +39,22 @@ class BatchAllTripletLoss(nn.Module):
             1. Each sentence must be labeled with a class.
             2. Your dataset must contain at least 2 examples per labels class.
 
-        Relations:
-            * :class:`BatchHardTripletLoss` uses only the hardest positive and negative samples, rather than all possible, valid triplets.
-            * :class:`BatchHardSoftMarginTripletLoss` uses only the hardest positive and negative samples, rather than all possible, valid triplets.
-              Also, it does not require setting a margin.
-            * :class:`BatchSemiHardTripletLoss` uses only semi-hard triplets, valid triplets, rather than all possible, valid triplets.
-
         Inputs:
             +------------------+--------+
             | Texts            | Labels |
             +==================+========+
             | single sentences | class  |
             +------------------+--------+
+
+        Recommendations:
+            - Use ``BatchSamplers.GROUP_BY_LABEL`` (:class:`docs <sentence_transformers.training_args.BatchSamplers>`) to
+              ensure that each batch contains 2+ examples per label class.
+
+        Relations:
+            * :class:`BatchHardTripletLoss` uses only the hardest positive and negative samples, rather than all possible, valid triplets.
+            * :class:`BatchHardSoftMarginTripletLoss` uses only the hardest positive and negative samples, rather than all possible, valid triplets.
+              Also, it does not require setting a margin.
+            * :class:`BatchSemiHardTripletLoss` uses only semi-hard triplets, valid triplets, rather than all possible, valid triplets.
 
         Example:
             ::

--- a/sentence_transformers/losses/BatchHardSoftMarginTripletLoss.py
+++ b/sentence_transformers/losses/BatchHardSoftMarginTripletLoss.py
@@ -44,15 +44,19 @@ class BatchHardSoftMarginTripletLoss(BatchHardTripletLoss):
             2. Your dataset must contain at least 2 examples per labels class.
             3. Your dataset should contain hard positives and negatives.
 
-        Relations:
-            * :class:`BatchHardTripletLoss` uses a user-specified margin, while this loss does not require setting a margin.
-
         Inputs:
             +------------------+--------+
             | Texts            | Labels |
             +==================+========+
             | single sentences | class  |
             +------------------+--------+
+
+        Recommendations:
+            - Use ``BatchSamplers.GROUP_BY_LABEL`` (:class:`docs <sentence_transformers.training_args.BatchSamplers>`) to
+              ensure that each batch contains 2+ examples per label class.
+
+        Relations:
+            * :class:`BatchHardTripletLoss` uses a user-specified margin, while this loss does not require setting a margin.
 
         Example:
             ::

--- a/sentence_transformers/losses/BatchHardTripletLoss.py
+++ b/sentence_transformers/losses/BatchHardTripletLoss.py
@@ -102,6 +102,10 @@ class BatchHardTripletLoss(nn.Module):
             | single sentences | class  |
             +------------------+--------+
 
+        Recommendations:
+            - Use ``BatchSamplers.GROUP_BY_LABEL`` (:class:`docs <sentence_transformers.training_args.BatchSamplers>`) to
+              ensure that each batch contains 2+ examples per label class.
+
         Relations:
             * :class:`BatchAllTripletLoss` uses all possible, valid triplets, rather than only the hardest positive and negative samples.
             * :class:`BatchSemiHardTripletLoss` uses only semi-hard triplets, valid triplets, rather than only the hardest positive and negative samples.

--- a/sentence_transformers/losses/BatchSemiHardTripletLoss.py
+++ b/sentence_transformers/losses/BatchSemiHardTripletLoss.py
@@ -50,18 +50,22 @@ class BatchSemiHardTripletLoss(nn.Module):
             2. Your dataset must contain at least 2 examples per labels class.
             3. Your dataset should contain semi hard positives and negatives.
 
-        Relations:
-            * :class:`BatchHardTripletLoss` uses only the hardest positive and negative samples, rather than only semi hard positive and negatives.
-            * :class:`BatchAllTripletLoss` uses all possible, valid triplets, rather than only semi hard positive and negatives.
-            * :class:`BatchHardSoftMarginTripletLoss` uses only the hardest positive and negative samples, rather than only semi hard positive and negatives.
-            Also, it does not require setting a margin.
-
         Inputs:
             +------------------+--------+
             | Texts            | Labels |
             +==================+========+
             | single sentences | class  |
             +------------------+--------+
+
+        Recommendations:
+            - Use ``BatchSamplers.GROUP_BY_LABEL`` (:class:`docs <sentence_transformers.training_args.BatchSamplers>`) to
+              ensure that each batch contains 2+ examples per label class.
+
+        Relations:
+            * :class:`BatchHardTripletLoss` uses only the hardest positive and negative samples, rather than only semi hard positive and negatives.
+            * :class:`BatchAllTripletLoss` uses all possible, valid triplets, rather than only semi hard positive and negatives.
+            * :class:`BatchHardSoftMarginTripletLoss` uses only the hardest positive and negative samples, rather than only semi hard positive and negatives.
+            Also, it does not require setting a margin.
 
         Example:
             ::

--- a/sentence_transformers/losses/CachedGISTEmbedLoss.py
+++ b/sentence_transformers/losses/CachedGISTEmbedLoss.py
@@ -99,9 +99,6 @@ class CachedGISTEmbedLoss(nn.Module):
             1. (anchor, positive) pairs or (anchor, positive, negative pairs)
             2. Should be used with large batch sizes for superior performance, but has slower training time than :class:`MultipleNegativesRankingLoss`
 
-        Relations:
-            - Equivalent to :class:`GISTEmbedLoss`, but with caching that allows for much higher batch sizes
-
         Inputs:
             +---------------------------------------+--------+
             | Texts                                 | Labels |
@@ -110,6 +107,13 @@ class CachedGISTEmbedLoss(nn.Module):
             +---------------------------------------+--------+
             | (anchor, positive, negative) triplets | none   |
             +---------------------------------------+--------+
+
+        Recommendations:
+            - Use ``BatchSamplers.NO_DUPLICATES`` (:class:`docs <sentence_transformers.training_args.BatchSamplers>`) to
+              ensure that no in-batch negatives are duplicates of the anchor or positive samples.
+
+        Relations:
+            - Equivalent to :class:`GISTEmbedLoss`, but with caching that allows for much higher batch sizes
 
         Example:
             ::

--- a/sentence_transformers/losses/CachedMultipleNegativesRankingLoss.py
+++ b/sentence_transformers/losses/CachedMultipleNegativesRankingLoss.py
@@ -104,11 +104,6 @@ class CachedMultipleNegativesRankingLoss(nn.Module):
             1. (anchor, positive) pairs or (anchor, positive, negative pairs)
             2. Should be used with large batch sizes for superior performance, but has slower training time than :class:`MultipleNegativesRankingLoss`
 
-        Relations:
-            - Equivalent to :class:`MultipleNegativesRankingLoss`, but with caching that allows for much higher batch sizes
-            (and thus better performance) without extra memory usage. This loss also trains roughly 2x to 2.4x slower than
-            :class:`MultipleNegativesRankingLoss`.
-
         Inputs:
             +---------------------------------------+--------+
             | Texts                                 | Labels |
@@ -117,6 +112,15 @@ class CachedMultipleNegativesRankingLoss(nn.Module):
             +---------------------------------------+--------+
             | (anchor, positive, negative) triplets | none   |
             +---------------------------------------+--------+
+
+        Recommendations:
+            - Use ``BatchSamplers.NO_DUPLICATES`` (:class:`docs <sentence_transformers.training_args.BatchSamplers>`) to
+              ensure that no in-batch negatives are duplicates of the anchor or positive samples.
+
+        Relations:
+            - Equivalent to :class:`MultipleNegativesRankingLoss`, but with caching that allows for much higher batch sizes
+            (and thus better performance) without extra memory usage. This loss also trains roughly 2x to 2.4x slower than
+            :class:`MultipleNegativesRankingLoss`.
 
         Example:
             ::

--- a/sentence_transformers/losses/CachedMultipleNegativesSymmetricRankingLoss.py
+++ b/sentence_transformers/losses/CachedMultipleNegativesSymmetricRankingLoss.py
@@ -74,16 +74,20 @@ class CachedMultipleNegativesSymmetricRankingLoss(nn.Module):
             1. (anchor, positive) pairs
             2. Should be used with large batch sizes for superior performance, but has slower training time than non-cached versions
 
-        Relations:
-            - Like :class:`MultipleNegativesRankingLoss`, but with an additional symmetric loss term and caching mechanism.
-            - Inspired by :class:`CachedMultipleNegativesRankingLoss`, adapted for symmetric loss calculation.
-
         Inputs:
             +---------------------------------------+--------+
             | Texts                                 | Labels |
             +=======================================+========+
             | (anchor, positive) pairs              | none   |
             +---------------------------------------+--------+
+
+        Recommendations:
+            - Use ``BatchSamplers.NO_DUPLICATES`` (:class:`docs <sentence_transformers.training_args.BatchSamplers>`) to
+              ensure that no in-batch negatives are duplicates of the anchor or positive samples.
+
+        Relations:
+            - Like :class:`MultipleNegativesRankingLoss`, but with an additional symmetric loss term and caching mechanism.
+            - Inspired by :class:`CachedMultipleNegativesRankingLoss`, adapted for symmetric loss calculation.
 
         Example:
             ::

--- a/sentence_transformers/losses/CoSENTLoss.py
+++ b/sentence_transformers/losses/CoSENTLoss.py
@@ -40,16 +40,16 @@ class CoSENTLoss(nn.Module):
         Requirements:
             - Sentence pairs with corresponding similarity scores in range of the similarity function. Default is [-1,1].
 
-        Relations:
-            - :class:`AnglELoss` is CoSENTLoss with ``pairwise_angle_sim`` as the metric, rather than ``pairwise_cos_sim``.
-            - :class:`CosineSimilarityLoss` seems to produce a weaker training signal than CoSENTLoss. In our experiments, CoSENTLoss is recommended.
-
         Inputs:
             +--------------------------------+------------------------+
             | Texts                          | Labels                 |
             +================================+========================+
             | (sentence_A, sentence_B) pairs | float similarity score |
             +--------------------------------+------------------------+
+
+        Relations:
+            - :class:`AnglELoss` is CoSENTLoss with ``pairwise_angle_sim`` as the metric, rather than ``pairwise_cos_sim``.
+            - :class:`CosineSimilarityLoss` seems to produce a weaker training signal than CoSENTLoss. In our experiments, CoSENTLoss is recommended.
 
         Example:
             ::

--- a/sentence_transformers/losses/ContrastiveLoss.py
+++ b/sentence_transformers/losses/ContrastiveLoss.py
@@ -45,16 +45,16 @@ class ContrastiveLoss(nn.Module):
         Requirements:
             1. (anchor, positive/negative) pairs
 
-        Relations:
-            - :class:`OnlineContrastiveLoss` is similar, but uses hard positive and hard negative pairs.
-            It often yields better results.
-
         Inputs:
             +-----------------------------------------------+------------------------------+
             | Texts                                         | Labels                       |
             +===============================================+==============================+
             | (anchor, positive/negative) pairs             | 1 if positive, 0 if negative |
             +-----------------------------------------------+------------------------------+
+
+        Relations:
+            - :class:`OnlineContrastiveLoss` is similar, but uses hard positive and hard negative pairs.
+            It often yields better results.
 
         Example:
             ::

--- a/sentence_transformers/losses/ContrastiveTensionLoss.py
+++ b/sentence_transformers/losses/ContrastiveTensionLoss.py
@@ -33,15 +33,15 @@ class ContrastiveTensionLoss(nn.Module):
         * Semantic Re-Tuning with Contrastive Tension: https://openreview.net/pdf?id=Ov_sMNau-PF
         * `Unsupervised Learning > CT <../../examples/unsupervised_learning/CT/README.html>`_
 
-    Relations:
-        * :class:`ContrastiveTensionLossInBatchNegatives` uses in-batch negative sampling, which gives a stronger training signal than this loss.
-
     Inputs:
         +------------------+--------+
         | Texts            | Labels |
         +==================+========+
         | single sentences | none   |
         +------------------+--------+
+
+    Relations:
+        * :class:`ContrastiveTensionLossInBatchNegatives` uses in-batch negative sampling, which gives a stronger training signal than this loss.
 
     Example:
         ::

--- a/sentence_transformers/losses/CosineSimilarityLoss.py
+++ b/sentence_transformers/losses/CosineSimilarityLoss.py
@@ -37,16 +37,16 @@ class CosineSimilarityLoss(nn.Module):
         Requirements:
             1. Sentence pairs with corresponding similarity scores in range `[0, 1]`
 
-        Relations:
-            - :class:`CoSENTLoss` seems to produce a stronger training signal than CosineSimilarityLoss. In our experiments, CoSENTLoss is recommended.
-            - :class:`AnglELoss` is :class:`CoSENTLoss` with ``pairwise_angle_sim`` as the metric, rather than ``pairwise_cos_sim``. It also produces a stronger training signal than CosineSimilarityLoss.
-
         Inputs:
             +--------------------------------+------------------------+
             | Texts                          | Labels                 |
             +================================+========================+
             | (sentence_A, sentence_B) pairs | float similarity score |
             +--------------------------------+------------------------+
+
+        Relations:
+            - :class:`CoSENTLoss` seems to produce a stronger training signal than CosineSimilarityLoss. In our experiments, CoSENTLoss is recommended.
+            - :class:`AnglELoss` is :class:`CoSENTLoss` with ``pairwise_angle_sim`` as the metric, rather than ``pairwise_cos_sim``. It also produces a stronger training signal than CosineSimilarityLoss.
 
         Example:
             ::

--- a/sentence_transformers/losses/GISTEmbedLoss.py
+++ b/sentence_transformers/losses/GISTEmbedLoss.py
@@ -37,11 +37,6 @@ class GISTEmbedLoss(nn.Module):
             1. (anchor, positive, negative) triplets
             2. (anchor, positive) pairs
 
-        Relations:
-            - :class:`MultipleNegativesRankingLoss` is similar to this loss, but it does not use
-              a guide model to guide the in-batch negative sample selection. `GISTEmbedLoss` yields
-              a stronger training signal at the cost of some training overhead.
-
         Inputs:
             +---------------------------------------+--------+
             | Texts                                 | Labels |
@@ -50,6 +45,15 @@ class GISTEmbedLoss(nn.Module):
             +---------------------------------------+--------+
             | (anchor, positive) pairs              | none   |
             +---------------------------------------+--------+
+
+        Recommendations:
+            - Use ``BatchSamplers.NO_DUPLICATES`` (:class:`docs <sentence_transformers.training_args.BatchSamplers>`) to
+              ensure that no in-batch negatives are duplicates of the anchor or positive samples.
+
+        Relations:
+            - :class:`MultipleNegativesRankingLoss` is similar to this loss, but it does not use
+              a guide model to guide the in-batch negative sample selection. `GISTEmbedLoss` yields
+              a stronger training signal at the cost of some training overhead.
 
         Example:
             ::

--- a/sentence_transformers/losses/MSELoss.py
+++ b/sentence_transformers/losses/MSELoss.py
@@ -28,10 +28,7 @@ class MSELoss(nn.Module):
         Requirements:
             1. Usually uses a finetuned teacher M in a knowledge distillation setup
 
-        Relations:
-            - :class:`MarginMSELoss` is equivalent to this loss, but with a margin through a negative pair.
-
-        Input:
+        Inputs:
             +-----------------------------------------+-----------------------------+
             | Texts                                   | Labels                      |
             +=========================================+=============================+
@@ -39,6 +36,9 @@ class MSELoss(nn.Module):
             +-----------------------------------------+-----------------------------+
             | sentence_1, sentence_2, ..., sentence_N | model sentence embeddings   |
             +-----------------------------------------+-----------------------------+
+
+        Relations:
+            - :class:`MarginMSELoss` is equivalent to this loss, but with a margin through a negative pair.
 
         Example:
             ::

--- a/sentence_transformers/losses/MarginMSELoss.py
+++ b/sentence_transformers/losses/MarginMSELoss.py
@@ -32,15 +32,15 @@ class MarginMSELoss(nn.Module):
             1. (query, passage_one, passage_two) triplets
             2. Usually used with a finetuned teacher M in a knowledge distillation setup
 
-        Relations:
-            - :class:`MSELoss` is equivalent to this loss, but without a margin through the negative pair.
-
         Inputs:
             +-----------------------------------------------+-----------------------------------------------+
             | Texts                                         | Labels                                        |
             +===============================================+===============================================+
             | (query, passage_one, passage_two) triplets    | M(query, passage_one) - M(query, passage_two) |
             +-----------------------------------------------+-----------------------------------------------+
+
+        Relations:
+            - :class:`MSELoss` is equivalent to this loss, but without a margin through the negative pair.
 
         Example:
 

--- a/sentence_transformers/losses/Matryoshka2dLoss.py
+++ b/sentence_transformers/losses/Matryoshka2dLoss.py
@@ -81,16 +81,16 @@ class Matryoshka2dLoss(AdaptiveLayerLoss):
         Requirements:
             1. The base loss cannot be :class:`CachedMultipleNegativesRankingLoss`.
 
-        Relations:
-            - :class:`MatryoshkaLoss` is used in this loss, and it is responsible for the dimensionality reduction.
-            - :class:`AdaptiveLayerLoss` is used in this loss, and it is responsible for the layer reduction.
-
-        Input:
+        Inputs:
             +---------------------------------------+--------+
             | Texts                                 | Labels |
             +=======================================+========+
             | any                                   | any    |
             +---------------------------------------+--------+
+
+        Relations:
+            - :class:`MatryoshkaLoss` is used in this loss, and it is responsible for the dimensionality reduction.
+            - :class:`AdaptiveLayerLoss` is used in this loss, and it is responsible for the layer reduction.
 
         Example:
             ::

--- a/sentence_transformers/losses/MatryoshkaLoss.py
+++ b/sentence_transformers/losses/MatryoshkaLoss.py
@@ -86,16 +86,16 @@ class MatryoshkaLoss(nn.Module):
         Requirements:
             1. The base loss cannot be :class:`CachedMultipleNegativesRankingLoss` or :class:`CachedGISTEmbedLoss`.
 
-        Relations:
-            - :class:`Matryoshka2dLoss` uses this loss in combination with :class:`AdaptiveLayerLoss` which allows for
-                layer reduction for faster inference.
-
-        Input:
+        Inputs:
             +---------------------------------------+--------+
             | Texts                                 | Labels |
             +=======================================+========+
             | any                                   | any    |
             +---------------------------------------+--------+
+
+        Relations:
+            - :class:`Matryoshka2dLoss` uses this loss in combination with :class:`AdaptiveLayerLoss` which allows for
+                layer reduction for faster inference.
 
         Example:
             ::

--- a/sentence_transformers/losses/MegaBatchMarginLoss.py
+++ b/sentence_transformers/losses/MegaBatchMarginLoss.py
@@ -45,12 +45,16 @@ class MegaBatchMarginLoss(nn.Module):
             1. (anchor, positive) pairs
             2. Large batches (500 or more examples)
 
-        Input:
+        Inputs:
             +---------------------------------------+--------+
             | Texts                                 | Labels |
             +=======================================+========+
             | (anchor, positive) pairs              | none   |
             +---------------------------------------+--------+
+
+        Recommendations:
+            - Use ``BatchSamplers.NO_DUPLICATES`` (:class:`docs <sentence_transformers.training_args.BatchSamplers>`) to
+              ensure that no in-batch negatives are duplicates of the anchor or positive samples.
 
         Example:
             ::

--- a/sentence_transformers/losses/MultipleNegativesRankingLoss.py
+++ b/sentence_transformers/losses/MultipleNegativesRankingLoss.py
@@ -48,14 +48,6 @@ class MultipleNegativesRankingLoss(nn.Module):
         Requirements:
             1. (anchor, positive) pairs or (anchor, positive, negative) triplets
 
-        Relations:
-            - :class:`CachedMultipleNegativesRankingLoss` is equivalent to this loss, but it uses caching that allows for
-              much higher batch sizes (and thus better performance) without extra memory usage. However, it is slightly
-              slower.
-            - :class:`MultipleNegativesSymmetricRankingLoss` is equivalent to this loss, but with an additional loss term.
-            - :class:`GISTEmbedLoss` is equivalent to this loss, but uses a guide model to guide the in-batch negative
-              sample selection. `GISTEmbedLoss` yields a stronger training signal at the cost of some training overhead.
-
         Inputs:
             +---------------------------------------+--------+
             | Texts                                 | Labels |
@@ -64,6 +56,18 @@ class MultipleNegativesRankingLoss(nn.Module):
             +---------------------------------------+--------+
             | (anchor, positive, negative) triplets | none   |
             +---------------------------------------+--------+
+
+        Recommendations:
+            - Use ``BatchSamplers.NO_DUPLICATES`` (:class:`docs <sentence_transformers.training_args.BatchSamplers>`) to
+              ensure that no in-batch negatives are duplicates of the anchor or positive samples.
+
+        Relations:
+            - :class:`CachedMultipleNegativesRankingLoss` is equivalent to this loss, but it uses caching that allows for
+              much higher batch sizes (and thus better performance) without extra memory usage. However, it is slightly
+              slower.
+            - :class:`MultipleNegativesSymmetricRankingLoss` is equivalent to this loss, but with an additional loss term.
+            - :class:`GISTEmbedLoss` is equivalent to this loss, but uses a guide model to guide the in-batch negative
+              sample selection. `GISTEmbedLoss` yields a stronger training signal at the cost of some training overhead.
 
         Example:
             ::

--- a/sentence_transformers/losses/MultipleNegativesSymmetricRankingLoss.py
+++ b/sentence_transformers/losses/MultipleNegativesSymmetricRankingLoss.py
@@ -35,18 +35,22 @@ class MultipleNegativesSymmetricRankingLoss(nn.Module):
         Requirements:
             1. (anchor, positive) pairs
 
-        Relations:
-            - Like :class:`MultipleNegativesRankingLoss`, but with an additional loss term.
-            - :class:`CachedMultipleNegativesSymmetricRankingLoss` is equivalent to this loss, but it uses caching that
-              allows for much higher batch sizes (and thus better performance) without extra memory usage. However, it
-              is slightly slower.
-
         Inputs:
             +---------------------------------------+--------+
             | Texts                                 | Labels |
             +=======================================+========+
             | (anchor, positive) pairs              | none   |
             +---------------------------------------+--------+
+
+        Recommendations:
+            - Use ``BatchSamplers.NO_DUPLICATES`` (:class:`docs <sentence_transformers.training_args.BatchSamplers>`) to
+              ensure that no in-batch negatives are duplicates of the anchor or positive samples.
+
+        Relations:
+            - Like :class:`MultipleNegativesRankingLoss`, but with an additional loss term.
+            - :class:`CachedMultipleNegativesSymmetricRankingLoss` is equivalent to this loss, but it uses caching that
+              allows for much higher batch sizes (and thus better performance) without extra memory usage. However, it
+              is slightly slower.
 
         Example:
             ::

--- a/sentence_transformers/losses/OnlineContrastiveLoss.py
+++ b/sentence_transformers/losses/OnlineContrastiveLoss.py
@@ -34,16 +34,16 @@ class OnlineContrastiveLoss(nn.Module):
             1. (anchor, positive/negative) pairs
             2. Data should include hard positives and hard negatives
 
-        Relations:
-            - :class:`ContrastiveLoss` is similar, but does not use hard positive and hard negative pairs.
-            :class:`OnlineContrastiveLoss` often yields better results.
-
         Inputs:
             +-----------------------------------------------+------------------------------+
             | Texts                                         | Labels                       |
             +===============================================+==============================+
             | (anchor, positive/negative) pairs             | 1 if positive, 0 if negative |
             +-----------------------------------------------+------------------------------+
+
+        Relations:
+            - :class:`ContrastiveLoss` is similar, but does not use hard positive and hard negative pairs.
+            :class:`OnlineContrastiveLoss` often yields better results.
 
         Example:
             ::

--- a/sentence_transformers/trainer.py
+++ b/sentence_transformers/trainer.py
@@ -464,6 +464,25 @@ class SentenceTransformerTrainer(Trainer):
         valid_label_columns: list[str] | None = None,
         generator: torch.Generator | None = None,
     ) -> BatchSampler:
+        """
+        Returns the appropriate batch sampler based on the ``batch_sampler`` argument in ``self.args``.
+        This batch sampler class supports ``__len__`` and ``__iter__`` methods, and is used as the ``batch_sampler``
+        to create the :class:`torch.utils.data.DataLoader`.
+
+        .. note::
+            Override this method to provide a custom batch sampler.
+
+        Args:
+            dataset (Dataset): The dataset to sample from.
+            batch_size (int): Number of samples per batch.
+            drop_last (bool): If True, drop the last incomplete batch if the dataset size
+                is not divisible by the batch size.
+            valid_label_columns (List[str]): List of column names to check for labels.
+                The first column name from ``valid_label_columns`` found in the dataset will
+                be used as the label column.
+            generator (torch.Generator, optional): Optional random number generator for shuffling
+                the indices.
+        """
         if self.args.batch_sampler == BatchSamplers.NO_DUPLICATES:
             return NoDuplicatesBatchSampler(
                 dataset=dataset,
@@ -495,6 +514,20 @@ class SentenceTransformerTrainer(Trainer):
         generator: torch.Generator | None = None,
         seed: int | None = 0,
     ) -> BatchSampler:
+        """
+        Returns the appropriate multi-dataset batch sampler based on the ``multi_dataset_batch_sampler`` argument
+        in ``self.args``. This batch sampler class supports ``__len__`` and ``__iter__`` methods, and is used as the
+        ``batch_sampler`` to create the :class:`torch.utils.data.DataLoader`.
+
+        .. note::
+            Override this method to provide a custom multi-dataset batch sampler.
+
+        Args:
+            dataset (ConcatDataset): The concatenation of all datasets.
+            batch_samplers (List[BatchSampler]): List of batch samplers for each dataset in the concatenated dataset.
+            generator (torch.Generator, optional): Optional random number generator for shuffling the indices.
+            seed (int, optional): Optional seed for the random number generator
+        """
         if self.args.multi_dataset_batch_sampler == MultiDatasetBatchSamplers.ROUND_ROBIN:
             return RoundRobinBatchSampler(
                 dataset=dataset,

--- a/sentence_transformers/training_args.py
+++ b/sentence_transformers/training_args.py
@@ -17,9 +17,52 @@ class BatchSamplers(ExplicitEnum):
     The batch sampler is responsible for determining how samples are grouped into batches during training.
     Valid options are:
 
-    - ``BatchSamplers.BATCH_SAMPLER``: The default PyTorch batch sampler.
-    - ``BatchSamplers.NO_DUPLICATES``: Ensures no duplicate samples in a batch.
-    - ``BatchSamplers.GROUP_BY_LABEL``: Ensures each batch has 2+ samples from the same label.
+    - ``BatchSamplers.BATCH_SAMPLER``: **[default]** Uses :class:`~sentence_transformers.sampler.DefaultBatchSampler`, the default
+      PyTorch batch sampler.
+    - ``BatchSamplers.NO_DUPLICATES``: Uses :class:`~sentence_transformers.sampler.NoDuplicatesBatchSampler`,
+      ensuring no duplicate samples in a batch. Recommended for losses that use in-batch negatives, such as:
+
+        - :class:`~sentence_transformers.losses.MultipleNegativesRankingLoss`
+        - :class:`~sentence_transformers.losses.CachedMultipleNegativesRankingLoss`
+        - :class:`~sentence_transformers.losses.MultipleNegativesSymmetricRankingLoss`
+        - :class:`~sentence_transformers.losses.CachedMultipleNegativesSymmetricRankingLoss`
+        - :class:`~sentence_transformers.losses.MegaBatchMarginLoss`
+        - :class:`~sentence_transformers.losses.GISTEmbedLoss`
+        - :class:`~sentence_transformers.losses.CachedGISTEmbedLoss`
+    - ``BatchSamplers.GROUP_BY_LABEL``: Uses :class:`~sentence_transformers.sampler.GroupByLabelBatchSampler`,
+      ensuring that each batch has 2+ samples from the same label. Recommended for losses that require multiple
+      samples from the same label, such as:
+
+        - :class:`~sentence_transformers.losses.BatchAllTripletLoss`
+        - :class:`~sentence_transformers.losses.BatchHardSoftMarginTripletLoss`
+        - :class:`~sentence_transformers.losses.BatchHardTripletLoss`
+        - :class:`~sentence_transformers.losses.BatchSemiHardTripletLoss`
+
+    Usage:
+        ::
+
+            from sentence_transformers import SentenceTransformer, SentenceTransformerTrainer, SentenceTransformerTrainingArguments
+            from sentence_transformers.training_args import BatchSamplers
+            from sentence_transformers.losses import MultipleNegativesRankingLoss
+            from datasets import Dataset
+
+            model = SentenceTransformer("microsoft/mpnet-base")
+            train_dataset = Dataset.from_dict({
+                "anchor": ["It's nice weather outside today.", "He drove to work."],
+                "positive": ["It's so sunny.", "He took the car to the office."],
+            })
+            loss = MultipleNegativesRankingLoss(model)
+            args = SentenceTransformerTrainingArguments(
+                output_dir="checkpoints",
+                batch_sampler=BatchSamplers.NO_DUPLICATES,
+            )
+            trainer = SentenceTransformerTrainer(
+                model=model,
+                args=args,
+                train_dataset=train_dataset,
+                loss=loss,
+            )
+            trainer.train()
     """
 
     BATCH_SAMPLER = "batch_sampler"
@@ -34,11 +77,56 @@ class MultiDatasetBatchSamplers(ExplicitEnum):
     The multi-dataset batch sampler is responsible for determining in what order batches are sampled from multiple
     datasets during training. Valid options are:
 
-    - ``MultiDatasetBatchSamplers.ROUND_ROBIN``: Round-robin sampling from each dataset until one is exhausted.
+    - ``MultiDatasetBatchSamplers.ROUND_ROBIN``: Uses :class:`~sentence_transformers.sampler.RoundRobinBatchSampler`,
+      which uses round-robin sampling from each dataset until one is exhausted.
       With this strategy, it's likely that not all samples from each dataset are used, but each dataset is sampled
       from equally.
-    - ``MultiDatasetBatchSamplers.PROPORTIONAL``: Sample from each dataset in proportion to its size [default].
+    - ``MultiDatasetBatchSamplers.PROPORTIONAL``: **[default]** Uses :class:`~sentence_transformers.sampler.ProportionalBatchSampler`,
+      which samples from each dataset in proportion to its size.
       With this strategy, all samples from each dataset are used and larger datasets are sampled from more frequently.
+
+    Usage:
+        ::
+
+            from sentence_transformers import SentenceTransformer, SentenceTransformerTrainer, SentenceTransformerTrainingArguments
+            from sentence_transformers.training_args import MultiDatasetBatchSamplers
+            from sentence_transformers.losses import CoSENTLoss
+            from datasets import Dataset, DatasetDict
+
+            model = SentenceTransformer("microsoft/mpnet-base")
+            train_general = Dataset.from_dict({
+                "sentence_A": ["It's nice weather outside today.", "He drove to work."],
+                "sentence_B": ["It's so sunny.", "He took the car to the bank."],
+                "score": [0.9, 0.4],
+            })
+            train_medical = Dataset.from_dict({
+                "sentence_A": ["The patient has a fever.", "The doctor prescribed medication.", "The patient is sweating."],
+                "sentence_B": ["The patient feels hot.", "The medication was given to the patient.", "The patient is perspiring."],
+                "score": [0.8, 0.6, 0.7],
+            })
+            train_legal = Dataset.from_dict({
+                "sentence_A": ["This contract is legally binding.", "The parties agree to the terms and conditions."],
+                "sentence_B": ["Both parties acknowledge their obligations.", "By signing this agreement, the parties enter into a legal relationship."],
+                "score": [0.7, 0.8],
+            })
+            train_dataset = DatasetDict({
+                "general": train_general,
+                "medical": train_medical,
+                "legal": train_legal,
+            })
+
+            loss = CoSENTLoss(model)
+            args = SentenceTransformerTrainingArguments(
+                output_dir="checkpoints",
+                multi_dataset_batch_sampler=MultiDatasetBatchSamplers.PROPORTIONAL,
+            )
+            trainer = SentenceTransformerTrainer(
+                model=model,
+                args=args,
+                train_dataset=train_dataset,
+                loss=loss,
+            )
+            trainer.train()
     """
 
     ROUND_ROBIN = "round_robin"  # Round-robin sampling from each dataset

--- a/sentence_transformers/training_args.py
+++ b/sentence_transformers/training_args.py
@@ -38,6 +38,12 @@ class BatchSamplers(ExplicitEnum):
         - :class:`~sentence_transformers.losses.BatchHardTripletLoss`
         - :class:`~sentence_transformers.losses.BatchSemiHardTripletLoss`
 
+    If you want to use a custom batch sampler, you can create a new Trainer class that inherits from
+    :class:`~sentence_transformers.trainer.SentenceTransformerTrainer` and overrides the
+    :meth:`~sentence_transformers.trainer.SentenceTransformerTrainer.get_batch_sampler` method. The
+    method must return a class instance that supports ``__iter__`` and ``__len__`` methods. The former
+    should yield a list of indices for each batch, and the latter should return the number of batches.
+
     Usage:
         ::
 


### PR DESCRIPTION
Hello!

## Pull Request overview
* Add new Samplers tab in Package Reference
* Add "Recommended for losses such as:" in BatchSamplers
* Add Usage in BatchSamplers and MultiDatasetBatchSamplers
* Add "Recommendations" section to some losses, pointing to specific samplers

## Details
Following #2920, I realised that the documentation for samplers was lacking. I've added some more, focusing primarily on 1) recommendations and 2) usage snippets. 

The new BatchSamplers:
![image](https://github.com/user-attachments/assets/4a25798a-5fcf-44d1-aad5-810215541dfb)

which was previously:
![image](https://github.com/user-attachments/assets/0a5b47ee-bb45-4868-bb85-2a8475b20ec4)

New docs for previously undocumented samplers:
![image](https://github.com/user-attachments/assets/8e15cc03-1133-4352-9e9d-4b3160a94cfd)

New recommendation section for some losses:
![image](https://github.com/user-attachments/assets/99520b91-5044-4e44-9d4a-612d8c49506e)

- Tom Aarsen