### PR TITLE
CachedGISTEmbedLoss Adding Margin

### DIFF
--- a/sentence_transformers/losses/CachedGISTEmbedLoss.py
+++ b/sentence_transformers/losses/CachedGISTEmbedLoss.py
@@ -107,7 +107,6 @@ class CachedGISTEmbedLoss(nn.Module):
             - Efficient Natural Language Response Suggestion for Smart Reply, Section 4.4: https://arxiv.org/pdf/1705.00652.pdf
             - Scaling Deep Contrastive Learning Batch Size under Memory Limited Setup: https://arxiv.org/pdf/2101.06983.pdf
             - GISTEmbed: Guided In-sample Selection of Training Negatives for Text Embedding Fine-tuning https://arxiv.org/abs/2402.16829
-            - NV-Retriever: Improving text embedding models with effective hard-negative mining https://arxiv.org/pdf/2407.15831v2
 
         Requirements:
             1. (anchor, positive) pairs or (anchor, positive, negative pairs)
@@ -125,11 +124,10 @@ class CachedGISTEmbedLoss(nn.Module):
             +-------------------------------------------------+--------+
 
         Recommendations:
-            - Use ``BatchSamplers.NO_DUPLICATES`` (:class:`docs <sentence_transformers.training_args.BatchSamplers>`) to
-            ensure that no in-batch negatives are duplicates of the anchor or positive samples.
+            - Use ``BatchSamplers.NO_DUPLICATES`` (:class:`docs <sentence_transformers.training_args.BatchSamplers>`) to ensure that no in-batch negatives are duplicates of the anchor or positive samples.
 
         Relations:
-            - Equivalent to :class:`GISTEmbedLoss`, but with caching that allows for much higher batch sizes.
+            - Equivalent to :class:`GISTEmbedLoss`, but with caching that allows for much higher batch sizes
 
         Example:
             ::

--- a/sentence_transformers/losses/CachedGISTEmbedLoss.py
+++ b/sentence_transformers/losses/CachedGISTEmbedLoss.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import Iterable, Iterator
 from contextlib import nullcontext
 from functools import partial
-from typing import Any, Optional
+from typing import Any
 
 import torch
 import tqdm
@@ -68,7 +68,7 @@ class CachedGISTEmbedLoss(nn.Module):
         temperature: float = 0.01,
         mini_batch_size: int = 32,
         show_progress_bar: bool = False,
-        margin_strategy: Optional[str] = None,   # None, "absolute", or "percentage"
+        margin_strategy: str | None = None,
         margin: float = 0.0,
     ) -> None:
         """
@@ -124,8 +124,8 @@ class CachedGISTEmbedLoss(nn.Module):
             +-------------------------------------------------+--------+
 
         Recommendations:
-            - Use ``BatchSamplers.NO_DUPLICATES`` (:class:`docs <sentence_transformers.training_args.BatchSamplers>`) to ensure that no in-batch negatives are duplicates of the anchor or positive samples.
-
+            - Use ``BatchSamplers.NO_DUPLICATES`` (:class:`docs <sentence_transformers.training_args.BatchSamplers>`) to
+              ensure that no in-batch negatives are duplicates of the anchor or positive samples.
         Relations:
             - Equivalent to :class:`GISTEmbedLoss`, but with caching that allows for much higher batch sizes
 
@@ -146,7 +146,7 @@ class CachedGISTEmbedLoss(nn.Module):
                     guide,
                     mini_batch_size=64,
                     margin_strategy="absolute",   # or "percentage" (e.g., margin=0.95)
-                    margin=0.1                    
+                    margin=0.1
                 )
 
                 trainer = SentenceTransformerTrainer(
@@ -181,7 +181,10 @@ class CachedGISTEmbedLoss(nn.Module):
         if self.must_retokenize:
             self.tokenizer = model.tokenizer
         if margin_strategy is not None:
-            assert margin_strategy in ("absolute", "percentage"), "margin_strategy must be 'absolute', 'percentage', or None"
+            assert margin_strategy in (
+                "absolute",
+                "percentage",
+            ), "margin_strategy must be 'absolute', 'percentage', or None"
         else:
             if margin != 0:
                 raise ValueError(
@@ -300,7 +303,7 @@ class CachedGISTEmbedLoss(nn.Module):
             pp_sim = self.sim_matrix(concatenated_reps[1][b:e], concatenated_reps[1])  # positive-positive similarity
 
             # This uses guided (teacher) similarity as a dynamic threshold to identify and suppress false negatives
-            def mask_false_negatives(guided_sim_mat, raw_sim_mat, positive_mask: Optional[Tensor] = None):
+            def mask_false_negatives(guided_sim_mat, raw_sim_mat, positive_mask: Tensor | None = None):
                 if self.margin_strategy == "absolute":
                     # Remove samples whose guided similarity is higher than (positive_sim - margin)
                     mask = guided_sim_mat > (guided_sim - self.margin)
@@ -388,6 +391,6 @@ class CachedGISTEmbedLoss(nn.Module):
             "guide": self.guide,
             "temperature": self.temperature,
             "mini_batch_size": self.mini_batch_size,
-            "margin_strategy": self.margin_strategy, 
-            "margin": self.margin,                   
+            "margin_strategy": self.margin_strategy,
+            "margin": self.margin,
         }

--- a/sentence_transformers/losses/CachedGISTEmbedLoss.py
+++ b/sentence_transformers/losses/CachedGISTEmbedLoss.py
@@ -91,11 +91,14 @@ class CachedGISTEmbedLoss(nn.Module):
             - None: No margin filtering is applied, but negatives more similar than positives are still excluded.
 
         Args:
-            model: SentenceTransformer model.
+            model: SentenceTransformer model
             guide: SentenceTransformer model to guide the in-batch negative sample selection.
             temperature: Temperature parameter to scale the cosine similarities.
-            mini_batch_size: Mini-batch size for the forward pass. Larger values reduce memory usage per step but may slow down training.
-            show_progress_bar: If True, shows a progress bar during mini-batch processing.
+            mini_batch_size: Mini-batch size for the forward pass, this denotes how much memory is actually used during
+                training and evaluation. The larger the mini-batch size, the more memory efficient the training is, but
+                the slower the training will be. It's recommended to set it as high as your GPU memory allows. The default
+                value is 32.
+            show_progress_bar: If True, a progress bar for the mini-batches is shown during training. The default is False.
             margin_strategy: Strategy used for false negative filtering. One of {"absolute", "percentage", None}.
                             If None, margin filtering is disabled (but negatives more similar than positives are still masked).
             margin: The margin value for filtering negatives. Required if margin_strategy is "absolute" or "percentage".

--- a/sentence_transformers/losses/CachedGISTEmbedLoss.py
+++ b/sentence_transformers/losses/CachedGISTEmbedLoss.py
@@ -182,10 +182,8 @@ class CachedGISTEmbedLoss(nn.Module):
         if self.must_retokenize:
             self.tokenizer = model.tokenizer
         if margin_strategy is not None:
-            assert margin_strategy in (
-                "absolute",
-                "percentage",
-            ), "margin_strategy must be 'absolute', 'percentage', or None"
+            if margin_strategy not in ("absolute", "percentage"):
+                raise ValueError("margin_strategy must be 'absolute', 'percentage', or None")
         else:
             if margin != 0:
                 raise ValueError(

--- a/sentence_transformers/losses/CachedGISTEmbedLoss.py
+++ b/sentence_transformers/losses/CachedGISTEmbedLoss.py
@@ -180,14 +180,8 @@ class CachedGISTEmbedLoss(nn.Module):
         )
         if self.must_retokenize:
             self.tokenizer = model.tokenizer
-        if margin_strategy is not None:
-            if margin_strategy not in ("absolute", "percentage"):
-                raise ValueError("margin_strategy must be 'absolute', 'percentage', or None")
-        else:
-            if margin != 0:
-                raise ValueError(
-                    "If you set a non-zero margin, you must also set margin_strategy to 'absolute' or 'percentage'"
-                )
+        if margin_strategy not in ("absolute", "percentage"):
+            raise ValueError("margin_strategy must be 'absolute' or 'percentage'.")
         self.margin_strategy = margin_strategy
         self.margin = margin
 

--- a/sentence_transformers/losses/CachedGISTEmbedLoss.py
+++ b/sentence_transformers/losses/CachedGISTEmbedLoss.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import Iterable, Iterator
 from contextlib import nullcontext
 from functools import partial
-from typing import Any
+from typing import Any, Optional
 
 import torch
 import tqdm
@@ -68,6 +68,8 @@ class CachedGISTEmbedLoss(nn.Module):
         temperature: float = 0.01,
         mini_batch_size: int = 32,
         show_progress_bar: bool = False,
+        margin_strategy: Optional[str] = None,   # None, "absolute", or "percentage"
+        margin: float = 0.0,
     ) -> None:
         """
         This loss is a combination of :class:`GISTEmbedLoss` and :class:`CachedMultipleNegativesRankingLoss`.
@@ -81,20 +83,28 @@ class CachedGISTEmbedLoss(nn.Module):
         :class:`CachedMultipleNegativesRankingLoss`, it is possible to reduce memory usage while maintaining performance
         levels comparable to those of :class:`GISTEmbedLoss`.
 
+        Optionally, you can apply false-negative filtering strategies to discard hard negatives that are too similar to the
+        positive. Two strategies are supported:
+
+            - "absolute": Discards negatives whose similarity score is greater than or equal to (positive_score - margin).
+            - "percentage": Discards negatives whose similarity score is greater than or equal to (positive_score * margin).
+            - None: No margin filtering is applied, but negatives more similar than positives are still excluded.
+
         Args:
-            model: SentenceTransformer model
+            model: SentenceTransformer model.
             guide: SentenceTransformer model to guide the in-batch negative sample selection.
             temperature: Temperature parameter to scale the cosine similarities.
-            mini_batch_size: Mini-batch size for the forward pass, this denotes how much memory is actually used during
-                training and evaluation. The larger the mini-batch size, the more memory efficient the training is, but
-                the slower the training will be. It's recommended to set it as high as your GPU memory allows. The default
-                value is 32.
-            show_progress_bar: If True, a progress bar for the mini-batches is shown during training. The default is False.
+            mini_batch_size: Mini-batch size for the forward pass. Larger values reduce memory usage per step but may slow down training.
+            show_progress_bar: If True, shows a progress bar during mini-batch processing.
+            margin_strategy: Strategy used for false negative filtering. One of {"absolute", "percentage", None}.
+                            If None, margin filtering is disabled (but negatives more similar than positives are still masked).
+            margin: The margin value for filtering negatives. Required if margin_strategy is "absolute" or "percentage".
 
         References:
             - Efficient Natural Language Response Suggestion for Smart Reply, Section 4.4: https://arxiv.org/pdf/1705.00652.pdf
             - Scaling Deep Contrastive Learning Batch Size under Memory Limited Setup: https://arxiv.org/pdf/2101.06983.pdf
             - GISTEmbed: Guided In-sample Selection of Training Negatives for Text Embedding Fine-tuning https://arxiv.org/abs/2402.16829
+            - NV-Retriever: Improving text embedding models with effective hard-negative mining https://arxiv.org/pdf/2407.15831v2
 
         Requirements:
             1. (anchor, positive) pairs or (anchor, positive, negative pairs)
@@ -113,10 +123,10 @@ class CachedGISTEmbedLoss(nn.Module):
 
         Recommendations:
             - Use ``BatchSamplers.NO_DUPLICATES`` (:class:`docs <sentence_transformers.training_args.BatchSamplers>`) to
-              ensure that no in-batch negatives are duplicates of the anchor or positive samples.
+            ensure that no in-batch negatives are duplicates of the anchor or positive samples.
 
         Relations:
-            - Equivalent to :class:`GISTEmbedLoss`, but with caching that allows for much higher batch sizes
+            - Equivalent to :class:`GISTEmbedLoss`, but with caching that allows for much higher batch sizes.
 
         Example:
             ::
@@ -130,7 +140,13 @@ class CachedGISTEmbedLoss(nn.Module):
                     "anchor": ["It's nice weather outside today.", "He drove to work."],
                     "positive": ["It's so sunny.", "He took the car to the office."],
                 })
-                loss = losses.CachedGISTEmbedLoss(model, guide, mini_batch_size=64)
+                loss = losses.CachedGISTEmbedLoss(
+                    model,
+                    guide,
+                    mini_batch_size=64,
+                    margin_strategy="absolute",   # or "percentage" (e.g., margin=0.95)
+                    margin=0.1                    
+                )
 
                 trainer = SentenceTransformerTrainer(
                     model=model,
@@ -163,6 +179,15 @@ class CachedGISTEmbedLoss(nn.Module):
         )
         if self.must_retokenize:
             self.tokenizer = model.tokenizer
+        if margin_strategy is not None:
+            assert margin_strategy in ("absolute", "percentage"), "margin_strategy must be 'absolute', 'percentage', or None"
+        else:
+            if margin != 0:
+                raise ValueError(
+                    "If you set a non-zero margin, you must also set margin_strategy to 'absolute' or 'percentage'"
+                )
+        self.margin_strategy = margin_strategy
+        self.margin = margin
 
     def sim_matrix(self, embed1: Tensor, embed2: Tensor) -> Tensor:
         return self.similarity_fct(embed1.unsqueeze(1), embed2.unsqueeze(0))
@@ -273,10 +298,35 @@ class CachedGISTEmbedLoss(nn.Module):
             aa_sim = self.sim_matrix(concatenated_reps[0][b:e], concatenated_reps[0])  # anchor-anchor similarity
             pp_sim = self.sim_matrix(concatenated_reps[1][b:e], concatenated_reps[1])  # positive-positive similarity
 
-            # Apply thresholds based on guided model similarities
-            ap_sim[guided_ap_sim > guided_sim] = -torch.inf
-            aa_sim[guided_aa_sim > guided_sim] = -torch.inf
-            pp_sim[guided_pp_sim > guided_sim] = -torch.inf
+            # This uses guided (teacher) similarity as a dynamic threshold to identify and suppress false negatives
+            def mask_false_negatives(guided_sim_mat, raw_sim_mat, positive_mask: Optional[Tensor] = None):
+                if self.margin_strategy == "absolute":
+                    # Remove samples whose guided similarity is higher than (positive_sim - margin)
+                    mask = guided_sim_mat > (guided_sim - self.margin)
+                elif self.margin_strategy == "percentage":
+                    # Remove samples whose guided similarity is higher than (positive_sim * margin)
+                    mask = guided_sim_mat > (guided_sim * self.margin)
+                else:
+                    # Default strategy: remove samples with guided similarity higher than positive_sim
+                    mask = guided_sim_mat > guided_sim
+
+                if positive_mask is not None:
+                    # Ensure true positive pairs are not masked out
+                    mask = mask & ~positive_mask
+                raw_sim_mat[mask] = -torch.inf
+                return raw_sim_mat
+
+            # Create a mask to protect true positive pairs in the anchor-positive matrix (i.e., diagonal elements)
+            positive_mask = torch.zeros_like(guided_ap_sim, dtype=torch.bool)
+            for i in range(guided_ap_sim.size(0)):
+                pos_idx = i + b
+                if pos_idx < guided_ap_sim.size(1):
+                    positive_mask[i, pos_idx] = True
+
+            # Apply false negative suppression to each similarity matrix using guided similarity as anchor
+            ap_sim = mask_false_negatives(guided_ap_sim, ap_sim, positive_mask=positive_mask)  # anchor-positive
+            aa_sim = mask_false_negatives(guided_aa_sim, aa_sim)  # anchor-anchor
+            pp_sim = mask_false_negatives(guided_pp_sim, pp_sim)  # positive-positive
 
             # Concatenate the similarity matrices for anchor-positive, anchor-anchor, and positive-positive
             scores = torch.cat([ap_sim, aa_sim, pp_sim], dim=1)
@@ -286,7 +336,7 @@ class CachedGISTEmbedLoss(nn.Module):
                 for i in range(2, len(concatenated_reps)):  # Start from 2 since first 2 are anchor-positive
                     guided_neg_sim = self.sim_matrix(concatenated_guided_reps[0][b:e], concatenated_guided_reps[i])
                     neg_sim = self.sim_matrix(concatenated_reps[0][b:e], concatenated_reps[i])
-                    neg_sim[guided_neg_sim > guided_sim] = -torch.inf
+                    neg_sim = mask_false_negatives(guided_neg_sim, neg_sim)
                     scores = torch.cat([scores, neg_sim], dim=1)
 
             # Normalize the scores and calculate the cross-entropy loss
@@ -337,4 +387,6 @@ class CachedGISTEmbedLoss(nn.Module):
             "guide": self.guide,
             "temperature": self.temperature,
             "mini_batch_size": self.mini_batch_size,
+            "margin_strategy": self.margin_strategy, 
+            "margin": self.margin,                   
         }

--- a/sentence_transformers/losses/CachedGISTEmbedLoss.py
+++ b/sentence_transformers/losses/CachedGISTEmbedLoss.py
@@ -101,7 +101,7 @@ class CachedGISTEmbedLoss(nn.Module):
             show_progress_bar: If True, a progress bar for the mini-batches is shown during training. The default is False.
             margin_strategy: Strategy used for false negative filtering. One of {"absolute", "percentage", None}.
                             If None, margin filtering is disabled (but negatives more similar than positives are still masked).
-            margin: The margin value for filtering negatives. Required if margin_strategy is "absolute" or "percentage".
+            margin: The margin value for filtering negatives. Required if ``margin_strategy`` is "absolute" or "percentage".
 
         References:
             - Efficient Natural Language Response Suggestion for Smart Reply, Section 4.4: https://arxiv.org/pdf/1705.00652.pdf
@@ -126,6 +126,7 @@ class CachedGISTEmbedLoss(nn.Module):
         Recommendations:
             - Use ``BatchSamplers.NO_DUPLICATES`` (:class:`docs <sentence_transformers.training_args.BatchSamplers>`) to
               ensure that no in-batch negatives are duplicates of the anchor or positive samples.
+
         Relations:
             - Equivalent to :class:`GISTEmbedLoss`, but with caching that allows for much higher batch sizes
 

--- a/sentence_transformers/losses/CachedGISTEmbedLoss.py
+++ b/sentence_transformers/losses/CachedGISTEmbedLoss.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import Iterable, Iterator
 from contextlib import nullcontext
 from functools import partial
-from typing import Any
+from typing import Any, Literal
 
 import torch
 import tqdm
@@ -68,7 +68,7 @@ class CachedGISTEmbedLoss(nn.Module):
         temperature: float = 0.01,
         mini_batch_size: int = 32,
         show_progress_bar: bool = False,
-        margin_strategy: str | None = None,
+        margin_strategy: Literal["absolute", "percentage"] | None = None,
         margin: float = 0.0,
     ) -> None:
         """

--- a/sentence_transformers/losses/CachedGISTEmbedLoss.py
+++ b/sentence_transformers/losses/CachedGISTEmbedLoss.py
@@ -83,8 +83,8 @@ class CachedGISTEmbedLoss(nn.Module):
         :class:`CachedMultipleNegativesRankingLoss`, it is possible to reduce memory usage while maintaining performance
         levels comparable to those of :class:`GISTEmbedLoss`.
 
-        Optionally, you can apply false-negative filtering strategies to discard hard negatives that are too similar to the
-        positive. Two strategies are supported:
+        You can apply different false-negative filtering strategies to discard hard negatives that are too similar to
+        the positive. Two strategies are supported:
 
             - "absolute": Discards negatives whose similarity score is greater than or equal to (positive_score - margin).
             - "percentage": Discards negatives whose similarity score is greater than or equal to (positive_score * margin).
@@ -100,7 +100,7 @@ class CachedGISTEmbedLoss(nn.Module):
                 value is 32.
             show_progress_bar: If True, a progress bar for the mini-batches is shown during training. The default is False.
             margin_strategy: Strategy used for false negative filtering. One of {"absolute", "percentage", None}.
-                            If None, margin filtering is disabled (but negatives more similar than positives are still masked).
+                If None, margin filtering is disabled (but negatives more similar than positives are still masked).
             margin: The margin value for filtering negatives. Required if ``margin_strategy`` is "absolute" or "percentage".
 
         References:

--- a/sentence_transformers/losses/GISTEmbedLoss.py
+++ b/sentence_transformers/losses/GISTEmbedLoss.py
@@ -107,7 +107,7 @@ class GISTEmbedLoss(nn.Module):
                 )
 
         if margin_strategy not in ("absolute", "percentage"):
-            raise ValueError("margin_strategy must be 'absolute' or 'percentage'")
+            raise ValueError("margin_strategy must be 'absolute' or 'percentage'.")
         self.margin_strategy = margin_strategy
         self.margin = margin
 

--- a/sentence_transformers/losses/GISTEmbedLoss.py
+++ b/sentence_transformers/losses/GISTEmbedLoss.py
@@ -196,7 +196,7 @@ class GISTEmbedLoss(nn.Module):
         if negative is not None:
             an_sim = self.sim_matrix(anchor, negative)
             guided_an_sim = self.sim_matrix(anchor_guide, negative_guide)
-            an_sim[guided_an_sim > guided_sim] = -torch.inf
+            an_sim = mask_false_negatives(guided_an_sim, an_sim)
 
             scores.append(an_sim)
 
@@ -212,6 +212,8 @@ class GISTEmbedLoss(nn.Module):
         return {
             "guide": self.guide,
             "temperature": self.temperature,
+            "margin_strategy": self.margin_strategy,
+            "margin": self.margin,
         }
 
     @property

--- a/sentence_transformers/losses/GISTEmbedLoss.py
+++ b/sentence_transformers/losses/GISTEmbedLoss.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
-from typing import Any
+from typing import Any, Literal
 
 import torch
 from torch import Tensor, nn
@@ -16,6 +16,8 @@ class GISTEmbedLoss(nn.Module):
         model: SentenceTransformer,
         guide: SentenceTransformer,
         temperature: float = 0.01,
+        margin_strategy: Literal["absolute", "percentage"] | None = None,
+        margin: float = 0.0,
     ) -> None:
         """
         This loss is used to train a SentenceTransformer model using the GISTEmbed algorithm.
@@ -23,13 +25,20 @@ class GISTEmbedLoss(nn.Module):
         in-batch negative sample selection. The cosine similarity is used to compute the loss
         and the temperature parameter is used to scale the cosine similarities.
 
+        You can apply different false-negative filtering strategies to discard hard negatives that are too similar to
+        the positive. Two strategies are supported:
+
+            - "absolute": Discards negatives whose similarity score is greater than or equal to (positive_score - margin).
+            - "percentage": Discards negatives whose similarity score is greater than or equal to (positive_score * margin).
+            - None: No margin filtering is applied, but negatives more similar than positives are still excluded.
+
         Args:
-            model: SentenceTransformer model based on a `transformers`
-                model.
-            guide: SentenceTransformer model to guide the in-batch
-                negative sample selection.
-            temperature: Temperature parameter to scale the cosine
-                similarities.
+            model: SentenceTransformer model based on a `transformers` model.
+            guide: SentenceTransformer model to guide the in-batch negative sample selection.
+            temperature: Temperature parameter to scale the cosine similarities.
+            margin_strategy: Strategy used for false negative filtering. One of {"absolute", "percentage", None}.
+                If None, margin filtering is disabled (but negatives more similar than positives are still masked).
+            margin: The margin value for filtering negatives. Required if ``margin_strategy`` is "absolute" or "percentage".
 
         References:
             - For further details, see: https://arxiv.org/abs/2402.16829
@@ -98,6 +107,17 @@ class GISTEmbedLoss(nn.Module):
                     "then the Sentence Transformer model must not be based on a StaticEmbedding."
                 )
 
+        if margin_strategy is not None:
+            if margin_strategy not in ("absolute", "percentage"):
+                raise ValueError("margin_strategy must be 'absolute', 'percentage', or None")
+        else:
+            if margin != 0:
+                raise ValueError(
+                    "If you set a non-zero margin, you must also set margin_strategy to 'absolute' or 'percentage'"
+                )
+        self.margin_strategy = margin_strategy
+        self.margin = margin
+
     def sim_matrix(self, embed1: Tensor, embed2: Tensor) -> Tensor:
         return self.similarity_fct(embed1.unsqueeze(1), embed2.unsqueeze(0))
 
@@ -144,13 +164,31 @@ class GISTEmbedLoss(nn.Module):
         # Define the anchor threshold
         guided_sim = guided_ap_sim.diagonal().view(-1, 1)
 
-        # Find which samples cannot be used as negatives because they are
-        # more similar to the query than the assigned positive as deemed by the guide model.
-        # For these samples, we mask them with -inf to basically ignore their contribution to
-        # the loss.
-        ap_sim[guided_ap_sim > guided_sim] = -torch.inf
-        aa_sim[guided_aa_sim > guided_sim] = -torch.inf
-        pp_sim[guided_pp_sim > guided_sim] = -torch.inf
+        # This uses guided (teacher) similarity as a dynamic threshold to identify and suppress false negatives
+        def mask_false_negatives(guided_sim_mat, sim_mat, positive_mask: Tensor | None = None):
+            if self.margin_strategy == "absolute":
+                # Remove samples whose guided similarity is higher than (positive_sim - margin)
+                mask = guided_sim_mat > (guided_sim - self.margin)
+            elif self.margin_strategy == "percentage":
+                # Remove samples whose guided similarity is higher than (positive_sim * margin)
+                mask = guided_sim_mat > (guided_sim * self.margin)
+            else:
+                # Default strategy: remove samples with guided similarity higher than positive_sim
+                mask = guided_sim_mat > guided_sim
+
+            if positive_mask is not None:
+                # Ensure true positive pairs are not masked out
+                mask = mask & ~positive_mask
+            sim_mat[mask] = -torch.inf
+            return sim_mat
+
+        # Create a mask to protect true positive pairs in the anchor-positive matrix (i.e., diagonal elements)
+        positive_mask = torch.eye(*guided_ap_sim.shape, dtype=torch.bool, device=guided_ap_sim.device)
+
+        # Apply false negative suppression to each similarity matrix using guided similarity as anchor
+        ap_sim = mask_false_negatives(guided_ap_sim, ap_sim, positive_mask=positive_mask)  # anchor-positive
+        aa_sim = mask_false_negatives(guided_aa_sim, aa_sim)  # anchor-anchor
+        pp_sim = mask_false_negatives(guided_pp_sim, pp_sim)  # positive-positive
 
         scores = [ap_sim, aa_sim, pp_sim]
 


### PR DESCRIPTION
## 🧪 Margin-enhanced GISTEmbedLoss: Inspired by NV-Retriever

Hello. I read the paper **[[NV-Retriever: Improving text embedding models with effective hard-negative mining](https://arxiv.org/pdf/2407.15831v2)](https://arxiv.org/pdf/2407.15831v2)** and applied its ideas to **GISTEmbedLoss** by introducing a margin-based filtering mechanism. Below, we share interesting experimental results and insights.

---

### 🔧 Key Update: Margin-Based False Negative Filtering

The updated `CachedGISTEmbedLoss` introduces a mechanism to **filter false negatives** using explicit **margin constraints**.

Previously, negative samples more similar than the positive were masked out, but now you can specify how *close* is *too close* by using either:

- `"absolute"`:  
  A negative is discarded if  
  `similarity(neg) > similarity(pos) - margin`
  
- `"percentage"`:  
  A negative is discarded if  
  `similarity(neg) > similarity(pos) * margin`

This filtering is guided by a separate **teacher model** to identify potentially mislabeled negatives. The filtering logic is encapsulated in `mask_false_negatives()`, which masks out these negatives in the similarity matrix by assigning `-inf`, thus ignoring them during softmax loss calculation.

#### ✅ Benefits:
- Reduces the impact of **false negatives** during training
- Improves model robustness and **training stability**
- Especially effective for **large batch sizes**, where false negatives are more frequent
- Inspired by techniques in the **NV-Retriever** paper

If `margin_strategy=None`, the loss behaves like the original GISTEmbedLoss (negatives more similar than the positive are masked, but no margin threshold is applied).

---

### ⚙️ Experimental Setup

To evaluate the effectiveness of this margin-based filtering, we trained models with two different batch sizes:

#### **Setting 1**
- Batch size: `512`  
- Learning rate: `2e-5`

#### **Setting 2**
- Batch size: `2048`  
- Learning rate: `4e-5`

These settings allow us to observe how **larger batches** (which naturally introduce more difficult negatives) interact with the margin strategy.

📌 The rest of the training setup (optimizer, scheduler, warmup, etc.) follows the official SBERT `Trainer` configuration:  
🔗 [[SBERT Training Overview – Trainer Section](https://sbert.net/docs/sentence_transformer/training_overview.html)](https://sbert.net/docs/sentence_transformer/training_overview.html)

We trained each model for **1 epoch** on a 100,000-sample subset of the [[AllNLI Triplet Dataset](https://huggingface.co/datasets/sentence-transformers/all-nli)](https://huggingface.co/datasets/sentence-transformers/all-nli):

```python
from datasets import load_dataset

dataset = load_dataset("sentence-transformers/all-nli", "triplet")
train_dataset = dataset["train"].select(range(100_000))
```

---

### 📊 Experimental Results

Across both batch sizes, the following performance order (based on **cosine accuracy**) was observed:

```
CachedMultipleNegativesRankingLoss < CachedGISTEmbedLoss < CachedGISTEmbedLoss with Margin
```

Furthermore, the **magnitude of the margin** had a measurable effect:

- In `"absolute"` margin setting:
  - `margin = 0.1` outperformed `margin = 0.05`

- In `"percentage"` margin setting:
  - `margin = 0.9` outperformed `margin = 0.95`

These results demonstrate that:
> **Applying a margin effectively filters out false negatives, leading to more stable and effective training than previous loss functions.**

We believe that even stronger improvements can be observed when scaling to **larger datasets (>100k)**, where false negatives become even more prevalent.

---

### 🔗 Resources

- 📎 **Reference Paper**: [[NV-Retriever (arXiv)](https://arxiv.org/pdf/2407.15831v2)](https://arxiv.org/pdf/2407.15831v2)  
- 🧪 **Experimental Code (Colab)**: [[Colab Notebook](https://colab.research.google.com/drive/1-csyL71tXNXSL-FOeg1x_r9le7AZCVYx?usp=sharing)](https://colab.research.google.com/drive/1-csyL71tXNXSL-FOeg1x_r9le7AZCVYx?usp=sharing)  
- 📊 **Training Logs (W&B)**: [[W&B Experiment Page](https://wandb.ai/ysg5025/mpnet-GIST-margin?nw=oht3iaao7p)](https://wandb.ai/ysg5025/mpnet-GIST-margin?nw=oht3iaao7p)
