### PR TITLE
[fix] revision of the adapter model can now be specified.

### DIFF
--- a/sentence_transformers/models/Transformer.py
+++ b/sentence_transformers/models/Transformer.py
@@ -5,16 +5,19 @@ import logging
 import os
 from fnmatch import fnmatch
 from pathlib import Path
-from typing import Any, Callable
+from typing import TYPE_CHECKING, Any, Callable
 
 import huggingface_hub
 import torch
 from torch import nn
-from transformers import AutoConfig, AutoModel, AutoTokenizer, MT5Config, T5Config
+from transformers import AutoConfig, AutoModel, AutoTokenizer, MT5Config, PretrainedConfig, T5Config
 from transformers.utils.import_utils import is_peft_available
 from transformers.utils.peft_utils import find_adapter_config_file
 
 logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING and is_peft_available():
+    from peft import PeftConfig
 
 
 def _save_pretrained_wrapper(_save_pretrained_fn: Callable, subfolder: str) -> Callable[..., None]:
@@ -99,8 +102,21 @@ class Transformer(nn.Module):
         if tokenizer_name_or_path is not None:
             self.auto_model.config.tokenizer_class = self.tokenizer.__class__.__name__
 
-    def _load_config(self, model_name_or_path: str, cache_dir: str | None, backend: str, config_args: dict[str, Any]):
-        """Loads the configuration of a model"""
+    def _load_config(
+        self, model_name_or_path: str, cache_dir: str | None, backend: str, config_args: dict[str, Any]
+    ) -> tuple[PeftConfig | PretrainedConfig, bool]:
+        """Loads the transformers or PEFT configuration
+
+        Args:
+            model_name_or_path (str): The model name on Hugging Face (e.g. 'sentence-transformers/all-MiniLM-L6-v2')
+                or the path to a local model directory.
+            cache_dir (str | None): The cache directory to store the model configuration.
+            backend (str): The backend used for model inference. Can be `torch`, `onnx`, or `openvino`.
+            config_args (dict[str, Any]): Keyword arguments passed to the Hugging Face Transformers config.
+
+        Returns:
+            tuple[PretrainedConfig, bool]: The model configuration and a boolean indicating whether the model is a PEFT model.
+        """
         if (
             find_adapter_config_file(
                 model_name_or_path,
@@ -127,8 +143,26 @@ class Transformer(nn.Module):
 
         return AutoConfig.from_pretrained(model_name_or_path, **config_args, cache_dir=cache_dir), False
 
-    def _load_model(self, model_name_or_path, config, cache_dir, backend, is_peft_model, **model_args) -> None:
-        """Loads the transformer model"""
+    def _load_model(
+        self,
+        model_name_or_path: str,
+        config: PeftConfig | PretrainedConfig,
+        cache_dir: str,
+        backend: str,
+        is_peft_model: bool,
+        **model_args,
+    ) -> None:
+        """Loads the transformers or PEFT model into the `auto_model` attribute
+
+        Args:
+            model_name_or_path (str): The model name on Hugging Face (e.g. 'sentence-transformers/all-MiniLM-L6-v2')
+                or the path to a local model directory.
+            config ("PeftConfig" | PretrainedConfig): The model configuration.
+            cache_dir (str | None): The cache directory to store the model configuration.
+            backend (str): The backend used for model inference. Can be `torch`, `onnx`, or `openvino`.
+            is_peft_model (bool): Whether the model is a PEFT model.
+            model_args (dict[str, Any]): Keyword arguments passed to the Hugging Face Transformers model.
+        """
         if backend == "torch":
             # When loading a PEFT model, we need to load the base model first,
             # but some model_args are only for the adapter
@@ -156,14 +190,16 @@ class Transformer(nn.Module):
         else:
             raise ValueError(f"Unsupported backend '{backend}'. `backend` should be `torch`, `onnx`, or `openvino`.")
 
-    def _load_peft_model(self, model_name_or_path, config, cache_dir, **model_args) -> None:
+    def _load_peft_model(self, model_name_or_path: str, config: PeftConfig, cache_dir: str, **model_args) -> None:
         from peft import PeftModel
 
         self.auto_model = PeftModel.from_pretrained(
             self.auto_model, model_name_or_path, config=config, cache_dir=cache_dir, **model_args
         )
 
-    def _load_openvino_model(self, model_name_or_path, config, cache_dir, **model_args) -> None:
+    def _load_openvino_model(
+        self, model_name_or_path: str, config: PretrainedConfig, cache_dir: str, **model_args
+    ) -> None:
         if isinstance(config, T5Config) or isinstance(config, MT5Config):
             raise ValueError("T5 models are not yet supported by the OpenVINO backend.")
 
@@ -218,7 +254,9 @@ class Transformer(nn.Module):
         if export:
             self._backend_warn_to_save(model_name_or_path, is_local, backend_name)
 
-    def _load_onnx_model(self, model_name_or_path, config, cache_dir, **model_args) -> None:
+    def _load_onnx_model(
+        self, model_name_or_path: str, config: PretrainedConfig, cache_dir: str, **model_args
+    ) -> None:
         try:
             import onnxruntime as ort
             from optimum.onnxruntime import ONNX_WEIGHTS_NAME, ORTModelForFeatureExtraction
@@ -371,7 +409,7 @@ class Transformer(nn.Module):
             to_log += f" Do so with `model.push_to_hub({model_name_or_path!r}, create_pr=True)`."
         logger.warning(to_log)
 
-    def _load_t5_model(self, model_name_or_path, config, cache_dir, **model_args) -> None:
+    def _load_t5_model(self, model_name_or_path: str, config: PretrainedConfig, cache_dir: str, **model_args) -> None:
         """Loads the encoder model from T5"""
         from transformers import T5EncoderModel
 
@@ -380,7 +418,7 @@ class Transformer(nn.Module):
             model_name_or_path, config=config, cache_dir=cache_dir, **model_args
         )
 
-    def _load_mt5_model(self, model_name_or_path, config, cache_dir, **model_args) -> None:
+    def _load_mt5_model(self, model_name_or_path: str, config: PretrainedConfig, cache_dir: str, **model_args) -> None:
         """Loads the encoder model from T5"""
         from transformers import MT5EncoderModel
 

--- a/tests/test_sentence_transformer.py
+++ b/tests/test_sentence_transformer.py
@@ -781,3 +781,12 @@ def test_multiple_adapters() -> None:
     model = SentenceTransformer("sentence-transformers/average_word_embeddings_levy_dependency")
     with pytest.raises(ValueError, match="PEFT methods are only supported"):
         model.add_adapter(peft_config)
+
+
+@pytest.mark.skipif(not is_peft_available(), reason="PEFT must be available to test loading PEFT models.")
+def test_load_adapter_with_revision():
+    model = SentenceTransformer(
+        "sentence-transformers-testing/stsb-bert-tiny-lora", revision="3b4f75bcb3dec36a7e05da8c44ee2f7f1d023b1a"
+    )
+    embeddings = model.encode("Hello, World!")
+    assert embeddings.shape == (128,)


### PR DESCRIPTION
Resolved: https://github.com/UKPLab/sentence-transformers/issues/3061

## Solution

I modified the `_load_peft_model` method so that when the config is `PeftConfig`, it handles loading both the base model and the adapter model. Additionally, when loading the base model, I temporarily save and remove the `revision` from `model_args` before loading the base model.

This ensures that the base model is loaded using the default revision instead of the adapter model's revision, resolving the error.

## Verification

The following three codes were tested and worked correctly.

- verification1:
```python
from sentence_transformers.models.Transformer import Transformer

args = {
    "token": <your token>,
    "trust_remote_code": False,
    "revision": <your repository revision>,
    "local_files_only": False
}

transformer = Transformer(
    model_name_or_path=<your model_path>,
    cache_dir=None,
    backend="torch",
    max_seq_length=512,
    do_lower_case=True,
    model_args=args,
    tokenizer_args=args,
    config_args=args
)
```

- verification2:
```python
from sentence_transformers import SentenceTransformer
model = SentenceTransformer("sentence-transformers-testing/stsb-bert-tiny-safetensors")
model.encode("Hello, World!")
```

- verification3:
```python
from sentence_transformers import SentenceTransformer

kwargs = {
    "revision": <your revision>,
}
model = SentenceTransformer(<your model repository path>,
                            use_auth_token=<your token>,
                            model_kwargs=kwargs,
                            config_kwargs=kwargs,
                            tokenizer_kwargs=kwargs)
model.encode("Hello, World!")
```
