### PR TITLE
add an ImportError to tell the user that `datasets` must be install to fit a model

### DIFF
--- a/sentence_transformers/fit_mixin.py
+++ b/sentence_transformers/fit_mixin.py
@@ -231,6 +231,9 @@ class FitMixin:
             checkpoint_save_total_limit: Total number of checkpoints to
                 store
         """
+        if not is_datasets_available():
+            raise ImportError("Please install `datasets` to use this function: `pip install datasets`.")
+
         # Delayed import to counter the SentenceTransformers -> FitMixin -> SentenceTransformerTrainer -> SentenceTransformers circular import
         from sentence_transformers.trainer import SentenceTransformerTrainer
 


### PR DESCRIPTION
Minor change to add an ImportError when `datasets` is not installed and the user try to fit a model ( Closes #3019 )