### PR TITLE
fix: propagate cache dir to find adapter

### DIFF
--- a/sentence_transformers/models/Transformer.py
+++ b/sentence_transformers/models/Transformer.py
@@ -120,6 +120,7 @@ class Transformer(nn.Module):
         if (
             find_adapter_config_file(
                 model_name_or_path,
+                cache_dir=cache_dir,
                 token=config_args.get("token"),
                 revision=config_args.get("revision"),
                 local_files_only=config_args.get("local_files_only", False),


### PR DESCRIPTION
`cache_dir` is not currently propagated to the `find_adapter_config_file` function therefore the default cache directory is always used. This has caused us issues when trying to cache models running on a pyspark enabled Dataproc cluster as the agent does not have a `home`.