### PR TITLE
Additional Trainer Argument for features of different modalities

### DIFF
--- a/sentence_transformers/evaluation/BinaryClassificationEvaluator.py
+++ b/sentence_transformers/evaluation/BinaryClassificationEvaluator.py
@@ -289,9 +289,9 @@ class BinaryClassificationEvaluator(SentenceEvaluator):
 
             output_scores[similarity_fn_name] = {
                 "accuracy": acc,
-                "accuracy_threshold": acc_threshold,
+                "accuracy_threshold": np.float64(acc_threshold),
                 "f1": f1,
-                "f1_threshold": f1_threshold,
+                "f1_threshold": np.float64(f1_threshold),
                 "precision": precision,
                 "recall": recall,
                 "ap": ap,

--- a/sentence_transformers/trainer.py
+++ b/sentence_transformers/trainer.py
@@ -441,23 +441,25 @@ class SentenceTransformerTrainer(Trainer):
         # All inputs ending with `_input_ids` (Transformers), `_sentence_embedding` (BoW), `_pixel_values` (CLIPModel)
         # are considered to correspond to a feature
         features = []
+        extra_suffixes = {key: "_" + key for key in self.extra_feature_keys}
         for column in inputs:
                 prefix = None  # Reset prefix for each column
                 
                 # First, check extra feature keys
-                for suffix in self.extra_feature_keys:
+                # add "_" infront of every key
+                for key, suffix in extra_suffixes.items():
                     if column.endswith(suffix):
-                        prefix = column[: -len(suffix)]
+                        prefix = column[: -len(key)]
                         break  # Stop checking once we find a match
 
                 # If no match found, check predefined suffixes
                 if prefix is None:
                     if column.endswith("_input_ids"):
-                        prefix = column[: -len("_input_ids")]
+                        prefix = column[: -len("input_ids")]
                     elif column.endswith("_sentence_embedding"):
-                        prefix = column[: -len("_sentence_embedding")]
+                        prefix = column[: -len("sentence_embedding")]
                     elif column.endswith("_pixel_values"):
-                        prefix = column[: -len("_pixel_values")]
+                        prefix = column[: -len("pixel_values")]
 
                 # Skip columns with no matching suffix
                 if prefix is None:

--- a/sentence_transformers/trainer.py
+++ b/sentence_transformers/trainer.py
@@ -438,7 +438,7 @@ class SentenceTransformerTrainer(Trainer):
                 prefix = column[: -len("input_ids")]
             elif column.endswith("_sentence_embedding"):
                 prefix = column[: -len("sentence_embedding")]
-            elif column.endswith("_omics_embedding"):
+            elif column.endswith("_omics_representation"):
                 prefix = column[: -len("omics_representation")]
             elif column.endswith("_pixel_values"):
                 prefix = column[: -len("pixel_values")]

--- a/sentence_transformers/trainer.py
+++ b/sentence_transformers/trainer.py
@@ -438,6 +438,8 @@ class SentenceTransformerTrainer(Trainer):
                 prefix = column[: -len("input_ids")]
             elif column.endswith("_sentence_embedding"):
                 prefix = column[: -len("sentence_embedding")]
+            elif column.endswith("_omics_embedding"):
+                prefix = column[: -len("omics_embedding")]
             elif column.endswith("_pixel_values"):
                 prefix = column[: -len("pixel_values")]
             else:

--- a/sentence_transformers/trainer.py
+++ b/sentence_transformers/trainer.py
@@ -439,7 +439,7 @@ class SentenceTransformerTrainer(Trainer):
             elif column.endswith("_sentence_embedding"):
                 prefix = column[: -len("sentence_embedding")]
             elif column.endswith("_omics_embedding"):
-                prefix = column[: -len("omics_embedding")]
+                prefix = column[: -len("omics_representation")]
             elif column.endswith("_pixel_values"):
                 prefix = column[: -len("pixel_values")]
             else:

--- a/tests/evaluation/test_nanobeir_evaluator.py
+++ b/tests/evaluation/test_nanobeir_evaluator.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from sentence_transformers import SentenceTransformer
+from sentence_transformers.evaluation import NanoBEIREvaluator
+
+
+def test_nanobeir_evaluator():
+    """Tests that the NanoBERTEvaluator can be loaded and produces expected metrics"""
+    datasets = ["QuoraRetrieval", "MSMARCO"]
+    query_prompts = {
+        "QuoraRetrieval": "Instruct: Given a question, retrieve questions that are semantically equivalent to the given question\\nQuery: ",
+        "MSMARCO": "Instruct: Given a web search query, retrieve relevant passages that answer the query\\nQuery: ",
+    }
+
+    model = SentenceTransformer("sentence-transformers-testing/stsb-bert-tiny-safetensors")
+
+    evaluator = NanoBEIREvaluator(
+        dataset_names=datasets,
+        query_prompts=query_prompts,
+    )
+
+    results = evaluator(model)
+
+    assert len(results) > 0
+    assert all(isinstance(results[metric], float) for metric in results)
+
+
+def test_nanobeir_evaluator_with_invalid_dataset():
+    """Test that NanoBEIREvaluator raises an error for invalid dataset names."""
+    invalid_datasets = ["invalidDataset"]
+
+    with pytest.raises(
+        ValueError,
+        match=re.escape(
+            r"Dataset(s) ['invalidDataset'] not found in the NanoBEIR collection. "
+            r"Valid dataset names are: ['climatefever', 'dbpedia', 'fever', 'fiqa2018', 'hotpotqa', 'msmarco', 'nfcorpus', 'nq', 'quoraretrieval', 'scidocs', 'arguana', 'scifact', 'touche2020']"
+        ),
+    ):
+        NanoBEIREvaluator(dataset_names=invalid_datasets)
+
+
+def test_nanobeir_evaluator_empty_inputs():
+    """Test that NanoBEIREvaluator behaves correctly with empty datasets."""
+    with pytest.raises(ValueError, match="dataset_names cannot be empty. Use None to evaluate on all datasets."):
+        NanoBEIREvaluator(dataset_names=[])


### PR DESCRIPTION
Hi,

I have been working on multi-modal embedding models based on the sentence-transformers framework and found that I need to hard code keys into the "collect_features" method within the trainer. I simply **added an argument to allow passing a list of additional keys** that might be present in your features (similar to "pixel_values" for CLIP). I would appreciate a merge so I don't need to rely on my fork for the multi-modal embedding model.

Best,
Jonatan