### PR TITLE
Update CoSENTLoss.py

### DIFF
--- a/sentence_transformers/losses/CoSENTLoss.py
+++ b/sentence_transformers/losses/CoSENTLoss.py
@@ -19,7 +19,7 @@ class CoSENTLoss(nn.Module):
 
         It computes the following loss function:
 
-        ``loss = logsum(1+exp(s(k,l)-s(i,j))+exp...)``, where ``(i,j)`` and ``(k,l)`` are any of the input pairs in the
+        ``loss = logsum(1+exp(s(i,j)-s(k,l))+exp...)``, where ``(i,j)`` and ``(k,l)`` are any of the input pairs in the
         batch such that the expected similarity of ``(i,j)`` is greater than ``(k,l)``. The summation is over all possible
         pairs of input pairs in the batch that match this condition.
 


### PR DESCRIPTION
## Context

Resolves the documentation issue [Dawnik17](https://github.com/UKPLab/sentence-transformers/issues/2437#issuecomment-2304623160) noted in the `CoSENTLoss.py` class.

## Details

Fixes variable ordering in documentation for the `CoSENTLoss.py` class; the docs should read `loss = logsum(1+exp(s(i,j)-s(k,l))+exp...)` not `loss = logsum(1+exp(s(k,l)-s(i,j))+exp...)`.