### PR TITLE
[Fix] Resolve loading private Transformer model in version 3.3.0

### DIFF
--- a/sentence_transformers/models/Transformer.py
+++ b/sentence_transformers/models/Transformer.py
@@ -101,7 +101,14 @@ class Transformer(nn.Module):
 
     def _load_config(self, model_name_or_path: str, cache_dir: str | None, backend: str, config_args: dict[str, Any]):
         """Loads the configuration of a model"""
-        if find_adapter_config_file(model_name_or_path) is not None:
+        if (
+            find_adapter_config_file(
+                model_name_or_path,
+                token=config_args.get("token"),
+                local_files_only=config_args.get("local_files_only"),
+            )
+            is not None
+        ):
             if not is_peft_available():
                 raise Exception(
                     "Loading a PEFT model requires installing the `peft` package. You can install it via `pip install peft`."

--- a/sentence_transformers/models/Transformer.py
+++ b/sentence_transformers/models/Transformer.py
@@ -105,6 +105,7 @@ class Transformer(nn.Module):
             find_adapter_config_file(
                 model_name_or_path,
                 token=config_args.get("token"),
+                revision=config_args.get("revision"),
                 local_files_only=config_args.get("local_files_only"),
             )
             is not None
@@ -293,12 +294,12 @@ class Transformer(nn.Module):
         """
 
         export = model_args.pop("export", None)
-        if export:
+        if export is not None:
             return export, model_args
 
         file_name = model_args.get("file_name", target_file_name)
         subfolder = model_args.get("subfolder", None)
-        primary_full_path = Path(subfolder, file_name).as_posix() if subfolder else Path(file_name).as_posix()
+        primary_full_path = Path(subfolder, file_name).as_posix() if subfolder else file_name
         secondary_full_path = (
             Path(subfolder, self.backend, file_name).as_posix()
             if subfolder
@@ -321,10 +322,10 @@ class Transformer(nn.Module):
         # First check if the expected file exists in the root of the model directory
         # If it doesn't, check if it exists in the backend subfolder.
         # If it does, set the subfolder to include the backend
-        model_found = primary_full_path in model_file_names
-        if not model_found and "subfolder" not in model_args:
-            model_found = secondary_full_path in model_file_names
-            if model_found:
+        export = primary_full_path not in model_file_names
+        if export and "subfolder" not in model_args:
+            export = secondary_full_path not in model_file_names
+            if not export:
                 if len(model_file_names) > 1 and "file_name" not in model_args:
                     logger.warning(
                         f"Multiple {backend_name} files found in {load_path.as_posix()!r}: {model_file_names}, defaulting to {secondary_full_path!r}. "
@@ -332,8 +333,6 @@ class Transformer(nn.Module):
                     )
                 model_args["subfolder"] = self.backend
                 model_args["file_name"] = file_name
-        if export is None:
-            export = not model_found
 
         # If the file_name contains subfolders, set it as the subfolder instead
         file_name_parts = Path(file_name).parts

--- a/sentence_transformers/models/Transformer.py
+++ b/sentence_transformers/models/Transformer.py
@@ -294,12 +294,12 @@ class Transformer(nn.Module):
         """
 
         export = model_args.pop("export", None)
-        if export is not None:
+        if export:
             return export, model_args
 
         file_name = model_args.get("file_name", target_file_name)
         subfolder = model_args.get("subfolder", None)
-        primary_full_path = Path(subfolder, file_name).as_posix() if subfolder else file_name
+        primary_full_path = Path(subfolder, file_name).as_posix() if subfolder else Path(file_name).as_posix()
         secondary_full_path = (
             Path(subfolder, self.backend, file_name).as_posix()
             if subfolder
@@ -322,10 +322,10 @@ class Transformer(nn.Module):
         # First check if the expected file exists in the root of the model directory
         # If it doesn't, check if it exists in the backend subfolder.
         # If it does, set the subfolder to include the backend
-        export = primary_full_path not in model_file_names
-        if export and "subfolder" not in model_args:
-            export = secondary_full_path not in model_file_names
-            if not export:
+        model_found = primary_full_path in model_file_names
+        if not model_found and "subfolder" not in model_args:
+            model_found = secondary_full_path in model_file_names
+            if model_found:
                 if len(model_file_names) > 1 and "file_name" not in model_args:
                     logger.warning(
                         f"Multiple {backend_name} files found in {load_path.as_posix()!r}: {model_file_names}, defaulting to {secondary_full_path!r}. "
@@ -333,6 +333,8 @@ class Transformer(nn.Module):
                     )
                 model_args["subfolder"] = self.backend
                 model_args["file_name"] = file_name
+        if export is None:
+            export = not model_found
 
         # If the file_name contains subfolders, set it as the subfolder instead
         file_name_parts = Path(file_name).parts

--- a/sentence_transformers/models/Transformer.py
+++ b/sentence_transformers/models/Transformer.py
@@ -106,7 +106,7 @@ class Transformer(nn.Module):
                 model_name_or_path,
                 token=config_args.get("token"),
                 revision=config_args.get("revision"),
-                local_files_only=config_args.get("local_files_only"),
+                local_files_only=config_args.get("local_files_only", False),
             )
             is not None
         ):


### PR DESCRIPTION
Resolves: https://github.com/UKPLab/sentence-transformers/issues/3053

# Details

- Add token and local_files_only and revision to the find_adapter_config_file arguments.

# Check

I have confirmed that I can load a private Transformer model with an adapter with the following code.

code:
```python
from sentence_transformers.models.Transformer import Transformer

args = {
    "token": <AUTH TOKEN>,
    "trust_remote_code": False,
    "revision": None,
    "local_files_only": False
}

transformer = Transformer(
    model_name_or_path=<PRIVATE MODEL PATH>,
    cache_dir=None,
    backend="torch",
    max_seq_length=512,
    do_lower_case=True,
    model_args=args,
    tokenizer_args=args,
    config_args=args
)
```

logs: 
```
model.safetensors: 100%|██████████████████████████████████████████████████████████████████████████████████████| 2.27G/2.27G [01:17<00:00, 24.1MB/s]
tokenizer_config.json: 100%|██████████████████████████████████████████████████████████████████████████████████| 1.17k/1.17k [00:00<00:00, 1.03MB/s]
sentencepiece.bpe.model: 100%|████████████████████████████████████████████████████████████████████████████████| 5.07M/5.07M [00:00<00:00, 9.80MB/s]
tokenizer.json: 100%|█████████████████████████████████████████████████████████████████████████████████████████| 17.1M/17.1M [00:00<00:00, 24.9MB/s]
special_tokens_map.json: 100%|████████████████████████████████████████████████████████████████████████████████████| 964/964 [00:00<00:00, 1.87MB/s]
```

