### PR TITLE
Fix missing normalize_embeddings argument

### DIFF
--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -685,6 +685,8 @@ class SentenceTransformer(nn.Sequential, FitMixin, PeftAdapterMixin):
             return super().forward(input)
 
         for module_name, module in self.named_children():
+            if not kwargs.get("normalize_embeddings", False) and isinstance(module, Normalize):
+                return input
             module_kwarg_keys = self.module_kwargs.get(module_name, [])
             module_kwargs = {key: value for key, value in kwargs.items() if key in module_kwarg_keys}
             input = module(input, **module_kwargs)

--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -526,6 +526,7 @@ class SentenceTransformer(nn.Sequential, FitMixin, PeftAdapterMixin):
                 print(embeddings.shape)
                 # (3, 768)
         """
+        kwargs["normalize_embeddings"] = normalize_embeddings
         if self.device.type == "hpu" and not self.is_hpu_graph_enabled:
             import habana_frameworks.torch as ht
 


### PR DESCRIPTION
In the current implementation, receiving non-normalized embeddings is impossible if modules include module `Normalize`. Now the normalize_embeddings argument works regardless of the modules.json file https://github.com/UKPLab/sentence-transformers/issues/3200.