### PR TITLE
normalize to float in NanoBEIREvaluator, InformationRetrievalEvaluator, MSEEvaluator

### DIFF
--- a/sentence_transformers/evaluation/SentenceEvaluator.py
+++ b/sentence_transformers/evaluation/SentenceEvaluator.py
@@ -57,7 +57,7 @@ class SentenceEvaluator:
     def prefix_name_to_metrics(self, metrics: dict[str, float], name: str) -> dict[str, float]:
         if not name:
             return metrics
-        metrics = {name + "_" + key: value for key, value in metrics.items()}
+        metrics = {name + "_" + key: float(value) for key, value in metrics.items()}
         if hasattr(self, "primary_metric") and not self.primary_metric.startswith(name + "_"):
             self.primary_metric = name + "_" + self.primary_metric
         return metrics


### PR DESCRIPTION
I found NanoBEIREvaluator, InformationRetrievalEvaluator, MSEEvaluator returning a mix of np.floats and native floats.

I zeroed in on the issue and found that the 'prefix_name_to_metrics' was causing the problem, this simple fix just converts to floats the value element while destructing the dictionary.

Fixes #3093 

@tomaarsen 