### PR TITLE
raises error when dataset is an empty list in NanoBEIREvaluator

### DIFF
--- a/sentence_transformers/evaluation/NanoBEIREvaluator.py
+++ b/sentence_transformers/evaluation/NanoBEIREvaluator.py
@@ -420,6 +420,8 @@ class NanoBEIREvaluator(SentenceEvaluator):
         )
 
     def _validate_dataset_names(self):
+        if self.dataset_names == []:
+            raise ValueError("dataset_names cannot be empty. Use None to evaluate on all datasets.")
         if missing_datasets := [
             dataset_name for dataset_name in self.dataset_names if dataset_name.lower() not in dataset_name_to_id
         ]:


### PR DESCRIPTION
Raises an error when dataset names are a empty list in NanoBEIREvaluator.

Fixes #3103 


Who can review?
@tomaarsen 