### PR TITLE
Fix JSON Serialization Error in TrainerState due to np.float32 #3250

### DIFF
--- a/examples/training/distillation/model_distillation.py
+++ b/examples/training/distillation/model_distillation.py
@@ -19,7 +19,10 @@ weights in the student from scratch.
 There is a performance - speed trade-off. However, we found that a student with 4 instead of 12 layers keeps about 99.4%
 of the teacher performance, while being 2.3 times faster.
 """
-
+import numpy as np
+import json
+import dataclasses
+import transformers
 import logging
 import traceback
 from datetime import datetime


### PR DESCRIPTION
TrainerState.save_to_json fails due to np.float32 values not being JSON serializable, causing crashes when saving training state.
Problem:
The TrainerState.save_to_json method in the transformers library fails when trying to save training state because np.float32 values are not natively serializable in JSON. This issue causes the training process to crash when saving checkpoints.

Steps to Reproduce:
Run the model distillation script using SentenceTransformerTrainer.
The training proceeds normally but fails when saving state due to an np.float32 serialization error.
The error message typically looks like:

TypeError: Object of type float32 is not JSON serializable
Expected Behavior:
The training state should save without errors.
The script should complete training and store checkpoints correctly.

Proposed Fix:
Convert np.float32 values to Python float before saving JSON.
Patch TrainerState.save_to_json to handle this conversion.