### PR TITLE
max_seq_length should not be larger than any options

### DIFF
--- a/sentence_transformers/models/Transformer.py
+++ b/sentence_transformers/models/Transformer.py
@@ -88,16 +88,18 @@ class Transformer(nn.Module):
             **tokenizer_args,
         )
 
-        # No max_seq_length set. Try to infer from model
+        max_seq_options = []
         if max_seq_length is None:
-            if (
-                hasattr(self.auto_model, "config")
-                and hasattr(self.auto_model.config, "max_position_embeddings")
-                and hasattr(self.tokenizer, "model_max_length")
-            ):
-                max_seq_length = min(self.auto_model.config.max_position_embeddings, self.tokenizer.model_max_length)
-
-        self.max_seq_length = max_seq_length
+            max_seq_options.append(max_seq_length)
+        if (
+            hasattr(self.auto_model, "config")
+            and hasattr(self.auto_model.config, "max_position_embeddings")
+        ):
+            max_seq_options.append(self.auto_model.config.max_position_embeddings)
+        if hasattr(self.tokenizer, "model_max_length"):
+            max_seq_options.append(self.tokenizer.model_max_length)
+        
+        self.max_seq_length = min(max_seq_options)
 
         if tokenizer_name_or_path is not None:
             self.auto_model.config.tokenizer_class = self.tokenizer.__class__.__name__


### PR DESCRIPTION
Hi,

when loading an auto-model, max_seq_length is read directedly from huggingface and it cannot be overwritten easily.

example:

```python
model = SentenceTransformer("BAAI/bge-small-en-v1.5", tokenizer_kwargs={"model_max_length": 32})

assert model.max_seq_length == 32, f"expected 32, but got {model.max_seq_length=}"
```

This PR ensure that `max_seq_length` is overwritten, even when it exists