### PR TITLE
fix backward pass for cached losses

### DIFF
--- a/sentence_transformers/losses/CachedGISTEmbedLoss.py
+++ b/sentence_transformers/losses/CachedGISTEmbedLoss.py
@@ -229,7 +229,7 @@ class CachedGISTEmbedLoss(nn.Module):
 
     def calculate_loss_and_cache_gradients(self, reps: list[list[Tensor]], reps_guided: list[list[Tensor]]) -> Tensor:
         """Generalized function to calculate the cross-entropy loss and cache the gradients wrt. the embeddings."""
-        loss = self.calculate_loss(reps, reps_guided)
+        loss = self.calculate_loss(reps, reps_guided, with_backward=True)
         loss = loss.detach().requires_grad_()
 
         self.cache = [[r.grad for r in rs] for rs in reps]

--- a/sentence_transformers/losses/CachedGISTEmbedLoss.py
+++ b/sentence_transformers/losses/CachedGISTEmbedLoss.py
@@ -230,14 +230,15 @@ class CachedGISTEmbedLoss(nn.Module):
     def calculate_loss_and_cache_gradients(self, reps: list[list[Tensor]], reps_guided: list[list[Tensor]]) -> Tensor:
         """Generalized function to calculate the cross-entropy loss and cache the gradients wrt. the embeddings."""
         loss = self.calculate_loss(reps, reps_guided)
-        loss.backward()
         loss = loss.detach().requires_grad_()
 
         self.cache = [[r.grad for r in rs] for rs in reps]
 
         return loss
 
-    def calculate_loss(self, reps: list[list[Tensor]], reps_guided: list[list[Tensor]]) -> Tensor:
+    def calculate_loss(
+        self, reps: list[list[Tensor]], reps_guided: list[list[Tensor]], with_backward: bool = False
+    ) -> Tensor:
         """Generalized function to calculate the cross-entropy loss without caching gradients."""
         if len(reps) != len(reps_guided):
             raise ValueError("reps and reps_guided must have the same length")
@@ -291,6 +292,9 @@ class CachedGISTEmbedLoss(nn.Module):
             # Normalize the scores and calculate the cross-entropy loss
             scores = scores / self.temperature
             loss_mbatch: torch.Tensor = self.cross_entropy_loss(scores, labels[b:e]) * len(scores) / batch_size
+            if with_backward:
+                loss_mbatch.backward()
+                loss_mbatch = loss_mbatch.detach()
             losses.append(loss_mbatch)
 
         loss = sum(losses)

--- a/sentence_transformers/losses/MatryoshkaLoss.py
+++ b/sentence_transformers/losses/MatryoshkaLoss.py
@@ -81,7 +81,7 @@ class CachedLossDecorator:
         self.matryoshka_weights = matryoshka_weights
         self.n_dims_per_step = n_dims_per_step
 
-    def __call__(self, reps: list[list[Tensor]], *args) -> Tensor:
+    def __call__(self, reps: list[list[Tensor]], *args, **kwargs) -> Tensor:
         dim_indices = range(len(self.matryoshka_dims))
         if self.n_dims_per_step > 0 and self.n_dims_per_step < len(dim_indices):
             dim_indices = random.sample(dim_indices, self.n_dims_per_step)
@@ -91,9 +91,16 @@ class CachedLossDecorator:
             dim = self.matryoshka_dims[idx]
             weight = self.matryoshka_weights[idx]
 
-            truncated = [[shrink(r, dim) for r in rs] for rs in reps]
-            loss += weight * self.fn(truncated, *args)
-
+            truncated = [[shrink(r, dim) for r in minibatch] for minibatch in reps]
+            # we need to detach the truncated embeddings,
+            # otherwise the first backward pass of the underlying function will clear the computation graph of the embedding truncation
+            detached = [[r.detach().requires_grad_() for r in minibatch] for minibatch in truncated]
+            loss += weight * self.fn(detached, *args, **kwargs)
+            # After computing the gradients in minibatches, we need to continue the backward pass through the truncation calculation
+            # the gradients must be multipied with the weights because otherwise the matryoshka weights are not considered in the backward pass
+            for t_minibatch, d_minibatch in zip(truncated, detached):
+                for t, d in zip(t_minibatch, d_minibatch):
+                    t.backward(weight * d.grad)
         return loss
 
 


### PR DESCRIPTION
Here is a draft for a fix of the backward pass in the cached losses, while still maintaining the compatibility with the matryoshka loss. The problem is a bit more difficult than I originally thought because we need to detach the tensor before doing the minibatch loss computation.

If anyone has suggestions for improvements, let me know 😀