### PR TITLE
[`deps`] Attempt to remove numpy restrictions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,6 @@ dependencies = [
     "transformers>=4.38.0,<5.0.0",
     "tqdm",
     "torch>=1.11.0",
-    "numpy<2.0.0",
     "scikit-learn",
     "scipy",
     "huggingface-hub>=0.19.3",


### PR DESCRIPTION
Resolves #2933

Hello!

## Pull Request overview
* Attempt to remove numpy restrictions

## Details
I have some good luck with this locally; perhaps some of the problematic third-party dependencies have also been updated to support Numpy. For context: Numpy 2 used to break for Windows: https://github.com/UKPLab/sentence-transformers/actions/runs/9547213601/job/26311747682?pr=2757

- Tom Aarsen