### PR TITLE
[`fix`] Use HfArgumentParser-compatible typing for prompts

### DIFF
--- a/sentence_transformers/training_args.py
+++ b/sentence_transformers/training_args.py
@@ -170,7 +170,14 @@ class SentenceTransformerTrainingArguments(TransformersTrainingArguments):
             for valid options. Defaults to ``MultiDatasetBatchSamplers.PROPORTIONAL``.
     """
 
-    prompts: dict[str, dict[str, str]] | dict[str, str] | str | None = None
+    prompts: str | None = field(
+        default=None,
+        metadata={
+            "help": "The prompts to use for each column in the datasets. "
+            "Either 1) a single string prompt, 2) a mapping of column names to prompts, 3) a mapping of dataset names "
+            "to prompts, or 4) a mapping of dataset names to a mapping of column names to prompts."
+        },
+    )
     batch_sampler: BatchSamplers | str = field(
         default=BatchSamplers.BATCH_SAMPLER, metadata={"help": "The batch sampler to use."}
     )

--- a/sentence_transformers/training_args.py
+++ b/sentence_transformers/training_args.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
+from typing import Optional, Union
 
 from transformers import TrainingArguments as TransformersTrainingArguments
 from transformers.training_args import ParallelMode
@@ -170,7 +171,7 @@ class SentenceTransformerTrainingArguments(TransformersTrainingArguments):
             for valid options. Defaults to ``MultiDatasetBatchSamplers.PROPORTIONAL``.
     """
 
-    prompts: str | None = field(
+    prompts: Optional[str] = field(  # noqa: UP007
         default=None,
         metadata={
             "help": "The prompts to use for each column in the datasets. "
@@ -178,10 +179,10 @@ class SentenceTransformerTrainingArguments(TransformersTrainingArguments):
             "to prompts, or 4) a mapping of dataset names to a mapping of column names to prompts."
         },
     )
-    batch_sampler: BatchSamplers | str = field(
+    batch_sampler: Union[BatchSamplers, str] = field(  # noqa: UP007
         default=BatchSamplers.BATCH_SAMPLER, metadata={"help": "The batch sampler to use."}
     )
-    multi_dataset_batch_sampler: MultiDatasetBatchSamplers | str = field(
+    multi_dataset_batch_sampler: Union[MultiDatasetBatchSamplers, str] = field(  # noqa: UP007
         default=MultiDatasetBatchSamplers.PROPORTIONAL, metadata={"help": "The multi-dataset batch sampler to use."}
     )
 

--- a/tests/test_training_args.py
+++ b/tests/test_training_args.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import json
+
+from transformers import HfArgumentParser
+
+from sentence_transformers import SentenceTransformerTrainingArguments
+
+
+def test_hf_argument_parser():
+    # See https://github.com/UKPLab/sentence-transformers/issues/3090;
+    # Ensure that the HfArgumentParser can be used to parse SentenceTransformerTrainingArguments.
+    parser = HfArgumentParser(SentenceTransformerTrainingArguments)
+    args = parser.parse_args(
+        args=[
+            "--output_dir",
+            "test_output_dir",
+            "--prompts",
+            '{"query_column": "query_prompt", "positive_column": "positive_prompt", "negative_column": "negative_prompt"}',
+        ]
+    )
+    assert args.output_dir == "test_output_dir"
+    assert json.loads(args.prompts) == {
+        "query_column": "query_prompt",
+        "positive_column": "positive_prompt",
+        "negative_column": "negative_prompt",
+    }


### PR DESCRIPTION
Resolves #3090

Hello!

## Pull Request overview
* Use HfArgumentParser-compatible typing for prompts

## Details
Resolves #3090 by updating the typing from `dict[str, dict[str, str]] | dict[str, str] | str | None` to just `str | None`. I've also added the explanation in the `metadata` to make sure people are aware that there's more valid options.

And I added a simple test case that just ensures there's no crash. This should ensure that this same issue won't happen anymore.

- Tom Aarsen