### PR TITLE
[`warn`] Throw a warning if compute_metrics is set, as it's not used

### DIFF
--- a/sentence_transformers/trainer.py
+++ b/sentence_transformers/trainer.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import logging
 import os
-import warnings
 from collections import OrderedDict
 from contextlib import nullcontext
 from typing import TYPE_CHECKING, Any, Callable
@@ -156,13 +155,19 @@ class SentenceTransformerTrainer(Trainer):
                 raise RuntimeError("`Trainer` requires either a `model` or `model_init` argument")
         else:
             if model_init is not None:
-                warnings.warn(
+                logger.warning(
                     "`Trainer` requires either a `model` or `model_init` argument, but not both. `model_init` will"
                     " overwrite your model when calling the `train` method. This will become a fatal error in the next"
-                    " release.",
-                    FutureWarning,
+                    " release."
                 )
             self.model_init = model_init
+
+        if compute_metrics is not None:
+            logger.warning(
+                "`compute_metrics` is currently not compatible with the SentenceTransformerTrainer. Please use the "
+                "`evaluator` argument instead for detailed evaluation metrics, or the `eval_dataset` argument for "
+                "the evaluation loss.",
+            )
 
         # Get a dictionary of the default training arguments, so we can determine which arguments have been changed
         # for the model card

--- a/sentence_transformers/trainer.py
+++ b/sentence_transformers/trainer.py
@@ -165,7 +165,7 @@ class SentenceTransformerTrainer(Trainer):
             logger.warning(
                 "`compute_metrics` is currently not compatible with the SentenceTransformerTrainer. Please use the "
                 "`evaluator` argument instead for detailed evaluation metrics, or the `eval_dataset` argument for "
-                "the evaluation loss.",
+                "the evaluation loss."
             )
 
         # Get a dictionary of the default training arguments, so we can determine which arguments have been changed

--- a/sentence_transformers/trainer.py
+++ b/sentence_transformers/trainer.py
@@ -157,8 +157,7 @@ class SentenceTransformerTrainer(Trainer):
             if model_init is not None:
                 logger.warning(
                     "`Trainer` requires either a `model` or `model_init` argument, but not both. `model_init` will"
-                    " overwrite your model when calling the `train` method. This will become a fatal error in the next"
-                    " release."
+                    " overwrite your model when calling the `train` method."
                 )
             self.model_init = model_init
 


### PR DESCRIPTION
Resolves #2888

Hello!

## Pull Request overview
* Throw a warning if compute_metrics is set, as it's not used
* Update the model + model_init warning to a logger-based one, as we're not making it an error.

## Details
See #2888 for a discussion, but in short: `compute_metrics` isn't currently used. An alternative fix is to remove it altogether, but perhaps in the future I'll start using it, so I've kept it for now.

- Tom Aarsen