### PR TITLE
NoDuplicatesDataLoader Compatability with Asymmetric models

### DIFF
--- a/sentence_transformers/datasets/NoDuplicatesDataLoader.py
+++ b/sentence_transformers/datasets/NoDuplicatesDataLoader.py
@@ -36,7 +36,7 @@ class NoDuplicatesDataLoader:
 
                 valid_example = True
                 for text in example.texts:
-                    if isinstance(text, dict):
+                    if not isinstance(text, str):
                         text = str(text)
                     if text.strip().lower() in texts_in_batch:
                         valid_example = False
@@ -45,7 +45,7 @@ class NoDuplicatesDataLoader:
                 if valid_example:
                     batch.append(example)
                     for text in example.texts:
-                        if isinstance(text, dict):
+                        if not isinstance(text, str):
                             text = str(text)
                         texts_in_batch.add(text.strip().lower())
 

--- a/sentence_transformers/datasets/NoDuplicatesDataLoader.py
+++ b/sentence_transformers/datasets/NoDuplicatesDataLoader.py
@@ -36,6 +36,8 @@ class NoDuplicatesDataLoader:
 
                 valid_example = True
                 for text in example.texts:
+                    if isinstance(text, dict):
+                        text = str(text)
                     if text.strip().lower() in texts_in_batch:
                         valid_example = False
                         break
@@ -43,6 +45,8 @@ class NoDuplicatesDataLoader:
                 if valid_example:
                     batch.append(example)
                     for text in example.texts:
+                        if isinstance(text, dict):
+                            text = str(text)
                         texts_in_batch.add(text.strip().lower())
 
                 self.data_pointer += 1

--- a/sentence_transformers/sampler.py
+++ b/sentence_transformers/sampler.py
@@ -193,7 +193,7 @@ class NoDuplicatesBatchSampler(SetEpochMixin, BatchSampler):
             batch_indices = []
             for index in remaining_indices:
                 sample_values = {
-                    value
+                    str(value)
                     for key, value in self.dataset[index].items()
                     if not key.endswith("_prompt_length") and key != "dataset_name"
                 }


### PR DESCRIPTION
Currently, I'm working with an asymmetric model, MNRL and providing the InputExamples as follows as in the documentation.
`            texts = [{"QRY": item["query"]}, {"PROD": item["titles"][0]}] + [{"PROD": t} for t in item["titles"][1:]]
`
Using `NoDuplicatesDataLoader` resulted in the following error `AttributeError: 'dict' object has no attribute 'strip'`

@tomaarsen 
