### PR TITLE
[`fix`] Fix breaking change in PyLate when loading modules

### DIFF
--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -1559,8 +1559,8 @@ print(similarities)
                     revision=revision,
                     code_revision=code_revision,
                 )
-            except OSError:
-                # Ignore the error if the file does not exist, and fall back to the default import
+            except (OSError, ValueError):
+                # Ignore the error if 1) the file does not exist, or 2) the class_ref is not correctly formatted/found
                 pass
 
         return import_from_string(class_ref)


### PR DESCRIPTION
Resolves #3108

Hello!

## Pull Request overview
* Prevent crash when calling `get_class_from_dynamic_module` with incorrect `class_ref`.

## Details
If the `class_ref` in `_load_module_class_from_ref` does not start with `sentence_transformers.`, and it's not a remote module, but e.g. `pylate`'s `Dense`, then `get_class_from_dynamic_module` will fail due to `a, b = c.split(".")` where `c` has more than 1 dot.

I think the cleanest solution is to ignore the `ValueError` - as otherwise we risk missing some edge cases if we e.g. expand on the `if trust_remote_code ...` before the `get_class_from_dynamic_module` call.

@NohTow I believe you already verified that this solution works, right?

- Tom Aarsen