### PR TITLE
fix loss name in documentation of CachedMultipleNegativesRankingLoss

### DIFF
--- a/sentence_transformers/losses/CachedMultipleNegativesRankingLoss.py
+++ b/sentence_transformers/losses/CachedMultipleNegativesRankingLoss.py
@@ -137,7 +137,7 @@ class CachedMultipleNegativesRankingLoss(nn.Module):
                     "anchor": ["It's nice weather outside today.", "He drove to work."],
                     "positive": ["It's so sunny.", "He took the car to the office."],
                 })
-                loss = losses.CachedGISTEmbedLoss(model, mini_batch_size=64)
+                loss = losses.CachedMultipleNegativesRankingLoss(model, mini_batch_size=64)
 
                 trainer = SentenceTransformerTrainer(
                     model=model,


### PR DESCRIPTION
Fixed the incorrect loss name in the CachedMultipleNegativesRankingLoss documentation.


Who can review?
@tomaarsen 