### PR TITLE
[`memory`] Avoid storing trainer in ModelCardCallback and SentenceTransformerModelCardData

### DIFF
--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -1252,7 +1252,7 @@ class SentenceTransformer(nn.Sequential, FitMixin, PeftAdapterMixin):
 
         # If we loaded a Sentence Transformer model from the Hub, and no training was done, then
         # we don't generate a new model card, but reuse the old one instead.
-        if self._model_card_text and self.model_card_data.trainer is None:
+        if self._model_card_text and "generated_from_trainer" not in self.model_card_data.tags:
             model_card = self._model_card_text
             if self.model_card_data.model_id:
                 # If the original model card was saved without a model_id, we replace the model_id with the new model_id

--- a/sentence_transformers/evaluation/BinaryClassificationEvaluator.py
+++ b/sentence_transformers/evaluation/BinaryClassificationEvaluator.py
@@ -212,7 +212,7 @@ class BinaryClassificationEvaluator(SentenceEvaluator):
             self.primary_metric = f"{self.similarity_fn_names[0]}_ap"
 
         metrics = self.prefix_name_to_metrics(metrics, self.name)
-        self.store_metrics_in_model_card_data(model, metrics)
+        self.store_metrics_in_model_card_data(model, metrics, epoch, steps)
         return metrics
 
     def compute_metrices(self, model: SentenceTransformer) -> dict[str, dict[str, float]]:

--- a/sentence_transformers/evaluation/EmbeddingSimilarityEvaluator.py
+++ b/sentence_transformers/evaluation/EmbeddingSimilarityEvaluator.py
@@ -249,7 +249,7 @@ class EmbeddingSimilarityEvaluator(SentenceEvaluator):
                 self.primary_metric = f"spearman_{self.similarity_fn_names[0]}"
 
         metrics = self.prefix_name_to_metrics(metrics, self.name)
-        self.store_metrics_in_model_card_data(model, metrics)
+        self.store_metrics_in_model_card_data(model, metrics, epoch, steps)
         return metrics
 
     @property

--- a/sentence_transformers/evaluation/InformationRetrievalEvaluator.py
+++ b/sentence_transformers/evaluation/InformationRetrievalEvaluator.py
@@ -277,7 +277,7 @@ class InformationRetrievalEvaluator(SentenceEvaluator):
             for k, value in values.items()
         }
         metrics = self.prefix_name_to_metrics(metrics, self.name)
-        self.store_metrics_in_model_card_data(model, metrics)
+        self.store_metrics_in_model_card_data(model, metrics, epoch, steps)
         return metrics
 
     def compute_metrices(

--- a/sentence_transformers/evaluation/LabelAccuracyEvaluator.py
+++ b/sentence_transformers/evaluation/LabelAccuracyEvaluator.py
@@ -91,5 +91,5 @@ class LabelAccuracyEvaluator(SentenceEvaluator):
 
         metrics = {"accuracy": accuracy}
         metrics = self.prefix_name_to_metrics(metrics, self.name)
-        self.store_metrics_in_model_card_data(model, metrics)
+        self.store_metrics_in_model_card_data(model, metrics, epoch, steps)
         return metrics

--- a/sentence_transformers/evaluation/MSEEvaluator.py
+++ b/sentence_transformers/evaluation/MSEEvaluator.py
@@ -138,7 +138,7 @@ class MSEEvaluator(SentenceEvaluator):
         # Return negative score as SentenceTransformers maximizes the performance
         metrics = {"negative_mse": -mse}
         metrics = self.prefix_name_to_metrics(metrics, self.name)
-        self.store_metrics_in_model_card_data(model, metrics)
+        self.store_metrics_in_model_card_data(model, metrics, epoch, steps)
         return metrics
 
     @property

--- a/sentence_transformers/evaluation/MSEEvaluatorFromDataFrame.py
+++ b/sentence_transformers/evaluation/MSEEvaluatorFromDataFrame.py
@@ -120,7 +120,7 @@ class MSEEvaluatorFromDataFrame(SentenceEvaluator):
         # Return negative score as SentenceTransformers maximizes the performance
         metrics = {"negative_mse": -np.mean(mse_scores).item()}
         metrics = self.prefix_name_to_metrics(metrics, self.name)
-        self.store_metrics_in_model_card_data(model, metrics)
+        self.store_metrics_in_model_card_data(model, metrics, epoch, steps)
         return metrics
 
     @property

--- a/sentence_transformers/evaluation/NanoBEIREvaluator.py
+++ b/sentence_transformers/evaluation/NanoBEIREvaluator.py
@@ -377,7 +377,7 @@ class NanoBEIREvaluator(SentenceEvaluator):
 
         # TODO: Ensure this primary_metric works as expected, also with bolding the right thing in the model card
         agg_results = self.prefix_name_to_metrics(agg_results, self.name)
-        self.store_metrics_in_model_card_data(model, agg_results)
+        self.store_metrics_in_model_card_data(model, agg_results, epoch, steps)
 
         per_dataset_results.update(agg_results)
 

--- a/sentence_transformers/evaluation/ParaphraseMiningEvaluator.py
+++ b/sentence_transformers/evaluation/ParaphraseMiningEvaluator.py
@@ -241,7 +241,7 @@ class ParaphraseMiningEvaluator(SentenceEvaluator):
             "threshold": threshold,
         }
         metrics = self.prefix_name_to_metrics(metrics, self.name)
-        self.store_metrics_in_model_card_data(model, metrics)
+        self.store_metrics_in_model_card_data(model, metrics, epoch, steps)
         return metrics
 
     @staticmethod

--- a/sentence_transformers/evaluation/RerankingEvaluator.py
+++ b/sentence_transformers/evaluation/RerankingEvaluator.py
@@ -151,7 +151,7 @@ class RerankingEvaluator(SentenceEvaluator):
             f"ndcg@{self.at_k}": mean_ndcg,
         }
         metrics = self.prefix_name_to_metrics(metrics, self.name)
-        self.store_metrics_in_model_card_data(model, metrics)
+        self.store_metrics_in_model_card_data(model, metrics, epoch, steps)
         return metrics
 
     def compute_metrices(self, model):

--- a/sentence_transformers/evaluation/SentenceEvaluator.py
+++ b/sentence_transformers/evaluation/SentenceEvaluator.py
@@ -62,8 +62,10 @@ class SentenceEvaluator:
             self.primary_metric = name + "_" + self.primary_metric
         return metrics
 
-    def store_metrics_in_model_card_data(self, model: SentenceTransformer, metrics: dict[str, Any]) -> None:
-        model.model_card_data.set_evaluation_metrics(self, metrics)
+    def store_metrics_in_model_card_data(
+        self, model: SentenceTransformer, metrics: dict[str, Any], epoch: int = 0, step: int = 0
+    ) -> None:
+        model.model_card_data.set_evaluation_metrics(self, metrics, epoch, step)
 
     @property
     def description(self) -> str:

--- a/sentence_transformers/evaluation/TranslationEvaluator.py
+++ b/sentence_transformers/evaluation/TranslationEvaluator.py
@@ -183,5 +183,5 @@ class TranslationEvaluator(SentenceEvaluator):
             "mean_accuracy": (acc_src2trg + acc_trg2src) / 2,
         }
         metrics = self.prefix_name_to_metrics(metrics, self.name)
-        self.store_metrics_in_model_card_data(model, metrics)
+        self.store_metrics_in_model_card_data(model, metrics, epoch, steps)
         return metrics

--- a/sentence_transformers/evaluation/TripletEvaluator.py
+++ b/sentence_transformers/evaluation/TripletEvaluator.py
@@ -261,5 +261,5 @@ class TripletEvaluator(SentenceEvaluator):
                 self.primary_metric = f"{self.similarity_fn_names[0]}_accuracy"
 
         metrics = self.prefix_name_to_metrics(metrics, self.name)
-        self.store_metrics_in_model_card_data(model, metrics)
+        self.store_metrics_in_model_card_data(model, metrics, epoch, steps)
         return metrics

--- a/sentence_transformers/trainer.py
+++ b/sentence_transformers/trainer.py
@@ -295,9 +295,9 @@ class SentenceTransformerTrainer(Trainer):
             This method can be overriden by subclassing the trainer to remove/customize this callback in custom uses cases
         """
 
-        model_card_callback = ModelCardCallback(self, default_args_dict)
+        model_card_callback = ModelCardCallback(default_args_dict)
         self.add_callback(model_card_callback)
-        model_card_callback.on_init_end(self.args, self.state, self.control, self.model)
+        model_card_callback.on_init_end(self.args, self.state, self.control, self.model, trainer=self)
 
     def call_model_init(self, trial=None) -> SentenceTransformer:
         model = super().call_model_init(trial=trial)


### PR DESCRIPTION
Resolves #3136

Hello!

## Pull Request overview
* Avoid storing trainer in ModelCardCallback and SentenceTransformerModelCardData

## Details
This seems to prevent cleanup, as there's a cyclical dependency between trainer -> model -> model card -> trainer. This means that once the trainer and model get overridden (e.g. in https://github.com/UKPLab/sentence-transformers/blob/master/examples/training/data_augmentation/train_sts_seed_optimization.py), the old model/trainer/model_card_data don't get automatically eaten by the garbage disposal.

I've moved a lot of components around, and now ModelCardCallback nor SentenceTransformerModelCardData need to store the Trainer. Although annoying, this does mean that memory should be cleared if the model/trainer gets overridden/deleted.

### Before:
Approximate highest recorded VRAM during [train_sts_seed_optimization](https://github.com/UKPLab/sentence-transformers/blob/master/examples/training/data_augmentation/train_sts_seed_optimization.py):
```
16332MiB /  24576MiB
```

### After
Approximate highest recorded VRAM during [train_sts_seed_optimization](https://github.com/UKPLab/sentence-transformers/blob/master/examples/training/data_augmentation/train_sts_seed_optimization.py):
```
8222MiB /  24576MiB
```

Note that the VRAM usage does still grow, albeit a lot more slowly, so this might not have resolved all issues. Having said that, because most people only make 1 trainer, it's not that big of an issue I suspect.

- Tom Aarsen