### PR TITLE
Add embedding cache mechanism to avoid redundant recomputation

### DIFF
--- a/sentence_transformers/util.py
+++ b/sentence_transformers/util.py
@@ -774,7 +774,7 @@ def mine_hard_negatives(
 
     # Deduplicate the corpus
     # make sure all the positives are also in the corpus and de-duplicate it.
-    corpus = list(set(corpus) | set(positives))
+    corpus = list(dict.fromkeys(corpus + positives))
 
     # corpus_idx maps the corpus text into its position in the corpus
     # This position does not necessarily matches the original corpus, as it was de-duplicated.
@@ -782,7 +782,7 @@ def mine_hard_negatives(
 
     # Deduplicate the queries, but keep the original one for later reference.
     all_queries = queries.copy()
-    queries = list(set(queries))
+    queries = list(dict.fromkeys(queries))
     queries_idx = {query: idx for idx, query in enumerate(queries)}
     n_queries = len(queries)
     batch_idx = torch.arange(n_queries).unsqueeze(-1)


### PR DESCRIPTION
### 📝 Description

This contribution introduces **embedding caching** during the `mine_hard_negatives()` process to avoid redundant computation.  

Currently, every time `mine_hard_negatives()` is executed, embeddings for the queries and corpus are re-encoded, even if the data hasn't changed. This is inefficient, especially when working with large-scale datasets.  

With this update:
- Query and corpus embeddings are cached (e.g., as `.npy` files).
- On re-run, the function checks whether the cache exists **and matches the number of inputs**.
- If valid, cached embeddings are loaded instead of recomputing.

This is particularly useful when performing repeated hard negative mining with different combinations of:
```python
range_max, max_score, min_score, absolute_margin, relative_margin, num_negatives
```
These parameters affect the mining strategy, not the input data itself. Therefore, embedding recomputation is unnecessary across such runs.

---

### 🚀 Motivation

In my case, I ran `mine_hard_negatives()` on a large corpus using **Runpod**, which took **over 8 hours** just for embedding.  
During experimentation (e.g., tuning mining parameters), I encountered **CPU RAM OOM** errors and had to restart with larger resources.  
This meant re-encoding embeddings every time, wasting **time and compute cost**.

By introducing this caching mechanism, repeated runs can reuse previous embeddings — saving both time and money while supporting more iterative experimentation.

---

### 💡 Additional Note
Even if this exact implementation isn't merged, I believe that adding a caching mechanism for embeddings (either based on this approach or a refined version) would be very helpful to the community.
It enables more efficient development and experimentation, especially in retrieval tasks involving large corpora.