### PR TITLE
Adding evaluation checks to prevent Transformer ValueError

### DIFF
--- a/sentence_transformers/trainer.py
+++ b/sentence_transformers/trainer.py
@@ -223,6 +223,13 @@ class SentenceTransformerTrainer(Trainer):
             super_kwargs["processing_class"] = tokenizer
         else:
             super_kwargs["tokenizer"] = tokenizer
+        # Ensure `eval_dataset` and `evaluator` are not both None. If neither is provided, raise a ValueError unless `eval_strategy` is "no".
+        if eval_dataset is None and evaluator is None:
+            if args.eval_strategy != "no":
+                raise ValueError(
+                    "Either `eval_dataset` or `evaluator` must be provided for evaluation, "
+                    "or set `eval_strategy='no'` to skip evaluation."
+                )
         super().__init__(**super_kwargs)
         # Transformers v4.46.0 introduced a ValueError if `eval_dataset` is None while eval_strategy is not "no",
         # but in Sentence Transformers you can also evaluate without an eval_dataset via an evaluator, so we set

--- a/sentence_transformers/trainer.py
+++ b/sentence_transformers/trainer.py
@@ -226,10 +226,7 @@ class SentenceTransformerTrainer(Trainer):
         # Ensure `eval_dataset` and `evaluator` are not both None. If neither is provided, raise a ValueError unless `eval_strategy` is "no".
         if eval_dataset is None and evaluator is None:
             if args.eval_strategy != "no":
-                raise ValueError(
-                    "Either `eval_dataset` or `evaluator` must be provided for evaluation, "
-                    "or set `args.eval_strategy='no'` to skip evaluation."
-                )
+                raise ValueError("Either `eval_dataset` or `evaluator` must be provided for evaluation, or set `args.eval_strategy='no'` to skip evaluation.")
         super().__init__(**super_kwargs)
         # Transformers v4.46.0 introduced a ValueError if `eval_dataset` is None while eval_strategy is not "no",
         # but in Sentence Transformers you can also evaluate without an eval_dataset via an evaluator, so we set

--- a/sentence_transformers/trainer.py
+++ b/sentence_transformers/trainer.py
@@ -226,7 +226,7 @@ class SentenceTransformerTrainer(Trainer):
         # Ensure `eval_dataset` and `evaluator` are not both None. If neither is provided, raise a ValueError unless `eval_strategy` is "no".
         if eval_dataset is None and evaluator is None:
             if args.eval_strategy != "no":
-                raise ValueError("Either `eval_dataset` or `evaluator` must be provided for evaluation, or set `args.eval_strategy='no'` to skip evaluation.")
+                raise ValueError("Either `eval_dataset` or `evaluator` must be provided for evaluation, or set `args.eval_strategy='no'` to skip evaluation. Check `args.eval_strategy` setting.")
         super().__init__(**super_kwargs)
         # Transformers v4.46.0 introduced a ValueError if `eval_dataset` is None while eval_strategy is not "no",
         # but in Sentence Transformers you can also evaluate without an eval_dataset via an evaluator, so we set

--- a/sentence_transformers/trainer.py
+++ b/sentence_transformers/trainer.py
@@ -206,6 +206,10 @@ class SentenceTransformerTrainer(Trainer):
             train_dataset = DatasetDict(train_dataset)
         if isinstance(eval_dataset, dict) and not isinstance(eval_dataset, DatasetDict):
             eval_dataset = DatasetDict(eval_dataset)
+
+        # Transformers v4.46.0 introduced a ValueError if `eval_dataset` is None while eval_strategy is not "no",
+        # but in Sentence Transformers you can also evaluate without an eval_dataset via an evaluator, so we set
+        # it to "dummy" in that case to avoid the ValueError
         super_kwargs = {
             "model": None if self.model_init else model,
             "args": args,
@@ -223,14 +227,18 @@ class SentenceTransformerTrainer(Trainer):
             super_kwargs["processing_class"] = tokenizer
         else:
             super_kwargs["tokenizer"] = tokenizer
-        # Ensure `eval_dataset` and `evaluator` are not both None. If neither is provided, raise a ValueError unless `eval_strategy` is "no".
-        if eval_dataset is None and evaluator is None:
-            if args.eval_strategy != "no":
-                raise ValueError("Either `eval_dataset` or `evaluator` must be provided for evaluation, or set `args.eval_strategy='no'` to skip evaluation. Check `args.eval_strategy` setting.")
+
+        # super.__init__() will still raise a ValueError if `eval_dataset` is None, `evaluator` is None,
+        # while eval_strategy is not "no", so let's get ahead of it with a more useful ST-specific error message
+        if eval_dataset is None and evaluator is None and args.eval_strategy != "no":
+            raise ValueError(
+                f"You have set `args.eval_strategy` to {args.eval_strategy}, but you didn't provide an `eval_dataset` or an `evaluator`. "
+                "Either provide an `eval_dataset` or an `evaluator` for to `SentenceTransformerTrainer`, "
+                "or set `args.eval_strategy='no'` to skip evaluation."
+            )
+
         super().__init__(**super_kwargs)
-        # Transformers v4.46.0 introduced a ValueError if `eval_dataset` is None while eval_strategy is not "no",
-        # but in Sentence Transformers you can also evaluate without an eval_dataset via an evaluator, so we set
-        # it to "dummy" in that case to avoid the ValueError
+        # If the eval_dataset is "dummy", then we set it back to None
         if self.eval_dataset == "dummy":
             self.eval_dataset = None
 

--- a/sentence_transformers/trainer.py
+++ b/sentence_transformers/trainer.py
@@ -228,7 +228,7 @@ class SentenceTransformerTrainer(Trainer):
             if args.eval_strategy != "no":
                 raise ValueError(
                     "Either `eval_dataset` or `evaluator` must be provided for evaluation, "
-                    "or set `eval_strategy='no'` to skip evaluation."
+                    "or set `args.eval_strategy='no'` to skip evaluation."
                 )
         super().__init__(**super_kwargs)
         # Transformers v4.46.0 introduced a ValueError if `eval_dataset` is None while eval_strategy is not "no",

--- a/sentence_transformers/trainer.py
+++ b/sentence_transformers/trainer.py
@@ -233,7 +233,7 @@ class SentenceTransformerTrainer(Trainer):
         if eval_dataset is None and evaluator is None and args.eval_strategy != "no":
             raise ValueError(
                 f"You have set `args.eval_strategy` to {args.eval_strategy}, but you didn't provide an `eval_dataset` or an `evaluator`. "
-                "Either provide an `eval_dataset` or an `evaluator` for to `SentenceTransformerTrainer`, "
+                "Either provide an `eval_dataset` or an `evaluator` to `SentenceTransformerTrainer`, "
                 "or set `args.eval_strategy='no'` to skip evaluation."
             )
 

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -645,7 +645,14 @@ def test_trainer_no_eval_dataset_with_eval_strategy(
         kwargs["evaluator"] = evaluator
 
     if not use_eval_dataset and not use_evaluator:
-        context = pytest.raises(ValueError, match=".*`args.eval_strategy`.*")
+        context = pytest.raises(
+            ValueError,
+            match=(
+                "You have set `args.eval_strategy` to IntervalStrategy.STEPS, but you didn't provide an "
+                "`eval_dataset` or an `evaluator`. Either provide an `eval_dataset` or an `evaluator` "
+                "to `SentenceTransformerTrainer`, or set `args.eval_strategy='no'` to skip evaluation."
+            ),
+        )
     else:
         context = nullcontext()
 

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -648,7 +648,7 @@ def test_trainer_no_eval_dataset_with_eval_strategy(
         context = pytest.raises(
             ValueError,
             match=(
-                "You have set `args.eval_strategy` to IntervalStrategy.STEPS, but you didn't provide an "
+                "You have set `args.eval_strategy` to (IntervalStrategy.STEPS|steps), but you didn't provide an "
                 "`eval_dataset` or an `evaluator`. Either provide an `eval_dataset` or an `evaluator` "
                 "to `SentenceTransformerTrainer`, or set `args.eval_strategy='no'` to skip evaluation."
             ),


### PR DESCRIPTION
When neither eval_dataset nor evaluator is provided, Transformers raises a ValueError stating that an eval_dataset must be passed or eval_strategy. However, this error does not account for the `evaluator` parameter.

Error raised by Transformers:
```
ValueError: You have set `args.eval_strategy` to "steps" but you didn't pass an `eval_dataset` to `Trainer`. 
Either set `args.eval_strategy` to "no" or pass an `eval_dataset`.
```

Instead, we now raise a more specific error:
```
ValueError: Either `eval_dataset` or `evaluator` must be provided for evaluation, 
or set `eval_strategy='no'` to skip evaluation.
```