### PR TITLE
[`fix`] Only save first module in root if "save_in_root" is specified.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -67,6 +67,7 @@ exclude_patterns = [
 intersphinx_mapping = {
     "datasets": ("https://huggingface.co/docs/datasets/main/en/", None),
     "transformers": ("https://huggingface.co/docs/transformers/main/en/", None),
+    "huggingface_hub": ("https://huggingface.co/docs/huggingface_hub/main/en/", None),
     "torch": ("https://pytorch.org/docs/stable/", None),
 }
 

--- a/docs/sentence_transformer/usage/custom_models.rst
+++ b/docs/sentence_transformer/usage/custom_models.rst
@@ -30,7 +30,7 @@ Whenever a Sentence Transformer model is saved, three types of files are generat
 
 * ``modules.json``: This file contains a list of module names, paths, and types that are used to reconstruct the model.
 * ``config_sentence_transformers.json``: This file contains some configuration options of the Sentence Transformer model, including saved prompts, the model its similarity function, and the Sentence Transformer package version used by the model author.
-* **Module-specific files**: Each module is saved in a separate folder, with the first module saved in the root folder and all subsequent modules saved in subfolders named after the module index and the model name (e.g., ``1_Pooling``, ``2_Normalize``).
+* **Module-specific files**: Each module is saved in separate subfolders named after the module index and the model name (e.g., ``1_Pooling``, ``2_Normalize``), except the first module may be saved in the root directory if it has a ``save_in_root`` attribute set to ``True``. In Sentence Transformers, this is the case for the :class:`~sentence_transformers.models.Transformer` and :class:`~sentence_transformers.models.CLIPModel` modules.
   Most module folders contain a ``config.json`` (or ``sentence_bert_config.json`` for the :class:`~sentence_transformers.models.Transformer` module) file that stores default values for keyword arguments passed to that Module. So, a ``sentence_bert_config.json`` of::
 
     {
@@ -187,6 +187,10 @@ For example, we can create a custom pooling method by implementing a custom Modu
 .. note::
 
    Adding ``**kwargs`` to the ``__init__``, ``forward``, ``save``, ``load``, and ``tokenize`` methods is recommended to ensure that the methods are compatible with future updates to the Sentence Transformers library.
+
+.. note::
+
+   If your module is the first module, then you can set ``save_in_root = True`` in the module's class definition if you want your module to be saved in the root directory upon save. Do note that unlike the subdirectories, the root directory is not downloaded from the Hugging Face Hub before loading the module. As a result, the module should first check if the required files exist locally and otherwise use :func:`huggingface_hub.hf_hub_download` to download them.
 
 This can now be used as a module in a Sentence Transformer model::
    

--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -1128,7 +1128,7 @@ class SentenceTransformer(nn.Sequential, FitMixin):
         # Save modules
         for idx, name in enumerate(self._modules):
             module = self._modules[name]
-            if idx == 0:  # Save first module in the main folder
+            if idx == 0 and hasattr(module, "save_in_root"):  # Save first module in the main folder
                 model_path = path + "/"
             else:
                 model_path = os.path.join(path, str(idx) + "_" + type(module).__name__)

--- a/sentence_transformers/models/CLIPModel.py
+++ b/sentence_transformers/models/CLIPModel.py
@@ -7,6 +7,8 @@ from torch import nn
 
 
 class CLIPModel(nn.Module):
+    save_in_root: bool = True
+
     def __init__(self, model_name: str = "openai/clip-vit-base-patch32", processor_name=None) -> None:
         super().__init__()
 

--- a/sentence_transformers/models/Transformer.py
+++ b/sentence_transformers/models/Transformer.py
@@ -31,6 +31,8 @@ class Transformer(nn.Module):
             None, then model_name_or_path is used
     """
 
+    save_in_root: bool = True
+
     def __init__(
         self,
         model_name_or_path: str,


### PR DESCRIPTION
Hello!

## Pull Request overview
* Only save first module in root if "save_in_root" is specified.

## Details
Required to avoid issues with loading expecting local files, but the root is kept on the Hub to avoid downloading the entire repository (with multiple model files, etc.)

You can reproduce the issue by:
1. Loading e.g. a WordEmbedding model like sentence-transformers/average_word_embeddings_glove.6B.300d.
2. Pushing the loaded model to the Hub. You'll notice that the WordEmbedding module is saved in the root.
3. Loading the pushed model again.

Because the WordEmbedding `load` method expects local files, this'll fail.

cc @NohTow I don't think should affect you, but we discussed this bit of code in the past, so I'm pinging you just in case.

- Tom Aarsen