### PR TITLE
[`fix`] Ensure that the embeddings from hard negative mining are normalized

### DIFF
--- a/sentence_transformers/util.py
+++ b/sentence_transformers/util.py
@@ -714,8 +714,12 @@ def mine_hard_negatives(
         except Exception:
             pass
 
-        corpus_embeddings = model.encode(corpus, batch_size=batch_size, convert_to_numpy=True, show_progress_bar=True)
-        query_embeddings = model.encode(queries, batch_size=batch_size, convert_to_numpy=True, show_progress_bar=True)
+        corpus_embeddings = model.encode(
+            corpus, batch_size=batch_size, normalize_embeddings=True, convert_to_numpy=True, show_progress_bar=True
+        )
+        query_embeddings = model.encode(
+            queries, batch_size=batch_size, normalize_embeddings=True, convert_to_numpy=True, show_progress_bar=True
+        )
         index.add(corpus_embeddings)
 
         scores_list = []
@@ -731,8 +735,12 @@ def mine_hard_negatives(
 
     else:
         # Embed the corpus and the queries
-        corpus_embeddings = model.encode(corpus, batch_size=batch_size, convert_to_numpy=True, show_progress_bar=True)
-        query_embeddings = model.encode(queries, batch_size=batch_size, convert_to_numpy=True, show_progress_bar=True)
+        corpus_embeddings = model.encode(
+            corpus, batch_size=batch_size, normalize_embeddings=True, convert_to_numpy=True, show_progress_bar=True
+        )
+        query_embeddings = model.encode(
+            queries, batch_size=batch_size, normalize_embeddings=True, convert_to_numpy=True, show_progress_bar=True
+        )
         scores = model.similarity(query_embeddings, corpus_embeddings).to(device)
 
         # Keep only the range_max + max_positives highest scores. We offset by 1 to potentially include the positive pair


### PR DESCRIPTION
Hello!

## Pull Request overview
* Ensure that the embeddings from hard negative mining are normalized

## Details
If you use `use_faiss` in [`mine_hard_negatives`](https://sbert.net/docs/package_reference/util.html#sentence_transformers.util.mine_hard_negatives), then FAISS expects normalized embeddings. However, the models aren't necessarily normalized. This results in `nan` for larger datasets and really large `scores` for smaller datasets. This PR should resolve that by enforcing that all embeddings are normalized in `mine_hard_negatives`.

- Tom Aarsen