### PR TITLE
Fix type hint of StaticEmbedding.__init__

### DIFF
--- a/sentence_transformers/models/StaticEmbedding.py
+++ b/sentence_transformers/models/StaticEmbedding.py
@@ -19,7 +19,7 @@ class StaticEmbedding(nn.Module):
     def __init__(
         self,
         tokenizer: Tokenizer | PreTrainedTokenizerFast,
-        embedding_weights: np.array | torch.Tensor | None = None,
+        embedding_weights: np.ndarray | torch.Tensor | None = None,
         embedding_dim: int | None = None,
         **kwargs,
     ) -> None:
@@ -30,7 +30,7 @@ class StaticEmbedding(nn.Module):
         Args:
             tokenizer (Tokenizer | PreTrainedTokenizerFast): The tokenizer to be used. Must be a fast tokenizer
                 from ``transformers`` or ``tokenizers``.
-            embedding_weights (np.array | torch.Tensor | None, optional): Pre-trained embedding weights.
+            embedding_weights (np.ndarray | torch.Tensor | None, optional): Pre-trained embedding weights.
                 Defaults to None.
             embedding_dim (int | None, optional): Dimension of the embeddings. Required if embedding_weights
                 is not provided. Defaults to None.


### PR DESCRIPTION
Hi there 👋 
This is a small change of type annotation in ` StaticEmbedding.__init__`: `np.array` -> `np.ndarray`

`np.array | None` is not evaluated correctly
```python
>>> import typing
>>> from sentence_transformers.models.StaticEmbedding import StaticEmbedding
>>> typing.get_type_hints(StaticEmbedding.__init__)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/opt/homebrew/Cellar/python@3.12/3.12.8/Frameworks/Python.framework/Versions/3.12/lib/python3.12/typing.py", line 2311, in get_type_hints
    hints[name] = _eval_type(value, globalns, localns, type_params)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.12/3.12.8/Frameworks/Python.framework/Versions/3.12/lib/python3.12/typing.py", line 415, in _eval_type
    return t._evaluate(globalns, localns, type_params, recursive_guard=recursive_guard)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.12/3.12.8/Frameworks/Python.framework/Versions/3.12/lib/python3.12/typing.py", line 947, in _evaluate
    eval(self.__forward_code__, globalns, localns),
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<string>", line 1, in <module>
TypeError: unsupported operand type(s) for |: 'builtin_function_or_method' and 'torch._C._TensorMeta'
```