### PR TITLE
[`fix`] Fix Syntax issue; move 'as fIn' to after the if-else in `STSDataReader`

### DIFF
--- a/sentence_transformers/readers/STSDataReader.py
+++ b/sentence_transformers/readers/STSDataReader.py
@@ -51,8 +51,8 @@ class STSDataReader:
         with (
             gzip.open(filepath, "rt", encoding="utf8")
             if filename.endswith(".gz")
-            else open(filepath, encoding="utf-8") as fIn
-        ):
+            else open(filepath, encoding="utf-8")
+        ) as fIn:
             data = csv.reader(fIn, delimiter=self.delimiter, quoting=self.quoting)
             examples = []
             for id, row in enumerate(data):


### PR DESCRIPTION
Resolves #3232

Hello!

## Pull Request overview
* Move 'as fIn' to after the if-else in `STSDataReader`

## Details
I'm not sure how it ended up this way, and why it doesn't give a SyntaxError for others or the CI tests, but as @rookie12138000 reported in #3232, the original code of

```python
        with (
            gzip.open(filepath, "rt", encoding="utf8")
            if filename.endswith(".gz")
            else open(filepath, encoding="utf-8") as fIn
        ):
```
was quite odd. 

- Tom Aarsen