### PR TITLE
revert float type cast manually in BinaryClassificationEvaluator

### DIFF
--- a/sentence_transformers/evaluation/BinaryClassificationEvaluator.py
+++ b/sentence_transformers/evaluation/BinaryClassificationEvaluator.py
@@ -288,14 +288,14 @@ class BinaryClassificationEvaluator(SentenceEvaluator):
             logger.info(f"Matthews Correlation with {name}: {mcc * 100:.2f}\n")
 
             output_scores[similarity_fn_name] = {
-                "accuracy": float(acc),
-                "accuracy_threshold": float(acc_threshold),
-                "f1": float(f1),
-                "f1_threshold": float(f1_threshold),
-                "precision": float(precision),
-                "recall": float(recall),
-                "ap": float(ap),
-                "mcc": float(mcc),
+                "accuracy": acc,
+                "accuracy_threshold": acc_threshold,
+                "f1": f1,
+                "f1_threshold": f1_threshold,
+                "precision": precision,
+                "recall": recall,
+                "ap": ap,
+                "mcc": mcc,
             }
 
         return output_scores


### PR DESCRIPTION
Undos the manual type cast in BinaryClassificationEvaluator from the PR #3076 since its fixed by PR #3096