### PR TITLE
[`fix`] Save custom module `kwargs` if specified

### DIFF
--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -1554,7 +1554,7 @@ print(similarities)
         if class_ref.startswith("sentence_transformers."):
             return import_from_string(class_ref)
 
-        if trust_remote_code:
+        if trust_remote_code or os.path.exists(model_name_or_path):
             code_revision = model_kwargs.pop("code_revision", None) if model_kwargs else None
             try:
                 return get_class_from_dynamic_module(

--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -1187,7 +1187,11 @@ class SentenceTransformer(nn.Sequential, FitMixin, PeftAdapterMixin):
             # For other cases, we want to add the class name:
             elif not class_ref.startswith("sentence_transformers."):
                 class_ref = f"{class_ref}.{type(module).__name__}"
-            modules_config.append({"idx": idx, "name": name, "path": os.path.basename(model_path), "type": class_ref})
+
+            module_config = {"idx": idx, "name": name, "path": os.path.basename(model_path), "type": class_ref}
+            if self.module_kwargs and name in self.module_kwargs and (module_kwargs := self.module_kwargs[name]):
+                module_config["kwargs"] = module_kwargs
+            modules_config.append(module_config)
 
         with open(os.path.join(path, "modules.json"), "w") as fOut:
             json.dump(modules_config, fOut, indent=2)


### PR DESCRIPTION
Resolves #3111

Hello!

## Pull Request overview
* Save custom module `kwargs` if specified, e.g. required for locally saving models like `jina-embeddings-v3`.

## Details
This should have been included in the save all along, but wasn't due to oversight.

cc @guenthermi - thanks for raising this!

- Tom Aarsen