### PR TITLE
feat: add 'Path' parameter for ModelCard template

### DIFF
--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -1266,7 +1266,7 @@ class SentenceTransformer(nn.Sequential, FitMixin, PeftAdapterMixin):
                 )
         else:
             try:
-                model_card = generate_model_card(self)
+                model_card = generate_model_card(self, self.model_card_data.model_card_template_path)
             except Exception:
                 logger.error(
                     f"Error while generating model card:\n{traceback.format_exc()}"

--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -1266,7 +1266,7 @@ class SentenceTransformer(nn.Sequential, FitMixin, PeftAdapterMixin):
                 )
         else:
             try:
-                model_card = generate_model_card(self, self.model_card_data.model_card_template_path)
+                model_card = generate_model_card(self)
             except Exception:
                 logger.error(
                     f"Error while generating model card:\n{traceback.format_exc()}"

--- a/sentence_transformers/model_card.py
+++ b/sentence_transformers/model_card.py
@@ -253,7 +253,6 @@ class SentenceTransformerModelCardData(CardData):
             e.g. "semantic textual similarity, semantic search, paraphrase mining, text classification, clustering, and more".
         tags (`Optional[List[str]]`): A list of tags for the model,
             e.g. ["sentence-transformers", "sentence-similarity", "feature-extraction"].
-        template_path (`Path`): The path to the model card template. Default is the model_card_template.md from Sentence Transformers.
 
     .. tip::
 
@@ -291,7 +290,6 @@ class SentenceTransformerModelCardData(CardData):
             "feature-extraction",
         ]
     )
-    template_path: Path = field(default=Path(__file__).parent / "model_card_template.md")
     generate_widget_examples: Literal["deprecated"] = "deprecated"
 
     # Automatically filled by `ModelCardCallback` and the Trainer directly
@@ -317,6 +315,7 @@ class SentenceTransformerModelCardData(CardData):
     pipeline_tag: str = field(default="sentence-similarity", init=False)
     library_name: str = field(default="sentence-transformers", init=False)
     version: dict[str, str] = field(default_factory=get_versions, init=False)
+    template_path: Path = field(default=Path(__file__).parent / "model_card_template.md", init=False)
 
     # Passed via `register_model` only
     model: SentenceTransformer | None = field(default=None, init=False, repr=False)

--- a/sentence_transformers/model_card.py
+++ b/sentence_transformers/model_card.py
@@ -253,6 +253,7 @@ class SentenceTransformerModelCardData(CardData):
             e.g. "semantic textual similarity, semantic search, paraphrase mining, text classification, clustering, and more".
         tags (`Optional[List[str]]`): A list of tags for the model,
             e.g. ["sentence-transformers", "sentence-similarity", "feature-extraction"].
+        model_card_template_path (`Path`): The path to the model card template. Default is the model_card_template.md from Sentence Transformers.
 
     .. tip::
 
@@ -290,6 +291,7 @@ class SentenceTransformerModelCardData(CardData):
             "feature-extraction",
         ]
     )
+    model_card_template_path: Path = field(default=Path(__file__).parent / "model_card_template.md")
     generate_widget_examples: Literal["deprecated"] = "deprecated"
 
     # Automatically filled by `ModelCardCallback` and the Trainer directly
@@ -1015,7 +1017,8 @@ class SentenceTransformerModelCardData(CardData):
         ).strip()
 
 
-def generate_model_card(model: SentenceTransformer) -> str:
-    template_path = Path(__file__).parent / "model_card_template.md"
+def generate_model_card(model: SentenceTransformer, template_path: Path | None = None) -> str:
+    if not template_path:
+        template_path = Path(__file__).parent / "model_card_template.md"
     model_card = ModelCard.from_template(card_data=model.model_card_data, template_path=template_path, hf_emoji="🤗")
     return model_card.content

--- a/sentence_transformers/model_card.py
+++ b/sentence_transformers/model_card.py
@@ -253,7 +253,7 @@ class SentenceTransformerModelCardData(CardData):
             e.g. "semantic textual similarity, semantic search, paraphrase mining, text classification, clustering, and more".
         tags (`Optional[List[str]]`): A list of tags for the model,
             e.g. ["sentence-transformers", "sentence-similarity", "feature-extraction"].
-        model_card_template_path (`Path`): The path to the model card template. Default is the model_card_template.md from Sentence Transformers.
+        template_path (`Path`): The path to the model card template. Default is the model_card_template.md from Sentence Transformers.
 
     .. tip::
 
@@ -291,7 +291,7 @@ class SentenceTransformerModelCardData(CardData):
             "feature-extraction",
         ]
     )
-    model_card_template_path: Path = field(default=Path(__file__).parent / "model_card_template.md")
+    template_path: Path = field(default=Path(__file__).parent / "model_card_template.md")
     generate_widget_examples: Literal["deprecated"] = "deprecated"
 
     # Automatically filled by `ModelCardCallback` and the Trainer directly
@@ -1017,8 +1017,8 @@ class SentenceTransformerModelCardData(CardData):
         ).strip()
 
 
-def generate_model_card(model: SentenceTransformer, template_path: Path | None = None) -> str:
-    if not template_path:
-        template_path = Path(__file__).parent / "model_card_template.md"
-    model_card = ModelCard.from_template(card_data=model.model_card_data, template_path=template_path, hf_emoji="🤗")
+def generate_model_card(model: SentenceTransformer) -> str:
+    model_card = ModelCard.from_template(
+        card_data=model.model_card_data, template_path=model.model_card_data.template_path, hf_emoji="🤗"
+    )
     return model_card.content


### PR DESCRIPTION
Allowing users to pass the `Path` to a template to create the model card from it:

`SentenceTransformerModelCardData( model_card_template_path=...)`

This eliminates the need to override `_create_model_card()`, making it easier for `PyLate`, and enables users to provide their own model template.


cc @NohTow