### PR TITLE
[`deprecation`] Clarify that datasets and readers are deprecated since v3

### DIFF
--- a/sentence_transformers/datasets/DenoisingAutoEncoderDataset.py
+++ b/sentence_transformers/datasets/DenoisingAutoEncoderDataset.py
@@ -1,3 +1,14 @@
+"""
+This file contains deprecated code that can only be used with the old `model.fit`-style Sentence Transformers v2.X training.
+It exists for backwards compatibility with the `model.old_fit` method, but will be removed in a future version.
+
+Nowadays, with Sentence Transformers v3+, it is recommended to use the `SentenceTransformerTrainer` class to train models.
+See https://www.sbert.net/docs/sentence_transformer/training_overview.html for more information.
+
+See this script for more details on how to use the new training API:
+https://github.com/UKPLab/sentence-transformers/blob/master/examples/unsupervised_learning/TSDAE/train_stsb_tsdae.py
+"""
+
 from __future__ import annotations
 
 import numpy as np

--- a/sentence_transformers/datasets/NoDuplicatesDataLoader.py
+++ b/sentence_transformers/datasets/NoDuplicatesDataLoader.py
@@ -1,3 +1,13 @@
+"""
+This file contains deprecated code that can only be used with the old `model.fit`-style Sentence Transformers v2.X training.
+It exists for backwards compatibility with the `model.old_fit` method, but will be removed in a future version.
+
+Nowadays, with Sentence Transformers v3+, it is recommended to use the `SentenceTransformerTrainer` class to train models.
+See https://www.sbert.net/docs/sentence_transformer/training_overview.html for more information.
+
+In particular, you can pass "no_duplicates" to `batch_sampler` in the `SentenceTransformerTrainingArguments` class.
+"""
+
 from __future__ import annotations
 
 import math

--- a/sentence_transformers/datasets/ParallelSentencesDataset.py
+++ b/sentence_transformers/datasets/ParallelSentencesDataset.py
@@ -1,3 +1,13 @@
+"""
+This file contains deprecated code that can only be used with the old `model.fit`-style Sentence Transformers v2.X training.
+It exists for backwards compatibility with the `model.old_fit` method, but will be removed in a future version.
+
+Nowadays, with Sentence Transformers v3+, it is recommended to use the `SentenceTransformerTrainer` class to train models.
+See https://www.sbert.net/docs/sentence_transformer/training_overview.html for more information.
+
+Instead, you should create a `datasets` `Dataset` for training: https://huggingface.co/docs/datasets/create_dataset
+"""
+
 from __future__ import annotations
 
 import gzip

--- a/sentence_transformers/datasets/SentenceLabelDataset.py
+++ b/sentence_transformers/datasets/SentenceLabelDataset.py
@@ -1,3 +1,13 @@
+"""
+This file contains deprecated code that can only be used with the old `model.fit`-style Sentence Transformers v2.X training.
+It exists for backwards compatibility with the `model.old_fit` method, but will be removed in a future version.
+
+Nowadays, with Sentence Transformers v3+, it is recommended to use the `SentenceTransformerTrainer` class to train models.
+See https://www.sbert.net/docs/sentence_transformer/training_overview.html for more information.
+
+In particular, you can pass "group_by_label" to `batch_sampler` in the `SentenceTransformerTrainingArguments` class.
+"""
+
 from __future__ import annotations
 
 import logging

--- a/sentence_transformers/datasets/SentencesDataset.py
+++ b/sentence_transformers/datasets/SentencesDataset.py
@@ -1,3 +1,11 @@
+"""
+This file contains deprecated code that can only be used with the old `model.fit`-style Sentence Transformers v2.X training.
+It exists for backwards compatibility with the `model.old_fit` method, but will be removed in a future version.
+
+Nowadays, with Sentence Transformers v3+, it is recommended to use the `SentenceTransformerTrainer` class to train models.
+See https://www.sbert.net/docs/sentence_transformer/training_overview.html for more information.
+"""
+
 from __future__ import annotations
 
 from torch.utils.data import Dataset

--- a/sentence_transformers/datasets/__init__.py
+++ b/sentence_transformers/datasets/__init__.py
@@ -1,3 +1,11 @@
+"""
+This directory contains deprecated code that can only be used with the old `model.fit`-style Sentence Transformers v2.X training.
+It exists for backwards compatibility with the `model.old_fit` method, but will be removed in a future version.
+
+Nowadays, with Sentence Transformers v3+, it is recommended to use the `SentenceTransformerTrainer` class to train models.
+See https://www.sbert.net/docs/sentence_transformer/training_overview.html for more information.
+"""
+
 from __future__ import annotations
 
 from .DenoisingAutoEncoderDataset import DenoisingAutoEncoderDataset

--- a/sentence_transformers/readers/InputExample.py
+++ b/sentence_transformers/readers/InputExample.py
@@ -1,3 +1,13 @@
+"""
+This file contains deprecated code that can only be used with the old `model.fit`-style Sentence Transformers v2.X training.
+It exists for backwards compatibility with the `model.old_fit` method, but will be removed in a future version.
+
+Nowadays, with Sentence Transformers v3+, it is recommended to use the `SentenceTransformerTrainer` class to train models.
+See https://www.sbert.net/docs/sentence_transformer/training_overview.html for more information.
+
+Instead, you should create a `datasets` `Dataset` for training: https://huggingface.co/docs/datasets/create_dataset
+"""
+
 from __future__ import annotations
 
 

--- a/sentence_transformers/readers/LabelSentenceReader.py
+++ b/sentence_transformers/readers/LabelSentenceReader.py
@@ -1,3 +1,13 @@
+"""
+This file contains deprecated code that can only be used with the old `model.fit`-style Sentence Transformers v2.X training.
+It exists for backwards compatibility with the `model.old_fit` method, but will be removed in a future version.
+
+Nowadays, with Sentence Transformers v3+, it is recommended to use the `SentenceTransformerTrainer` class to train models.
+See https://www.sbert.net/docs/sentence_transformer/training_overview.html for more information.
+
+Instead, you should create a `datasets` `Dataset` for training: https://huggingface.co/docs/datasets/create_dataset
+"""
+
 from __future__ import annotations
 
 import os

--- a/sentence_transformers/readers/NLIDataReader.py
+++ b/sentence_transformers/readers/NLIDataReader.py
@@ -1,3 +1,13 @@
+"""
+This file contains deprecated code that can only be used with the old `model.fit`-style Sentence Transformers v2.X training.
+It exists for backwards compatibility with the `model.old_fit` method, but will be removed in a future version.
+
+Nowadays, with Sentence Transformers v3+, it is recommended to use the `SentenceTransformerTrainer` class to train models.
+See https://www.sbert.net/docs/sentence_transformer/training_overview.html for more information.
+
+Instead, you should create a `datasets` `Dataset` for training: https://huggingface.co/docs/datasets/create_dataset
+"""
+
 from __future__ import annotations
 
 import gzip

--- a/sentence_transformers/readers/PairedFilesReader.py
+++ b/sentence_transformers/readers/PairedFilesReader.py
@@ -1,3 +1,13 @@
+"""
+This file contains deprecated code that can only be used with the old `model.fit`-style Sentence Transformers v2.X training.
+It exists for backwards compatibility with the `model.old_fit` method, but will be removed in a future version.
+
+Nowadays, with Sentence Transformers v3+, it is recommended to use the `SentenceTransformerTrainer` class to train models.
+See https://www.sbert.net/docs/sentence_transformer/training_overview.html for more information.
+
+Instead, you should create a `datasets` `Dataset` for training: https://huggingface.co/docs/datasets/create_dataset
+"""
+
 from __future__ import annotations
 
 import gzip

--- a/sentence_transformers/readers/STSDataReader.py
+++ b/sentence_transformers/readers/STSDataReader.py
@@ -1,3 +1,13 @@
+"""
+This file contains deprecated code that can only be used with the old `model.fit`-style Sentence Transformers v2.X training.
+It exists for backwards compatibility with the `model.old_fit` method, but will be removed in a future version.
+
+Nowadays, with Sentence Transformers v3+, it is recommended to use the `SentenceTransformerTrainer` class to train models.
+See https://www.sbert.net/docs/sentence_transformer/training_overview.html for more information.
+
+Instead, you should create a `datasets` `Dataset` for training: https://huggingface.co/docs/datasets/create_dataset
+"""
+
 from __future__ import annotations
 
 import csv

--- a/sentence_transformers/readers/TripletReader.py
+++ b/sentence_transformers/readers/TripletReader.py
@@ -1,3 +1,13 @@
+"""
+This file contains deprecated code that can only be used with the old `model.fit`-style Sentence Transformers v2.X training.
+It exists for backwards compatibility with the `model.old_fit` method, but will be removed in a future version.
+
+Nowadays, with Sentence Transformers v3+, it is recommended to use the `SentenceTransformerTrainer` class to train models.
+See https://www.sbert.net/docs/sentence_transformer/training_overview.html for more information.
+
+Instead, you should create a `datasets` `Dataset` for training: https://huggingface.co/docs/datasets/create_dataset
+"""
+
 from __future__ import annotations
 
 import csv

--- a/sentence_transformers/readers/__init__.py
+++ b/sentence_transformers/readers/__init__.py
@@ -1,3 +1,11 @@
+"""
+This directory contains deprecated code that can only be used with the old `model.fit`-style Sentence Transformers v2.X training.
+It exists for backwards compatibility with the `model.old_fit` method, but will be removed in a future version.
+
+Nowadays, with Sentence Transformers v3+, it is recommended to use the `SentenceTransformerTrainer` class to train models.
+See https://www.sbert.net/docs/sentence_transformer/training_overview.html for more information.
+"""
+
 from __future__ import annotations
 
 from .InputExample import InputExample


### PR DESCRIPTION
Hello!

## Pull Request overview
* Clarify that datasets and readers are deprecated since v3

## Details
These files only exist for backwards compatibility, and will be removed eventually. Some have been replaced with batch samplers, and others are no longer really relevant. Instead, users should prepare a `datasets` `Dataset` for training.

- Tom Aarsen