### PR TITLE
Fix device assignment in `get_device_name` for distributed training

### DIFF
--- a/sentence_transformers/util.py
+++ b/sentence_transformers/util.py
@@ -1517,18 +1517,23 @@ def save_to_hub_args_decorator(func):
     return wrapper
 
 
-def get_device_name() -> Literal["mps", "cuda", "npu", "hpu", "cpu"]:
+def get_device_name() -> str:
     """
     Returns the name of the device where this module is running on.
 
-    It's a simple implementation that doesn't cover cases when more powerful GPUs are available and
-    not a primary device ('cuda:0') or MPS device is available, but not configured properly.
+    This function only supports single device or basic distributed training setups.
+    In distributed mode for cuda device, it uses the rank to assign a specific CUDA device.
 
     Returns:
-        str: Device name, like 'cuda' or 'cpu'
+        str: Device name, like 'cuda:2', 'mps', 'npu', 'hpu', or 'cpu'
     """
     if torch.cuda.is_available():
-        return "cuda"
+        if torch.distributed.is_initialized():
+            device = f"cuda:{torch.distributed.get_rank()}"
+        else:
+            local_rank = int(os.environ.get("LOCAL_RANK", 0))
+            device = f"cuda:{local_rank}"
+        return device
     elif torch.backends.mps.is_available():
         return "mps"
     elif is_torch_npu_available():

--- a/sentence_transformers/util.py
+++ b/sentence_transformers/util.py
@@ -1529,11 +1529,10 @@ def get_device_name() -> str:
     """
     if torch.cuda.is_available():
         if torch.distributed.is_initialized():
-            device = f"cuda:{torch.distributed.get_rank()}"
+            local_rank = torch.distributed.get_rank()
         else:
             local_rank = int(os.environ.get("LOCAL_RANK", 0))
-            device = f"cuda:{local_rank}"
-        return device
+        return f"cuda:{local_rank}"
     elif torch.backends.mps.is_available():
         return "mps"
     elif is_torch_npu_available():


### PR DESCRIPTION
This PR updates the `sentence_transformers.util.get_device_name` utility to better support multi-GPU setups using tools like `accelerate` and `torchrun`.

## Context

This [issue](https://github.com/lightonai/pylate/issues/105) in Pylate shows a small problem when not explicitly providing a device for a `SentenceTransformer` model, and launching a training run with `accelerate` or `torchrun`: Multiple unexpected processes with low VRAM usage remains on the same GPU.

It seems to happen because in the `SentenceTransformer` constructor, the `get_device_name` function sets `cuda` as the device for every rank by default, which causes multiple processes remain on `cuda:0` even after `accelerate` distributes the model across all GPUs. 

Even if the script runs fine and performance doesn't seem to be impacted, it's still VRAM on GPU 0 that could be better utilized.

This can be reproduced even when using a pure `sentence_transformers` script like this one: [training_gooaq_lora.py](https://github.com/UKPLab/sentence-transformers/blob/master/examples/sentence_transformer/training/peft/training_gooaq_lora.py). The same behavior happens when launching with:

```bash
torchrun --nproc_per_node=8 training_gooaq_lora.py
```
or
```bash
accelerate launch --num_processes 8 training_gooaq_lora.py
```

(even when the code is properly wrapped in a `main()` block.)

## Proposed Fix

We can update the `get_device_name()` function to:

- Use `torch.distributed.get_rank()` when distributed training is initialized.
- Otherwise, check for `LOCAL_RANK` from the environment and resolve to `cuda:{LOCAL_RANK}`.
- Fall back to `"cpu"`, `"mps"`, `"npu"`, or `"hpu"` as before.

This ensures that by default, the correct GPU device is used per process, even when a model is set with `device=None`.

**Note**: This shouldn't change the behavior when launching as usual with `python script.py`, since if no local rank is found, it will default to `cuda:0`.

cc @NohTow 


