### PR TITLE
[`tests`] Remove evaluation_steps from model.fit test without evaluator

### DIFF
--- a/tests/test_train_stsb.py
+++ b/tests/test_train_stsb.py
@@ -90,7 +90,6 @@ def test_train_stsb_slow(
         train_objectives=[(train_dataloader, train_loss)],
         evaluator=None,
         epochs=1,
-        evaluation_steps=1000,
         warmup_steps=int(len(train_dataloader) * 0.1),
         use_amp=torch.cuda.is_available(),
     )
@@ -115,7 +114,6 @@ def test_train_stsb(
         train_objectives=[(train_dataloader, train_loss)],
         evaluator=None,
         epochs=1,
-        evaluation_steps=1000,
         warmup_steps=int(len(train_dataloader) * 0.1),
         use_amp=torch.cuda.is_available(),
     )


### PR DESCRIPTION
Follow-up from #3035

Hello!

## Pull Request overview
* Remove evaluation_steps from model.fit test without evaluator

## Details
Using `evaluation_steps` sets `args.eval_strategy`, which now throws an error with transformers >=v4.46.0 and #3035 if you don't have an evaluation dataset nor an evaluator.

- Tom Aarsen