### PR TITLE
[`enh`] Add Support for multiple adapters on Transformers-based models

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ train = ["datasets", "accelerate>=0.20.3"]
 onnx = ["optimum[onnxruntime]>=1.23.1"]
 onnx-gpu = ["optimum[onnxruntime-gpu]>=1.23.1"]
 openvino = ["optimum-intel[openvino]>=1.20.0"]
-dev = ["datasets", "accelerate>=0.20.3", "pre-commit", "pytest", "pytest-cov"]
+dev = ["datasets", "accelerate>=0.20.3", "pre-commit", "pytest", "pytest-cov", "peft"]
 
 [build-system]
 requires = ["setuptools>=42", "wheel"]

--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -35,8 +35,8 @@ from sentence_transformers.similarity_functions import SimilarityFunction
 from . import __MODEL_HUB_ORGANIZATION__, __version__
 from .evaluation import SentenceEvaluator
 from .fit_mixin import FitMixin
-from .peft_mixin import PeftAdapterMixin
 from .models import Normalize, Pooling, Transformer
+from .peft_mixin import PeftAdapterMixin
 from .quantization import quantize_embeddings
 from .util import (
     batch_to_device,

--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -35,6 +35,7 @@ from sentence_transformers.similarity_functions import SimilarityFunction
 from . import __MODEL_HUB_ORGANIZATION__, __version__
 from .evaluation import SentenceEvaluator
 from .fit_mixin import FitMixin
+from .peft_mixin import PeftAdapterMixin
 from .models import Normalize, Pooling, Transformer
 from .quantization import quantize_embeddings
 from .util import (
@@ -51,7 +52,7 @@ from .util import (
 logger = logging.getLogger(__name__)
 
 
-class SentenceTransformer(nn.Sequential, FitMixin):
+class SentenceTransformer(nn.Sequential, FitMixin, PeftAdapterMixin):
     """
     Loads or creates a SentenceTransformer model that can be used to map sentences / text to embeddings.
 

--- a/sentence_transformers/peft_mixin.py
+++ b/sentence_transformers/peft_mixin.py
@@ -1,0 +1,114 @@
+import logging
+from transformers.integrations.peft import PeftAdapterMixin as PeftAdapterMixinTransformers
+logger = logging.getLogger(__name__)
+
+
+class PeftAdapterMixin:
+    """
+    Wrapper Mixin that adds the functionality to easily load and use adapters on the model. For
+    more details about adapters check out the documentation of PEFT
+    library: https://huggingface.co/docs/peft/index
+
+    Currently supported PEFT methods follow those supported by transformers library, 
+    you can find more information on:
+    https://huggingface.co/docs/transformers/main/en/peft#transformers.integrations.PeftAdapterMixin
+    """
+
+    def load_adapter(
+        self,
+        *args,
+        **kwargs,
+    ) -> None:
+        """
+        Load adapter weights from file or remote Hub folder." If you are not familiar with adapters and PEFT methods, we
+        invite you to read more about them on PEFT official documentation: https://huggingface.co/docs/peft
+
+        Requires peft as a backend to load the adapter weights.
+
+        Args:
+            *args:
+                Positional arguments to pass to the underlying AutoModel `load_adapter` function. More information can be found in the transformers documentation
+                https://huggingface.co/docs/transformers/main/en/peft#transformers.integrations.PeftAdapterMixin.load_adapter
+            **kwargs:
+                Keyword arguments to pass to the underlying AutoModel `load_adapter` function. More information can be found in the transformers documentation
+                https://huggingface.co/docs/transformers/main/en/peft#transformers.integrations.PeftAdapterMixin.load_adapter
+        """
+        self._modules["0"].auto_model.load_adapter(*args, **kwargs)
+
+    def add_adapter(self, *args, **kwargs) -> None:
+        """
+        Adds a fresh new adapter to the current model for training purpose. If no adapter name is passed, a default
+        name is assigned to the adapter to follow the convention of PEFT library (in PEFT we use "default" as the
+        default adapter name).
+
+        Args:
+            *args:
+                Positional arguments to pass to the underlying AutoModel `add_adapter` function. More information can be found in the transformers documentation
+                https://huggingface.co/docs/transformers/main/en/peft#transformers.integrations.PeftAdapterMixin.add_adapter
+            **kwargs:
+                Keyword arguments to pass to the underlying AutoModel `add_adapter` function. More information can be found in the transformers documentation
+                https://huggingface.co/docs/transformers/main/en/peft#transformers.integrations.PeftAdapterMixin.add_adapter
+            
+        """
+        self._modules["0"].auto_model.add_adapter(*args, **kwargs)
+
+    def set_adapter(self, *args, **kwargs) -> None:
+        """
+        Sets a specific adapter by forcing the model to use a that adapter and disable the other adapters.
+
+        Args:
+            *args:
+                Positional arguments to pass to the underlying AutoModel `set_adapter` function. More information can be found in the transformers documentation
+                https://huggingface.co/docs/transformers/main/en/peft#transformers.integrations.PeftAdapterMixin.set_adapter
+            **kwargs:
+                Keyword arguments to pass to the underlying AutoModel `set_adapter` function. More information can be found in the transformers documentation
+                https://huggingface.co/docs/transformers/main/en/peft#transformers.integrations.PeftAdapterMixin.set_adapter
+        """
+        self._modules["0"].auto_model.set_adapter(*args, **kwargs)
+
+    def disable_adapters(self) -> None:
+        """
+        Disable all adapters that are attached to the model. This leads to inferring with the base model only.
+        """
+        self._modules["0"].auto_model.disable_adapters()
+        
+
+    def enable_adapters(self) -> None:
+        """
+        Enable adapters that are attached to the model. The model will use `self.active_adapter()`
+        """
+        self._modules["0"].auto_model.enable_adapters()
+
+    def active_adapters(self) -> list[str]:
+        """
+        If you are not familiar with adapters and PEFT methods, we invite you to read more about them on the PEFT
+        official documentation: https://huggingface.co/docs/peft
+
+        Gets the current active adapters of the model. In case of multi-adapter inference (combining multiple adapters
+        for inference) returns the list of all active adapters so that users can deal with them accordingly.
+
+        For previous PEFT versions (that does not support multi-adapter inference), `module.active_adapter` will return
+        a single string.
+        """
+        return self._modules["0"].auto_model.active_adapters()
+
+    def active_adapter(self) -> str:
+        return self._modules["0"].auto_model.active_adapter()
+
+    def get_adapter_state_dict(self, *args, **kwargs) -> dict:
+        """
+        If you are not familiar with adapters and PEFT methods, we invite you to read more about them on the PEFT
+        official documentation: https://huggingface.co/docs/peft
+
+        Gets the adapter state dict that should only contain the weights tensors of the specified adapter_name adapter.
+        If no adapter_name is passed, the active adapter is used.
+
+        Args:
+            *args:
+                Positional arguments to pass to the underlying AutoModel `get_adapter_state_dict` function. More information can be found in the transformers documentation
+                https://huggingface.co/docs/transformers/main/en/peft#transformers.integrations.PeftAdapterMixin.get_adapter_state_dict
+            **kwargs:
+                Keyword arguments to pass to the underlying AutoModel `get_adapter_state_dict` function. More information can be found in the transformers documentation
+                https://huggingface.co/docs/transformers/main/en/peft#transformers.integrations.PeftAdapterMixin.get_adapter_state_dict
+        """
+        return self._modules["0"].auto_model.get_adapter_state_dict(*args, **kwargs)


### PR DESCRIPTION
Hi!
## Pull Request overview
Adds support for loading, activating and deactivating adapters for a SentenceTransformer model when its underlying model is Transformers-based.

## Details
Adds a wrapper mixin so that the methods to manipulate adapters are exposed on the SentenceTransformer model. It includes checks to ensure that the underlying model supports it.

I wanted to implement it in a manner that won't break or require maintenance if the transformers library changes the signature for these methods, this however compromises typing and hints, so if that is more of a concern than maintenance, the implementation could be changed to a more hard-coded one.

As it is only a wrapper, the functionality follows that documented on the [hf docs for transformers ](https://huggingface.co/docs/transformers/v4.45.2/en/peft#load-adapters-with--peft).

### Usage example

Pre-trained adapter
```python
from sentence_transformers import SentenceTransformer

model = SentenceTransformer("my_org/mymodel")
model.load_adapter("my_org/my_pretrained_adapter", "my_adapter")
```

Adapter from scratch for training purposes
```python
from sentence_transformers import SentenceTransformer
from peft import LoraConfig, TaskType

model = SentenceTransformer("my_org/mymodel")

peft_config = LoraConfig(
    target_modules=["query", "key", "value"],
    task_type=TaskType.FEATURE_EXTRACTION,
    inference_mode=False,
    r=8,
    lora_alpha=32,
    lora_dropout=0.1
)
model.add_adapter(peft_config)

```

### Additional considerations
- Consider incorporating adapter switching to the `SentenceTransformer.encode` function
- Test with a pretrained model is commented out on this PR waiting for feedback from a maintainer on if an adapter model should be uploaded to the sentence-transformers hf hub
- Might be worth including documentation about the feature

