### PR TITLE
[`integration`] Work towards full model2vec integration

### DIFF
--- a/sentence_transformers/models/StaticEmbedding.py
+++ b/sentence_transformers/models/StaticEmbedding.py
@@ -127,7 +127,11 @@ class StaticEmbedding(nn.Module):
             weights = torch.load(
                 os.path.join(load_dir, "pytorch_model.bin"), map_location=torch.device("cpu"), weights_only=True
             )
-        weights = weights["embedding.weight"]
+        try:
+            weights = weights["embedding.weight"]
+        except KeyError:
+            # For compatibility with model2vec models, which are saved with just an "embeddings" key
+            weights = weights["embeddings"]
         return StaticEmbedding(tokenizer, embedding_weights=weights)
 
     @classmethod

--- a/tests/models/test_static_embedding.py
+++ b/tests/models/test_static_embedding.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+import math
 from pathlib import Path
 
 import numpy as np
 import pytest
 from tokenizers import Tokenizer
 
+from sentence_transformers import SentenceTransformer
 from sentence_transformers.models.StaticEmbedding import StaticEmbedding
 
 try:
@@ -74,3 +76,15 @@ def test_from_distillation() -> None:
 def test_from_model2vec() -> None:
     model = StaticEmbedding.from_model2vec("minishlab/M2V_base_output")
     assert model.embedding.weight.shape == (29528, 256)
+
+
+def test_loading_model2vec() -> None:
+    model = SentenceTransformer("minishlab/potion-base-8M")
+    assert model.get_sentence_embedding_dimension() == 256
+    assert model.max_seq_length == math.inf
+
+    test_sentences = ["It's so sunny outside!", "The sun is shining outside!"]
+    embeddings = model.encode(test_sentences)
+    assert embeddings.shape == (2, 256)
+    similarity = model.similarity(embeddings[0], embeddings[1])
+    assert similarity.item() > 0.7


### PR DESCRIPTION
Hello!

## Pull Request overview
* Be able to load Model2Vec weight files as long as the model itself has a `modules.json` pointing to `StaticEmbedding`.

## Details
This PR is to work towards compatibility of:
```python
from sentence_transformers import SentenceTransformer

model = SentenceTransformer(".")
embeddings = model.encode(["It's wonderful weather!", "I love the weather today.", "It's raining cats and dogs."])
print(embeddings.shape)

similarity = model.similarity(embeddings, embeddings)
print(similarity)
```
```
(3, 256)
tensor([[1.0000, 0.7467, 0.3813],
        [0.7467, 1.0000, 0.4091],
        [0.3813, 0.4091, 1.0000]])
```

Beyond the changes in this PR, the Model2Vec models must be updated with a `modules.json` like:
```json
[
    {
        "idx": 0,
        "name": "0",
        "path": ".",
        "type": "sentence_transformers.models.StaticEmbedding"
    }
]
```
or
```json
[
    {
        "idx": 0,
        "name": "0",
        "path": ".",
        "type": "sentence_transformers.models.StaticEmbedding"
    },
    {
        "idx": 1,
        "name": "1",
        "path": "1_Normalize",
        "type": "sentence_transformers.models.Normalize"
    }
]
```

@Pringled and @stephantul are working towards the changes on the model2vec side.

- Tom Aarsen