### PR TITLE
fix MatryoshkaLoss bug: sort sampled dimension indices to maintain descending dimension order

### DIFF
--- a/sentence_transformers/losses/MatryoshkaLoss.py
+++ b/sentence_transformers/losses/MatryoshkaLoss.py
@@ -218,6 +218,7 @@ class MatryoshkaLoss(nn.Module):
             dim_indices = range(len(self.matryoshka_dims))
             if self.n_dims_per_step > 0 and self.n_dims_per_step < len(dim_indices):
                 dim_indices = random.sample(dim_indices, self.n_dims_per_step)
+                dim_indices.sort()
 
             loss = 0.0
             for idx in dim_indices:


### PR DESCRIPTION
The Issue: When MatryoshkaLoss randomly samples dimension indices, they must be processed in ascending order (which corresponds to descending embedding dimensions).

What Was Happening:

- If a smaller dimension (e.g., 128) was processed first, ForwardDecorator would:
  - Cache the output tensors
  - Shrink it to the smaller dimension
  - Since the cached tensors and the shrunk tensors reference the same underlying memory, the cache will contain truncated embeddings
  
The Problem: When later processing a larger dimension (e.g., 256), the system would:

- Try to access the cached tensors
- Find it already truncated to 128 dimensions
- Trigger a misleading ValueError: "Dimension 256 cannot be greater than the model's embedding dimension: 128"

Steps to Reproduce Error:
- Edit: `/examples/training/matryoshka/matryoshka_sts.py`
  - On line 56, replace `train_loss = losses.MatryoshkaLoss(model, loss=inner_train_loss, matryoshka_dims=matryoshka_dims)` with `train_loss = losses.MatryoshkaLoss(model, loss=inner_train_loss, matryoshka_dims=matryoshka_dims, n_dims_per_step=2)`
- Run the edited script. 

The Fix: Sorting dimension indices ensures proper processing order, maintaining cache integrity and preventing the false dimension validation error.