### PR TITLE
[`deprecation`] Push deprecation cycle for `use_auth_token` to v4

### DIFF
--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -175,7 +175,7 @@ class SentenceTransformer(nn.Sequential, FitMixin):
         self._model_config = {}
         if use_auth_token is not None:
             warnings.warn(
-                "The `use_auth_token` argument is deprecated and will be removed in v3 of SentenceTransformers.",
+                "The `use_auth_token` argument is deprecated and will be removed in v4 of SentenceTransformers.",
                 FutureWarning,
             )
             if token is not None:


### PR DESCRIPTION
Hello!

## Pull Request overview
* Push deprecation cycle for `use_auth_token` to v4

## Details
v3 was a bit too soon, and already happened, so let's move it to v4.

- Tom Aarsen