### PR TITLE
Always convert the evaluation metrics to float, also without a 'name'

### DIFF
--- a/sentence_transformers/evaluation/SentenceEvaluator.py
+++ b/sentence_transformers/evaluation/SentenceEvaluator.py
@@ -56,7 +56,7 @@ class SentenceEvaluator:
 
     def prefix_name_to_metrics(self, metrics: dict[str, float], name: str) -> dict[str, float]:
         if not name:
-            return metrics
+            return {key: float(value) for key, value in metrics.items()}
         metrics = {name + "_" + key: float(value) for key, value in metrics.items()}
         if hasattr(self, "primary_metric") and not self.primary_metric.startswith(name + "_"):
             self.primary_metric = name + "_" + self.primary_metric


### PR DESCRIPTION
Replaces #3251

Hello!

## Pull Request overview
* Always convert the evaluation metrics to float, also without a 'name'

## Details
It might not be the best place for it, but I think it should work fine.

In short, if the evaluation results are np or torch, they can't easily be saved with json. Beyond that, it's unexpected if the results are sometimes np.floats and sometimes regular python floats.

cc @belo-involead I'm hopeful that this resolves your issue! Apologies for taking long to reproduce it, I don't really understand why it only sometimes resulted in a crash for me.

- Tom Aarsen