### PR TITLE
Fix cross encoder device issue

### DIFF
--- a/sentence_transformers/cross_encoder/CrossEncoder.py
+++ b/sentence_transformers/cross_encoder/CrossEncoder.py
@@ -606,5 +606,16 @@ class CrossEncoder(PushToHubMixin):
         return self.model.to(device)
 
     @property
+    def _target_device(self) -> torch.device:
+        logger.warning(
+            "`CrossEncoder._target_device` has been removed, please use `CrossEncoder.device` instead.",
+        )
+        return self.device
+
+    @_target_device.setter
+    def _target_device(self, device: int | str | torch.device | None = None) -> None:
+        self.to(device)
+
+    @property
     def device(self) -> torch.device:
         return self.model.device

--- a/sentence_transformers/cross_encoder/CrossEncoder.py
+++ b/sentence_transformers/cross_encoder/CrossEncoder.py
@@ -123,8 +123,8 @@ class CrossEncoder(PushToHubMixin):
         if device is None:
             device = get_device_name()
             logger.info(f"Use pytorch device: {device}")
-
-        self._target_device = torch.device(device)
+        self.device = device
+        self.model.to(self.device)
 
         if default_activation_function is not None:
             self.default_activation_function = default_activation_function
@@ -154,11 +154,11 @@ class CrossEncoder(PushToHubMixin):
             *texts, padding=True, truncation="longest_first", return_tensors="pt", max_length=self.max_length
         )
         labels = torch.tensor(labels, dtype=torch.float if self.config.num_labels == 1 else torch.long).to(
-            self._target_device
+            self.device
         )
 
         for name in tokenized:
-            tokenized[name] = tokenized[name].to(self._target_device)
+            tokenized[name] = tokenized[name].to(self.device)
 
         return tokenized, labels
 
@@ -174,7 +174,7 @@ class CrossEncoder(PushToHubMixin):
         )
 
         for name in tokenized:
-            tokenized[name] = tokenized[name].to(self._target_device)
+            tokenized[name] = tokenized[name].to(self.device)
 
         return tokenized
 
@@ -232,7 +232,6 @@ class CrossEncoder(PushToHubMixin):
                 scaler = torch.npu.amp.GradScaler()
             else:
                 scaler = torch.cuda.amp.GradScaler()
-        self.model.to(self._target_device)
 
         if output_path is not None:
             os.makedirs(output_path, exist_ok=True)
@@ -272,7 +271,7 @@ class CrossEncoder(PushToHubMixin):
                 train_dataloader, desc="Iteration", smoothing=0.05, disable=not show_progress_bar
             ):
                 if use_amp:
-                    with torch.autocast(device_type=self._target_device.type):
+                    with torch.autocast(device_type=self.device.type):
                         model_predictions = self.model(**features, return_dict=True)
                         logits = activation_fct(model_predictions.logits)
                         if self.config.num_labels == 1:
@@ -438,7 +437,6 @@ class CrossEncoder(PushToHubMixin):
 
         pred_scores = []
         self.model.eval()
-        self.model.to(self._target_device)
         with torch.no_grad():
             for features in iterator:
                 model_predictions = self.model(**features, return_dict=True)
@@ -604,3 +602,16 @@ class CrossEncoder(PushToHubMixin):
             tags=tags,
             **kwargs,
         )
+
+    def to(self, device: int | str | torch.device | None = None) -> None:
+        self.model.to(device)
+        self.device = device
+
+    @property
+    def device(self) -> torch.device:
+        return self.device
+
+    @device.setter
+    def device(self, device: int | str | torch.device | None = None) -> None:
+        self.model.to(device)
+        self.device = device

--- a/sentence_transformers/cross_encoder/CrossEncoder.py
+++ b/sentence_transformers/cross_encoder/CrossEncoder.py
@@ -603,7 +603,7 @@ class CrossEncoder(PushToHubMixin):
         )
 
     def to(self, device: int | str | torch.device | None = None) -> None:
-        self.model.to(device)
+        return self.model.to(device)
 
     @property
     def device(self) -> torch.device:

--- a/tests/test_cross_encoder.py
+++ b/tests/test_cross_encoder.py
@@ -195,19 +195,10 @@ def test_bfloat16() -> None:
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA must be available to test moving devices effectively.")
-def test_device_assignment():
-    # check for the cpu device
-    model = CrossEncoder("cross-encoder/stsb-distilroberta-base", device="cpu")
-
-    assert model.device.type == "cpu"
-    del model
-
-    # check for the cuda device
-    model = CrossEncoder("cross-encoder/stsb-distilroberta-base", device="cuda")
-    assert model.device.type == "cuda"
-
-    del model
-    torch.cuda.empty_cache()
+@pytest.mark.parametrize("device", ["cpu", "cuda"])
+def test_device_assignment(device):
+    model = CrossEncoder("cross-encoder/stsb-distilroberta-base", device=device)
+    assert model.device.type == device
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA must be available to test moving devices effectively.")

--- a/tests/test_cross_encoder.py
+++ b/tests/test_cross_encoder.py
@@ -214,3 +214,13 @@ def test_device_switching():
 
     del model
     torch.cuda.empty_cache()
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA must be available to test moving devices effectively.")
+def test_target_device_backwards_compat():
+    model = CrossEncoder("cross-encoder/stsb-distilroberta-base", device="cpu")
+    assert model.device.type == "cpu"
+
+    assert model._target_device.type == "cpu"
+    model._target_device = "cuda"
+    assert model.device.type == "cuda"

--- a/tests/test_cross_encoder.py
+++ b/tests/test_cross_encoder.py
@@ -198,28 +198,28 @@ def test_bfloat16() -> None:
 def test_device_assignment():
     # check for the cpu device
     model = CrossEncoder("cross-encoder/stsb-distilroberta-base", device="cpu")
-    assert model.device=="cpu"
+
+    assert model.device.type == "cpu"
     del model
 
     # check for the cuda device
     model = CrossEncoder("cross-encoder/stsb-distilroberta-base", device="cuda")
-    assert model.device == "cuda"
+    assert model.device.type == "cuda"
 
     del model
     torch.cuda.empty_cache()
+
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA must be available to test moving devices effectively.")
 def test_device_switching():
     # test assignment using .to
     model = CrossEncoder("cross-encoder/stsb-distilroberta-base", device="cpu")
-    model.to("cuda")
-    assert model.device == "cuda"
-    assert model.model.device == "cuda"
+    assert model.device.type == "cpu"
+    assert model.model.device.type == "cpu"
 
-    # test assignment using device setter
-    model.device = "cpu"
-    assert model.device == "cpu"
-    assert model.model.device == "cpu"
+    model.to("cuda")
+    assert model.device.type == "cuda"
+    assert model.model.device.type == "cuda"
 
     del model
     torch.cuda.empty_cache()

--- a/tests/test_cross_encoder.py
+++ b/tests/test_cross_encoder.py
@@ -192,3 +192,34 @@ def test_bfloat16() -> None:
 
     ranking = model.rank("Hello there!", ["Hello, World!", "Heya!"])
     assert isinstance(ranking, list)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA must be available to test moving devices effectively.")
+def test_device_assignment():
+    # check for the cpu device
+    model = CrossEncoder("cross-encoder/stsb-distilroberta-base", device="cpu")
+    assert model.device=="cpu"
+    del model
+
+    # check for the cuda device
+    model = CrossEncoder("cross-encoder/stsb-distilroberta-base", device="cuda")
+    assert model.device == "cuda"
+
+    del model
+    torch.cuda.empty_cache()
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA must be available to test moving devices effectively.")
+def test_device_switching():
+    # test assignment using .to
+    model = CrossEncoder("cross-encoder/stsb-distilroberta-base", device="cpu")
+    model.to("cuda")
+    assert model.device == "cuda"
+    assert model.model.device == "cuda"
+
+    # test assignment using device setter
+    model.device = "cpu"
+    assert model.device == "cpu"
+    assert model.model.device == "cpu"
+
+    del model
+    torch.cuda.empty_cache()


### PR DESCRIPTION
Fixes #3078

- fixed the previous issue and now the model is pushed to the specified device when the object is created.
- added new method `to` which directly pushes the model to the specified device, removing the need to use model.model.to
- added 2 tests to make sure it works as expected