### PR TITLE
[`typing`] Fix typing for CrossEncoder.to

### DIFF
--- a/sentence_transformers/cross_encoder/CrossEncoder.py
+++ b/sentence_transformers/cross_encoder/CrossEncoder.py
@@ -653,9 +653,6 @@ class CrossEncoder(nn.Module, PushToHubMixin, FitMixin):
             return folder_url.pr_url
         return folder_url.commit_url
 
-    def to(self, device: int | str | torch.device | None = None) -> None:
-        return self.model.to(device)
-
     @property
     def _target_device(self) -> torch.device:
         logger.warning(


### PR DESCRIPTION
Resolves #3322

Hello!

## Pull Request overview
* Fix typing for CrossEncoder.to

## Details
Since we're now subclassing `nn.Module`, we don't actually need to override `.to` at all, so I can just remove it and rely on the superclass' `to`, which has some nice overrides and should have correct typings with `Self` as the return. 

Thank you @jeyendranbalakrishnan for reporting this!

- Tom Aarsen