### PR TITLE
[fix]  add dtype propetry for fsdp2

### DIFF
--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -1917,6 +1917,10 @@ print(similarities)
         self.to(device)
 
     @property
+    def dtype(self) -> torch.dtype:
+        return self[0].auto_model.dtype
+
+    @property
     def _no_split_modules(self) -> list[str]:
         try:
             return self._first_module()._no_split_modules

--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -1917,8 +1917,11 @@ print(similarities)
         self.to(device)
 
     @property
-    def dtype(self) -> torch.dtype:
-        return self[0].auto_model.dtype
+    def dtype(self) -> torch.dtype | None:
+        for child in self.modules():
+            if child is not self and hasattr(child, "dtype"):
+                return child.dtype
+        return None
 
     @property
     def _no_split_modules(self) -> list[str]:


### PR DESCRIPTION
Hello!

# Pull Request overview
I add dtype propetry in SentenceTransformer Class for fsdp2

# Detail
When using fsdp2, following error was raised.
```
[rank1]:   File "/home/hiroki_iida/work/orca/trainings/.venv/lib/python3.12/site-packages/accelerate/utils/fsdp_utils.py", line 562, in fsdp2_prepare_model                   
[rank1]:     if accelerator.mixed_precision != "no" and model.dtype != torch.float32:                                                                                                                           
[rank1]:                                                ^^^^^^^^^^^                                                                                                                                             
[rank1]:   File "/home/hiroki_iida/work/orca/trainings/.venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1928, in __getattr__                              
[rank1]:     raise AttributeError(                                                                                                                                                                              
[rank1]: AttributeError: 'FSDPSentenceTransformer' object has no attribute 'dtype'. Did you mean: 'type'? 
```

I guess this is because SentenceTransformer class lacks dtype property.
And I can run fsdp2 adding dtype property.
I run test/test_sentence_transformer.py and pass it.

# Reference
I used the same sample code in #3023 to check it though I removed evaluator and kind of settings.
In addition, I converted accelerate config to fsdp2 version using `accelerate to-fsdp2`. 
The result is here.
```
ompute_environment: LOCAL_MACHINE
debug: true
distributed_type: FSDP
downcast_bf16: 'no'
enable_cpu_affinity: false
fsdp_config:
  fsdp_auto_wrap_policy: TRANSFORMER_BASED_WRAP
  fsdp_backward_prefetch: BACKWARD_PRE
  fsdp_cpu_ram_efficient_loading: false
  fsdp_forward_prefetch: false
  fsdp_offload_params: false
  fsdp_reshard_after_forward: true
  fsdp_state_dict_type: SHARDED_STATE_DICT
  fsdp_sync_module_states: true
  fsdp_transformer_layer_cls_to_wrap: BertLayer
  fsdp_use_orig_params: true
  fsdp_version: 2
machine_rank: 0
main_training_function: main
mixed_precision: 'no'
num_machines: 1
num_processes: 2
rdzv_backend: static
same_network: true
tpu_env: []
tpu_use_cluster: false
tpu_use_sudo: false
use_cpu: false
```