### PR TITLE
Suport for embedded representation

### DIFF
--- a/sentence_transformers/models/Transformer.py
+++ b/sentence_transformers/models/Transformer.py
@@ -432,15 +432,11 @@ class Transformer(nn.Module):
 
     def forward(self, features: dict[str, torch.Tensor], **kwargs) -> dict[str, torch.Tensor]:
         """Returns token_embeddings, cls_token"""
-        trans_features = {"attention_mask": features["attention_mask"]}
-
-        if "inputs_embeds" in features:
-            trans_features["inputs_embeds"] = features["inputs_embeds"]
-        else:
-            trans_features["input_ids"] = features["input_ids"]
-
-        if "token_type_ids" in features:
-            trans_features["token_type_ids"] = features["token_type_ids"]
+        trans_features = {
+            key: value
+            for key, value in features.items()
+            if key in ["input_ids", "attention_mask", "token_type_ids", "inputs_embeds"]
+        }
 
         output_states = self.auto_model(**trans_features, **kwargs, return_dict=False)
         output_tokens = output_states[0]

--- a/sentence_transformers/models/Transformer.py
+++ b/sentence_transformers/models/Transformer.py
@@ -432,7 +432,13 @@ class Transformer(nn.Module):
 
     def forward(self, features: dict[str, torch.Tensor], **kwargs) -> dict[str, torch.Tensor]:
         """Returns token_embeddings, cls_token"""
-        trans_features = {"input_ids": features["input_ids"], "attention_mask": features["attention_mask"]}
+        trans_features = {"attention_mask": features["attention_mask"]}
+
+        if "inputs_embeds" in features:
+            trans_features["inputs_embeds"] = features["inputs_embeds"]
+        else:
+            trans_features["input_ids"] = features["input_ids"]
+
         if "token_type_ids" in features:
             trans_features["token_type_ids"] = features["token_type_ids"]
 


### PR DESCRIPTION
Previously, the SentenceTransformer wrapper did not allow passing precomputed embeddings (embedded representation).
Many models from the transformers library support this, such as [llama](https://github.com/huggingface/transformers/blob/main/src/transformers/models/llama/modeling_llama.py#L463), [gemma](https://github.com/huggingface/transformers/blob/main/src/transformers/models/gemma2/modeling_gemma2.py#L489), [gemma2](https://github.com/huggingface/transformers/blob/main/src/transformers/models/gemma2/modeling_gemma2.py#L489), [mistral](https://github.com/huggingface/transformers/blob/main/src/transformers/models/gemma2/modeling_gemma2.py#L489), bert etc.

This feature is particularly (but not only) useful for experimenting with different techniques of custom soft prompting. 


The implementations do not support passing both `input_ids` and `inputs_embeds` simultaneously: [example](https://github.com/huggingface/transformers/blob/main/src/transformers/models/mistral/modeling_mistral.py#L514). Therefore, i implemented them as being mutually exclusive, with `inputs_embeds` taking precedence.
