### PR TITLE
[`fix`] Use return_dict=True in Transformer; improve how all_layer_embeddings are determined

### DIFF
--- a/sentence_transformers/models/Transformer.py
+++ b/sentence_transformers/models/Transformer.py
@@ -439,8 +439,9 @@ class Transformer(nn.Module):
             if key in ["input_ids", "attention_mask", "token_type_ids", "inputs_embeds"]
         }
 
-        output_states = self.auto_model(**trans_features, **kwargs, return_dict=False)
-        output_tokens = output_states[0]
+        outputs = self.auto_model(**trans_features, **kwargs, return_dict=True)
+        token_embeddings = outputs[0]
+        features["token_embeddings"] = token_embeddings
 
         # If the AutoModel is wrapped with a PeftModelForFeatureExtraction, then it may have added virtual tokens
         # We need to extend the attention mask to include these virtual tokens, or the pooling will fail
@@ -451,22 +452,15 @@ class Transformer(nn.Module):
                 isinstance(self.auto_model, PeftModelForFeatureExtraction)
                 and self.auto_model.active_peft_config.is_prompt_learning
             ):
-                batch_size = output_tokens.size(0)
+                batch_size = token_embeddings.size(0)
                 attention_mask = features["attention_mask"]
                 prefix_attention_mask = torch.ones(
                     batch_size, self.auto_model.active_peft_config.num_virtual_tokens, device=attention_mask.device
                 )
                 features["attention_mask"] = torch.cat((prefix_attention_mask, attention_mask), dim=1)
 
-        features["token_embeddings"] = output_tokens
-
-        if self.auto_model.config.output_hidden_states and len(output_states) > 2:
-            all_layer_idx = 2  # I.e. after last_hidden_states and pooler_output
-            if len(output_states) < 3:  # Some models only output last_hidden_states and all_hidden_states
-                all_layer_idx = 1
-
-            hidden_states = output_states[all_layer_idx]
-            features["all_layer_embeddings"] = hidden_states
+        if self.auto_model.config.output_hidden_states and "hidden_states" in outputs:
+            features["all_layer_embeddings"] = outputs["hidden_states"]
 
         return features
 


### PR DESCRIPTION
Fixes #3318

Hello!

## Pull Request overview
* Improve how all_layer_embeddings are determined

## Details
In short, instead of `return_dict=False` where we just get a tuple without any keys, we now use `return_dict=True`, allowing us to see the output names. `transformers` seems to have a pretty strong convention to use `hidden_states` for the `output_hidden_states`, so this should be fairly safe. Beyond that, I'm still using `[0]` indexing for the token embeddings (also known as `last_hidden_state`).

My intention is not to introduce any backwards breaking here, but there's always a risk. Let me know if your code breaks because of this!

- Tom Aarsen