### PR TITLE
[`model cards`] Prevent crash on generating widgets if dataset column is empty

### DIFF
--- a/sentence_transformers/model_card.py
+++ b/sentence_transformers/model_card.py
@@ -427,6 +427,9 @@ class SentenceTransformerModelCardData(CardData):
             ]
             str_dataset = dataset[dataset_name].select_columns(columns)
             dataset_size = len(str_dataset)
+            if dataset_size == 0:
+                continue
+
             lengths = {}
             for idx, sample in enumerate(
                 str_dataset.select(random.sample(range(dataset_size), k=min(num_samples_to_check, dataset_size)))


### PR DESCRIPTION
Resolves #2996

Hello!

## Pull Request overview
* Prevent crash on generating widgets if dataset column is empty/has no string columns.

## Details
Thanks for reporting this @yaohwang. This should be fixed in the next release!
See #2996 for the crash that happens.

- Tom Aarsen