### PR TITLE
[`typo`] Add missing space between sentences in error message

### DIFF
--- a/sentence_transformers/evaluation/NanoBEIREvaluator.py
+++ b/sentence_transformers/evaluation/NanoBEIREvaluator.py
@@ -424,7 +424,7 @@ class NanoBEIREvaluator(SentenceEvaluator):
             dataset_name for dataset_name in self.dataset_names if dataset_name.lower() not in dataset_name_to_id
         ]:
             raise ValueError(
-                f"Dataset(s) {missing_datasets} not found in the NanoBEIR collection."
+                f"Dataset(s) {missing_datasets} not found in the NanoBEIR collection. "
                 f"Valid dataset names are: {list(dataset_name_to_id.keys())}"
             )
 


### PR DESCRIPTION
Hello!

## Pull Request overview
* Add missing space between sentences in error message

## Details
The code here should speak for itself.

- Tom Aarsen