### PR TITLE
[`security`] Load weights only with torch.load & pytorch_model.bin

### DIFF
--- a/sentence_transformers/models/CNN.py
+++ b/sentence_transformers/models/CNN.py
@@ -81,6 +81,8 @@ class CNN(nn.Module):
             load_safetensors_model(model, os.path.join(input_path, "model.safetensors"))
         else:
             model.load_state_dict(
-                torch.load(os.path.join(input_path, "pytorch_model.bin"), map_location=torch.device("cpu"))
+                torch.load(
+                    os.path.join(input_path, "pytorch_model.bin"), map_location=torch.device("cpu"), weights_only=True
+                )
             )
         return model

--- a/sentence_transformers/models/Dense.py
+++ b/sentence_transformers/models/Dense.py
@@ -87,6 +87,8 @@ class Dense(nn.Module):
             load_safetensors_model(model, os.path.join(input_path, "model.safetensors"))
         else:
             model.load_state_dict(
-                torch.load(os.path.join(input_path, "pytorch_model.bin"), map_location=torch.device("cpu"))
+                torch.load(
+                    os.path.join(input_path, "pytorch_model.bin"), map_location=torch.device("cpu"), weights_only=True
+                )
             )
         return model

--- a/sentence_transformers/models/LSTM.py
+++ b/sentence_transformers/models/LSTM.py
@@ -83,6 +83,8 @@ class LSTM(nn.Module):
             load_safetensors_model(model, os.path.join(input_path, "model.safetensors"))
         else:
             model.load_state_dict(
-                torch.load(os.path.join(input_path, "pytorch_model.bin"), map_location=torch.device("cpu"))
+                torch.load(
+                    os.path.join(input_path, "pytorch_model.bin"), map_location=torch.device("cpu"), weights_only=True
+                )
             )
         return model

--- a/sentence_transformers/models/LayerNorm.py
+++ b/sentence_transformers/models/LayerNorm.py
@@ -41,6 +41,8 @@ class LayerNorm(nn.Module):
             load_safetensors_model(model, os.path.join(input_path, "model.safetensors"))
         else:
             model.load_state_dict(
-                torch.load(os.path.join(input_path, "pytorch_model.bin"), map_location=torch.device("cpu"))
+                torch.load(
+                    os.path.join(input_path, "pytorch_model.bin"), map_location=torch.device("cpu"), weights_only=True
+                )
             )
         return model

--- a/sentence_transformers/models/WeightedLayerPooling.py
+++ b/sentence_transformers/models/WeightedLayerPooling.py
@@ -63,6 +63,8 @@ class WeightedLayerPooling(nn.Module):
             load_safetensors_model(model, os.path.join(input_path, "model.safetensors"))
         else:
             model.load_state_dict(
-                torch.load(os.path.join(input_path, "pytorch_model.bin"), map_location=torch.device("cpu"))
+                torch.load(
+                    os.path.join(input_path, "pytorch_model.bin"), map_location=torch.device("cpu"), weights_only=True
+                )
             )
         return model

--- a/sentence_transformers/models/WordEmbeddings.py
+++ b/sentence_transformers/models/WordEmbeddings.py
@@ -105,7 +105,9 @@ class WordEmbeddings(nn.Module):
         if os.path.exists(os.path.join(input_path, "model.safetensors")):
             weights = load_safetensors_file(os.path.join(input_path, "model.safetensors"))
         else:
-            weights = torch.load(os.path.join(input_path, "pytorch_model.bin"), map_location=torch.device("cpu"))
+            weights = torch.load(
+                os.path.join(input_path, "pytorch_model.bin"), map_location=torch.device("cpu"), weights_only=True
+            )
         embedding_weights = weights["emb_layer.weight"]
         model = WordEmbeddings(
             tokenizer=tokenizer, embedding_weights=embedding_weights, update_embeddings=config["update_embeddings"]


### PR DESCRIPTION
Hello!

## Pull Request overview
* Load weights only with torch.load & pytorch_model.bin

## Details
Although usually you'd want to use safetensors anyways, this PR gets rid of a warning:
```
  [sic]\sentence_transformers\models\WordEmbeddings.py:108: FutureWarning: You are using `torch.load` with `weights_only=False` (the current default value), which uses the default pickle module implicitly. It is possible to construct malicious pickle data which will execute arbitrary code during unpickling (See https://github.com/pytorch/pytorch/blob/main/SECURITY.md#untrusted-models for more details). In a future release, the default value for `weights_only` will be flipped to `True`. This limits the functions that could be executed during unpickling. Arbitrary objects will no longer be allowed to be loaded via this mode unless they are explicitly allowlisted by the user via `torch.serialization.add_safe_globals`. We recommend you start setting `weights_only=True` for any use case where you don't have full control of the loaded file. Please open an issue on GitHub for any issues related to this experimental feature.
    weights = torch.load(os.path.join(input_path, "pytorch_model.bin"), map_location=torch.device("cpu"))
```

- Tom Aarsen