### PR TITLE
Fix: Reorder dataset columns for DenoisingAutoEncoderLoss in TSADE examples

### DIFF
--- a/examples/unsupervised_learning/TSDAE/train_askubuntu_tsdae.py
+++ b/examples/unsupervised_learning/TSDAE/train_askubuntu_tsdae.py
@@ -108,7 +108,7 @@ def noise_fn(text, del_ratio=0.6):
 # Here we are using a function to delete some words, but you can use any other method to noisify your text
 train_dataset = train_dataset.map(noise_fn, input_columns="text")
 # Reorder columns to [(damaged_sentence, original_sentence) pairs] to ensure compatibility with ``DenoisingAutoEncoderDataset``.
-train_dataset = train_dataset.select_columns(['noisy', 'text'])
+train_dataset = train_dataset.select_columns(["noisy", "text"])
 print(train_dataset)
 print(train_dataset[0])
 """
@@ -194,5 +194,5 @@ except Exception:
     logging.error(
         f"Error uploading model to the Hugging Face Hub:\n{traceback.format_exc()}To upload it manually, you can run "
         f"`huggingface-cli login`, followed by loading the model using `model = SentenceTransformer({final_output_dir!r})` "
-        f"and saving it using `model.push_to_hub('{model_name}-tsdae')`."
+        f"and saving it using `model.push_to_hub('{model_name}-tsdae-askubuntu')`."
     )

--- a/examples/unsupervised_learning/TSDAE/train_askubuntu_tsdae.py
+++ b/examples/unsupervised_learning/TSDAE/train_askubuntu_tsdae.py
@@ -107,16 +107,18 @@ def noise_fn(text, del_ratio=0.6):
 # TSDAE requires a dataset with 2 columns: a text column and a noisified text column
 # Here we are using a function to delete some words, but you can use any other method to noisify your text
 train_dataset = train_dataset.map(noise_fn, input_columns="text")
+# Reorder columns to [(damaged_sentence, original_sentence) pairs] to ensure compatibility with ``DenoisingAutoEncoderDataset``.
+train_dataset = train_dataset.select_columns(['noisy', 'text'])
 print(train_dataset)
 print(train_dataset[0])
 """
 Dataset({
-    features: ['text', 'noisy'],
+    features: ['noisy', 'text'],
     num_rows: 160436
 })
 {
-    'text': "how to get the `` your battery is broken '' message to go away ?",
     'noisy': 'how to get "battery is broken go?',
+    'text': "how to get the `` your battery is broken '' message to go away ?",
 }
 """
 print(eval_dataset)

--- a/examples/unsupervised_learning/TSDAE/train_stsb_tsdae.py
+++ b/examples/unsupervised_learning/TSDAE/train_stsb_tsdae.py
@@ -58,7 +58,7 @@ def noise_fn(text, del_ratio=0.6):
 # Here we are using a function to delete some words, but you can use any other method to noisify your text
 dataset = dataset.map(noise_fn, input_columns="text")
 # Reorder columns to [(damaged_sentence, original_sentence) pairs] to ensure compatibility with ``DenoisingAutoEncoderDataset``.
-dataset = dataset.select_columns(['noisy', 'text'])
+dataset = dataset.select_columns(["noisy", "text"])
 dataset = dataset.train_test_split(test_size=10000)
 train_dataset = dataset["train"]
 eval_dataset = dataset["test"]

--- a/examples/unsupervised_learning/TSDAE/train_stsb_tsdae.py
+++ b/examples/unsupervised_learning/TSDAE/train_stsb_tsdae.py
@@ -57,6 +57,8 @@ def noise_fn(text, del_ratio=0.6):
 # TSDAE requires a dataset with 2 columns: a text column and a noisified text column
 # Here we are using a function to delete some words, but you can use any other method to noisify your text
 dataset = dataset.map(noise_fn, input_columns="text")
+# Reorder columns to [(damaged_sentence, original_sentence) pairs] to ensure compatibility with ``DenoisingAutoEncoderDataset``.
+dataset = dataset.select_columns(['noisy', 'text'])
 dataset = dataset.train_test_split(test_size=10000)
 train_dataset = dataset["train"]
 eval_dataset = dataset["test"]
@@ -64,12 +66,12 @@ print(train_dataset)
 print(train_dataset[0])
 """
 Dataset({
-    features: ['text', 'noisy'],
+    features: ['noisy', 'text'],
     num_rows: 990000
 })
 {
-    'text': 'Oseltamivir is considered to be the primary antiviral drug used to combat avian influenza, commonly known as the bird flu.',
     'noisy': 'to be the primary antiviral drug used combat influenza commonly as the bird flu.',
+    'text': 'Oseltamivir is considered to be the primary antiviral drug used to combat avian influenza, commonly known as the bird flu.',
 }
 """
 

--- a/examples/unsupervised_learning/TSDAE/train_tsdae_from_file.py
+++ b/examples/unsupervised_learning/TSDAE/train_tsdae_from_file.py
@@ -74,7 +74,7 @@ def noise_fn(text, del_ratio=0.6):
 # Here we are using a function to delete some words, but you can use any other method to noisify your text
 dataset = dataset.map(noise_fn, input_columns="text")
 # Reorder columns to [(damaged_sentence, original_sentence) pairs] to ensure compatibility with ``DenoisingAutoEncoderDataset``.
-dataset = dataset.select_columns(['noisy', 'text'])
+dataset = dataset.select_columns(["noisy", "text"])
 dataset = dataset.train_test_split(test_size=10000)
 train_dataset = dataset["train"]
 eval_dataset = dataset["test"]

--- a/examples/unsupervised_learning/TSDAE/train_tsdae_from_file.py
+++ b/examples/unsupervised_learning/TSDAE/train_tsdae_from_file.py
@@ -73,6 +73,8 @@ def noise_fn(text, del_ratio=0.6):
 # TSDAE requires a dataset with 2 columns: a text column and a noisified text column
 # Here we are using a function to delete some words, but you can use any other method to noisify your text
 dataset = dataset.map(noise_fn, input_columns="text")
+# Reorder columns to [(damaged_sentence, original_sentence) pairs] to ensure compatibility with ``DenoisingAutoEncoderDataset``.
+dataset = dataset.select_columns(['noisy', 'text'])
 dataset = dataset.train_test_split(test_size=10000)
 train_dataset = dataset["train"]
 eval_dataset = dataset["test"]
@@ -80,12 +82,12 @@ print(train_dataset)
 print(train_dataset[0])
 """
 Dataset({
-    features: ['text', 'noisy'],
+    features: ['noisy', 'text'],
     num_rows: 990000
 })
 {
-    'text': 'Oseltamivir is considered to be the primary antiviral drug used to combat avian influenza, commonly known as the bird flu.',
     'noisy': 'to be the primary antiviral drug used combat influenza commonly as the bird flu.',
+    'text': 'Oseltamivir is considered to be the primary antiviral drug used to combat avian influenza, commonly known as the bird flu.',
 }
 """
 


### PR DESCRIPTION
This PR fixes the TSADE examples.
As the [official instruction](https://github.com/UKPLab/sentence-transformers/blob/master/docs/sentence_transformer/training_overview.md#dataset-format), and the below description of ```DenoisingAutoEncoderLoss.py```https://github.com/UKPLab/sentence-transformers/blob/a3466a0471fff5264360b3cda741ac60270b6618/sentence_transformers/losses/DenoisingAutoEncoderLoss.py#L44-L51
The expected dataset column order for `DenoisingAutoEncoderLoss` is:
```
Dataset({
    features: ['noisy', 'text'],
    num_rows: 990000
})
```

This PR reorders the dataset columns in the examples to align with this requirement, ensuring correct functionality and preventing potential errors.

Who can review it?
@tomaarsen