### PR TITLE
feature - mine hard negatives working with prompts

### DIFF
--- a/sentence_transformers/util.py
+++ b/sentence_transformers/util.py
@@ -324,6 +324,8 @@ def paraphrase_mining(
     max_pairs: int = 500000,
     top_k: int = 100,
     score_function: Callable[[Tensor, Tensor], Tensor] = cos_sim,
+    prompt_name: str | None = None,
+    prompt: str | None = None,
 ) -> list[list[float | int]]:
     """
     Given a list of sentences / texts, this function performs paraphrase mining. It compares all sentences against all
@@ -339,6 +341,20 @@ def paraphrase_mining(
         max_pairs (int, optional): Maximal number of text pairs returned. Defaults to 500000.
         top_k (int, optional): For each sentence, we retrieve up to top_k other sentences. Defaults to 100.
         score_function (Callable[[Tensor, Tensor], Tensor], optional): Function for computing scores. By default, cosine similarity. Defaults to cos_sim.
+        prompt_name (Optional[str], optional): The name of a predefined prompt to use when encoding the sentence.
+            It must match a key in the `prompts` dictionary, which can be set during model initialization
+            or loaded from the model configuration.
+
+            Ignored if `prompt` is provided. Defaults to None.
+
+        prompt (Optional[str], optional): A raw prompt string to prepend directly to the input sentence during encoding.
+
+            For instance, `prompt="query: "` transforms the sentence
+            "What is the capital of France?" into:
+                "query: What is the capital of France?"
+
+            Use this to override the prompt logic entirely and supply your own prefix.
+            This takes precedence over `prompt_name`. Defaults to None.
 
     Returns:
         List[List[Union[float, int]]]: Returns a list of triplets with the format [score, id1, id2]
@@ -346,7 +362,8 @@ def paraphrase_mining(
 
     # Compute embedding for the sentences
     embeddings = model.encode(
-        sentences, show_progress_bar=show_progress_bar, batch_size=batch_size, convert_to_tensor=True
+        sentences, show_progress_bar=show_progress_bar, batch_size=batch_size, convert_to_tensor=True,
+        prompt_name=prompt_name, prompt=prompt
     )
 
     return paraphrase_mining_embeddings(
@@ -541,6 +558,8 @@ def mine_hard_negatives(
     verbose: bool = True,
     as_triplets: bool | None = None,
     margin: float | None = None,
+    prompt_name: str | None = None,
+    prompt: str | None = None,
 ) -> Dataset:
     """
     Add hard negatives to a dataset of (anchor, positive) pairs to create (anchor, positive, negative) triplets or
@@ -553,6 +572,8 @@ def mine_hard_negatives(
     This function uses a SentenceTransformer model to embed the sentences in the dataset, and then finds the closest
     matches to each anchor sentence in the dataset. It then samples negatives from the closest matches, optionally
     using a CrossEncoder model to rescore the candidates.
+
+    Supports prompt formatting for models that expect specific instruction-style input.
 
     You can influence the candidate negative selection in various ways:
 
@@ -688,6 +709,30 @@ def mine_hard_negatives(
         verbose (bool): Whether to print statistics and logging. Defaults to True.
         as_triplets (bool, optional): Deprecated. Use `output_format` instead. Defaults to None.
         margin (float, optional): Deprecated. Use `absolute_margin` or `relative_margin` instead. Defaults to None.
+        prompt_name (Optional[str], optional):
+            The name of a predefined prompt to use when encoding the sentence.
+            It must match a key in the `prompts` dictionary, which can be set during model initialization
+            or loaded from the model configuration.
+
+            For example, if `prompt_name="query"` and the prompts dictionary includes {"query": "query: "},
+            then the sentence "What is the capital of France?" is transformed into:
+                "query: What is the capital of France?"
+            before encoding.
+
+            This is useful for models that were trained or fine-tuned with specific prompt formats.
+
+            Ignored if `prompt` is provided. Defaults to None.
+
+        prompt (Optional[str], optional):
+            A raw prompt string to prepend directly to the input sentence during encoding.
+
+            For instance, `prompt="query: "` transforms the sentence
+            "What is the capital of France?" into:
+                "query: What is the capital of France?"
+
+            Use this to override the prompt logic entirely and supply your own prefix.
+            This takes precedence over `prompt_name`. Defaults to None.
+
 
     Returns:
         Dataset: A dataset containing (anchor, positive, negative) triplets, (anchor, passage, label) text tuples with
@@ -800,15 +845,18 @@ def mine_hard_negatives(
             target_devices=None if isinstance(use_multi_process, bool) else use_multi_process
         )
         corpus_embeddings = model.encode_multi_process(
-            corpus, pool, batch_size=batch_size, normalize_embeddings=True, show_progress_bar=True
+            corpus, pool, batch_size=batch_size, normalize_embeddings=True, show_progress_bar=True,
+            prompt_name=prompt_name, prompt=prompt
         )
         query_embeddings = model.encode_multi_process(
-            queries, pool, batch_size=batch_size, normalize_embeddings=True, show_progress_bar=True
+            queries, pool, batch_size=batch_size, normalize_embeddings=True, show_progress_bar=True,
+            prompt_name=prompt_name, prompt=prompt
         )
         model.stop_multi_process_pool(pool)
     else:
         corpus_embeddings = model.encode(
-            corpus, batch_size=batch_size, normalize_embeddings=True, convert_to_numpy=True, show_progress_bar=True
+            corpus, batch_size=batch_size, normalize_embeddings=True, convert_to_numpy=True, show_progress_bar=True,
+            prompt_name=prompt_name, prompt=prompt
         )
         query_embeddings = model.encode(
             queries,
@@ -816,6 +864,8 @@ def mine_hard_negatives(
             normalize_embeddings=True,
             convert_to_numpy=True,
             show_progress_bar=True,
+            prompt_name=prompt_name,
+            prompt=prompt
         )
 
     if use_faiss:

--- a/sentence_transformers/util.py
+++ b/sentence_transformers/util.py
@@ -362,8 +362,12 @@ def paraphrase_mining(
 
     # Compute embedding for the sentences
     embeddings = model.encode(
-        sentences, show_progress_bar=show_progress_bar, batch_size=batch_size, convert_to_tensor=True,
-        prompt_name=prompt_name, prompt=prompt
+        sentences,
+        show_progress_bar=show_progress_bar,
+        batch_size=batch_size,
+        convert_to_tensor=True,
+        prompt_name=prompt_name,
+        prompt=prompt,
     )
 
     return paraphrase_mining_embeddings(
@@ -845,18 +849,33 @@ def mine_hard_negatives(
             target_devices=None if isinstance(use_multi_process, bool) else use_multi_process
         )
         corpus_embeddings = model.encode_multi_process(
-            corpus, pool, batch_size=batch_size, normalize_embeddings=True, show_progress_bar=True,
-            prompt_name=prompt_name, prompt=prompt
+            corpus,
+            pool,
+            batch_size=batch_size,
+            normalize_embeddings=True,
+            show_progress_bar=True,
+            prompt_name=prompt_name,
+            prompt=prompt,
         )
         query_embeddings = model.encode_multi_process(
-            queries, pool, batch_size=batch_size, normalize_embeddings=True, show_progress_bar=True,
-            prompt_name=prompt_name, prompt=prompt
+            queries,
+            pool,
+            batch_size=batch_size,
+            normalize_embeddings=True,
+            show_progress_bar=True,
+            prompt_name=prompt_name,
+            prompt=prompt,
         )
         model.stop_multi_process_pool(pool)
     else:
         corpus_embeddings = model.encode(
-            corpus, batch_size=batch_size, normalize_embeddings=True, convert_to_numpy=True, show_progress_bar=True,
-            prompt_name=prompt_name, prompt=prompt
+            corpus,
+            batch_size=batch_size,
+            normalize_embeddings=True,
+            convert_to_numpy=True,
+            show_progress_bar=True,
+            prompt_name=prompt_name,
+            prompt=prompt,
         )
         query_embeddings = model.encode(
             queries,
@@ -865,7 +884,7 @@ def mine_hard_negatives(
             convert_to_numpy=True,
             show_progress_bar=True,
             prompt_name=prompt_name,
-            prompt=prompt
+            prompt=prompt,
         )
 
     if use_faiss:

--- a/sentence_transformers/util.py
+++ b/sentence_transformers/util.py
@@ -550,6 +550,8 @@ def mine_hard_negatives(
     relative_margin: float | None = None,
     num_negatives: int = 3,
     sampling_strategy: Literal["random", "top"] = "top",
+    prompt_name: str | None = None,
+    prompt: str | None = None,
     include_positives: bool = False,
     output_format: Literal["triplet", "n-tuple", "labeled-pair", "labeled-list"] = "triplet",
     batch_size: int = 32,
@@ -559,8 +561,6 @@ def mine_hard_negatives(
     verbose: bool = True,
     as_triplets: bool | None = None,
     margin: float | None = None,
-    prompt_name: str | None = None,
-    prompt: str | None = None,
 ) -> Dataset:
     """
     Add hard negatives to a dataset of (anchor, positive) pairs to create (anchor, positive, negative) triplets or
@@ -689,6 +689,21 @@ def mine_hard_negatives(
             95% as similar to the anchor as the positive. Defaults to None.
         num_negatives (int): Number of negatives to sample. Defaults to 3.
         sampling_strategy (Literal["random", "top"]): Sampling strategy for negatives: "top" or "random". Defaults to "top".
+        prompt_name (Optional[str], optional): The name of a predefined prompt to use when encoding the sentence.
+            It must match a key in the model `prompts` dictionary, which can be set during model initialization
+            or loaded from the model configuration.
+
+            For example, if `prompt_name="query"` and the model prompts dictionary includes {"query": "query: "},
+            then the sentence "What is the capital of France?" is transformed into: "query: What is the capital of France?"
+            before encoding. This is useful for models that were trained or fine-tuned with specific prompt formats.
+
+            Ignored if `prompt` is provided. Defaults to None.
+
+        prompt (Optional[str], optional): A raw prompt string to prepend directly to the input sentence during encoding.
+
+            For instance, `prompt="query: "` transforms the sentence "What is the capital of France?" into:
+            "query: What is the capital of France?". Use this to override the prompt logic entirely and supply your own prefix.
+            This takes precedence over `prompt_name`. Defaults to None.
         include_positives (bool): Whether to include the positives in the negative candidates.
             Setting this to True is primarily useful for creating Reranking evaluation datasets for CrossEncoder models,
             where it can be useful to get a full ranking (including the positives) from a first-stage retrieval model.
@@ -710,21 +725,6 @@ def mine_hard_negatives(
         verbose (bool): Whether to print statistics and logging. Defaults to True.
         as_triplets (bool, optional): Deprecated. Use `output_format` instead. Defaults to None.
         margin (float, optional): Deprecated. Use `absolute_margin` or `relative_margin` instead. Defaults to None.
-        prompt_name (Optional[str], optional): The name of a predefined prompt to use when encoding the sentence.
-            It must match a key in the model `prompts` dictionary, which can be set during model initialization
-            or loaded from the model configuration.
-
-            For example, if `prompt_name="query"` and the model prompts dictionary includes {"query": "query: "},
-            then the sentence "What is the capital of France?" is transformed into: "query: What is the capital of France?"
-            before encoding. This is useful for models that were trained or fine-tuned with specific prompt formats.
-
-            Ignored if `prompt` is provided. Defaults to None.
-
-        prompt (Optional[str], optional): A raw prompt string to prepend directly to the input sentence during encoding.
-
-            For instance, `prompt="query: "` transforms the sentence "What is the capital of France?" into:
-            "query: What is the capital of France?". Use this to override the prompt logic entirely and supply your own prefix.
-            This takes precedence over `prompt_name`. Defaults to None.
 
 
     Returns:

--- a/sentence_transformers/util.py
+++ b/sentence_transformers/util.py
@@ -552,8 +552,10 @@ def mine_hard_negatives(
     relative_margin: float | None = None,
     num_negatives: int = 3,
     sampling_strategy: Literal["random", "top"] = "top",
-    prompt_name: str | None = None,
-    prompt: str | None = None,
+    query_prompt_name: str | None = None,
+    query_prompt: str | None = None,
+    corpus_prompt_name: str | None = None,
+    corpus_prompt: str | None = None,
     include_positives: bool = False,
     output_format: Literal["triplet", "n-tuple", "labeled-pair", "labeled-list"] = "triplet",
     batch_size: int = 32,
@@ -692,21 +694,25 @@ def mine_hard_negatives(
             95% as similar to the anchor as the positive. Defaults to None.
         num_negatives (int): Number of negatives to sample. Defaults to 3.
         sampling_strategy (Literal["random", "top"]): Sampling strategy for negatives: "top" or "random". Defaults to "top".
-        prompt_name (Optional[str], optional): The name of a predefined prompt to use when encoding the sentence.
-            It must match a key in the model `prompts` dictionary, which can be set during model initialization
+        query_prompt_name (Optional[str], optional): The name of a predefined prompt to use when encoding the first/anchor dataset column.
+            It must match a key in the ``model.prompts`` dictionary, which can be set during model initialization
             or loaded from the model configuration.
 
-            For example, if `prompt_name="query"` and the model prompts dictionary includes {"query": "query: "},
+            For example, if ``query_prompt_name="query"`` and the model prompts dictionary includes {"query": "query: "},
             then the sentence "What is the capital of France?" is transformed into: "query: What is the capital of France?"
             before encoding. This is useful for models that were trained or fine-tuned with specific prompt formats.
 
-            Ignored if `prompt` is provided. Defaults to None.
+            Ignored if ``query_prompt`` is provided. Defaults to None.
 
-        prompt (Optional[str], optional): A raw prompt string to prepend directly to the input sentence during encoding.
+        query_prompt (Optional[str], optional): A raw prompt string to prepend directly to the first/anchor dataset column during encoding.
 
-            For instance, `prompt="query: "` transforms the sentence "What is the capital of France?" into:
+            For instance, `query_prompt="query: "` transforms the sentence "What is the capital of France?" into:
             "query: What is the capital of France?". Use this to override the prompt logic entirely and supply your own prefix.
-            This takes precedence over `prompt_name`. Defaults to None.
+            This takes precedence over ``query_prompt_name``. Defaults to None.
+        corpus_prompt_name (Optional[str], optional): The name of a predefined prompt to use when encoding the corpus. See
+            ``query_prompt_name`` for more information. Defaults to None.
+        corpus_prompt (Optional[str], optional): A raw prompt string to prepend directly to the corpus during encoding.
+            See ``query_prompt`` for more information. Defaults to None.
         include_positives (bool): Whether to include the positives in the negative candidates.
             Setting this to True is primarily useful for creating Reranking evaluation datasets for CrossEncoder models,
             where it can be useful to get a full ranking (including the positives) from a first-stage retrieval model.
@@ -875,8 +881,8 @@ def mine_hard_negatives(
                     batch_size=batch_size,
                     normalize_embeddings=True,
                     show_progress_bar=True,
-                    prompt_name=prompt_name,
-                    prompt=prompt,
+                    prompt_name=corpus_prompt_name,
+                    prompt=corpus_prompt,
                 )
             if query_embeddings is None:
                 query_embeddings = model.encode_multi_process(
@@ -885,8 +891,8 @@ def mine_hard_negatives(
                     batch_size=batch_size,
                     normalize_embeddings=True,
                     show_progress_bar=True,
-                    prompt_name=prompt_name,
-                    prompt=prompt,
+                    prompt_name=query_prompt_name,
+                    prompt=query_prompt,
                 )
             model.stop_multi_process_pool(pool)
         else:
@@ -897,8 +903,8 @@ def mine_hard_negatives(
                     normalize_embeddings=True,
                     convert_to_numpy=True,
                     show_progress_bar=True,
-                    prompt_name=prompt_name,
-                    prompt=prompt,
+                    prompt_name=corpus_prompt_name,
+                    prompt=corpus_prompt,
                 )
             if query_embeddings is None:
                 query_embeddings = model.encode(
@@ -907,8 +913,8 @@ def mine_hard_negatives(
                     normalize_embeddings=True,
                     convert_to_numpy=True,
                     show_progress_bar=True,
-                    prompt_name=prompt_name,
-                    prompt=prompt,
+                    prompt_name=query_prompt_name,
+                    prompt=query_prompt,
                 )
 
     if cache_folder:

--- a/sentence_transformers/util.py
+++ b/sentence_transformers/util.py
@@ -342,18 +342,15 @@ def paraphrase_mining(
         top_k (int, optional): For each sentence, we retrieve up to top_k other sentences. Defaults to 100.
         score_function (Callable[[Tensor, Tensor], Tensor], optional): Function for computing scores. By default, cosine similarity. Defaults to cos_sim.
         prompt_name (Optional[str], optional): The name of a predefined prompt to use when encoding the sentence.
-            It must match a key in the `prompts` dictionary, which can be set during model initialization
+            It must match a key in the model `prompts` dictionary, which can be set during model initialization
             or loaded from the model configuration.
 
             Ignored if `prompt` is provided. Defaults to None.
 
         prompt (Optional[str], optional): A raw prompt string to prepend directly to the input sentence during encoding.
 
-            For instance, `prompt="query: "` transforms the sentence
-            "What is the capital of France?" into:
-                "query: What is the capital of France?"
-
-            Use this to override the prompt logic entirely and supply your own prefix.
+            For instance, `prompt="query: "` transforms the sentence "What is the capital of France?" into:
+            "query: What is the capital of France?". Use this to override the prompt logic entirely and supply your own prefix.
             This takes precedence over `prompt_name`. Defaults to None.
 
     Returns:
@@ -713,28 +710,20 @@ def mine_hard_negatives(
         verbose (bool): Whether to print statistics and logging. Defaults to True.
         as_triplets (bool, optional): Deprecated. Use `output_format` instead. Defaults to None.
         margin (float, optional): Deprecated. Use `absolute_margin` or `relative_margin` instead. Defaults to None.
-        prompt_name (Optional[str], optional):
-            The name of a predefined prompt to use when encoding the sentence.
-            It must match a key in the `prompts` dictionary, which can be set during model initialization
+        prompt_name (Optional[str], optional): The name of a predefined prompt to use when encoding the sentence.
+            It must match a key in the model `prompts` dictionary, which can be set during model initialization
             or loaded from the model configuration.
 
-            For example, if `prompt_name="query"` and the prompts dictionary includes {"query": "query: "},
-            then the sentence "What is the capital of France?" is transformed into:
-                "query: What is the capital of France?"
-            before encoding.
-
-            This is useful for models that were trained or fine-tuned with specific prompt formats.
+            For example, if `prompt_name="query"` and the model prompts dictionary includes {"query": "query: "},
+            then the sentence "What is the capital of France?" is transformed into: "query: What is the capital of France?"
+            before encoding. This is useful for models that were trained or fine-tuned with specific prompt formats.
 
             Ignored if `prompt` is provided. Defaults to None.
 
-        prompt (Optional[str], optional):
-            A raw prompt string to prepend directly to the input sentence during encoding.
+        prompt (Optional[str], optional): A raw prompt string to prepend directly to the input sentence during encoding.
 
-            For instance, `prompt="query: "` transforms the sentence
-            "What is the capital of France?" into:
-                "query: What is the capital of France?"
-
-            Use this to override the prompt logic entirely and supply your own prefix.
+            For instance, `prompt="query: "` transforms the sentence "What is the capital of France?" into:
+            "query: What is the capital of France?". Use this to override the prompt logic entirely and supply your own prefix.
             This takes precedence over `prompt_name`. Defaults to None.
 
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -277,7 +277,6 @@ def test_community_detection_gpu_support():
     assert sorted([sorted(community) for community in result]) == sorted([sorted(community) for community in expected])
 
 
-
 def test_mine_hard_negatives_with_prompt(paraphrase_distilroberta_base_v1_model: SentenceTransformer) -> None:
     """
     Tests that mine_hard_negatives runs with and without a prompt.
@@ -305,12 +304,13 @@ def test_mine_hard_negatives_with_prompt(paraphrase_distilroberta_base_v1_model:
             "Christopher Marlowe wrote 'Doctor Faustus'.",
             "Ethanol boils at 78 degrees Celsius.",
             "Quantum mechanics describes the smallest scales of energy.",
-        ]
+        ],
     }
 
     from datasets import Dataset
+
     dataset = Dataset.from_dict(data)
-    corpus = data["positive"] + data["negative_pool"] # Corpus includes positives and other docs
+    corpus = data["positive"] + data["negative_pool"]  # Corpus includes positives and other docs
 
     prompt = "query: "
     num_negatives = 1
@@ -326,12 +326,12 @@ def test_mine_hard_negatives_with_prompt(paraphrase_distilroberta_base_v1_model:
             num_negatives=num_negatives,
             batch_size=4,
             verbose=False,
-            output_format="triplet"
+            output_format="triplet",
         )
         # Assert basic success criteria
         assert isinstance(result_no_prompt, Dataset)
         assert "negative" in result_no_prompt.column_names
-        assert len(result_no_prompt) > 0 # Check that some negatives were found
+        assert len(result_no_prompt) > 0  # Check that some negatives were found
 
     except Exception as e:
         pytest.fail(f"mine_hard_negatives failed without prompt: {e}")
@@ -348,7 +348,7 @@ def test_mine_hard_negatives_with_prompt(paraphrase_distilroberta_base_v1_model:
             batch_size=4,
             verbose=False,
             prompt=prompt,
-            output_format="triplet"
+            output_format="triplet",
         )
         assert isinstance(result_with_prompt, Dataset)
         assert "negative" in result_with_prompt.column_names


### PR DESCRIPTION
Hi sentence transformers DEVs.

 This is my first PR here so first, thank you for your precious package that I have been using for a while!
 
 Recently I have tried to mine hard negatives on a difficult dataset and I noticed that some of the best models do require a prompt. This PR is a minor change to the functions and documentation that makes it possible to pass a prompt.

I have just a couple of comments:
- I have copied and modified the description of the parameters from model.encode, as I found the original description a bit confusing
- I have added a very basic test, which essentially checks some negatives are found on a mock up dataset