### PR TITLE
[`fix`] Use .get_vocab() instead of .vocab for checking tokenizer vocabulary

### DIFF
--- a/sentence_transformers/losses/GISTEmbedLoss.py
+++ b/sentence_transformers/losses/GISTEmbedLoss.py
@@ -87,7 +87,7 @@ class GISTEmbedLoss(nn.Module):
                 "Both the training model and the guiding model must be based on the `transformers` architecture."
             )
         self.must_retokenize = (
-            model.tokenizer.vocab != guide.tokenizer.vocab or guide.max_seq_length < model.max_seq_length
+            model.tokenizer.get_vocab() != guide.tokenizer.get_vocab() or guide.max_seq_length < model.max_seq_length
         )
         if self.must_retokenize:
             self.tokenizer = self.model.tokenizer


### PR DESCRIPTION
Resolves #3219

Hello!

## Pull Request overview
* Use `.get_vocab()` instead of `.vocab` for checking tokenizer vocabulary.

## Details
The `PreTrainedTokenizerBase` from `transformers` implements a `get_vocab` method that should be overridden by all tokenizers, so this should be more consistent than the `.vocab` attribute, which seemingly only a portion of all tokenizers have.

- Tom Aarsen