### PR TITLE
[`fix`] Prevent IndexError if output_hidden_states & ONNX

### DIFF
--- a/sentence_transformers/models/Transformer.py
+++ b/sentence_transformers/models/Transformer.py
@@ -352,8 +352,8 @@ class Transformer(nn.Module):
 
         features.update({"token_embeddings": output_tokens, "attention_mask": features["attention_mask"]})
 
-        if self.auto_model.config.output_hidden_states:
-            all_layer_idx = 2
+        if self.auto_model.config.output_hidden_states and len(output_states) > 2:
+            all_layer_idx = 2  # I.e. after last_hidden_states and pooler_output
             if len(output_states) < 3:  # Some models only output last_hidden_states and all_hidden_states
                 all_layer_idx = 1
 


### PR DESCRIPTION
Resolves #3004

Hello!

## Pull Request overview
* Prevent IndexError if output_hidden_states & ONNX

## Details
Some models specify output_hidden_states in their config, but the ONNX model doesn't respect this. As a result, the `output_states` is just 1 value: the `last_hidden_states`, whereas the code expects that there's also a `all_hidden_states` value.

Now we ensure that there's at least 2 outputs to prevent a crash.

## Code

```python
from sentence_transformers import SentenceTransformer

model = SentenceTransformer(
    "distiluse-base-multilingual-cased",
    backend="onnx",
    model_kwargs={"provider": "CPUExecutionProvider"},
)

sentences = ["This is an example sentence", "Each sentence is converted"]
embeddings = model.encode(sentences)
print(embeddings.shape)
```

This script used to fail, see #3004.

- Tom Aarsen