### PR TITLE
[`training`] Pass `steps`/`epoch`/`output_path` to Evaluator during training

### DIFF
--- a/sentence_transformers/evaluation/EmbeddingSimilarityEvaluator.py
+++ b/sentence_transformers/evaluation/EmbeddingSimilarityEvaluator.py
@@ -225,9 +225,9 @@ class EmbeddingSimilarityEvaluator(SentenceEvaluator):
                         steps,
                     ]
                     + [
-                        metrics[f"{fn_name}_{m}"]
+                        metrics[f"{metric}_{fn_name}"]
                         for fn_name in self.similarity_fn_names
-                        for m in ["pearson", "spearman"]
+                        for metric in ["pearson", "spearman"]
                     ]
                 )
 

--- a/sentence_transformers/evaluation/NanoBEIREvaluator.py
+++ b/sentence_transformers/evaluation/NanoBEIREvaluator.py
@@ -326,20 +326,20 @@ class NanoBEIREvaluator(SentenceEvaluator):
             output_data = [epoch, steps]
             for name in self.score_function_names:
                 for k in self.accuracy_at_k:
-                    output_data.append(per_dataset_results[name]["accuracy@k"][k])
+                    output_data.append(agg_results[f"{name}_accuracy@{k}"])
 
                 for k in self.precision_recall_at_k:
-                    output_data.append(per_dataset_results[name]["precision@k"][k])
-                    output_data.append(per_dataset_results[name]["recall@k"][k])
+                    output_data.append(agg_results[f"{name}_precision@{k}"])
+                    output_data.append(agg_results[f"{name}_recall@{k}"])
 
                 for k in self.mrr_at_k:
-                    output_data.append(per_dataset_results[name]["mrr@k"][k])
+                    output_data.append(agg_results[f"{name}_mrr@{k}"])
 
                 for k in self.ndcg_at_k:
-                    output_data.append(per_dataset_results[name]["ndcg@k"][k])
+                    output_data.append(agg_results[f"{name}_ndcg@{k}"])
 
                 for k in self.map_at_k:
-                    output_data.append(per_dataset_results[name]["map@k"][k])
+                    output_data.append(agg_results[f"{name}_map@{k}"])
 
             fOut.write(",".join(map(str, output_data)))
             fOut.write("\n")

--- a/sentence_transformers/trainer.py
+++ b/sentence_transformers/trainer.py
@@ -478,7 +478,13 @@ class SentenceTransformerTrainer(Trainer):
                 return output
 
         with nullcontext() if self.is_local_process_zero() else disable_logging(logging.INFO):
-            evaluator_metrics = self.evaluator(self.model)
+            output_path = self.args.output_dir
+            if output_path is not None:
+                output_path = os.path.join(output_path, "eval")
+                os.makedirs(output_path, exist_ok=True)
+            evaluator_metrics = self.evaluator(
+                self.model, output_path=output_path, epoch=self.state.epoch, steps=self.state.global_step
+            )
         if not isinstance(evaluator_metrics, dict):
             evaluator_metrics = {"evaluator": evaluator_metrics}
 

--- a/tests/evaluation/test_information_retrieval_evaluator.py
+++ b/tests/evaluation/test_information_retrieval_evaluator.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from pathlib import Path
 from unittest.mock import Mock, PropertyMock
 
 import pytest
@@ -63,7 +64,7 @@ def test_data():
     return queries, corpus, relevant_docs
 
 
-def test_simple(test_data):
+def test_simple(test_data, tmp_path: Path):
     queries, corpus, relevant_docs = test_data
     model = SentenceTransformer("sentence-transformers-testing/stsb-bert-tiny-safetensors")
 
@@ -78,7 +79,7 @@ def test_simple(test_data):
         ndcg_at_k=[3],
         map_at_k=[5],
     )
-    results = ir_evaluator(model)
+    results = ir_evaluator(model, output_path=str(tmp_path))
     expected_keys = [
         "test_cosine_accuracy@1",
         "test_cosine_accuracy@3",
@@ -93,7 +94,7 @@ def test_simple(test_data):
     assert set(results.keys()) == set(expected_keys)
 
 
-def test_metrices(test_data, mock_model):
+def test_metrices(test_data, mock_model, tmp_path: Path):
     queries, corpus, relevant_docs = test_data
 
     ir_evaluator = InformationRetrievalEvaluator(
@@ -107,7 +108,7 @@ def test_metrices(test_data, mock_model):
         ndcg_at_k=[3],
         map_at_k=[5],
     )
-    results = ir_evaluator(mock_model)
+    results = ir_evaluator(mock_model, output_path=str(tmp_path))
     # We expect test_cosine_precision@3 to be 0.4, since 6 out of 15 (5 queries * 3) are True Positives
     # We expect test_cosine_recall@1 to be 0.9; the average of 4 times a recall of 1 and once a recall of 0.5
     expected_results = {

--- a/tests/evaluation/test_label_accuracy_evaluator.py
+++ b/tests/evaluation/test_label_accuracy_evaluator.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import csv
 import gzip
 import os
+from pathlib import Path
 
 from torch.utils.data import DataLoader
 
@@ -19,7 +20,7 @@ from sentence_transformers import (
 )
 
 
-def test_LabelAccuracyEvaluator(paraphrase_distilroberta_base_v1_model: SentenceTransformer) -> None:
+def test_LabelAccuracyEvaluator(paraphrase_distilroberta_base_v1_model: SentenceTransformer, tmp_path: Path) -> None:
     """Tests that the LabelAccuracyEvaluator can be loaded correctly"""
     model = paraphrase_distilroberta_base_v1_model
     nli_dataset_path = "datasets/AllNLI.tsv.gz"
@@ -45,6 +46,6 @@ def test_LabelAccuracyEvaluator(paraphrase_distilroberta_base_v1_model: Sentence
 
     dev_dataloader = DataLoader(dev_samples, shuffle=False, batch_size=16)
     evaluator = evaluation.LabelAccuracyEvaluator(dev_dataloader, softmax_model=train_loss)
-    metrics = evaluator(model)
+    metrics = evaluator(model, output_path=str(tmp_path))
     assert "accuracy" in metrics
     assert metrics["accuracy"] > 0.2

--- a/tests/evaluation/test_paraphrase_mining_evaluator.py
+++ b/tests/evaluation/test_paraphrase_mining_evaluator.py
@@ -4,13 +4,17 @@ Tests the correct computation of evaluation scores from BinaryClassificationEval
 
 from __future__ import annotations
 
+from pathlib import Path
+
 from sentence_transformers import (
     SentenceTransformer,
     evaluation,
 )
 
 
-def test_ParaphraseMiningEvaluator(paraphrase_distilroberta_base_v1_model: SentenceTransformer) -> None:
+def test_ParaphraseMiningEvaluator(
+    paraphrase_distilroberta_base_v1_model: SentenceTransformer, tmp_path: Path
+) -> None:
     """Tests that the ParaphraseMiningEvaluator can be loaded"""
     model = paraphrase_distilroberta_base_v1_model
     sentences = {
@@ -20,5 +24,5 @@ def test_ParaphraseMiningEvaluator(paraphrase_distilroberta_base_v1_model: Sente
         3: "On the table the cat is",
     }
     data_eval = evaluation.ParaphraseMiningEvaluator(sentences, [(0, 1), (2, 3)])
-    metrics = data_eval(model)
+    metrics = data_eval(model, output_path=str(tmp_path))
     assert metrics[data_eval.primary_metric] > 0.99


### PR DESCRIPTION
Resolves #3062

Hello!

## Pull Request overview
* Pass `steps`/`epoch`/`output_path` to Evaluator during training
  * Both for the deprecated `model.fit()` and the `SentenceTransformerTrainer`
* Fix EmbeddingSimilarityEvaluator and NanoBEIREvaluator who failed when writing to disk

## Details
The `model.fit` nor `SentenceTransformerTrainer` passed all available parameters down to the evaluator(s). In particular, the `output_path` wasn't sent, which meant that no csv files could be written for the evaluators. Beyond that, 2 evaluators failed when writing to disk. Some better tests for the evaluators would be appreciated, as this could've been caught.

- Tom Aarsen