### PR TITLE
Fix model name typo in example

### DIFF
--- a/docs/pretrained-models/msmarco-v3.md
+++ b/docs/pretrained-models/msmarco-v3.md
@@ -7,7 +7,7 @@ The training data consists of over 500k examples, while the complete  corpus con
 ```python
 from sentence_transformers import SentenceTransformer, util
 
-model = SentenceTransformer("msmarco-distilroberta-base-v3")
+model = SentenceTransformer("msmarco-distilbert-base-v3")
 
 query_embedding = model.encode("How big is London")
 passage_embedding = model.encode("London has 9,787,426 inhabitants at the 2011 census")


### PR DESCRIPTION
The model in the example: `msmarco-distilroberta-base-v3` is missing from huggingface.

The existing ones are `msmarco-distilbert-base-v3` and `msmarco-roberta-base-v3`.

Changed the model name to the former one since it downloads faster.