### PR TITLE
[fix] Added model2vec import compatible with current and newer version

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install '.[train, onnx, openvino]'
+          python -m pip install '.[train, onnx, openvino, dev]'
 
       - name: Install model2vec
         run: python -m pip install model2vec

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,7 +61,11 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install '.[train, onnx, openvino, dev]'
+          python -m pip install '.[train, onnx, openvino]'
+
+      - name: Install model2vec
+        run: python -m pip install model2vec
+        if: ${{ contains(fromJSON('["3.10", "3.11", "3.12"]'), matrix.python-version) }}
 
       - name: Run unit tests
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ train = ["datasets", "accelerate>=0.20.3"]
 onnx = ["optimum[onnxruntime]>=1.23.1"]
 onnx-gpu = ["optimum[onnxruntime-gpu]>=1.23.1"]
 openvino = ["optimum-intel[openvino]>=1.20.0"]
-dev = ["datasets", "accelerate>=0.20.3", "pre-commit", "pytest", "pytest-cov", "model2vec"]
+dev = ["datasets", "accelerate>=0.20.3", "pre-commit", "pytest", "pytest-cov"]
 
 [build-system]
 requires = ["setuptools>=42", "wheel"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ train = ["datasets", "accelerate>=0.20.3"]
 onnx = ["optimum[onnxruntime]>=1.23.1"]
 onnx-gpu = ["optimum[onnxruntime-gpu]>=1.23.1"]
 openvino = ["optimum-intel[openvino]>=1.20.0"]
-dev = ["datasets", "accelerate>=0.20.3", "pre-commit", "pytest", "pytest-cov"]
+dev = ["datasets", "accelerate>=0.20.3", "pre-commit", "pytest", "pytest-cov", "model2vec"]
 
 [build-system]
 requires = ["setuptools>=42", "wheel"]

--- a/sentence_transformers/models/StaticEmbedding.py
+++ b/sentence_transformers/models/StaticEmbedding.py
@@ -161,8 +161,10 @@ class StaticEmbedding(nn.Module):
         try:
             from model2vec.distill import distill
         except ImportError:
-            raise ImportError("To use this method, please install the `model2vec` package: `pip install model2vec[distill]`")
-        
+            raise ImportError(
+                "To use this method, please install the `model2vec` package: `pip install model2vec[distill]`"
+            )
+
         device = get_device_name()
         static_model = distill(
             model_name,

--- a/sentence_transformers/models/StaticEmbedding.py
+++ b/sentence_transformers/models/StaticEmbedding.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import math
-import importlib.metadata
 import os
 from pathlib import Path
 
@@ -160,15 +159,7 @@ class StaticEmbedding(nn.Module):
         """
 
         try:
-            m2v_version = importlib.metadata.version("model2vec")
-            if m2v_version >= '0.3':
-                # Import distill from model2vec.distill
-                from model2vec.distill import distill
-            else:
-                # Import distill from model2vec
-                from model2vec import distill
-        except importlib.metadata.PackageNotFoundError:
-            raise ImportError("To use this method, please install the `model2vec` package: `pip install model2vec[distill]`")
+            from model2vec.distill import distill
         except ImportError:
             raise ImportError("To use this method, please install the `model2vec` package: `pip install model2vec[distill]`")
         

--- a/sentence_transformers/models/StaticEmbedding.py
+++ b/sentence_transformers/models/StaticEmbedding.py
@@ -167,9 +167,11 @@ class StaticEmbedding(nn.Module):
             else:
                 # Import distill from model2vec
                 from model2vec import distill
+        except importlib.metadata.PackageNotFoundError:
+            raise ImportError("To use this method, please install the `model2vec` package: `pip install model2vec[distill]`")
         except ImportError:
             raise ImportError("To use this method, please install the `model2vec` package: `pip install model2vec[distill]`")
-            
+        
         device = get_device_name()
         static_model = distill(
             model_name,

--- a/sentence_transformers/models/StaticEmbedding.py
+++ b/sentence_transformers/models/StaticEmbedding.py
@@ -174,7 +174,10 @@ class StaticEmbedding(nn.Module):
             apply_zipf=apply_zipf,
             use_subword=use_subword,
         )
-        embedding_weights = static_model.embedding.weight
+        if isinstance(static_model.embedding, np.ndarray):
+            embedding_weights = torch.from_numpy(static_model.embedding)
+        else:
+            embedding_weights = static_model.embedding.weight
         tokenizer: Tokenizer = static_model.tokenizer
 
         return cls(tokenizer, embedding_weights=embedding_weights, base_model=model_name)
@@ -202,7 +205,10 @@ class StaticEmbedding(nn.Module):
             raise ImportError("To use this method, please install the `model2vec` package: `pip install model2vec`")
 
         static_model = StaticModel.from_pretrained(model_id_or_path)
-        embedding_weights = static_model.embedding.weight
+        if isinstance(static_model.embedding, np.ndarray):
+            embedding_weights = torch.from_numpy(static_model.embedding)
+        else:
+            embedding_weights = static_model.embedding.weight
         tokenizer: Tokenizer = static_model.tokenizer
 
         return cls(tokenizer, embedding_weights=embedding_weights, base_model=model_id_or_path)

--- a/sentence_transformers/models/StaticEmbedding.py
+++ b/sentence_transformers/models/StaticEmbedding.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import math
+import importlib.metadata
 import os
 from pathlib import Path
 
@@ -159,7 +160,7 @@ class StaticEmbedding(nn.Module):
         """
 
         try:
-            from model2vec import __version__ as m2v_version
+            m2v_version = importlib.metadata.version("model2vec")
             if m2v_version >= '0.3':
                 # Import distill from model2vec.distill
                 from model2vec.distill import distill

--- a/sentence_transformers/models/StaticEmbedding.py
+++ b/sentence_transformers/models/StaticEmbedding.py
@@ -159,10 +159,16 @@ class StaticEmbedding(nn.Module):
         """
 
         try:
-            from model2vec import distill
+            from model2vec import __version__ as m2v_version
+            if m2v_version >= '0.3':
+                # Import distill from model2vec.distill
+                from model2vec.distill import distill
+            else:
+                # Import distill from model2vec
+                from model2vec import distill
         except ImportError:
-            raise ImportError("To use this method, please install the `model2vec` package: `pip install model2vec`")
-
+            raise ImportError("To use this method, please install the `model2vec` package: `pip install model2vec[distill]`")
+            
         device = get_device_name()
         static_model = distill(
             model_name,

--- a/tests/models/test_static_embedding.py
+++ b/tests/models/test_static_embedding.py
@@ -8,6 +8,13 @@ from tokenizers import Tokenizer
 
 from sentence_transformers.models.StaticEmbedding import StaticEmbedding
 
+try:
+    import model2vec
+except ImportError:
+    model2vec = None
+
+skip_if_no_model2vec = pytest.mark.skipif(model2vec is None, reason="The model2vec library is not installed.")
+
 
 @pytest.fixture
 def tokenizer() -> Tokenizer:
@@ -57,11 +64,13 @@ def test_save_and_load(tmp_path: Path, static_embedding: StaticEmbedding) -> Non
     assert loaded_model.embedding.weight.shape == static_embedding.embedding.weight.shape
 
 
+@skip_if_no_model2vec()
 def test_from_distillation() -> None:
     model = StaticEmbedding.from_distillation("sentence-transformers-testing/stsb-bert-tiny-safetensors", pca_dims=32)
     assert model.embedding.weight.shape == (29528, 32)
 
 
+@skip_if_no_model2vec()
 def test_from_model2vec() -> None:
     model = StaticEmbedding.from_model2vec("minishlab/M2V_base_output")
     assert model.embedding.weight.shape == (29528, 256)

--- a/tests/models/test_static_embedding.py
+++ b/tests/models/test_static_embedding.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+from tokenizers import Tokenizer
+
+from sentence_transformers.models.StaticEmbedding import StaticEmbedding
+
+
+@pytest.fixture
+def tokenizer() -> Tokenizer:
+    return Tokenizer.from_pretrained("bert-base-uncased")
+
+
+@pytest.fixture
+def embedding_weights():
+    return np.random.rand(30522, 768)
+
+
+@pytest.fixture
+def static_embedding(tokenizer: Tokenizer, embedding_weights) -> StaticEmbedding:
+    return StaticEmbedding(tokenizer, embedding_weights=embedding_weights)
+
+
+def test_initialization_with_embedding_weights(tokenizer: Tokenizer, embedding_weights) -> None:
+    model = StaticEmbedding(tokenizer, embedding_weights=embedding_weights)
+    assert model.embedding.weight.shape == (30522, 768)
+
+
+def test_initialization_with_embedding_dim(tokenizer: Tokenizer) -> None:
+    model = StaticEmbedding(tokenizer, embedding_dim=768)
+    assert model.embedding.weight.shape == (30522, 768)
+
+
+def test_tokenize(static_embedding: StaticEmbedding) -> None:
+    texts = ["Hello world!", "How are you?"]
+    tokens = static_embedding.tokenize(texts)
+    assert "input_ids" in tokens
+    assert "offsets" in tokens
+
+
+def test_forward(static_embedding: StaticEmbedding) -> None:
+    texts = ["Hello world!", "How are you?"]
+    tokens = static_embedding.tokenize(texts)
+    output = static_embedding(tokens)
+    assert "sentence_embedding" in output
+
+
+def test_save_and_load(tmp_path: Path, static_embedding: StaticEmbedding) -> None:
+    save_dir = tmp_path / "model"
+    save_dir.mkdir()
+    static_embedding.save(str(save_dir))
+
+    loaded_model = StaticEmbedding.load(str(save_dir))
+    assert loaded_model.embedding.weight.shape == static_embedding.embedding.weight.shape
+
+
+def test_from_distillation() -> None:
+    model = StaticEmbedding.from_distillation("sentence-transformers-testing/stsb-bert-tiny-safetensors", pca_dims=32)
+    assert model.embedding.weight.shape == (29528, 32)
+
+
+def test_from_model2vec() -> None:
+    model = StaticEmbedding.from_model2vec("minishlab/M2V_base_output")
+    assert model.embedding.weight.shape == (29528, 256)


### PR DESCRIPTION
Hi!

# Pull Request overview
- Make sentence-transformers compatible with current and newer version of Model2Vec

# Details
Starting from model2vec version 0.3, inference and distillation will be split up since inference will only need Numpy. This makes it much faster to initialize and install, since there is no dependency on Torch anymore for inference. This PR makes sentence-transformers compatible with both the old and new version, including an updated ImportError message for from_disillation. 

Relevant Model2Vec commit: https://github.com/MinishLab/model2vec/commit/010a7b7347e72e6fa5a92e52314674359253a409