### PR TITLE
[`fix`] Avoid error if prompts & output_value=None

### DIFF
--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -699,10 +699,20 @@ class SentenceTransformer(nn.Sequential, FitMixin, PeftAdapterMixin):
 
                         embeddings.append(token_emb[0 : last_mask_id + 1])
                 elif output_value is None:  # Return all outputs
-                    embeddings = []
-                    for sent_idx in range(len(out_features["sentence_embedding"])):
-                        row = {name: out_features[name][sent_idx] for name in out_features}
-                        embeddings.append(row)
+
+                    def get_outputs_for_batch_idx(batch_idx: int) -> dict[str, Tensor]:
+                        row = {}
+                        for name, value in out_features.items():
+                            try:
+                                row[name] = value[batch_idx]
+                            except TypeError:
+                                # If we try and index a value that is not a list or tensor, we just add it as is
+                                # This is the case for the prompt length, which is a single int
+                                row[name] = value
+                        return row
+
+                    batch_size = len(out_features["sentence_embedding"])
+                    embeddings = [get_outputs_for_batch_idx(idx) for idx in range(batch_size)]
                 else:  # Sentence embeddings
                     embeddings = out_features[output_value]
                     embeddings = embeddings.detach()

--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -699,20 +699,16 @@ class SentenceTransformer(nn.Sequential, FitMixin, PeftAdapterMixin):
 
                         embeddings.append(token_emb[0 : last_mask_id + 1])
                 elif output_value is None:  # Return all outputs
-
-                    def get_outputs_for_batch_idx(batch_idx: int) -> dict[str, Tensor]:
-                        row = {}
+                    embeddings = []
+                    for idx in range(len(out_features["sentence_embedding"])):
+                        batch_item = {}
                         for name, value in out_features.items():
                             try:
-                                row[name] = value[batch_idx]
+                                batch_item[name] = value[idx]
                             except TypeError:
-                                # If we try and index a value that is not a list or tensor, we just add it as is
-                                # This is the case for the prompt length, which is a single int
-                                row[name] = value
-                        return row
-
-                    batch_size = len(out_features["sentence_embedding"])
-                    embeddings = [get_outputs_for_batch_idx(idx) for idx in range(batch_size)]
+                                # Handle non-indexable values (like prompt_length)
+                                batch_item[name] = value
+                        embeddings.append(batch_item)
                 else:  # Sentence embeddings
                     embeddings = out_features[output_value]
                     embeddings = embeddings.detach()

--- a/tests/test_sentence_transformer.py
+++ b/tests/test_sentence_transformer.py
@@ -376,6 +376,27 @@ def test_save_load_prompts() -> None:
         assert fresh_model.default_prompt_name == "query"
 
 
+def test_prompt_output_value_None(stsb_bert_tiny_model_reused) -> None:
+    model = stsb_bert_tiny_model_reused
+    outputs = model.encode(
+        ["Text one", "Text two"],
+        prompt="query: ",
+        output_value=None,
+    )
+    assert len(outputs) == 2
+    assert isinstance(outputs, list)
+    expected_keys = {
+        "input_ids",
+        "token_type_ids",
+        "attention_mask",
+        "sentence_embedding",
+        "token_embeddings",
+        "prompt_length",
+    }
+    assert set(outputs[0].keys()) == expected_keys
+    assert set(outputs[1].keys()) == expected_keys
+
+
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA must be available to test float16 support.")
 def test_load_with_torch_dtype() -> None:
     model = SentenceTransformer("sentence-transformers-testing/stsb-bert-tiny-safetensors")


### PR DESCRIPTION
Resolves #3325

Hello!

## Pull Request overview
* Avoid error if prompts & output_value=None

## Details
See #3325 for more details. In short, if you use `output_value=None`, then the expectation is that everything in `out_features` is batched and can be indexed accordingly. However, the `prompt_length` is just an integer as it's the same across the entire batch. This PR updates it such that the `prompt_length` is now returned as a value for all outputs.

```python
from sentence_transformers import SentenceTransformer

model = SentenceTransformer("all-MiniLM-L6-v2", prompts={'query': 'query:'}, default_prompt_name='query')
embeddings = model.encode(['sentence1', 'sentence2'], output_value=None)
print(embeddings[0].keys())
print(embeddings[1].keys())
```
```
dict_keys(['input_ids', 'token_type_ids', 'attention_mask', 'prompt_length', 'token_embeddings', 'sentence_embedding'])
dict_keys(['input_ids', 'token_type_ids', 'attention_mask', 'prompt_length', 'token_embeddings', 'sentence_embedding'])
```

Thank you @tma15 for reporting this. I believe this PR should resolve your issue.

- Tom Aarsen