### PR TITLE
[`fix`] Avoid "Only if model is wrapped" check which is faulty for FSDP

### DIFF
--- a/sentence_transformers/trainer.py
+++ b/sentence_transformers/trainer.py
@@ -399,7 +399,6 @@ class SentenceTransformerTrainer(Trainer):
         # if the loss stores the model. Only called once per process
         if (
             model == self.model_wrapped
-            and model != self.model  # Only if the model is wrapped
             and hasattr(loss_fn, "model")  # Only if the loss stores the model
             and loss_fn.model != model  # Only if the wrapped model is not already stored
         ):


### PR DESCRIPTION
Closes #3023, see https://github.com/UKPLab/sentence-transformers/issues/3023#issuecomment-2760519375

Hello!

## Pull Request overview
* Avoid "Only if model is wrapped" check which is faulty for FSDP

## Details
According to experiments by @meshidenn, by understanding that `model != self.model` checks whether a model is wrapped is faulty. In FSDP, even `self.model` is wrapped, so then both are the same.

cc @ShengYun-Peng

- Tom Aarsen