### PR TITLE
Update to fit_mixin.fit to allow fine tuning to resume from a checkpoint

### DIFF
--- a/sentence_transformers/fit_mixin.py
+++ b/sentence_transformers/fit_mixin.py
@@ -183,7 +183,7 @@ class FitMixin:
         checkpoint_path: str = None,
         checkpoint_save_steps: int = 500,
         checkpoint_save_total_limit: int = 0,
-        resume_from_checkpoint: bool = False
+        resume_from_checkpoint: bool = False,
     ) -> None:
         """
         Deprecated training method from before Sentence Transformers v3.0, it is recommended to use
@@ -387,12 +387,11 @@ class FitMixin:
 
         if checkpoint_path is not None and resume_from_checkpoint:
             if os.path.exists(checkpoint_path) and os.path.isdir(checkpoint_path):
-                logger.info(
-                    f"Looking for checkpoints in: {checkpoint_path}"
-                )
+                logger.info(f"Looking for checkpoints in: {checkpoint_path}")
 
                 all_checkpoints = [
-                    checkpoint for checkpoint in os.listdir(checkpoint_path)
+                    checkpoint
+                    for checkpoint in os.listdir(checkpoint_path)
                     if checkpoint.startswith("checkpoint-") and checkpoint.split("-")[-1].isdigit()
                 ]
 
@@ -401,16 +400,12 @@ class FitMixin:
                     resume_from_checkpoint = os.path.join(checkpoint_path, latest_checkpoint)
                     logger.info(f"Resuming from latest checkpoint: {resume_from_checkpoint}")
                 else:
-                    logger.warning(
-                        f"No checkpoints found in checkpoint directory: {checkpoint_path}"
-                    )
+                    logger.warning(f"No checkpoints found in checkpoint directory: {checkpoint_path}")
                     resume_from_checkpoint = None
             else:
-                logger.warning(
-                    f"Checkpoint directory does not exist or is not a directory: {checkpoint_path}"
-                )       
+                logger.warning(f"Checkpoint directory does not exist or is not a directory: {checkpoint_path}")
                 resume_from_checkpoint = None
-        
+
         trainer.train(resume_from_checkpoint=resume_from_checkpoint)
 
     @staticmethod

--- a/sentence_transformers/fit_mixin.py
+++ b/sentence_transformers/fit_mixin.py
@@ -386,15 +386,20 @@ class FitMixin:
             trainer.add_callback(SaveModelCallback(output_path, evaluator, save_best_model))
 
         if checkpoint_path is not None and resume_from_checkpoint:
-            if os.path.exists(checkpoint_path):
+            if os.path.exists(checkpoint_path) and os.path.isdir(checkpoint_path):
                 logger.info(
-                    f"Looking for checkpoints in checkpoint directory: {checkpoint_path}"
+                    f"Looking for checkpoints in: {checkpoint_path}"
                 )
-                all_checkpoints =  [checkpoint for checkpoint in os.listdir(checkpoint_path) if "checkpoint-" in checkpoint]
 
-                if len(all_checkpoints) > 1:
+                all_checkpoints = [
+                    checkpoint for checkpoint in os.listdir(checkpoint_path)
+                    if checkpoint.startswith("checkpoint-") and checkpoint.split("-")[-1].isdigit()
+                ]
+
+                if all_checkpoints:
                     latest_checkpoint = max(all_checkpoints, key=lambda x: int(x.split("-")[-1]))
-                    resume_from_checkpoint= os.path.join(checkpoint_path, latest_checkpoint)
+                    resume_from_checkpoint = os.path.join(checkpoint_path, latest_checkpoint)
+                    logger.info(f"Resuming from latest checkpoint: {resume_from_checkpoint}")
                 else:
                     logger.warning(
                         f"No checkpoints found in checkpoint directory: {checkpoint_path}"
@@ -402,7 +407,7 @@ class FitMixin:
                     resume_from_checkpoint = None
             else:
                 logger.warning(
-                    f"Checkpoint directory has not yet been created: {checkpoint_path}"
+                    f"Checkpoint directory does not exist or is not a directory: {checkpoint_path}"
                 )       
                 resume_from_checkpoint = None
         

--- a/sentence_transformers/fit_mixin.py
+++ b/sentence_transformers/fit_mixin.py
@@ -183,6 +183,7 @@ class FitMixin:
         checkpoint_path: str = None,
         checkpoint_save_steps: int = 500,
         checkpoint_save_total_limit: int = 0,
+        resume_from_checkpoint: bool = False
     ) -> None:
         """
         Deprecated training method from before Sentence Transformers v3.0, it is recommended to use
@@ -238,6 +239,8 @@ class FitMixin:
                 steps
             checkpoint_save_total_limit: Total number of checkpoints to
                 store
+            resume_from_checkpoint: If true, searches for checkpoints
+            to continue training from.
         """
         if not is_datasets_available():
             raise ImportError("Please install `datasets` to use this function: `pip install datasets`.")
@@ -382,7 +385,28 @@ class FitMixin:
         if output_path is not None:
             trainer.add_callback(SaveModelCallback(output_path, evaluator, save_best_model))
 
-        trainer.train()
+        if checkpoint_path is not None and resume_from_checkpoint:
+            if os.path.exists(checkpoint_path):
+                logger.info(
+                    f"Looking for checkpoints in checkpoint directory: {checkpoint_path}"
+                )
+                all_checkpoints =  [checkpoint for checkpoint in os.listdir(checkpoint_path) if "checkpoint-" in checkpoint]
+
+                if len(all_checkpoints) > 1:
+                    latest_checkpoint = max(all_checkpoints, key=lambda x: int(x.split("-")[-1]))
+                    resume_from_checkpoint= os.path.join(checkpoint_path, latest_checkpoint)
+                else:
+                    logger.warning(
+                        f"No checkpoints found in checkpoint directory: {checkpoint_path}"
+                    )
+                    resume_from_checkpoint = None
+            else:
+                logger.warning(
+                    f"Checkpoint directory has not yet been created: {checkpoint_path}"
+                )       
+                resume_from_checkpoint = None
+        
+        trainer.train(resume_from_checkpoint=resume_from_checkpoint)
 
     @staticmethod
     def _get_scheduler(optimizer, scheduler: str, warmup_steps: int, t_total: int) -> LambdaLR:

--- a/sentence_transformers/fit_mixin.py
+++ b/sentence_transformers/fit_mixin.py
@@ -240,7 +240,7 @@ class FitMixin:
             checkpoint_save_total_limit: Total number of checkpoints to
                 store
             resume_from_checkpoint: If true, searches for checkpoints
-            to continue training from.
+                to continue training from.
         """
         if not is_datasets_available():
             raise ImportError("Please install `datasets` to use this function: `pip install datasets`.")


### PR DESCRIPTION
### **Summary**
Adding a parameter to fit_mixin.fit method that allows for a fine-tune to be continued from the latest checkpoint if a checkpoint exists in the checkpoint directory

### Motivations
A faulty PSU and many hours of fine-tuning going to waste. The method in fit_mixin.fix has a parameter that allow for checkpoints to be saved, and the method that it uses for training, Transformer's trainer.train has a parameter that takes in a str, or a bool, that allows for resuming from a checkpoint, this change takes advantage of that parameter so that the saved checkpoints can now be used.

### Results 
When a checkpoint file is found, fine-tuning will begin from the latest step found inside of training_state.json, the good thing about this is it allows for continuing a fine-tune without retraining the model on data that it has already been processed.

### Changes
Adds an optional parameter resume_from_checkpoint to fit_mixin.fit that prompts a check for checkpoints in checkpoint_directory and continues fine-tuning from there if it finds them

### Related Issue
It is related to #1605 and gives a way to use resume_from_checkpoint at least with the fit() method in fit_mixin