### PR TITLE
[`docs`] Update incorrect name: pairwise_similarity -> similarity_pairwise

### DIFF
--- a/docs/sentence_transformer/usage/semantic_textual_similarity.rst
+++ b/docs/sentence_transformer/usage/semantic_textual_similarity.rst
@@ -89,7 +89,7 @@ This value can be changed in a handful of ways:
 Sentence Transformers implements two methods to calculate the similarity between embeddings:
 
 - :meth:`SentenceTransformer.similarity <sentence_transformers.SentenceTransformer.similarity>`: Calculates the similarity between all pairs of embeddings.
-- :meth:`SentenceTransformer.pairwise_similarity <sentence_transformers.SentenceTransformer.pairwise_similarity>`: Calculates the similarity between embeddings in a pairwise fashion.
+- :meth:`SentenceTransformer.similarity_pairwise <sentence_transformers.SentenceTransformer.similarity_pairwise>`: Calculates the similarity between embeddings in a pairwise fashion.
 
 ::
 


### PR DESCRIPTION
Resolves #3221

Hello!

## Pull Request overview
* Update incorrect name: pairwise_similarity -> similarity_pairwise

## Details
I've checked locally, and now the link to the method (or rather property) gets made correctly.

- Tom Aarsen