### PR TITLE
Exclude transformers==4.51.0 due to upstream bug

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-    "transformers>=4.41.0,<5.0.0",
+    "transformers>=4.41.0,<5.0.0,!=4.51.0",
     "tqdm",
     "torch>=1.11.0",
     "scikit-learn",


### PR DESCRIPTION
transformers==4.51.0 introduced a bug that has been fixed in 4.51.1.

This PR updates the version specifier to explicitly exclude 4.51.0 using:

    transformers>=4.41.0,<5.0.0,!=4.51.0

This ensures no one installs the broken version by accident.

Reference:
- https://github.com/huggingface/transformers/releases/tag/v4.51.1