### PR TITLE
[`tests`] Make TripletEvaluator test more consistent

### DIFF
--- a/tests/evaluation/test_triplet_evaluator.py
+++ b/tests/evaluation/test_triplet_evaluator.py
@@ -8,9 +8,9 @@ from sentence_transformers import SentenceTransformer
 from sentence_transformers.evaluation import TripletEvaluator
 
 
-def test_TripletEvaluator(stsb_bert_tiny_model_reused: SentenceTransformer) -> None:
+def test_TripletEvaluator(stsb_bert_tiny_model: SentenceTransformer) -> None:
     """Tests that the TripletEvaluator can be loaded & used"""
-    model = stsb_bert_tiny_model_reused
+    model = stsb_bert_tiny_model
     anchors = [
         "A person on a horse jumps over a broken down airplane.",
         "Children smiling and waving at camera",


### PR DESCRIPTION
Hello!

## Pull Request overview
* Make TripletEvaluator test more consistent

## Details
It's possible that the reused model has been used with `model.similarity`, which has set the primary metric already, potentially to something other than the default cosine.

- Tom Aarsen