### PR TITLE
[`cross-encoder`] Set the tokenizer model_max_length to the min. of model_max_length & max_pos_embeds

### DIFF
--- a/sentence_transformers/cross_encoder/CrossEncoder.py
+++ b/sentence_transformers/cross_encoder/CrossEncoder.py
@@ -271,6 +271,10 @@ class CrossEncoder(nn.Module, PushToHubMixin, FitMixin):
     def max_length(self) -> int:
         return self.tokenizer.model_max_length
 
+    @max_length.setter
+    def max_length(self, value: int) -> None:
+        self.tokenizer.model_max_length = value
+
     @property
     @deprecated(
         "The `default_activation_function` property was renamed and is now deprecated. "

--- a/sentence_transformers/cross_encoder/CrossEncoder.py
+++ b/sentence_transformers/cross_encoder/CrossEncoder.py
@@ -167,11 +167,8 @@ class CrossEncoder(nn.Module, PushToHubMixin, FitMixin):
             token=token,
             **model_kwargs,
         )
-        if "model_max_length" not in tokenizer_kwargs:
-            if max_length is not None:
-                tokenizer_kwargs["model_max_length"] = max_length
-            elif hasattr(self.config, "max_position_embeddings"):
-                tokenizer_kwargs["model_max_length"] = self.config.max_position_embeddings
+        if "model_max_length" not in tokenizer_kwargs and max_length is not None:
+            tokenizer_kwargs["model_max_length"] = max_length
 
         self.tokenizer = AutoTokenizer.from_pretrained(
             model_name_or_path,
@@ -182,6 +179,8 @@ class CrossEncoder(nn.Module, PushToHubMixin, FitMixin):
             token=token,
             **tokenizer_kwargs,
         )
+        if "model_max_length" not in tokenizer_kwargs and hasattr(self.config, "max_position_embeddings"):
+            self.tokenizer.model_max_length = min(self.tokenizer.model_max_length, self.config.max_position_embeddings)
 
         # Check if a readme exists
         model_card_path = load_file_path(

--- a/tests/cross_encoder/test_cross_encoder.py
+++ b/tests/cross_encoder/test_cross_encoder.py
@@ -589,3 +589,13 @@ def test_default_activation_fn(reranker_bert_tiny_model: CrossEncoder):
         DeprecationWarning, match="The `default_activation_function` property was renamed and is now deprecated.*"
     ):
         assert fullname(model.default_activation_function) == "torch.nn.modules.activation.Sigmoid"
+
+
+def test_bge_reranker_max_length():
+    model = CrossEncoder("BAAI/bge-reranker-base")
+    assert model.max_length == 512
+    assert model.tokenizer.model_max_length == 512
+
+    model.max_length = 256
+    assert model.max_length == 256
+    assert model.tokenizer.model_max_length == 256


### PR DESCRIPTION
Resolves #3302

Hello!

## Pull Request overview
* Set the tokenizer model_max_length to the min. of model_max_length & max_pos_embeds
* Add a setter for `model.max_length`
* Add a test showing that bge-reranker loads with the correct `model_max_length`

## Details
Set the tokenizer model_max_length to the min. of model_max_length & max_pos_embeds instead of taking max_position_embeddings as a default if nothing is specified. In the case of bge-reranker, it's set to 514 (a.k.a. too high).

- Tom Aarsen
