### PR TITLE
[`docs`] Move losses up in the package reference; they're more important

### DIFF
--- a/docs/package_reference/sentence_transformer/index.rst
+++ b/docs/package_reference/sentence_transformer/index.rst
@@ -7,8 +7,8 @@ Sentence Transformer
    SentenceTransformer
    trainer
    training_args
-   sampler
    losses
+   sampler
    evaluation
    datasets
    models


### PR DESCRIPTION
Hello!

## Pull Request overview
* Move losses up in the package reference, so that it's above "samplers"

## Details
Losses are notably more important than samplers, so I've moved the former above the latter.

- Tom Aarsen