### PR TITLE
[`model cards`] Keep evaluation order in training logs if there's multiple evaluators

### DIFF
--- a/sentence_transformers/model_card.py
+++ b/sentence_transformers/model_card.py
@@ -152,6 +152,8 @@ class ModelCardCallback(TrainerCallback):
         **kwargs,
     ) -> None:
         loss_dict = {" ".join(key.split("_")[1:]): metrics[key] for key in metrics if key.endswith("_loss")}
+        if len(loss_dict) == 1 and "loss" in loss_dict:
+            loss_dict = {"Validation Loss": loss_dict["loss"]}
         if (
             model.model_card_data.training_logs
             and model.model_card_data.training_logs[-1]["Step"] == state.global_step
@@ -830,19 +832,25 @@ class SentenceTransformerModelCardData(CardData):
 
     def format_training_logs(self):
         # Get the keys from all evaluation lines
-        eval_lines_keys = {key for lines in self.training_logs for key in lines.keys()}
+        eval_lines_keys = []
+        for lines in self.training_logs:
+            for key in lines.keys():
+                if key not in eval_lines_keys:
+                    eval_lines_keys.append(key)
 
         # Sort the metric columns: Epoch, Step, Training Loss, Validation Loss, Evaluator results
         def sort_metrics(key: str) -> str:
             if key == "Epoch":
-                return "0"
+                return 0
             if key == "Step":
-                return "1"
+                return 1
             if key == "Training Loss":
-                return "2"
+                return 2
+            if key == "Validation Loss":
+                return 3
             if key.endswith("loss"):
-                return "3"
-            return key
+                return 4
+            return eval_lines_keys.index(key) + 5
 
         sorted_eval_lines_keys = sorted(eval_lines_keys, key=sort_metrics)
         training_logs = [


### PR DESCRIPTION
Hello!

## Pull Request overview
* Keep evaluation order in training logs if there's multiple evaluators
* Rename "loss" to Validation Loss if there's only one loss

## Details
I move away from the set-based implementation to a list-based one, so I can reuse the original ordering of the evaluators used in a SequentialEvaluator passed to the Trainer. This gives us e.g.:
![image](https://github.com/user-attachments/assets/4ec391aa-13c4-4c1b-83b5-228743cc3d82)

Instead of e.g.

gooaq-1024-dev_cosine_map@100 | gooaq-128-dev_cosine_map@100 | gooaq-256-dev_cosine_map@100 | gooaq-32-dev_cosine_map@100 | gooaq-512-dev_cosine_map@100 | gooaq-64-dev_cosine_map@100
-- | -- | -- | -- | -- | --

Which was ordered based on the evaluation name (which isn't always useful, as can be seen here)

Also, we used to have

Epoch | Step | Training Loss | loss
-- | -- | -- | --

which just looked a bit odd, "loss" is now formatted as "Validation Loss" if there's only one loss.

- Tom Aarsen