### PR TITLE
[`metadata`] Extend pyproject.toml metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,15 @@
 [project]
 name = "sentence-transformers"
 version = "3.2.0.dev0"
-description = "Multilingual text embeddings"
-license = { file = "LICENSE" }
+description = "State-of-the-Art Text Embeddings"
+license = { text = "Apache 2.0" }
 readme = "README.md"
 authors = [
     { name = "Nils Reimers", email = "info@nils-reimers.de" },
-    { name = "Tom Aarsen" },
+    { name = "Tom Aarsen", email = "tom.aarsen@huggingface.co" },
+]
+maintainers = [
+    { name = "Tom Aarsen", email = "tom.aarsen@huggingface.co" }
 ]
 requires-python = ">=3.8"
 keywords = [


### PR DESCRIPTION
Hello!

## Pull Request overview
* Extend pyproject.toml metadata

## Details
This correctly puts @nreimers back as one of the Authors on pypi.org. This wasn't shown for the [3.1.0 release](https://pypi.org/project/sentence-transformers).
For some reason, if the `pyproject.toml` contains
```toml
authors = [
    { name = "Nils Reimers", email = "info@nils-reimers.de" },
    { name = "Tom Aarsen" },
]
```
Then this'll compile to:
```
Author: Tom Aarsen
Author-email: Nils Reimers <info@nils-reimers.de>
```
which pypi.org for some reason parses as 1 Author (Tom Aarsen) with 1 email (info@nils-reimers.de). If I add my own email, then it becomes:
```
Author-email: Nils Reimers <info@nils-reimers.de>, Tom Aarsen <tom.aarsen@huggingface.co>
```
and no `Author:`. This will still get parsed as just one Author by pypi.org... Except then it does link the correct email. I've also added myself as a maintainer, so we'll get:
```
Author-email: Tom Aarsen <tom.aarsen@huggingface.co>, Nils Reimers <info@nils-reimers.de>
Maintainer-email: Tom Aarsen <tom.aarsen@huggingface.co>
```
You can see what this becomes below. I'd rather just have 2 authors listed, but I can't seem to get that to work: the core metadata seems to only allow one author and one maintainer: https://packaging.python.org/en/latest/specifications/core-metadata/#author

## Before
![image](https://github.com/user-attachments/assets/85aaf75a-eb70-44d0-9723-a23d73387b9e)

## After
![image](https://github.com/user-attachments/assets/b1ff393e-35be-4a5a-8333-b20eab3df1f0)

- Tom Aarsen