### PR TITLE
[`fix`] Fix loading pre-exported OV/ONNX model if export=False

### DIFF
--- a/sentence_transformers/models/Transformer.py
+++ b/sentence_transformers/models/Transformer.py
@@ -255,7 +255,7 @@ class Transformer(nn.Module):
         """
 
         export = model_args.pop("export", None)
-        if export is not None:
+        if export:
             return export, model_args
 
         file_name = model_args.get("file_name", target_file_name)
@@ -283,10 +283,10 @@ class Transformer(nn.Module):
         # First check if the expected file exists in the root of the model directory
         # If it doesn't, check if it exists in the backend subfolder.
         # If it does, set the subfolder to include the backend
-        export = primary_full_path not in model_file_names
-        if export and "subfolder" not in model_args:
-            export = secondary_full_path not in model_file_names
-            if not export:
+        model_found = primary_full_path in model_file_names
+        if not model_found and "subfolder" not in model_args:
+            model_found = secondary_full_path in model_file_names
+            if model_found:
                 if len(model_file_names) > 1 and "file_name" not in model_args:
                     logger.warning(
                         f"Multiple {backend_name} files found in {load_path.as_posix()!r}: {model_file_names}, defaulting to {secondary_full_path!r}. "
@@ -294,6 +294,8 @@ class Transformer(nn.Module):
                     )
                 model_args["subfolder"] = self.backend
                 model_args["file_name"] = file_name
+        if export is None:
+            export = not model_found
 
         # If the file_name contains subfolders, set it as the subfolder instead
         file_name_parts = Path(file_name).parts

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -156,3 +156,38 @@ def test_openvino_backend() -> None:
         ), "OpenVINO saved model output differs from in-memory converted model"
         del local_openvino_model
         gc.collect()
+
+
+def test_export_false_subfolder() -> None:
+    model_id = "sentence-transformers-testing/stsb-bert-tiny-openvino"
+
+    def from_pretrained_decorator(method):
+        def decorator(*args, **kwargs):
+            assert not kwargs["export"]
+            assert kwargs["subfolder"] == "openvino"
+            assert kwargs["file_name"] == "openvino_model.xml"
+            return method(*args, **kwargs)
+
+        return decorator
+
+    OVModelForFeatureExtraction.from_pretrained = from_pretrained_decorator(
+        OVModelForFeatureExtraction.from_pretrained
+    )
+    SentenceTransformer(model_id, backend="openvino", model_kwargs={"export": False})
+
+
+def test_export_set_nested_filename() -> None:
+    model_id = "sentence-transformers-testing/stsb-bert-tiny-openvino"
+
+    def from_pretrained_decorator(method):
+        def decorator(*args, **kwargs):
+            assert kwargs["subfolder"] == "openvino"
+            assert kwargs["file_name"] == "openvino_model.xml"
+            return method(*args, **kwargs)
+
+        return decorator
+
+    OVModelForFeatureExtraction.from_pretrained = from_pretrained_decorator(
+        OVModelForFeatureExtraction.from_pretrained
+    )
+    SentenceTransformer(model_id, backend="openvino", model_kwargs={"file_name": "openvino/openvino_model.xml"})


### PR DESCRIPTION
Hello!

## Pull Request overview
* Fix loading pre-exported OV/ONNX model if export=False

## Details
If `export=False`, then the `subfolder` and `file_name` are not set based on the current situation. This results in the model not being found. For example:
```python
from sentence_transformers import SentenceTransformer

# Works!
model = SentenceTransformer("all-MiniLM-L6-v2", backend="onnx")
# Failed!
model = SentenceTransformer("all-MiniLM-L6-v2", backend="onnx", model_kwargs={"export": False})
```
After this PR, both work as expected.

- Tom Aarsen