### PR TITLE
[ENH] -- `CrossEncoder.rank`

### DIFF
--- a/sentence_transformers/cross_encoder/CrossEncoder.py
+++ b/sentence_transformers/cross_encoder/CrossEncoder.py
@@ -546,7 +546,7 @@ class CrossEncoder(PushToHubMixin):
         for i, score in enumerate(scores):
             results.append({"corpus_id": i, "score": score})
             if return_documents:
-                results[-1] |= {"text": documents[i]}
+                results[-1] = {**results[-1], "text": documents[i]}
 
         results = sorted(results, key=lambda x: x["score"], reverse=True)
         return results[:top_k]

--- a/sentence_transformers/cross_encoder/CrossEncoder.py
+++ b/sentence_transformers/cross_encoder/CrossEncoder.py
@@ -532,7 +532,7 @@ class CrossEncoder(PushToHubMixin):
         """
         query_doc_pairs = [[query, doc] for doc in documents]
         scores = self.predict(
-            query_doc_pairs,
+            sentences=query_doc_pairs,
             batch_size=batch_size,
             show_progress_bar=show_progress_bar,
             num_workers=num_workers,

--- a/sentence_transformers/cross_encoder/CrossEncoder.py
+++ b/sentence_transformers/cross_encoder/CrossEncoder.py
@@ -544,10 +544,9 @@ class CrossEncoder(PushToHubMixin):
 
         results = []
         for i, score in enumerate(scores):
+            results.append({"corpus_id": i, "score": score})
             if return_documents:
-                results.append({"corpus_id": i, "score": score, "text": documents[i]})
-            else:
-                results.append({"corpus_id": i, "score": score})
+                results[-1] |= {"text": documents[i]}
 
         results = sorted(results, key=lambda x: x["score"], reverse=True)
         return results[:top_k]

--- a/sentence_transformers/cross_encoder/CrossEncoder.py
+++ b/sentence_transformers/cross_encoder/CrossEncoder.py
@@ -546,7 +546,7 @@ class CrossEncoder(PushToHubMixin):
         for i, score in enumerate(scores):
             results.append({"corpus_id": i, "score": score})
             if return_documents:
-                results[-1] = {**results[-1], "text": documents[i]}
+                results[-1].update({"text": documents[i]})
 
         results = sorted(results, key=lambda x: x["score"], reverse=True)
         return results[:top_k]

--- a/sentence_transformers/cross_encoder/CrossEncoder.py
+++ b/sentence_transformers/cross_encoder/CrossEncoder.py
@@ -543,11 +543,11 @@ class CrossEncoder(PushToHubMixin):
         )
 
         results = []
-        for i in range(len(scores)):
+        for i, score in enumerate(scores):
             if return_documents:
-                results.append({"corpus_id": i, "score": scores[i], "text": documents[i]})
+                results.append({"corpus_id": i, "score": score, "text": documents[i]})
             else:
-                results.append({"corpus_id": i, "score": scores[i]})
+                results.append({"corpus_id": i, "score": score})
 
         results = sorted(results, key=lambda x: x["score"], reverse=True)
         return results[:top_k]

--- a/tests/test_cross_encoder.py
+++ b/tests/test_cross_encoder.py
@@ -133,7 +133,12 @@ def test_load_with_revision() -> None:
     assert not torch.equal(main_prob, older_model.predict(test_sentences, convert_to_tensor=True))
 
 
-def test_rank() -> None:
+@pytest.mark.parametrize(
+    argnames="return_documents",
+    argvalues=[True, False],
+    ids=["return-docs", "no-return-docs"],
+)
+def test_rank(return_documents: bool) -> None:
     model = CrossEncoder("cross-encoder/stsb-distilroberta-base")
     # We want to compute the similarity between the query sentence
     query = "A man is eating pasta."
@@ -153,7 +158,7 @@ def test_rank() -> None:
     expected_ranking = [0, 1, 3, 6, 2, 5, 7, 4, 8]
 
     # 1. We rank all sentences in the corpus for the query
-    ranks = model.rank(query, corpus)
+    ranks = model.rank(query=query, documents=corpus, return_documents=return_documents)
     pred_ranking = [rank["corpus_id"] for rank in ranks]
     assert pred_ranking == expected_ranking
 

--- a/tests/test_cross_encoder.py
+++ b/tests/test_cross_encoder.py
@@ -13,6 +13,7 @@ from typing import Generator
 import numpy as np
 import pytest
 import torch
+from pytest import FixtureRequest
 from torch.utils.data import DataLoader
 
 from sentence_transformers import CrossEncoder, util
@@ -138,7 +139,7 @@ def test_load_with_revision() -> None:
     argvalues=[True, False],
     ids=["return-docs", "no-return-docs"],
 )
-def test_rank(return_documents: bool) -> None:
+def test_rank(return_documents: bool, request: FixtureRequest) -> None:
     model = CrossEncoder("cross-encoder/stsb-distilroberta-base")
     # We want to compute the similarity between the query sentence
     query = "A man is eating pasta."
@@ -159,6 +160,9 @@ def test_rank(return_documents: bool) -> None:
 
     # 1. We rank all sentences in the corpus for the query
     ranks = model.rank(query=query, documents=corpus, return_documents=return_documents)
+    if request.node.callspec.id == "return-docs":
+        assert {*corpus} == {rank.get("text") for rank in ranks}
+
     pred_ranking = [rank["corpus_id"] for rank in ranks]
     assert pred_ranking == expected_ranking
 


### PR DESCRIPTION
I found some spots in the :method:`CrossEncoder.rank` that could be updated to reflect best practices. Feel free to cherry-pick or reject.

Tested with Python 3.8 for minimum version coverage.