### PR TITLE
[`refactor`] Refactor module loading; introduce Module subclass

### DIFF
--- a/docs/package_reference/sentence_transformer/models.md
+++ b/docs/package_reference/sentence_transformer/models.md
@@ -25,5 +25,7 @@
 ## Base Modules
 ```{eval-rst}
 .. autoclass:: sentence_transformers.models.Module
+    :members: config_file_name, config_keys, save_in_root, forward, get_config_dict, load, load_config, load_file_path, load_dir_path, load_torch_weights, save, save_config, save_torch_weights
 .. autoclass:: sentence_transformers.models.InputModule
+    :members: save_in_root, tokenizer, tokenize, save_tokenizer
 ```

--- a/docs/package_reference/sentence_transformer/models.md
+++ b/docs/package_reference/sentence_transformer/models.md
@@ -1,14 +1,14 @@
 # Models
-`sentence_transformers.models` defines different building blocks, that can be used to create SentenceTransformer networks from scratch. For more details, see [Training Overview](../../sentence_transformer/training_overview.md).
+`sentence_transformers.models` defines different building blocks, a.k.a. Modules, that can be used to create SentenceTransformer models from scratch. For more details, see [Creating Custom Models](../../sentence_transformer/usage/custom_models.rst).
 
-## Main Classes
+## Main Modules
 ```{eval-rst}
 .. autoclass:: sentence_transformers.models.Transformer
 .. autoclass:: sentence_transformers.models.Pooling
 .. autoclass:: sentence_transformers.models.Dense
 ```
 
-## Further Classes
+## Further Modules
 ```{eval-rst}
 .. autoclass:: sentence_transformers.models.Asym
 .. autoclass:: sentence_transformers.models.BoW
@@ -20,4 +20,10 @@
 .. autoclass:: sentence_transformers.models.WeightedLayerPooling
 .. autoclass:: sentence_transformers.models.WordEmbeddings
 .. autoclass:: sentence_transformers.models.WordWeights
+```
+
+## Base Modules
+```{eval-rst}
+.. autoclass:: sentence_transformers.models.Module
+.. autoclass:: sentence_transformers.models.InputModule
 ```

--- a/docs/sentence_transformer/usage/custom_models.rst
+++ b/docs/sentence_transformer/usage/custom_models.rst
@@ -24,7 +24,7 @@ For example, the popular `all-MiniLM-L6-v2 <https://huggingface.co/sentence-tran
    model = SentenceTransformer(modules=[transformer, pooling, normalize])
 
 Saving Sentence Transformer Models
-++++++++++++++++++++++++++++++++++
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Whenever a Sentence Transformer model is saved, three types of files are generated:
 
@@ -102,7 +102,7 @@ And a ``config_sentence_transformers.json`` with these contents:
 Additionally, the ``1_Pooling`` directory contains the configuration file for the :class:`~sentence_transformers.models.Pooling` module, while the ``2_Normalize`` directory is empty because the :class:`~sentence_transformers.models.Normalize` module does not require any configuration. The ``sentence_bert_config.json`` file contains the configuration of the :class:`~sentence_transformers.models.Transformer` module, and this module also saved a lot of files related to the tokenizer and the model itself in the root directory.
 
 Loading Sentence Transformer Models
-+++++++++++++++++++++++++++++++++++
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 To load a Sentence Transformer model from a saved model directory, the ``modules.json`` is read to determine the modules that make up the model. Each module is initialized with the configuration stored in the corresponding module directory, after which the SentenceTransformer class is instantiated with the loaded modules.
 
@@ -126,71 +126,93 @@ To be specific, these two snippets are identical::
    model = SentenceTransformer(modules=[transformer, pooling])
 
 Advanced: Custom Modules
-++++++++++++++++++++++++
+------------------------
 
-To create custom Sentence Transformer models, you can implement your own modules by subclassing PyTorch's :class:`torch.nn.Module` class and implementing these methods:
+Input Modules
+^^^^^^^^^^^^^
 
-* A :meth:`torch.nn.Module.forward` method that accepts a ``features`` dictionary with keys like ``input_ids``, ``attention_mask``, ``token_type_ids``, ``token_embeddings``, and ``sentence_embedding``, depending on where the module is in the model pipeline.
-* A ``save`` method that accepts a ``save_dir`` argument and saves the module's configuration to that directory.
-* A ``load`` static method that accepts a ``load_dir`` argument and initializes the Module given the module's configuration from that directory.
-* (If 1st module) A ``get_max_seq_length`` method that returns the maximum sequence length the module can process. Only required if the module processes input text.
-* (If 1st module) A ``tokenize`` method that accepts a list of inputs and returns a dictionary with keys like ``input_ids``, ``attention_mask``, ``token_type_ids``, ``pixel_values``, etc. This dictionary will be passed along to the module's ``forward`` method.
-* (Optional) A ``get_sentence_embedding_dimension`` method that returns the dimensionality of the sentence embeddings produced by the module. Only required if the module generated the embeddings or updates the embeddings' dimensionality.
-* (Optional) A ``get_config_dict`` method that returns a dictionary with the module's configuration. This method can be used to save the module's configuration to disk and to save the module config in a model card.
+The first module in a pipeline is called the input module. It is responsible for tokenizing the input text and generating the input features for the subsequent modules. The input module can be any module that implements the :class:`~sentence_transformers.models.InputModule` class, which is a subclass of the :class:`~sentence_transformers.models.Module` class.
+
+It has three abstract methods that you need to implement:
+
+* A :meth:`~sentence_transformers.models.Module.forward` method that accepts a ``features`` dictionary with keys like ``input_ids``, ``attention_mask``, ``token_type_ids``, ``token_embeddings``, and ``sentence_embedding``, depending on where the module is in the model pipeline.
+* A :meth:`~sentence_transformers.models.Module.save` method that saves the module's configuration and optionally weights to a provided directory.
+* A :meth:`~sentence_transformers.models.InputModule.tokenize` method that accepts a list of inputs and returns a dictionary with keys like ``input_ids``, ``attention_mask``, ``token_type_ids``, ``pixel_values``, etc. This dictionary will be passed along to the module's ``forward`` method.
+
+Optionally, you can also implement the following methods:
+
+* A :meth:`~sentence_transformers.models.Module.load` static method that accepts a ``model_name_or_path`` argument, keyword arguments for loading from Hugging Face (``subfolder``, ``token``, ``cache_folder``, etc.) and module kwargs (``model_kwargs``, ``trust_remote_code``, ``backend``, etc.) and initializes the Module given the module's configuration from that directory or model name.
+* A :meth:`~sentence_transformers.models.Module.get_sentence_embedding_dimension` method that returns the dimensionality of the sentence embeddings produced by the module. This is required if the module generates the embeddings or updates the embeddings' dimensionality.
+* A :meth:`~sentence_transformers.models.InputModule.get_max_seq_length` method that returns the maximum sequence length the module can process. Only required if the module processes input text.
+
+Subsequent Modules
+^^^^^^^^^^^^^^^^^^
+
+Subsequent modules in the pipeline are called non-input modules. They are responsible for processing the input features generated by the input module and generating the final sentence embeddings. Non-input modules can be any module that implements the :class:`~sentence_transformers.models.Module` class.
+
+It has two abstract methods that you need to implement:
+
+* A :meth:`~sentence_transformers.models.Module.forward` method that accepts a ``features`` dictionary with keys like ``input_ids``, ``attention_mask``, ``token_type_ids``, ``token_embeddings``, and ``sentence_embedding``, depending on where the module is in the model pipeline.
+* A :meth:`~sentence_transformers.models.Module.save` method that saves the module's configuration and optionally weights to a provided directory.
+
+Optionally, you can also implement the following methods:
+
+* A :meth:`~sentence_transformers.models.Module.load` static method that accepts a ``model_name_or_path`` argument, keyword arguments for loading from Hugging Face (``subfolder``, ``token``, ``cache_folder``, etc.) and module kwargs (``model_kwargs``, ``trust_remote_code``, ``backend``, etc.) and initializes the Module given the module's configuration from that directory or model name.
+* A :meth:`~sentence_transformers.models.Module.get_sentence_embedding_dimension` method that returns the dimensionality of the sentence embeddings produced by the module. This is required if the module generates the embeddings or updates the embeddings' dimensionality.
+
+Example Module
+^^^^^^^^^^^^^^
 
 For example, we can create a custom pooling method by implementing a custom Module.
 
 .. code-block:: python
 
    # decay_pooling.py
-   
-   import json
-   import os
+
    import torch
-   import torch.nn as nn
-   
-   class DecayMeanPooling(nn.Module):
-       def __init__(self, dimension: int, decay: float = 0.95) -> None:
+   from sentence_transformers.models import Module
+
+
+   class DecayMeanPooling(Module):
+       config_keys: list[str] = ["dimension", "decay"]
+
+       def __init__(self, dimension: int, decay: float = 0.95, **kwargs) -> None:
            super(DecayMeanPooling, self).__init__()
            self.dimension = dimension
            self.decay = decay
-   
-       def forward(self, features: dict[str, torch.Tensor], **kwargs) -> dict   [str, torch.Tensor]:
+
+       def forward(
+           self, features: dict[str, torch.Tensor], **kwargs
+       ) -> dict[str, torch.Tensor]:
+           # This module is expected to be used after some modules that provide "token_embeddings"
+           # and "attention_mask" in the features dictionary.
            token_embeddings = features["token_embeddings"]
            attention_mask = features["attention_mask"].unsqueeze(-1)
-   
+
            # Apply the attention mask to filter away padding tokens
            token_embeddings = token_embeddings * attention_mask
            # Calculate mean of token embeddings
            sentence_embeddings = token_embeddings.sum(1) / attention_mask.sum(1)
            # Apply exponential decay
-           importance_per_dim = self.decay ** torch.arange(sentence_embeddings.   size(1), device=sentence_embeddings.device)
-           features["sentence_embedding"] = sentence_embeddings *    importance_per_dim
+           importance_per_dim = self.decay ** torch.arange(
+               sentence_embeddings.size(1), device=sentence_embeddings.device
+           )
+           features["sentence_embedding"] = sentence_embeddings * importance_per_dim
            return features
-   
-       def get_config_dict(self) -> dict[str, float]:
-           return {"dimension": self.dimension, "decay": self.decay}
-   
+
        def get_sentence_embedding_dimension(self) -> int:
            return self.dimension
-   
-       def save(self, save_dir: str, **kwargs) -> None:
-           with open(os.path.join(save_dir, "config.json"), "w") as fOut:
-               json.dump(self.get_config_dict(), fOut, indent=4)
-   
-       def load(load_dir: str, **kwargs) -> "DecayMeanPooling":
-           with open(os.path.join(load_dir, "config.json")) as fIn:
-               config = json.load(fIn)
-   
-           return DecayMeanPooling(**config)
+
+       def save(self, output_path, *args, safe_serialization=True, **kwargs):
+           self.save_config(output_path)
+
+       # The `load` method by default loads the config.json file from the model directory
+       # and initializes the class with the loaded parameters, i.e. the `config_keys`.
+       # This works for us, so no need to override it.
 
 .. note::
 
-   Adding ``**kwargs`` to the ``__init__``, ``forward``, ``save``, ``load``, and ``tokenize`` methods is recommended to ensure that the methods are compatible with future updates to the Sentence Transformers library.
-
-.. note::
-
-   If your module is the first module, then you can set ``save_in_root = True`` in the module's class definition if you want your module to be saved in the root directory upon save. Do note that unlike the subdirectories, the root directory is not downloaded from the Hugging Face Hub before loading the module. As a result, the module should first check if the required files exist locally and otherwise use :func:`huggingface_hub.hf_hub_download` to download them.
+   Adding ``**kwargs`` to the ``__init__``, ``forward``, ``save``, ``load``, and ``tokenize`` methods is recommended to ensure that the methods reemain compatible with future updates to the Sentence Transformers library.
 
 This can now be used as a module in a Sentence Transformer model::
    
@@ -220,7 +242,7 @@ This can now be used as a module in a Sentence Transformer model::
    ]
    embeddings = model.encode(texts)
    print(embeddings.shape)
-   # [5, 384]
+   # [5, 768]
 
 You can save this model with :meth:`SentenceTransformer.save_pretrained <sentence_transformers.SentenceTransformer.save_pretrained>`, resulting in a ``modules.json`` of::
 
@@ -275,7 +297,7 @@ If you have your models and custom modelling code on the Hugging Face Hub, then 
    ]
 
 Advanced: Keyword argument passthrough in Custom Modules
-++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 If you want your users to be able to specify custom keyword arguments via the :meth:`SentenceTransformer.encode <sentence_transformers.SentenceTransformer.encode>` method, then you can add their names to the ``modules.json`` file. For example, if my module should behave differently if your users specify a ``task_type`` keyword argument, then your ``modules.json`` might look like::
 

--- a/docs/sentence_transformer/usage/custom_models.rst
+++ b/docs/sentence_transformer/usage/custom_models.rst
@@ -181,9 +181,7 @@ For example, we can create a custom pooling method by implementing a custom Modu
            self.dimension = dimension
            self.decay = decay
 
-       def forward(
-           self, features: dict[str, torch.Tensor], **kwargs
-       ) -> dict[str, torch.Tensor]:
+       def forward(self, features: dict[str, torch.Tensor], **kwargs) -> dict[str, torch.Tensor]:
            # This module is expected to be used after some modules that provide "token_embeddings"
            # and "attention_mask" in the features dictionary.
            token_embeddings = features["token_embeddings"]
@@ -203,7 +201,7 @@ For example, we can create a custom pooling method by implementing a custom Modu
        def get_sentence_embedding_dimension(self) -> int:
            return self.dimension
 
-       def save(self, output_path, *args, safe_serialization=True, **kwargs):
+       def save(self, output_path, *args, safe_serialization=True, **kwargs) -> None:
            self.save_config(output_path)
 
        # The `load` method by default loads the config.json file from the model directory
@@ -328,7 +326,7 @@ Then, you can access the ``task_type`` keyword argument in the ``forward`` metho
    from sentence_transformers.models import Transformer
 
    class CustomTransformer(Transformer):
-       def forward(self, features: dict[str, torch.Tensor], task_type: Optional[str] = None) -> dict[str, torch.Tensor]:
+       def forward(self, features: dict[str, torch.Tensor], task_type: Optional[str] = None, **kwargs) -> dict[str, torch.Tensor]:
            if task_type == "default":
                # Do something
            else:

--- a/examples/sentence_transformer/applications/image-search/example.py
+++ b/examples/sentence_transformer/applications/image-search/example.py
@@ -12,7 +12,7 @@ model = CLIPModel.from_pretrained("openai/clip-vit-base-patch32")
 processor = CLIPProcessor.from_pretrained("openai/clip-vit-base-patch32")
 
 
-inputs = processor(texts=["a cat", "a dog"], images=[image], return_tensors="pt", padding=True)
+inputs = processor(text=["a cat", "a dog"], images=[image], return_tensors="pt", padding=True)
 output = model(**inputs)
 # vision_outputs = model.vision_model(pixel_values=inputs['pixel_values'])
 # image_embeds = model.visual_projection(vision_outputs[1])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,8 @@ required-imports = ["from __future__ import annotations"]
 testpaths = [
     "tests"
 ]
-addopts = "--strict-markers -m 'not slow'"
+addopts = "--strict-markers -m 'not slow and not custom'"
 markers = [
-    "slow: marks tests as slow"
+    "slow: marks tests as slow",
+    "custom: tests for third-party models with custom modules"
 ]

--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -1749,12 +1749,19 @@ print(similarities)
             # Backwards compatibility: if the module is older and its `load` method only supports one parameter,
             # a path to a local directory containing the module files, then we load it with the old style
             load_signature = inspect.signature(module_class.load)
+            # Check if the `load` method only accepts a single parameter (the path to the local directory).
+            # This indicates an older module that does not support the newer loading method with multiple arguments.
             if len(load_signature.parameters) == 1:
                 signature = inspect.signature(module_class.__init__)
-                # If the module is likely Transformer-based, we try to load it with __init__ with common Transformer
-                # keyword arguments (model_args, config_args, tokenizer_args, etc.)
-                # E.g. models with custom modules on the Hub, like https://huggingface.co/jinaai/jina-embeddings-v3
+                # If the module's `__init__` method contains specific keyword arguments like `model_args` and `config_args`,
+                # it is likely Transformer-based. These arguments are commonly used in Transformer models to configure
+                # the model and tokenizer during initialization.
+                # Example: Models with custom modules on the Hugging Face Hub like
+                # https://huggingface.co/jinaai/jina-embeddings-v3 may use this logic.
                 if {"model_args", "config_args"} <= set(signature.parameters):
+                    # Load initialization arguments specific to Transformer-based modules. This includes
+                    # arguments for loading the model, tokenizer, and configuration, as well as any
+                    # additional module-specific keyword arguments.
                     common_transformer_init_kwargs = Transformer._load_init_kwargs(
                         model_name_or_path,
                         # Loading-specific keyword arguments

--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -1228,8 +1228,10 @@ class SentenceTransformer(nn.Sequential, FitMixin, PeftAdapterMixin):
 
         # Save modules
         for idx, name in enumerate(self._modules):
-            module = self._modules[name]
-            if idx == 0 and hasattr(module, "save_in_root"):  # Save first module in the main folder
+            module: Module = self._modules[name]
+            if (
+                idx == 0 and hasattr(module, "save_in_root") and module.save_in_root
+            ):  # Save first module in the main folder
                 model_path = path + "/"
             else:
                 model_path = os.path.join(path, str(idx) + "_" + type(module).__name__)

--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -1743,92 +1743,13 @@ print(similarities)
                 class_ref, model_name_or_path, trust_remote_code, revision, model_kwargs
             )
 
-            # For Transformer, don't load the full directory, rely on `transformers` instead
-            # But, do load the config file first.
-            """
-            if module_config["path"] == "":
-                kwargs = {}
-                for config_name in [
-                    "sentence_bert_config.json",
-                    "sentence_roberta_config.json",
-                    "sentence_distilbert_config.json",
-                    "sentence_camembert_config.json",
-                    "sentence_albert_config.json",
-                    "sentence_xlm-roberta_config.json",
-                    "sentence_xlnet_config.json",
-                ]:
-                    config_path = load_file_path(
-                        model_name_or_path,
-                        config_name,
-                        token=token,
-                        cache_folder=cache_folder,
-                        revision=revision,
-                        local_files_only=local_files_only,
-                    )
-                    if config_path is not None:
-                        with open(config_path) as fIn:
-                            kwargs = json.load(fIn)
-                            # Don't allow configs to set trust_remote_code
-                            if "model_args" in kwargs and "trust_remote_code" in kwargs["model_args"]:
-                                kwargs["model_args"].pop("trust_remote_code")
-                            if "tokenizer_args" in kwargs and "trust_remote_code" in kwargs["tokenizer_args"]:
-                                kwargs["tokenizer_args"].pop("trust_remote_code")
-                            if "config_args" in kwargs and "trust_remote_code" in kwargs["config_args"]:
-                                kwargs["config_args"].pop("trust_remote_code")
-                        break
-
-                hub_kwargs = {
-                    "token": token,
-                    "trust_remote_code": trust_remote_code,
-                    "revision": revision,
-                    "local_files_only": local_files_only,
-                }
-                # 3rd priority: config file
-                if "model_args" not in kwargs:
-                    kwargs["model_args"] = {}
-                if "tokenizer_args" not in kwargs:
-                    kwargs["tokenizer_args"] = {}
-                if "config_args" not in kwargs:
-                    kwargs["config_args"] = {}
-
-                # 2nd priority: hub_kwargs
-                kwargs["model_args"].update(hub_kwargs)
-                kwargs["tokenizer_args"].update(hub_kwargs)
-                kwargs["config_args"].update(hub_kwargs)
-
-                # 1st priority: kwargs passed to SentenceTransformer
-                if model_kwargs:
-                    kwargs["model_args"].update(model_kwargs)
-                if tokenizer_kwargs:
-                    kwargs["tokenizer_args"].update(tokenizer_kwargs)
-                if config_kwargs:
-                    kwargs["config_args"].update(config_kwargs)
-
-                # Try to initialize the module with a lot of kwargs, but only if the module supports them
-                # Otherwise we fall back to the load method
-                try:
-                    module = module_class(model_name_or_path, cache_dir=cache_folder, backend=self.backend, **kwargs)
-                except TypeError:
-                    module = module_class.load(model_name_or_path)
-            else:
-                # Normalize does not require any files to be loaded
-                if module_class == Normalize:
-                    module_path = None
-                else:
-                    module_path = load_dir_path(
-                        model_name_or_path,
-                        module_config["path"],
-                        token=token,
-                        cache_folder=cache_folder,
-                        revision=revision,
-                        local_files_only=local_files_only,
-                    )
-                module = module_class.load(module_path)
-            """
+            # Try to use the load method with many keyword arguments
+            # If the module is older and doesn't support this, we fall back to the old method
+            # with only a path to a local directory containing the module files
             try:
                 module = module_class.load(
                     model_name_or_path,
-                    module_config["path"],
+                    directory=module_config["path"],
                     # Loading specific keyword arguments
                     token=token,
                     cache_folder=cache_folder,

--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -1751,8 +1751,8 @@ print(similarities)
             try:
                 module = module_class.load(
                     model_name_or_path,
-                    directory=module_config["path"],
-                    # Loading specific keyword arguments
+                    # Loading-specific keyword arguments
+                    subfolder=module_config["path"],
                     token=token,
                     cache_folder=cache_folder,
                     revision=revision,
@@ -1768,7 +1768,7 @@ print(similarities)
                 # Backwards compatibility
                 local_path = load_dir_path(
                     model_name_or_path=model_name_or_path,
-                    directory=module_config["path"],
+                    subfolder=module_config["path"],
                     token=token,
                     cache_folder=cache_folder,
                     revision=revision,

--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -31,6 +31,7 @@ from torch import Tensor, device, nn
 from tqdm.autonotebook import trange
 from transformers import is_torch_npu_available
 from transformers.dynamic_module_utils import get_class_from_dynamic_module, get_relative_import_files
+from typing_extensions import deprecated
 
 from sentence_transformers.model_card import SentenceTransformerModelCardData, generate_model_card
 from sentence_transformers.models.Module import Module
@@ -1825,7 +1826,7 @@ print(similarities)
             self.model_card_data.set_base_model(model_name_or_path, revision=revision)
         return modules, module_kwargs
 
-    # TODO: Should we also update this?
+    @deprecated("SentenceTransformer.load(...) is deprecated, use SentenceTransformer(...) instead.")
     @staticmethod
     def load(input_path) -> SentenceTransformer:
         return SentenceTransformer(input_path)

--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -1826,8 +1826,8 @@ print(similarities)
             self.model_card_data.set_base_model(model_name_or_path, revision=revision)
         return modules, module_kwargs
 
-    @deprecated("SentenceTransformer.load(...) is deprecated, use SentenceTransformer(...) instead.")
     @staticmethod
+    @deprecated("SentenceTransformer.load(...) is deprecated, use SentenceTransformer(...) instead.")
     def load(input_path) -> SentenceTransformer:
         return SentenceTransformer(input_path)
 

--- a/sentence_transformers/models/Asym.py
+++ b/sentence_transformers/models/Asym.py
@@ -7,13 +7,13 @@ from typing import Self
 
 from torch import Tensor, nn
 
+from sentence_transformers.models.InputModule import InputModule
 from sentence_transformers.models.Module import Module
-from sentence_transformers.models.ModuleWithTokenizer import ModuleWithTokenizer
 from sentence_transformers.util import import_from_string, load_dir_path
 
 
-class Asym(ModuleWithTokenizer, nn.Sequential):
-    def __init__(self, sub_modules: dict[str, list[nn.Module]], allow_empty_key: bool = True):
+class Asym(InputModule, nn.Sequential):
+    def __init__(self, sub_modules: dict[str, list[Module]], allow_empty_key: bool = True):
         """
         This model allows to create asymmetric SentenceTransformer models, that apply different models depending on the specified input key.
 
@@ -173,10 +173,7 @@ class Asym(ModuleWithTokenizer, nn.Sequential):
         for model_id, model_type in config["types"].items():
             module_class: Module = import_from_string(model_type)
             try:
-                module = module_class.load(
-                    model_name_or_path,
-                    **hub_kwargs**kwargs,
-                )
+                module = module_class.load(model_name_or_path, **hub_kwargs, **kwargs)
             except TypeError:
                 local_path = load_dir_path(model_name_or_path=model_name_or_path, **hub_kwargs)
                 module = module_class.load(local_path)

--- a/sentence_transformers/models/Asym.py
+++ b/sentence_transformers/models/Asym.py
@@ -3,7 +3,11 @@ from __future__ import annotations
 import json
 import os
 from collections import OrderedDict
-from typing import Self
+
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 from torch import Tensor, nn
 

--- a/sentence_transformers/models/Asym.py
+++ b/sentence_transformers/models/Asym.py
@@ -150,28 +150,6 @@ class Asym(ModuleWithTokenizer, nn.Sequential):
             assert text_key == module_key  # Mixed batches are not allowed
         return self.sub_modules[module_key][0].tokenize(texts, **kwargs)
 
-    """
-    @staticmethod
-    def load(input_path):
-        with open(os.path.join(input_path, "config.json")) as fIn:
-            config = json.load(fIn)
-
-        modules = {}
-        for model_id, model_type in config["types"].items():
-            module_class = import_from_string(model_type)
-            module = module_class.load(os.path.join(input_path, model_id))
-            modules[model_id] = module
-
-        model_structure = {}
-        for key_name, models_list in config["structure"].items():
-            model_structure[key_name] = []
-            for model_id in models_list:
-                model_structure[key_name].append(modules[model_id])
-
-        model = Asym(model_structure, **config["parameters"])
-        return model
-    """
-
     @classmethod
     def load(
         cls,

--- a/sentence_transformers/models/Asym.py
+++ b/sentence_transformers/models/Asym.py
@@ -154,43 +154,31 @@ class Asym(ModuleWithTokenizer, nn.Sequential):
     def load(
         cls,
         model_name_or_path: str,
-        directory: str = "",
+        subfolder: str = "",
         token: bool | str | None = None,
         cache_folder: str | None = None,
         revision: str | None = None,
         local_files_only: bool = False,
         **kwargs,
     ) -> Self:
-        config = cls.load_config(
-            model_name_or_path=model_name_or_path,
-            directory=directory,
-            token=token,
-            cache_folder=cache_folder,
-            revision=revision,
-            local_files_only=local_files_only,
-        )
+        hub_kwargs = {
+            "subfolder": subfolder,
+            "token": token,
+            "cache_folder": cache_folder,
+            "revision": revision,
+            "local_files_only": local_files_only,
+        }
+        config = cls.load_config(model_name_or_path=model_name_or_path, **hub_kwargs)
         modules = {}
         for model_id, model_type in config["types"].items():
             module_class: Module = import_from_string(model_type)
             try:
                 module = module_class.load(
                     model_name_or_path,
-                    directory=model_id,
-                    token=token,
-                    cache_folder=cache_folder,
-                    revision=revision,
-                    local_files_only=local_files_only,
-                    **kwargs,
+                    **hub_kwargs**kwargs,
                 )
             except TypeError:
-                local_path = load_dir_path(
-                    model_name_or_path=model_name_or_path,
-                    directory=model_id,
-                    token=token,
-                    cache_folder=cache_folder,
-                    revision=revision,
-                    local_files_only=local_files_only,
-                )
+                local_path = load_dir_path(model_name_or_path=model_name_or_path, **hub_kwargs)
                 module = module_class.load(local_path)
             modules[model_id] = module
 

--- a/sentence_transformers/models/Asym.py
+++ b/sentence_transformers/models/Asym.py
@@ -3,13 +3,16 @@ from __future__ import annotations
 import json
 import os
 from collections import OrderedDict
+from typing import Self
 
 from torch import Tensor, nn
 
-from sentence_transformers.util import import_from_string
+from sentence_transformers.models.Module import Module
+from sentence_transformers.models.ModuleWithTokenizer import ModuleWithTokenizer
+from sentence_transformers.util import import_from_string, load_dir_path
 
 
-class Asym(nn.Sequential):
+class Asym(ModuleWithTokenizer, nn.Sequential):
     def __init__(self, sub_modules: dict[str, list[nn.Module]], allow_empty_key: bool = True):
         """
         This model allows to create asymmetric SentenceTransformer models, that apply different models depending on the specified input key.
@@ -147,6 +150,7 @@ class Asym(nn.Sequential):
             assert text_key == module_key  # Mixed batches are not allowed
         return self.sub_modules[module_key][0].tokenize(texts, **kwargs)
 
+    """
     @staticmethod
     def load(input_path):
         with open(os.path.join(input_path, "config.json")) as fIn:
@@ -156,6 +160,60 @@ class Asym(nn.Sequential):
         for model_id, model_type in config["types"].items():
             module_class = import_from_string(model_type)
             module = module_class.load(os.path.join(input_path, model_id))
+            modules[model_id] = module
+
+        model_structure = {}
+        for key_name, models_list in config["structure"].items():
+            model_structure[key_name] = []
+            for model_id in models_list:
+                model_structure[key_name].append(modules[model_id])
+
+        model = Asym(model_structure, **config["parameters"])
+        return model
+    """
+
+    @classmethod
+    def load(
+        cls,
+        model_name_or_path: str,
+        directory: str = "",
+        token: bool | str | None = None,
+        cache_folder: str | None = None,
+        revision: str | None = None,
+        local_files_only: bool = False,
+        **kwargs,
+    ) -> Self:
+        config = cls.load_config(
+            model_name_or_path=model_name_or_path,
+            directory=directory,
+            token=token,
+            cache_folder=cache_folder,
+            revision=revision,
+            local_files_only=local_files_only,
+        )
+        modules = {}
+        for model_id, model_type in config["types"].items():
+            module_class: Module = import_from_string(model_type)
+            try:
+                module = module_class.load(
+                    model_name_or_path,
+                    directory=model_id,
+                    token=token,
+                    cache_folder=cache_folder,
+                    revision=revision,
+                    local_files_only=local_files_only,
+                    **kwargs,
+                )
+            except TypeError:
+                local_path = load_dir_path(
+                    model_name_or_path=model_name_or_path,
+                    directory=model_id,
+                    token=token,
+                    cache_folder=cache_folder,
+                    revision=revision,
+                    local_files_only=local_files_only,
+                )
+                module = module_class.load(local_path)
             modules[model_id] = module
 
         model_structure = {}

--- a/sentence_transformers/models/BoW.py
+++ b/sentence_transformers/models/BoW.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Literal, Self
+from typing import Literal
 
 import torch
 from torch import Tensor
@@ -85,24 +85,3 @@ class BoW(ModuleWithTokenizer):
 
     def save(self, output_path: str, *args, safe_serialization: bool = True, **kwargs) -> None:
         self.save_config(output_path)
-
-    @classmethod
-    def load(
-        cls,
-        model_name_or_path: str,
-        directory: str = "",
-        token: bool | str | None = None,
-        cache_folder: str | None = None,
-        revision: str | None = None,
-        local_files_only: bool = False,
-        **kwargs,
-    ) -> Self:
-        config = cls.load_config(
-            model_name_or_path,
-            directory=directory,
-            token=token,
-            cache_folder=cache_folder,
-            revision=revision,
-            local_files_only=local_files_only,
-        )
-        return cls(**config)

--- a/sentence_transformers/models/BoW.py
+++ b/sentence_transformers/models/BoW.py
@@ -6,14 +6,14 @@ from typing import Literal
 import torch
 from torch import Tensor
 
-from sentence_transformers.models.ModuleWithTokenizer import ModuleWithTokenizer
+from sentence_transformers.models.InputModule import InputModule
 
 from .tokenizer import WhitespaceTokenizer
 
 logger = logging.getLogger(__name__)
 
 
-class BoW(ModuleWithTokenizer):
+class BoW(InputModule):
     """Implements a Bag-of-Words (BoW) model to derive sentence embeddings.
 
     A weighting can be added to allow the generation of tf-idf vectors. The output vector has the size of the vocab.

--- a/sentence_transformers/models/CLIPModel.py
+++ b/sentence_transformers/models/CLIPModel.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
-from typing import Self
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 import torch
 import transformers

--- a/sentence_transformers/models/CLIPModel.py
+++ b/sentence_transformers/models/CLIPModel.py
@@ -100,7 +100,7 @@ class CLIPModel(ModuleWithTokenizer):
     def load(
         cls,
         model_name_or_path: str,
-        directory: str = "",
+        subfolder: str = "",
         token: bool | str | None = None,
         cache_folder: str | None = None,
         revision: str | None = None,
@@ -109,7 +109,7 @@ class CLIPModel(ModuleWithTokenizer):
     ) -> Self:
         local_path = cls.load_dir_path(
             model_name_or_path=model_name_or_path,
-            directory=directory,
+            subfolder=subfolder,
             token=token,
             cache_folder=cache_folder,
             revision=revision,

--- a/sentence_transformers/models/CLIPModel.py
+++ b/sentence_transformers/models/CLIPModel.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
+from typing import Self
+
 import torch
 import transformers
 from PIL import Image
-from torch import nn
+
+from sentence_transformers.models.Asym import ModuleWithTokenizer
 
 
-class CLIPModel(nn.Module):
+class CLIPModel(ModuleWithTokenizer):
     save_in_root: bool = True
 
     def __init__(self, model_name: str = "openai/clip-vit-base-patch32", processor_name=None) -> None:
@@ -89,10 +92,27 @@ class CLIPModel(nn.Module):
     def tokenizer(self) -> transformers.CLIPProcessor:
         return self.processor
 
-    def save(self, output_path: str) -> None:
-        self.model.save_pretrained(output_path)
+    def save(self, output_path: str, *args, safe_serialization: bool = True, **kwargs) -> None:
+        self.model.save_pretrained(output_path, safe_serialization=safe_serialization)
         self.processor.save_pretrained(output_path)
 
-    @staticmethod
-    def load(input_path: str) -> CLIPModel:
-        return CLIPModel(model_name=input_path)
+    @classmethod
+    def load(
+        cls,
+        model_name_or_path: str,
+        directory: str = "",
+        token: bool | str | None = None,
+        cache_folder: str | None = None,
+        revision: str | None = None,
+        local_files_only: bool = False,
+        **kwargs,
+    ) -> Self:
+        local_path = cls.load_dir_path(
+            model_name_or_path=model_name_or_path,
+            directory=directory,
+            token=token,
+            cache_folder=cache_folder,
+            revision=revision,
+            local_files_only=local_files_only,
+        )
+        return cls(local_path)

--- a/sentence_transformers/models/CLIPModel.py
+++ b/sentence_transformers/models/CLIPModel.py
@@ -6,10 +6,10 @@ import torch
 import transformers
 from PIL import Image
 
-from sentence_transformers.models.Asym import ModuleWithTokenizer
+from sentence_transformers.models.Asym import InputModule
 
 
-class CLIPModel(ModuleWithTokenizer):
+class CLIPModel(InputModule):
     save_in_root: bool = True
 
     def __init__(self, model_name: str = "openai/clip-vit-base-patch32", processor_name=None) -> None:

--- a/sentence_transformers/models/CNN.py
+++ b/sentence_transformers/models/CNN.py
@@ -1,16 +1,18 @@
 from __future__ import annotations
 
-import json
-import os
+from typing import Self
 
 import torch
-from safetensors.torch import load_model as load_safetensors_model
-from safetensors.torch import save_model as save_safetensors_model
 from torch import nn
 
+from sentence_transformers.models.Module import Module
 
-class CNN(nn.Module):
+
+class CNN(Module):
     """CNN-layer with multiple kernel-sizes over the word embeddings"""
+
+    config_keys: list[str] = ["in_word_embedding_dimension", "out_channels", "kernel_sizes"]
+    config_file_name: str = "cnn_config.json"
 
     def __init__(
         self,
@@ -20,7 +22,6 @@ class CNN(nn.Module):
         stride_sizes: list[int] = None,
     ):
         nn.Module.__init__(self)
-        self.config_keys = ["in_word_embedding_dimension", "out_channels", "kernel_sizes"]
         self.in_word_embedding_dimension = in_word_embedding_dimension
         self.out_channels = out_channels
         self.kernel_sizes = kernel_sizes
@@ -56,33 +57,29 @@ class CNN(nn.Module):
     def get_word_embedding_dimension(self) -> int:
         return self.embeddings_dimension
 
-    def tokenize(self, text: str, **kwargs) -> list[int]:
-        raise NotImplementedError()
+    def save(self, output_path: str, *args, safe_serialization: bool = True, **kwargs) -> None:
+        self.save_config(output_path)
+        self.save_torch_weights(output_path, safe_serialization=safe_serialization)
 
-    def save(self, output_path: str, safe_serialization: bool = True):
-        with open(os.path.join(output_path, "cnn_config.json"), "w") as fOut:
-            json.dump(self.get_config_dict(), fOut, indent=2)
-
-        if safe_serialization:
-            save_safetensors_model(self, os.path.join(output_path, "model.safetensors"))
-        else:
-            torch.save(self.state_dict(), os.path.join(output_path, "pytorch_model.bin"))
-
-    def get_config_dict(self):
-        return {key: self.__dict__[key] for key in self.config_keys}
-
-    @staticmethod
-    def load(input_path: str):
-        with open(os.path.join(input_path, "cnn_config.json")) as fIn:
-            config = json.load(fIn)
-
-        model = CNN(**config)
-        if os.path.exists(os.path.join(input_path, "model.safetensors")):
-            load_safetensors_model(model, os.path.join(input_path, "model.safetensors"))
-        else:
-            model.load_state_dict(
-                torch.load(
-                    os.path.join(input_path, "pytorch_model.bin"), map_location=torch.device("cpu"), weights_only=True
-                )
-            )
+    @classmethod
+    def load(
+        cls,
+        model_name_or_path: str,
+        subfolder: str = "",
+        token: bool | str | None = None,
+        cache_folder: str | None = None,
+        revision: str | None = None,
+        local_files_only: bool = False,
+        **kwargs,
+    ) -> Self:
+        hub_kwargs = {
+            "subfolder": subfolder,
+            "token": token,
+            "cache_folder": cache_folder,
+            "revision": revision,
+            "local_files_only": local_files_only,
+        }
+        config = cls.load_config(model_name_or_path=model_name_or_path, **hub_kwargs)
+        model = cls(**config)
+        model = cls.load_torch_weights(model_name_or_path=model_name_or_path, model=model, **hub_kwargs)
         return model

--- a/sentence_transformers/models/CNN.py
+++ b/sentence_transformers/models/CNN.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
-from typing import Self
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 import torch
 from torch import nn

--- a/sentence_transformers/models/Dense.py
+++ b/sentence_transformers/models/Dense.py
@@ -107,8 +107,7 @@ class Dense(Module):
             **hub_kwargs,
         )
         config["activation_function"] = import_from_string(config["activation_function"])()
-
-        model = Dense(**config)
+        model = cls(**config)
 
         safetensors_path = cls.load_file_path(
             model_name_or_path,

--- a/sentence_transformers/models/Dense.py
+++ b/sentence_transformers/models/Dense.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
-from typing import Callable, Self
+from typing import Callable
+
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 from torch import Tensor, nn
 

--- a/sentence_transformers/models/Dense.py
+++ b/sentence_transformers/models/Dense.py
@@ -1,12 +1,7 @@
 from __future__ import annotations
 
-import os
-from pathlib import Path
 from typing import Callable, Self
 
-import torch
-from safetensors.torch import load_model as load_safetensors_model
-from safetensors.torch import save_model as save_safetensors_model
 from torch import Tensor, nn
 
 from sentence_transformers.models.Module import Module
@@ -75,11 +70,7 @@ class Dense(Module):
 
     def save(self, output_path: str, *args, safe_serialization: bool = True, **kwargs) -> None:
         self.save_config(output_path)
-
-        if safe_serialization:
-            save_safetensors_model(self, os.path.join(output_path, "model.safetensors"))
-        else:
-            torch.save(self.state_dict(), os.path.join(output_path, "pytorch_model.bin"))
+        self.save_torch_weights(output_path, safe_serialization=safe_serialization)
 
     def __repr__(self):
         return f"Dense({self.get_config_dict()})"
@@ -88,7 +79,7 @@ class Dense(Module):
     def load(
         cls,
         model_name_or_path: str,
-        directory: str = "",
+        subfolder: str = "",
         token: bool | str | None = None,
         cache_folder: str | None = None,
         revision: str | None = None,
@@ -96,34 +87,14 @@ class Dense(Module):
         **kwargs,
     ) -> Self:
         hub_kwargs = {
+            "subfolder": subfolder,
             "token": token,
             "cache_folder": cache_folder,
             "revision": revision,
             "local_files_only": local_files_only,
         }
-        config = cls.load_config(
-            model_name_or_path=model_name_or_path,
-            directory=directory,
-            **hub_kwargs,
-        )
+        config = cls.load_config(model_name_or_path=model_name_or_path, **hub_kwargs)
         config["activation_function"] = import_from_string(config["activation_function"])()
         model = cls(**config)
-
-        safetensors_path = cls.load_file_path(
-            model_name_or_path,
-            filename=Path(directory, "model.safetensors"),
-            **hub_kwargs,
-        )
-        if safetensors_path is not None:
-            load_safetensors_model(model, safetensors_path)
-        else:
-            pytorch_model_path = cls.load_file_path(
-                model_name_or_path,
-                filename=Path(directory, "pytorch_model.bin"),
-                **hub_kwargs,
-            )
-            if pytorch_model_path is None:
-                raise ValueError(f"Could not find 'model.safetensors' or 'pytorch_model.bin' in {model_name_or_path}.")
-
-            model.load_state_dict(torch.load(pytorch_model_path, map_location=torch.device("cpu"), weights_only=True))
+        model = cls.load_torch_weights(model_name_or_path=model_name_or_path, model=model, **hub_kwargs)
         return model

--- a/sentence_transformers/models/Dropout.py
+++ b/sentence_transformers/models/Dropout.py
@@ -1,17 +1,20 @@
 from __future__ import annotations
 
-import json
-import os
+from typing import Self
 
 from torch import Tensor, nn
 
+from sentence_transformers.SentenceTransformer import Module
 
-class Dropout(nn.Module):
+
+class Dropout(Module):
     """Dropout layer.
 
     Args:
         dropout: Sets a dropout value for dense layer.
     """
+
+    config_keys: list[str] = ["dropout"]
 
     def __init__(self, dropout: float = 0.2):
         super().__init__()
@@ -22,14 +25,26 @@ class Dropout(nn.Module):
         features.update({"sentence_embedding": self.dropout_layer(features["sentence_embedding"])})
         return features
 
-    def save(self, output_path):
-        with open(os.path.join(output_path, "config.json"), "w") as fOut:
-            json.dump({"dropout": self.dropout}, fOut)
+    def save(self, output_path: str, *args, safe_serialization: bool = True, **kwargs) -> None:
+        self.save_config(output_path)
 
-    @staticmethod
-    def load(input_path):
-        with open(os.path.join(input_path, "config.json")) as fIn:
-            config = json.load(fIn)
-
-        model = Dropout(**config)
-        return model
+    @classmethod
+    def load(
+        cls,
+        model_name_or_path: str,
+        directory: str = "",
+        token: bool | str | None = None,
+        cache_folder: str | None = None,
+        revision: str | None = None,
+        local_files_only: bool = False,
+        **kwargs,
+    ) -> Self:
+        config = cls.load_config(
+            model_name_or_path,
+            directory=directory,
+            token=token,
+            cache_folder=cache_folder,
+            revision=revision,
+            local_files_only=local_files_only,
+        )
+        return cls(**config)

--- a/sentence_transformers/models/Dropout.py
+++ b/sentence_transformers/models/Dropout.py
@@ -1,10 +1,8 @@
 from __future__ import annotations
 
-from typing import Self
-
 from torch import Tensor, nn
 
-from sentence_transformers.SentenceTransformer import Module
+from sentence_transformers.models.Module import Module
 
 
 class Dropout(Module):
@@ -27,24 +25,3 @@ class Dropout(Module):
 
     def save(self, output_path: str, *args, safe_serialization: bool = True, **kwargs) -> None:
         self.save_config(output_path)
-
-    @classmethod
-    def load(
-        cls,
-        model_name_or_path: str,
-        directory: str = "",
-        token: bool | str | None = None,
-        cache_folder: str | None = None,
-        revision: str | None = None,
-        local_files_only: bool = False,
-        **kwargs,
-    ) -> Self:
-        config = cls.load_config(
-            model_name_or_path,
-            directory=directory,
-            token=token,
-            cache_folder=cache_folder,
-            revision=revision,
-            local_files_only=local_files_only,
-        )
-        return cls(**config)

--- a/sentence_transformers/models/InputModule.py
+++ b/sentence_transformers/models/InputModule.py
@@ -10,9 +10,7 @@ from transformers.tokenization_utils_base import PreTrainedTokenizerBase
 from sentence_transformers.models.Module import Module
 
 
-# TODO: BaseModule? ModuleBase?
-# TODO: "WithTokenizer" might be problematic if we're going multi-modal
-class ModuleWithTokenizer(Module):
+class InputModule(Module):
     save_in_root: bool = True
     tokenizer: PreTrainedTokenizerBase | Tokenizer
 

--- a/sentence_transformers/models/InputModule.py
+++ b/sentence_transformers/models/InputModule.py
@@ -11,13 +11,77 @@ from sentence_transformers.models.Module import Module
 
 
 class InputModule(Module):
+    """
+    Subclass of :class:`sentence_transformers.models.Module`, base class for all input modules in the Sentence
+    Transformers library, i.e. modules that are used to process inputs and optionally also perform processing
+    in the forward pass.
+
+    This class provides a common interface for all input modules, including methods for loading and saving the module's
+    configuration and weights, as well as input processing. It also provides a method for performing the forward pass
+    of the module.
+
+    Three abstract methods are defined in this class, which must be implemented by subclasses:
+
+    - :meth:`sentence_transformers.models.Module.forward`: The forward pass of the module.
+    - :meth:`sentence_transformers.models.Module.save`: Save the module to disk.
+    - :meth:`sentence_transformers.models.InputModule.tokenize`: Tokenize the input texts and return a dictionary of tokenized features.
+
+    Optionally, you may also have to override:
+
+    - :meth:`sentence_transformers.models.Module.load`: Load the module from disk.
+
+    To assist with loading and saving the module, several utility methods are provided:
+
+    - :meth:`sentence_transformers.models.Module.load_config`: Load the module's configuration from a JSON file.
+    - :meth:`sentence_transformers.models.Module.load_file_path`: Load a file from the module's directory, regardless of whether the module is saved locally or on Hugging Face.
+    - :meth:`sentence_transformers.models.Module.load_dir_path`: Load a directory from the module's directory, regardless of whether the module is saved locally or on Hugging Face.
+    - :meth:`sentence_transformers.models.Module.load_torch_weights`: Load the PyTorch weights of the module, regardless of whether the module is saved locally or on Hugging Face.
+    - :meth:`sentence_transformers.models.Module.save_config`: Save the module's configuration to a JSON file.
+    - :meth:`sentence_transformers.models.Module.save_torch_weights`: Save the PyTorch weights of the module.
+    - :meth:`sentence_transformers.models.InputModule.save_tokenizer`: Save the tokenizer used by the module.
+    - :meth:`sentence_transformers.models.Module.get_config_dict`: Get the module's configuration as a dictionary.
+
+    And several class variables are defined to assist with loading and saving the module:
+
+    - :attr:`sentence_transformers.models.Module.config_file_name`: The name of the configuration file used to save the module's configuration.
+    - :attr:`sentence_transformers.models.Module.config_keys`: A list of keys used to save the module's configuration.
+    - :attr:`sentence_transformers.models.InputModule.save_in_root`: Whether to save the module's configuration in the root directory of the model or in a subdirectory named after the module.
+    - :attr:`sentence_transformers.models.InputModule.tokenizer`: The tokenizer used by the module.
+    """
+
     save_in_root: bool = True
     tokenizer: PreTrainedTokenizerBase | Tokenizer
+    """
+    The tokenizer used for tokenizing the input texts. It can be either a
+    :class:`transformers.PreTrainedTokenizerBase` subclass or a Tokenizer from the
+    ``tokenizers`` library.
+    """
 
     @abstractmethod
-    def tokenize(self, texts: list[str], **kwargs) -> dict[str, torch.Tensor | Any]: ...
+    def tokenize(self, texts: list[str], **kwargs) -> dict[str, torch.Tensor | Any]:
+        """
+        Tokenizes the input texts and returns a dictionary of tokenized features.
+
+        Args:
+            texts (list[str]): List of input texts to tokenize.
+            **kwargs: Additional keyword arguments for tokenization.
+
+        Returns:
+            dict[str, torch.Tensor | Any]: Dictionary containing tokenized features, e.g.
+                ``{"input_ids": ..., "attention_mask": ...}``
+        """
 
     def save_tokenizer(self, output_path: str, **kwargs) -> None:
+        """
+        Saves the tokenizer to the specified output path.
+
+        Args:
+            output_path (str): Path to save the tokenizer.
+            **kwargs: Additional keyword arguments for saving the tokenizer.
+
+        Returns:
+            None
+        """
         if not hasattr(self, "tokenizer"):
             return
 

--- a/sentence_transformers/models/LSTM.py
+++ b/sentence_transformers/models/LSTM.py
@@ -1,16 +1,18 @@
 from __future__ import annotations
 
-import json
-import os
+from typing import Self
 
 import torch
-from safetensors.torch import load_model as load_safetensors_model
-from safetensors.torch import save_model as save_safetensors_model
 from torch import nn
 
+from sentence_transformers.models.Module import Module
 
-class LSTM(nn.Module):
+
+class LSTM(Module):
     """Bidirectional LSTM running over word embeddings."""
+
+    config_keys: list[str] = ["word_embedding_dimension", "hidden_dim", "num_layers", "dropout", "bidirectional"]
+    config_file_name: str = "lstm_config.json"
 
     def __init__(
         self,
@@ -20,8 +22,7 @@ class LSTM(nn.Module):
         dropout: float = 0,
         bidirectional: bool = True,
     ):
-        nn.Module.__init__(self)
-        self.config_keys = ["word_embedding_dimension", "hidden_dim", "num_layers", "dropout", "bidirectional"]
+        super().__init__()
         self.word_embedding_dimension = word_embedding_dimension
         self.hidden_dim = hidden_dim
         self.num_layers = num_layers
@@ -56,35 +57,35 @@ class LSTM(nn.Module):
     def get_word_embedding_dimension(self) -> int:
         return self.embeddings_dimension
 
-    def tokenize(self, text: str, **kwargs) -> list[int]:
-        raise NotImplementedError()
+    def save(self, output_path: str, *args, safe_serialization: bool = True, **kwargs) -> None:
+        self.save_config(output_path)
 
-    def save(self, output_path: str, safe_serialization: bool = True):
-        with open(os.path.join(output_path, "lstm_config.json"), "w") as fOut:
-            json.dump(self.get_config_dict(), fOut, indent=2)
-
+        # Saving LSTM models with Safetensors does not work unless the weights are on CPU
+        # See https://github.com/UKPLab/sentence-transformers/pull/2722
         device = next(self.parameters()).device
-        if safe_serialization:
-            save_safetensors_model(self.cpu(), os.path.join(output_path, "model.safetensors"))
-            self.to(device)
-        else:
-            torch.save(self.state_dict(), os.path.join(output_path, "pytorch_model.bin"))
+        self.cpu()
+        self.save_torch_weights(output_path, safe_serialization=safe_serialization)
+        self.to(device)
 
-    def get_config_dict(self):
-        return {key: self.__dict__[key] for key in self.config_keys}
-
-    @staticmethod
-    def load(input_path: str):
-        with open(os.path.join(input_path, "lstm_config.json")) as fIn:
-            config = json.load(fIn)
-
-        model = LSTM(**config)
-        if os.path.exists(os.path.join(input_path, "model.safetensors")):
-            load_safetensors_model(model, os.path.join(input_path, "model.safetensors"))
-        else:
-            model.load_state_dict(
-                torch.load(
-                    os.path.join(input_path, "pytorch_model.bin"), map_location=torch.device("cpu"), weights_only=True
-                )
-            )
+    @classmethod
+    def load(
+        cls,
+        model_name_or_path: str,
+        subfolder: str = "",
+        token: bool | str | None = None,
+        cache_folder: str | None = None,
+        revision: str | None = None,
+        local_files_only: bool = False,
+        **kwargs,
+    ) -> Self:
+        hub_kwargs = {
+            "subfolder": subfolder,
+            "token": token,
+            "cache_folder": cache_folder,
+            "revision": revision,
+            "local_files_only": local_files_only,
+        }
+        config = cls.load_config(model_name_or_path=model_name_or_path, **hub_kwargs)
+        model = cls(**config)
+        model = cls.load_torch_weights(model_name_or_path=model_name_or_path, model=model, **hub_kwargs)
         return model

--- a/sentence_transformers/models/LSTM.py
+++ b/sentence_transformers/models/LSTM.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
-from typing import Self
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 import torch
 from torch import nn

--- a/sentence_transformers/models/LayerNorm.py
+++ b/sentence_transformers/models/LayerNorm.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
-from typing import Self
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 from torch import Tensor, nn
 

--- a/sentence_transformers/models/LayerNorm.py
+++ b/sentence_transformers/models/LayerNorm.py
@@ -1,12 +1,7 @@
 from __future__ import annotations
 
-import os
-from pathlib import Path
 from typing import Self
 
-import torch
-from safetensors.torch import load_model as load_safetensors_model
-from safetensors.torch import save_model as save_safetensors_model
 from torch import Tensor, nn
 
 from sentence_transformers.models.Module import Module
@@ -29,17 +24,13 @@ class LayerNorm(Module):
 
     def save(self, output_path, safe_serialization: bool = True) -> None:
         self.save_config(output_path)
-
-        if safe_serialization:
-            save_safetensors_model(self, os.path.join(output_path, "model.safetensors"))
-        else:
-            torch.save(self.state_dict(), os.path.join(output_path, "pytorch_model.bin"))
+        self.save_torch_weights(output_path, safe_serialization=safe_serialization)
 
     @classmethod
     def load(
         cls,
         model_name_or_path: str,
-        directory: str = "",
+        subfolder: str = "",
         token: bool | str | None = None,
         cache_folder: str | None = None,
         revision: str | None = None,
@@ -47,33 +38,13 @@ class LayerNorm(Module):
         **kwargs,
     ) -> Self:
         hub_kwargs = {
+            "subfolder": subfolder,
             "token": token,
             "cache_folder": cache_folder,
             "revision": revision,
             "local_files_only": local_files_only,
         }
-        config = cls.load_config(
-            model_name_or_path=model_name_or_path,
-            directory=directory,
-            **hub_kwargs,
-        )
+        config = cls.load_config(model_name_or_path=model_name_or_path, **hub_kwargs)
         model = cls(**config)
-
-        safetensors_path = cls.load_file_path(
-            model_name_or_path,
-            filename=Path(directory, "model.safetensors"),
-            **hub_kwargs,
-        )
-        if safetensors_path is not None:
-            load_safetensors_model(model, safetensors_path)
-        else:
-            pytorch_model_path = cls.load_file_path(
-                model_name_or_path,
-                filename=Path(directory, "pytorch_model.bin"),
-                **hub_kwargs,
-            )
-            if pytorch_model_path is None:
-                raise ValueError(f"Could not find 'model.safetensors' or 'pytorch_model.bin' in {model_name_or_path}.")
-
-            model.load_state_dict(torch.load(pytorch_model_path, map_location=torch.device("cpu"), weights_only=True))
+        model = cls.load_torch_weights(model_name_or_path=model_name_or_path, model=model, **hub_kwargs)
         return model

--- a/sentence_transformers/models/Module.py
+++ b/sentence_transformers/models/Module.py
@@ -8,7 +8,7 @@ from typing import Any, Self
 
 import torch
 
-from sentence_transformers.util import load_file_path
+from sentence_transformers.util import load_dir_path, load_file_path
 
 
 # BaseModule? ModuleBase?
@@ -93,6 +93,24 @@ class Module(ABC, torch.nn.Module):
         return load_file_path(
             model_name_or_path=model_name_or_path,
             filename=filename,
+            token=token,
+            cache_folder=cache_folder,
+            revision=revision,
+            local_files_only=local_files_only,
+        )
+
+    @staticmethod
+    def load_dir_path(
+        model_name_or_path: str,
+        directory: str = "",
+        token: bool | str | None = None,
+        cache_folder: str | None = None,
+        revision: str | None = None,
+        local_files_only: bool = False,
+    ) -> str:
+        return load_dir_path(
+            model_name_or_path=model_name_or_path,
+            directory=directory,
             token=token,
             cache_folder=cache_folder,
             revision=revision,

--- a/sentence_transformers/models/Module.py
+++ b/sentence_transformers/models/Module.py
@@ -99,6 +99,7 @@ class Module(ABC, torch.nn.Module):
             local_files_only=local_files_only,
         )
 
+    @abstractmethod
     def save(self, output_path: str, *args, safe_serialization: bool = True, **kwargs) -> None: ...
 
     def save_config(self, output_path: str, filename: str | None = None) -> None:

--- a/sentence_transformers/models/Module.py
+++ b/sentence_transformers/models/Module.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import json
+import os
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import Any, Self
+
+import torch
+
+from sentence_transformers.util import load_file_path
+
+
+# BaseModule? ModuleBase?
+class Module(ABC, torch.nn.Module):
+    config_file_name: str = "config.json"
+    save_in_root: bool = False
+    config_keys: list[str] = []
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    @abstractmethod
+    def forward(self, features: dict[str, torch.Tensor | Any], **kwargs) -> dict[str, torch.Tensor | Any]: ...
+
+    def get_config_dict(self) -> dict[str, Any]:
+        return {key: getattr(self, key) for key in self.config_keys}
+
+    @classmethod
+    def load(
+        cls,
+        model_name_or_path: str,
+        directory: str = "",
+        token: bool | str | None = None,
+        cache_folder: str | None = None,
+        revision: str | None = None,
+        local_files_only: bool = False,
+        **kwargs,
+    ) -> Self:
+        config = cls.load_config(
+            model_name_or_path,
+            directory=directory,
+            token=token,
+            cache_folder=cache_folder,
+            revision=revision,
+            local_files_only=local_files_only,
+        )
+        return cls(model_name_or_path, **config)
+
+    @classmethod
+    def load_config(
+        cls,
+        model_name_or_path: str,
+        directory: str = "",
+        config_filename: str | None = None,
+        token: bool | str | None = None,
+        cache_folder: str | None = None,
+        revision: str | None = None,
+        local_files_only: bool = False,
+    ) -> dict[str, Any]:
+        """
+        Load the config file from the model directory. The config file is expected to be in JSON format.
+
+        Args:
+            model_name_or_path (str): The path to the model directory or the name of the model.
+        """
+        config_filename = config_filename or cls.config_file_name
+        config_file_path = Path(directory) / config_filename
+        config_path = load_file_path(
+            model_name_or_path=model_name_or_path,
+            filename=config_file_path,
+            token=token,
+            cache_folder=cache_folder,
+            revision=revision,
+            local_files_only=local_files_only,
+        )
+        if config_path is None:
+            return {}
+
+        with open(config_path, encoding="utf-8") as f:
+            config = json.load(f)
+        return config
+
+    @staticmethod
+    def load_file_path(
+        model_name_or_path: str,
+        filename: str,
+        token: bool | str | None = None,
+        cache_folder: str | None = None,
+        revision: str | None = None,
+        local_files_only: bool = False,
+    ) -> str | None:
+        return load_file_path(
+            model_name_or_path=model_name_or_path,
+            filename=filename,
+            token=token,
+            cache_folder=cache_folder,
+            revision=revision,
+            local_files_only=local_files_only,
+        )
+
+    def save(self, output_path: str, *args, safe_serialization: bool = True, **kwargs) -> None: ...
+
+    def save_config(self, output_path: str, filename: str | None = None) -> None:
+        config = self.get_config_dict()
+        config_output_path = os.path.join(output_path, filename or self.config_file_name)
+        with open(config_output_path, "w", encoding="utf-8") as f:
+            json.dump(config, f, indent=4)

--- a/sentence_transformers/models/Module.py
+++ b/sentence_transformers/models/Module.py
@@ -13,7 +13,6 @@ from safetensors.torch import save_model as save_safetensors_model
 from sentence_transformers.util import load_dir_path, load_file_path
 
 
-# BaseModule? ModuleBase?
 class Module(ABC, torch.nn.Module):
     config_file_name: str = "config.json"
     config_keys: list[str] = []

--- a/sentence_transformers/models/Module.py
+++ b/sentence_transformers/models/Module.py
@@ -3,10 +3,12 @@ from __future__ import annotations
 import json
 import os
 from abc import ABC, abstractmethod
-from pathlib import Path
 from typing import Any, Self
 
 import torch
+from safetensors.torch import load_file as load_safetensors_file
+from safetensors.torch import load_model as load_safetensors_model
+from safetensors.torch import save_model as save_safetensors_model
 
 from sentence_transformers.util import load_dir_path, load_file_path
 
@@ -14,8 +16,8 @@ from sentence_transformers.util import load_dir_path, load_file_path
 # BaseModule? ModuleBase?
 class Module(ABC, torch.nn.Module):
     config_file_name: str = "config.json"
-    save_in_root: bool = False
     config_keys: list[str] = []
+    save_in_root: bool = False
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -30,7 +32,7 @@ class Module(ABC, torch.nn.Module):
     def load(
         cls,
         model_name_or_path: str,
-        directory: str = "",
+        subfolder: str = "",
         token: bool | str | None = None,
         cache_folder: str | None = None,
         revision: str | None = None,
@@ -39,19 +41,19 @@ class Module(ABC, torch.nn.Module):
     ) -> Self:
         config = cls.load_config(
             model_name_or_path,
-            directory=directory,
+            subfolder=subfolder,
             token=token,
             cache_folder=cache_folder,
             revision=revision,
             local_files_only=local_files_only,
         )
-        return cls(model_name_or_path, **config)
+        return cls(**config)
 
     @classmethod
     def load_config(
         cls,
         model_name_or_path: str,
-        directory: str = "",
+        subfolder: str = "",
         config_filename: str | None = None,
         token: bool | str | None = None,
         cache_folder: str | None = None,
@@ -59,16 +61,15 @@ class Module(ABC, torch.nn.Module):
         local_files_only: bool = False,
     ) -> dict[str, Any]:
         """
-        Load the config file from the model directory. The config file is expected to be in JSON format.
+        Load the config file from the model subfolder. The config file is expected to be in JSON format.
 
         Args:
-            model_name_or_path (str): The path to the model directory or the name of the model.
+            model_name_or_path (str): The path to the model subfolder or the name of the model.
         """
-        config_filename = config_filename or cls.config_file_name
-        config_file_path = Path(directory, config_filename)
         config_path = load_file_path(
             model_name_or_path=model_name_or_path,
-            filename=config_file_path,
+            filename=config_filename or cls.config_file_name,
+            subfolder=subfolder,
             token=token,
             cache_folder=cache_folder,
             revision=revision,
@@ -85,6 +86,7 @@ class Module(ABC, torch.nn.Module):
     def load_file_path(
         model_name_or_path: str,
         filename: str,
+        subfolder: str = "",
         token: bool | str | None = None,
         cache_folder: str | None = None,
         revision: str | None = None,
@@ -93,6 +95,7 @@ class Module(ABC, torch.nn.Module):
         return load_file_path(
             model_name_or_path=model_name_or_path,
             filename=filename,
+            subfolder=subfolder,
             token=token,
             cache_folder=cache_folder,
             revision=revision,
@@ -102,7 +105,7 @@ class Module(ABC, torch.nn.Module):
     @staticmethod
     def load_dir_path(
         model_name_or_path: str,
-        directory: str = "",
+        subfolder: str = "",
         token: bool | str | None = None,
         cache_folder: str | None = None,
         revision: str | None = None,
@@ -110,12 +113,53 @@ class Module(ABC, torch.nn.Module):
     ) -> str:
         return load_dir_path(
             model_name_or_path=model_name_or_path,
-            directory=directory,
+            subfolder=subfolder,
             token=token,
             cache_folder=cache_folder,
             revision=revision,
             local_files_only=local_files_only,
         )
+
+    @classmethod
+    def load_torch_weights(
+        cls,
+        model_name_or_path: str,
+        subfolder: str = "",
+        token: bool | str | None = None,
+        cache_folder: str | None = None,
+        revision: str | None = None,
+        local_files_only: bool = False,
+        model: torch.nn.Module | None = None,
+    ):
+        hub_kwargs = {
+            "subfolder": subfolder,
+            "token": token,
+            "cache_folder": cache_folder,
+            "revision": revision,
+            "local_files_only": local_files_only,
+        }
+        # 1. Attempt to load a safetensors file from the local or remote directory
+        safetensors_path = cls.load_file_path(model_name_or_path, filename="model.safetensors", **hub_kwargs)
+        if safetensors_path is not None:
+            # Either load the weights into the model or return the weights
+            if model is not None:
+                load_safetensors_model(model, safetensors_path)
+                return model
+            else:
+                weights = load_safetensors_file(safetensors_path)
+                return weights
+
+        # 2. If safetensors file is not found, attempt to load a pytorch model file
+        # from the local or remote directory
+        pytorch_model_path = cls.load_file_path(model_name_or_path, filename="pytorch_model.bin", **hub_kwargs)
+        if pytorch_model_path is None:
+            raise ValueError(f"Could not find 'model.safetensors' or 'pytorch_model.bin' in {model_name_or_path}.")
+
+        weights = torch.load(pytorch_model_path, map_location=torch.device("cpu"), weights_only=True)
+        if model is not None:
+            model.load_state_dict(weights)
+            return model
+        return weights
 
     @abstractmethod
     def save(self, output_path: str, *args, safe_serialization: bool = True, **kwargs) -> None: ...
@@ -125,3 +169,9 @@ class Module(ABC, torch.nn.Module):
         config_output_path = os.path.join(output_path, filename or self.config_file_name)
         with open(config_output_path, "w", encoding="utf-8") as f:
             json.dump(config, f, indent=4)
+
+    def save_torch_weights(self, output_path: str, safe_serialization: bool = True) -> None:
+        if safe_serialization:
+            save_safetensors_model(self, os.path.join(output_path, "model.safetensors"))
+        else:
+            torch.save(self.state_dict(), os.path.join(output_path, "pytorch_model.bin"))

--- a/sentence_transformers/models/Module.py
+++ b/sentence_transformers/models/Module.py
@@ -19,17 +19,94 @@ from sentence_transformers.util import load_dir_path, load_file_path
 
 
 class Module(ABC, torch.nn.Module):
+    """
+    Base class for all modules in the Sentence Transformers library.
+
+    This class provides a common interface for all modules, including methods for loading and saving the module's
+    configuration and weights. It also provides a method for performing the forward pass of the module.
+
+    Two abstract methods are defined in this class, which must be implemented by subclasses:
+
+    - :meth:`sentence_transformers.models.Module.forward`: The forward pass of the module.
+    - :meth:`sentence_transformers.models.Module.save`: Save the module to disk.
+
+    Optionally, you may also have to override:
+
+    - :meth:`sentence_transformers.models.Module.load`: Load the module from disk.
+
+    To assist with loading and saving the module, several utility methods are provided:
+
+    - :meth:`sentence_transformers.models.Module.load_config`: Load the module's configuration from a JSON file.
+    - :meth:`sentence_transformers.models.Module.load_file_path`: Load a file from the module's directory, regardless of whether the module is saved locally or on Hugging Face.
+    - :meth:`sentence_transformers.models.Module.load_dir_path`: Load a directory from the module's directory, regardless of whether the module is saved locally or on Hugging Face.
+    - :meth:`sentence_transformers.models.Module.load_torch_weights`: Load the PyTorch weights of the module, regardless of whether the module is saved locally or on Hugging Face.
+    - :meth:`sentence_transformers.models.Module.save_config`: Save the module's configuration to a JSON file.
+    - :meth:`sentence_transformers.models.Module.save_torch_weights`: Save the PyTorch weights of the module.
+    - :meth:`sentence_transformers.models.Module.get_config_dict`: Get the module's configuration as a dictionary.
+
+    And several class variables are defined to assist with loading and saving the module:
+
+    - :attr:`sentence_transformers.models.Module.config_file_name`: The name of the configuration file used to save the module's configuration.
+    - :attr:`sentence_transformers.models.Module.config_keys`: A list of keys used to save the module's configuration.
+    - :attr:`sentence_transformers.models.Module.save_in_root`: Whether to save the module's configuration in the root directory of the model or in a subdirectory named after the module.
+    """
+
     config_file_name: str = "config.json"
+    """
+    The name of the configuration file used to save the module's configuration. This file is used to initialize the
+    module when loading it from a pre-trained model.
+    """
     config_keys: list[str] = []
+    """
+    A list of keys used to save the module's configuration. These keys are used to save the module's configuration
+    when saving the model to disk.
+    """
     save_in_root: bool = False
+    """
+    Whether to save the module's configuration in the root directory of the model or in a subdirectory named after the module.
+    """
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
     @abstractmethod
-    def forward(self, features: dict[str, torch.Tensor | Any], **kwargs) -> dict[str, torch.Tensor | Any]: ...
+    def forward(self, features: dict[str, torch.Tensor | Any], **kwargs) -> dict[str, torch.Tensor | Any]:
+        """
+        Forward pass of the module. This method should be overridden by subclasses to implement the specific behavior of the module.
+
+        The forward method takes a dictionary of features as input and returns a dictionary of features as output.
+        The keys in the ``features`` dictionary depend on the position of the module in the model pipeline, as
+        the ``features`` dictionary is passed from one module to the next. Common keys in the ``features`` dictionary
+        are:
+
+            - ``input_ids``: The input IDs of the tokens in the input text.
+            - ``attention_mask``: The attention mask for the input tokens.
+            - ``token_type_ids``: The token type IDs for the input tokens.
+            - ``token_embeddings``: The token embeddings for the input tokens.
+            - ``sentence_embedding``: The sentence embedding for the input text, i.e. pooled token embeddings.
+
+        Optionally, the ``forward`` method can accept additional keyword arguments (``**kwargs``) that can be used to
+        pass additional information from ``model.encode`` to this module.
+
+        Args:
+            features (dict[str, torch.Tensor | Any]): A dictionary of features to be processed by the module.
+            **kwargs: Additional keyword arguments that can be used to pass additional information from ``model.encode``.
+
+        Returns:
+            dict[str, torch.Tensor | Any]: A dictionary of features after processing by the module.
+        """
 
     def get_config_dict(self) -> dict[str, Any]:
+        """
+        Returns a dictionary of the configuration parameters of the module.
+
+        These parameters are used to save the module's configuration when saving the model to disk, and again used
+        to initialize the module when loading it from a pre-trained model. The keys used in the dictionary are defined in the
+        ``config_keys`` class variable.
+
+        Returns:
+            dict[str, Any]: A dictionary of the configuration parameters of the module.
+        """
         return {key: getattr(self, key) for key in self.config_keys}
 
     @classmethod
@@ -43,6 +120,27 @@ class Module(ABC, torch.nn.Module):
         local_files_only: bool = False,
         **kwargs,
     ) -> Self:
+        """
+        Load this module from a model checkpoint. The checkpoint can be either a local directory or a model id on Hugging Face.
+
+        Args:
+            model_name_or_path (str): The path to the model directory or the name of the model on Hugging Face.
+            subfolder (str, optional): The subfolder within the model directory to load from, e.g. ``"1_Pooling"``.
+                Defaults to ``""``.
+            token (bool | str | None, optional): The token to use for authentication when loading from Hugging Face.
+                If None, tries to use a token saved using ``huggingface-cli login`` or the ``HF_TOKEN`` environment variable.
+                Defaults to None.
+            cache_folder (str | None, optional): The folder to use for caching the model files.
+                If None, uses the default cache folder for Hugging Face, ``~/.cache/huggingface``. Defaults to None.
+            revision (str | None, optional): The revision of the model to load.
+                If None, uses the latest revision. Defaults to None.
+            local_files_only (bool, optional): Whether to only load local files. Defaults to False.
+            **kwargs: Additional module-specific arguments used in an overridden ``load`` method, such as ``trust_remote_code``,
+                ``model_kwargs``, ``tokenizer_kwargs``, ``config_kwargs``, ``backend``, etc.
+
+        Returns:
+            Self: The loaded module.
+        """
         config = cls.load_config(
             model_name_or_path,
             subfolder=subfolder,
@@ -65,10 +163,27 @@ class Module(ABC, torch.nn.Module):
         local_files_only: bool = False,
     ) -> dict[str, Any]:
         """
-        Load the config file from the model subfolder. The config file is expected to be in JSON format.
+        Load the configuration of the module from a model checkpoint. The checkpoint can be either a local directory or a model id on Hugging Face.
+        The configuration is loaded from a JSON file, which contains the parameters used to initialize the module.
 
         Args:
-            model_name_or_path (str): The path to the model subfolder or the name of the model.
+            model_name_or_path (str): The path to the model directory or the name of the model on Hugging Face.
+            subfolder (str, optional): The subfolder within the model directory to load from, e.g. ``"1_Pooling"``.
+                Defaults to ``""``.
+            config_filename (str | None, optional): The name of the configuration file to load.
+                If None, uses the default configuration file name defined in the ``config_file_name`` class variable.
+                Defaults to None.
+            token (bool | str | None, optional): The token to use for authentication when loading from Hugging Face.
+                If None, tries to use a token saved using ``huggingface-cli login`` or the ``HF_TOKEN`` environment variable.
+                Defaults to None.
+            cache_folder (str | None, optional): The folder to use for caching the model files.
+                If None, uses the default cache folder for Hugging Face, ``~/.cache/huggingface``. Defaults to None.
+            revision (str | None, optional): The revision of the model to load.
+                If None, uses the latest revision. Defaults to None.
+            local_files_only (bool, optional): Whether to only load local files. Defaults to False.
+
+        Returns:
+            dict[str, Any]: A dictionary of the configuration parameters of the module.
         """
         config_path = load_file_path(
             model_name_or_path=model_name_or_path,
@@ -96,6 +211,27 @@ class Module(ABC, torch.nn.Module):
         revision: str | None = None,
         local_files_only: bool = False,
     ) -> str | None:
+        """
+        A utility function to load a file from a model checkpoint. The checkpoint can be either a local directory or a model id on Hugging Face.
+        The file is loaded from the specified subfolder within the model directory.
+
+        Args:
+            model_name_or_path (str): The path to the model directory or the name of the model on Hugging Face.
+            filename (str): The name of the file to load.
+            subfolder (str, optional): The subfolder within the model directory to load from, e.g. ``"1_Pooling"``.
+                Defaults to ``""``.
+            token (bool | str | None, optional): The token to use for authentication when loading from Hugging Face.
+                If None, tries to use a token saved using ``huggingface-cli login`` or the ``HF_TOKEN`` environment variable.
+                Defaults to None.
+            cache_folder (str | None, optional): The folder to use for caching the model files.
+                If None, uses the default cache folder for Hugging Face, ``~/.cache/huggingface``. Defaults to None.
+            revision (str | None, optional): The revision of the model to load.
+                If None, uses the latest revision. Defaults to None.
+            local_files_only (bool, optional): Whether to only load local files. Defaults to False.
+
+        Returns:
+            str | None: The path to the loaded file, or None if the file was not found.
+        """
         return load_file_path(
             model_name_or_path=model_name_or_path,
             filename=filename,
@@ -115,6 +251,25 @@ class Module(ABC, torch.nn.Module):
         revision: str | None = None,
         local_files_only: bool = False,
     ) -> str:
+        """
+        A utility function to load a directory from a model checkpoint. The checkpoint can be either a local directory or a model id on Hugging Face.
+
+        Args:
+            model_name_or_path (str): The path to the model directory or the name of the model on Hugging Face.
+            subfolder (str, optional): The subfolder within the model directory to load from, e.g. ``"1_Pooling"``.
+                Defaults to ``""``.
+            token (bool | str | None, optional): The token to use for authentication when loading from Hugging Face.
+                If None, tries to use a token saved using ``huggingface-cli login`` or the ``HF_TOKEN`` environment variable.
+                Defaults to None.
+            cache_folder (str | None, optional): The folder to use for caching the model files.
+                If None, uses the default cache folder for Hugging Face, ``~/.cache/huggingface``. Defaults to None.
+            revision (str | None, optional): The revision of the model to load.
+                If None, uses the latest revision. Defaults to None.
+            local_files_only (bool, optional): Whether to only load local files. Defaults to False.
+
+        Returns:
+            str: The path to the loaded directory.
+        """
         return load_dir_path(
             model_name_or_path=model_name_or_path,
             subfolder=subfolder,
@@ -133,8 +288,37 @@ class Module(ABC, torch.nn.Module):
         cache_folder: str | None = None,
         revision: str | None = None,
         local_files_only: bool = False,
-        model: torch.nn.Module | None = None,
+        model: Self | None = None,
     ):
+        """
+        A utility function to load the PyTorch weights of a model from a checkpoint. The checkpoint can be either a
+        local directory or a model id on Hugging Face. The weights are loaded from either a ``model.safetensors``
+        file or a ``pytorch_model.bin`` file, depending on which one is available. This method either loads the
+        weights into the model or returns the weights as a state dictionary.
+
+        Args:
+            model_name_or_path (str): The path to the model directory or the name of the model on Hugging Face.
+            subfolder (str, optional): The subfolder within the model directory to load from, e.g. ``"2_Dense"``.
+                Defaults to ``""``.
+            token (bool | str | None, optional): The token to use for authentication when loading from Hugging Face.
+                If None, tries to use a token saved using ``huggingface-cli login`` or the ``HF_TOKEN`` environment variable.
+                Defaults to None.
+            cache_folder (str | None, optional): The folder to use for caching the model files.
+                If None, uses the default cache folder for Hugging Face, ``~/.cache/huggingface``. Defaults to None.
+            revision (str | None, optional): The revision of the model to load.
+                If None, uses the latest revision. Defaults to None.
+            local_files_only (bool, optional): Whether to only load local files. Defaults to False.
+            model (Self | None, optional): The model to load the weights into. If None, returns the weights as a state
+                dictionary. Defaults to None.
+
+        Raises:
+            ValueError: If neither a ``model.safetensors`` file nor a ``pytorch_model.bin`` file is found in the model
+                checkpoint in the ``subfolder``.
+
+        Returns:
+            Self | dict[str, torch.Tensor]: The model with the loaded weights or the weights as a state dictionary,
+                depending on the value of the ``model`` argument.
+        """
         hub_kwargs = {
             "subfolder": subfolder,
             "token": token,
@@ -166,15 +350,47 @@ class Module(ABC, torch.nn.Module):
         return weights
 
     @abstractmethod
-    def save(self, output_path: str, *args, safe_serialization: bool = True, **kwargs) -> None: ...
+    def save(self, output_path: str, *args, safe_serialization: bool = True, **kwargs) -> None:
+        """
+        Save the module to disk. This method should be overridden by subclasses to implement the specific behavior of the module.
+
+        Args:
+            output_path (str): The path to the directory where the module should be saved.
+            *args: Additional arguments that can be used to pass additional information to the save method.
+            safe_serialization (bool, optional): Whether to use the safetensors format for saving the model weights.
+                Defaults to True.
+            **kwargs: Additional keyword arguments that can be used to pass additional information to the save method.
+        """
 
     def save_config(self, output_path: str, filename: str | None = None) -> None:
+        """
+        Save the configuration of the module to a JSON file.
+
+        Args:
+            output_path (str): The path to the directory where the configuration file should be saved.
+            filename (str | None, optional): The name of the configuration file. If None, uses the default configuration
+                file name defined in the ``config_file_name`` class variable. Defaults to None.
+
+        Returns:
+            None
+        """
         config = self.get_config_dict()
         config_output_path = os.path.join(output_path, filename or self.config_file_name)
         with open(config_output_path, "w", encoding="utf-8") as f:
             json.dump(config, f, indent=4)
 
     def save_torch_weights(self, output_path: str, safe_serialization: bool = True) -> None:
+        """
+        Save the PyTorch weights of the module to disk.
+
+        Args:
+            output_path (str): The path to the directory where the weights should be saved.
+            safe_serialization (bool, optional): Whether to use the safetensors format for saving the model weights.
+                Defaults to True.
+
+        Returns:
+            None
+        """
         if safe_serialization:
             save_safetensors_model(self, os.path.join(output_path, "model.safetensors"))
         else:

--- a/sentence_transformers/models/Module.py
+++ b/sentence_transformers/models/Module.py
@@ -3,7 +3,12 @@ from __future__ import annotations
 import json
 import os
 from abc import ABC, abstractmethod
-from typing import Any, Self
+from typing import Any
+
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 import torch
 from safetensors.torch import load_file as load_safetensors_file

--- a/sentence_transformers/models/Module.py
+++ b/sentence_transformers/models/Module.py
@@ -65,7 +65,7 @@ class Module(ABC, torch.nn.Module):
             model_name_or_path (str): The path to the model directory or the name of the model.
         """
         config_filename = config_filename or cls.config_file_name
-        config_file_path = Path(directory) / config_filename
+        config_file_path = Path(directory, config_filename)
         config_path = load_file_path(
             model_name_or_path=model_name_or_path,
             filename=config_file_path,

--- a/sentence_transformers/models/ModuleWithTokenizer.py
+++ b/sentence_transformers/models/ModuleWithTokenizer.py
@@ -13,6 +13,7 @@ from sentence_transformers.models.Module import Module
 # TODO: BaseModule? ModuleBase?
 class ModuleWithTokenizer(Module):
     save_in_root: bool = True
+    tokenizer: PreTrainedTokenizerBase | Tokenizer
 
     @abstractmethod
     def tokenize(self, texts: list[str], **kwargs) -> dict[str, torch.Tensor | Any]: ...

--- a/sentence_transformers/models/ModuleWithTokenizer.py
+++ b/sentence_transformers/models/ModuleWithTokenizer.py
@@ -11,6 +11,7 @@ from sentence_transformers.models.Module import Module
 
 
 # TODO: BaseModule? ModuleBase?
+# "WithTokenizer" might be problematic if we're going multi-modal
 class ModuleWithTokenizer(Module):
     save_in_root: bool = True
     tokenizer: PreTrainedTokenizerBase | Tokenizer

--- a/sentence_transformers/models/ModuleWithTokenizer.py
+++ b/sentence_transformers/models/ModuleWithTokenizer.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from abc import abstractmethod
+from typing import Any
+
+import torch
+from tokenizers import Tokenizer
+from transformers.tokenization_utils_base import PreTrainedTokenizerBase
+
+from sentence_transformers.models.Module import Module
+
+
+# TODO: BaseModule? ModuleBase?
+class ModuleWithTokenizer(Module):
+    save_in_root: bool = True
+
+    @abstractmethod
+    def tokenize(self, texts: list[str], **kwargs) -> dict[str, torch.Tensor | Any]: ...
+
+    def save_tokenizer(self, output_path: str, **kwargs) -> None:
+        if not hasattr(self, "tokenizer"):
+            return
+
+        if isinstance(self.tokenizer, PreTrainedTokenizerBase):
+            self.tokenizer.save_pretrained(output_path, **kwargs)
+        elif isinstance(self.tokenizer, Tokenizer):
+            self.tokenizer.save(output_path, **kwargs)
+        return

--- a/sentence_transformers/models/ModuleWithTokenizer.py
+++ b/sentence_transformers/models/ModuleWithTokenizer.py
@@ -11,7 +11,7 @@ from sentence_transformers.models.Module import Module
 
 
 # TODO: BaseModule? ModuleBase?
-# "WithTokenizer" might be problematic if we're going multi-modal
+# TODO: "WithTokenizer" might be problematic if we're going multi-modal
 class ModuleWithTokenizer(Module):
     save_in_root: bool = True
     tokenizer: PreTrainedTokenizerBase | Tokenizer

--- a/sentence_transformers/models/Normalize.py
+++ b/sentence_transformers/models/Normalize.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
-from typing import Self
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 import torch.nn.functional as F
 from torch import Tensor

--- a/sentence_transformers/models/Normalize.py
+++ b/sentence_transformers/models/Normalize.py
@@ -18,7 +18,7 @@ class Normalize(Module):
         features.update({"sentence_embedding": F.normalize(features["sentence_embedding"], p=2, dim=1)})
         return features
 
-    def save(self, output_path: str, **kwargs) -> None:
+    def save(self, output_path: str, *args, safe_serialization: bool = True, **kwargs) -> None:
         return
 
     @classmethod

--- a/sentence_transformers/models/Normalize.py
+++ b/sentence_transformers/models/Normalize.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
+from typing import Self
+
 import torch.nn.functional as F
-from torch import Tensor, nn
+from torch import Tensor
+
+from sentence_transformers.models.Module import Module
 
 
-class Normalize(nn.Module):
+class Normalize(Module):
     """This layer normalizes embeddings to unit length"""
 
     def __init__(self) -> None:
@@ -14,9 +18,9 @@ class Normalize(nn.Module):
         features.update({"sentence_embedding": F.normalize(features["sentence_embedding"], p=2, dim=1)})
         return features
 
-    def save(self, output_path) -> None:
-        pass
+    def save(self, output_path: str, **kwargs) -> None:
+        return
 
-    @staticmethod
-    def load(input_path) -> Normalize:
-        return Normalize()
+    @classmethod
+    def load(cls, *args, **kwargs) -> Self:
+        return cls()

--- a/sentence_transformers/models/Pooling.py
+++ b/sentence_transformers/models/Pooling.py
@@ -1,14 +1,14 @@
 from __future__ import annotations
 
-import json
-import os
-from typing import Any
+from typing import Self
 
 import torch
-from torch import Tensor, nn
+from torch import Tensor
+
+from sentence_transformers.models.Module import Module
 
 
-class Pooling(nn.Module):
+class Pooling(Module):
     """
     Performs pooling (max or mean) on the token embeddings.
 
@@ -51,6 +51,17 @@ class Pooling(nn.Module):
         "weightedmean",
     )
 
+    config_keys = [
+        "word_embedding_dimension",
+        "pooling_mode_cls_token",
+        "pooling_mode_mean_tokens",
+        "pooling_mode_max_tokens",
+        "pooling_mode_mean_sqrt_len_tokens",
+        "pooling_mode_weightedmean_tokens",
+        "pooling_mode_lasttoken",
+        "include_prompt",
+    ]
+
     def __init__(
         self,
         word_embedding_dimension: int,
@@ -64,17 +75,6 @@ class Pooling(nn.Module):
         include_prompt: bool = True,
     ) -> None:
         super().__init__()
-
-        self.config_keys = [
-            "word_embedding_dimension",
-            "pooling_mode_cls_token",
-            "pooling_mode_mean_tokens",
-            "pooling_mode_max_tokens",
-            "pooling_mode_mean_sqrt_len_tokens",
-            "pooling_mode_weightedmean_tokens",
-            "pooling_mode_lasttoken",
-            "include_prompt",
-        ]
 
         if pooling_mode is not None:  # Set pooling mode by string
             pooling_mode = pooling_mode.lower()
@@ -245,16 +245,39 @@ class Pooling(nn.Module):
     def get_sentence_embedding_dimension(self) -> int:
         return self.pooling_output_dimension
 
+    """
     def get_config_dict(self) -> dict[str, Any]:
         return {key: self.__dict__[key] for key in self.config_keys}
+    """
 
-    def save(self, output_path) -> None:
+    def save(self, output_path: str) -> None:
+        """
         with open(os.path.join(output_path, "config.json"), "w") as fOut:
             json.dump(self.get_config_dict(), fOut, indent=2)
+        """
+        self.save_config(output_path)
 
-    @staticmethod
-    def load(input_path) -> Pooling:
+    @classmethod
+    def load(
+        cls,
+        model_name_or_path: str,
+        directory: str = "",
+        token: bool | str | None = None,
+        cache_folder: str | None = None,
+        revision: str | None = None,
+        local_files_only: bool = False,
+        **kwargs,
+    ) -> Self:
+        """
         with open(os.path.join(input_path, "config.json")) as fIn:
             config = json.load(fIn)
-
-        return Pooling(**config)
+        """
+        config = cls.load_config(
+            model_name_or_path,
+            directory=directory,
+            token=token,
+            cache_folder=cache_folder,
+            revision=revision,
+            local_files_only=local_files_only,
+        )
+        return cls(**config)

--- a/sentence_transformers/models/Pooling.py
+++ b/sentence_transformers/models/Pooling.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import Self
-
 import torch
 from torch import Tensor
 
@@ -245,26 +243,5 @@ class Pooling(Module):
     def get_sentence_embedding_dimension(self) -> int:
         return self.pooling_output_dimension
 
-    def save(self, output_path: str) -> None:
+    def save(self, output_path: str, *args, safe_serialization: bool = True, **kwargs) -> None:
         self.save_config(output_path)
-
-    @classmethod
-    def load(
-        cls,
-        model_name_or_path: str,
-        directory: str = "",
-        token: bool | str | None = None,
-        cache_folder: str | None = None,
-        revision: str | None = None,
-        local_files_only: bool = False,
-        **kwargs,
-    ) -> Self:
-        config = cls.load_config(
-            model_name_or_path,
-            directory=directory,
-            token=token,
-            cache_folder=cache_folder,
-            revision=revision,
-            local_files_only=local_files_only,
-        )
-        return cls(**config)

--- a/sentence_transformers/models/Pooling.py
+++ b/sentence_transformers/models/Pooling.py
@@ -245,16 +245,7 @@ class Pooling(Module):
     def get_sentence_embedding_dimension(self) -> int:
         return self.pooling_output_dimension
 
-    """
-    def get_config_dict(self) -> dict[str, Any]:
-        return {key: self.__dict__[key] for key in self.config_keys}
-    """
-
     def save(self, output_path: str) -> None:
-        """
-        with open(os.path.join(output_path, "config.json"), "w") as fOut:
-            json.dump(self.get_config_dict(), fOut, indent=2)
-        """
         self.save_config(output_path)
 
     @classmethod
@@ -268,10 +259,6 @@ class Pooling(Module):
         local_files_only: bool = False,
         **kwargs,
     ) -> Self:
-        """
-        with open(os.path.join(input_path, "config.json")) as fIn:
-            config = json.load(fIn)
-        """
         config = cls.load_config(
             model_name_or_path,
             directory=directory,

--- a/sentence_transformers/models/StaticEmbedding.py
+++ b/sentence_transformers/models/StaticEmbedding.py
@@ -3,7 +3,11 @@ from __future__ import annotations
 import math
 import os
 from pathlib import Path
-from typing import Self
+
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 import numpy as np
 import torch

--- a/sentence_transformers/models/StaticEmbedding.py
+++ b/sentence_transformers/models/StaticEmbedding.py
@@ -12,11 +12,11 @@ from tokenizers import Tokenizer
 from torch import nn
 from transformers import PreTrainedTokenizerFast
 
-from sentence_transformers.models.ModuleWithTokenizer import ModuleWithTokenizer
+from sentence_transformers.models.InputModule import InputModule
 from sentence_transformers.util import get_device_name
 
 
-class StaticEmbedding(ModuleWithTokenizer):
+class StaticEmbedding(InputModule):
     def __init__(
         self,
         tokenizer: Tokenizer | PreTrainedTokenizerFast,

--- a/sentence_transformers/models/StaticEmbedding.py
+++ b/sentence_transformers/models/StaticEmbedding.py
@@ -104,11 +104,6 @@ class StaticEmbedding(ModuleWithTokenizer):
         features["sentence_embedding"] = self.embedding(features["input_ids"], features["offsets"])
         return features
 
-    """
-    def get_config_dict(self) -> dict[str, float]:
-        return {}
-    """
-
     @property
     def max_seq_length(self) -> int:
         return math.inf
@@ -116,38 +111,12 @@ class StaticEmbedding(ModuleWithTokenizer):
     def get_sentence_embedding_dimension(self) -> int:
         return self.embedding_dim
 
-    """
-    def save(self, save_dir: str, safe_serialization: bool = True, **kwargs) -> None:
-        if safe_serialization:
-            save_safetensors_file(self.state_dict(), os.path.join(save_dir, "model.safetensors"))
-        else:
-            torch.save(self.state_dict(), os.path.join(save_dir, "pytorch_model.bin"))
-        self.tokenizer.save(str(Path(save_dir) / "tokenizer.json"))
-    """
-
     def save(self, output_path: str, *args, safe_serialization: bool = True, **kwargs) -> None:
         if safe_serialization:
             save_safetensors_file(self.state_dict(), os.path.join(output_path, "model.safetensors"))
         else:
             torch.save(self.state_dict(), os.path.join(output_path, "pytorch_model.bin"))
         self.tokenizer.save(str(Path(output_path) / "tokenizer.json"))
-
-    """
-    def load(load_dir: str, **kwargs) -> StaticEmbedding:
-        tokenizer = Tokenizer.from_file(str(Path(load_dir) / "tokenizer.json"))
-        if os.path.exists(os.path.join(load_dir, "model.safetensors")):
-            weights = load_safetensors_file(os.path.join(load_dir, "model.safetensors"))
-        else:
-            weights = torch.load(
-                os.path.join(load_dir, "pytorch_model.bin"), map_location=torch.device("cpu"), weights_only=True
-            )
-        try:
-            weights = weights["embedding.weight"]
-        except KeyError:
-            # For compatibility with model2vec models, which are saved with just an "embeddings" key
-            weights = weights["embeddings"]
-        return StaticEmbedding(tokenizer, embedding_weights=weights)
-    """
 
     @classmethod
     def load(

--- a/sentence_transformers/models/StaticEmbedding.py
+++ b/sentence_transformers/models/StaticEmbedding.py
@@ -137,14 +137,14 @@ class StaticEmbedding(ModuleWithTokenizer):
         }
         tokenizer_path = cls.load_file_path(
             model_name_or_path,
-            filename=Path(directory) / "tokenizer.json",
+            filename=Path(directory, "tokenizer.json"),
             **hub_kwargs,
         )
         tokenizer = Tokenizer.from_file(tokenizer_path)
 
         safetensors_path = cls.load_file_path(
             model_name_or_path,
-            filename=Path(directory) / "model.safetensors",
+            filename=Path(directory, "model.safetensors"),
             **hub_kwargs,
         )
         if safetensors_path is not None:
@@ -152,7 +152,7 @@ class StaticEmbedding(ModuleWithTokenizer):
         else:
             pytorch_model_path = cls.load_file_path(
                 model_name_or_path,
-                filename=Path(directory) / "pytorch_model.bin",
+                filename=Path(directory, "pytorch_model.bin"),
                 **hub_kwargs,
             )
             if pytorch_model_path is None:

--- a/sentence_transformers/models/Transformer.py
+++ b/sentence_transformers/models/Transformer.py
@@ -5,7 +5,12 @@ import logging
 import os
 from fnmatch import fnmatch
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Self
+from typing import TYPE_CHECKING, Any, Callable
+
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 import huggingface_hub
 import torch

--- a/sentence_transformers/models/Transformer.py
+++ b/sentence_transformers/models/Transformer.py
@@ -5,14 +5,15 @@ import logging
 import os
 from fnmatch import fnmatch
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any, Callable, Self
 
 import huggingface_hub
 import torch
-from torch import nn
 from transformers import AutoConfig, AutoModel, AutoTokenizer, MT5Config, PretrainedConfig, T5Config
 from transformers.utils.import_utils import is_peft_available
 from transformers.utils.peft_utils import find_adapter_config_file
+
+from sentence_transformers.models.ModuleWithTokenizer import ModuleWithTokenizer
 
 logger = logging.getLogger(__name__)
 
@@ -28,7 +29,7 @@ def _save_pretrained_wrapper(_save_pretrained_fn: Callable, subfolder: str) -> C
     return wrapper
 
 
-class Transformer(nn.Module):
+class Transformer(ModuleWithTokenizer):
     """Hugging Face AutoModel to generate token embeddings.
     Loads the correct class, e.g. BERT / RoBERTa etc.
 
@@ -52,6 +53,8 @@ class Transformer(nn.Module):
             or `openvino`. Default is `torch`.
     """
 
+    config_file_name: str = "sentence_bert_config.json"
+    config_keys: list[str] = ["max_seq_length", "do_lower_case"]
     save_in_root: bool = True
 
     def __init__(
@@ -67,7 +70,6 @@ class Transformer(nn.Module):
         backend: str = "torch",
     ) -> None:
         super().__init__()
-        self.config_keys = ["max_seq_length", "do_lower_case"]
         self.do_lower_case = do_lower_case
         self.backend = backend
         if model_args is None:
@@ -507,16 +509,17 @@ class Transformer(nn.Module):
         )
         return output
 
+    """
     def get_config_dict(self) -> dict[str, Any]:
         return {key: self.__dict__[key] for key in self.config_keys}
+    """
 
     def save(self, output_path: str, safe_serialization: bool = True) -> None:
         self.auto_model.save_pretrained(output_path, safe_serialization=safe_serialization)
         self.tokenizer.save_pretrained(output_path)
+        self.save_config(output_path)
 
-        with open(os.path.join(output_path, "sentence_bert_config.json"), "w") as fOut:
-            json.dump(self.get_config_dict(), fOut, indent=2)
-
+    """
     @classmethod
     def load(cls, input_path: str) -> Transformer:
         # Old classes used other config names than 'sentence_bert_config.json'
@@ -543,3 +546,111 @@ class Transformer(nn.Module):
         if "config_args" in config and "trust_remote_code" in config["config_args"]:
             config["config_args"].pop("trust_remote_code")
         return cls(model_name_or_path=input_path, **config)
+    """
+
+    @classmethod
+    def load(
+        cls,
+        model_name_or_path: str,
+        directory: str = "",
+        # Loading arguments
+        token: bool | str | None = None,
+        cache_folder: str | None = None,
+        revision: str | None = None,
+        local_files_only: bool = False,
+        # Module-specific arguments
+        trust_remote_code: bool = False,
+        model_kwargs: dict[str, Any] | None = None,
+        tokenizer_kwargs: dict[str, Any] | None = None,
+        config_kwargs: dict[str, Any] | None = None,
+        backend: str = "torch",
+        **kwargs,
+    ) -> Self:
+        config = cls.load_config(
+            model_name_or_path=model_name_or_path,
+            directory=directory,
+            token=token,
+            cache_folder=cache_folder,
+            revision=revision,
+            local_files_only=local_files_only,
+        )
+
+        hub_kwargs = {
+            "token": token,
+            "trust_remote_code": trust_remote_code,
+            "revision": revision,
+            "local_files_only": local_files_only,
+        }
+        # 3rd priority: config file
+        if "model_args" not in config:
+            config["model_args"] = {}
+        if "tokenizer_args" not in config:
+            config["tokenizer_args"] = {}
+        if "config_args" not in config:
+            config["config_args"] = {}
+
+        # 2nd priority: hub_kwargs
+        config["model_args"].update(hub_kwargs)
+        config["tokenizer_args"].update(hub_kwargs)
+        config["config_args"].update(hub_kwargs)
+
+        # 1st priority: kwargs passed to SentenceTransformer
+        if model_kwargs:
+            config["model_args"].update(model_kwargs)
+        if tokenizer_kwargs:
+            config["tokenizer_args"].update(tokenizer_kwargs)
+        if config_kwargs:
+            config["config_args"].update(config_kwargs)
+
+        return cls(
+            model_name_or_path=model_name_or_path,
+            **config,
+            cache_dir=cache_folder,
+            backend=backend,
+        )
+
+    @classmethod
+    def load_config(
+        cls,
+        model_name_or_path: str,
+        directory: str = "",
+        config_filename: str | None = None,
+        token: bool | str | None = None,
+        cache_folder: str | None = None,
+        revision: str | None = None,
+        local_files_only: bool = False,
+    ) -> dict[str, Any]:
+        config_filenames = (
+            [config_filename]
+            if config_filename
+            else [
+                "sentence_bert_config.json",
+                "sentence_roberta_config.json",
+                "sentence_distilbert_config.json",
+                "sentence_camembert_config.json",
+                "sentence_albert_config.json",
+                "sentence_xlm-roberta_config.json",
+                "sentence_xlnet_config.json",
+            ]
+        )
+        for config_filename in config_filenames:
+            config = super().load_config(
+                model_name_or_path=model_name_or_path,
+                directory=directory,
+                config_filename=config_filename,
+                token=token,
+                cache_folder=cache_folder,
+                revision=revision,
+                local_files_only=local_files_only,
+            )
+            if config:
+                break
+
+        # Don't allow configs to set trust_remote_code
+        if "model_args" in config and "trust_remote_code" in config["model_args"]:
+            config["model_args"].pop("trust_remote_code")
+        if "tokenizer_args" in config and "trust_remote_code" in config["tokenizer_args"]:
+            config["tokenizer_args"].pop("trust_remote_code")
+        if "config_args" in config and "trust_remote_code" in config["config_args"]:
+            config["config_args"].pop("trust_remote_code")
+        return config

--- a/sentence_transformers/models/Transformer.py
+++ b/sentence_transformers/models/Transformer.py
@@ -372,7 +372,7 @@ class Transformer(ModuleWithTokenizer):
         # If it doesn't, check if it exists in the backend subfolder.
         # If it does, set the subfolder to include the backend
         model_found = primary_full_path in model_file_names
-        if not model_found and "subfolder" not in model_args:
+        if not model_found:
             model_found = secondary_full_path in model_file_names
             if model_found:
                 if len(model_file_names) > 1 and "file_name" not in model_args:
@@ -380,7 +380,7 @@ class Transformer(ModuleWithTokenizer):
                         f"Multiple {backend_name} files found in {load_path.as_posix()!r}: {model_file_names}, defaulting to {secondary_full_path!r}. "
                         f'Please specify the desired file name via `model_kwargs={{"file_name": "<file_name>"}}`.'
                     )
-                model_args["subfolder"] = self.backend
+                model_args["subfolder"] = Path(subfolder, self.backend).as_posix() if subfolder else self.backend
                 model_args["file_name"] = file_name
         if export is None:
             export = not model_found
@@ -601,6 +601,11 @@ class Transformer(ModuleWithTokenizer):
             config["tokenizer_args"].update(tokenizer_kwargs)
         if config_kwargs:
             config["config_args"].update(config_kwargs)
+
+        if directory:
+            config["model_args"]["subfolder"] = directory
+            config["tokenizer_args"]["subfolder"] = directory
+            config["config_args"]["subfolder"] = directory
 
         return cls(
             model_name_or_path=model_name_or_path,

--- a/sentence_transformers/models/Transformer.py
+++ b/sentence_transformers/models/Transformer.py
@@ -532,6 +532,39 @@ class Transformer(ModuleWithTokenizer):
         backend: str = "torch",
         **kwargs,
     ) -> Self:
+        init_kwargs = cls._load_init_kwargs(
+            model_name_or_path=model_name_or_path,
+            subfolder=subfolder,
+            token=token,
+            cache_folder=cache_folder,
+            revision=revision,
+            local_files_only=local_files_only,
+            trust_remote_code=trust_remote_code,
+            model_kwargs=model_kwargs,
+            tokenizer_kwargs=tokenizer_kwargs,
+            config_kwargs=config_kwargs,
+            backend=backend,
+        )
+        return cls(model_name_or_path=model_name_or_path, **init_kwargs)
+
+    @classmethod
+    def _load_init_kwargs(
+        cls,
+        model_name_or_path: str,
+        # Loading arguments
+        subfolder: str = "",
+        token: bool | str | None = None,
+        cache_folder: str | None = None,
+        revision: str | None = None,
+        local_files_only: bool = False,
+        # Module-specific arguments
+        trust_remote_code: bool = False,
+        model_kwargs: dict[str, Any] | None = None,
+        tokenizer_kwargs: dict[str, Any] | None = None,
+        config_kwargs: dict[str, Any] | None = None,
+        backend: str = "torch",
+        **kwargs,
+    ) -> dict[str, Any]:
         config = cls.load_config(
             model_name_or_path=model_name_or_path,
             subfolder=subfolder,
@@ -570,7 +603,7 @@ class Transformer(ModuleWithTokenizer):
         if config_kwargs:
             config["config_args"].update(config_kwargs)
 
-        return cls(model_name_or_path=model_name_or_path, **config, cache_dir=cache_folder, backend=backend)
+        return {**config, "cache_dir": cache_folder, "backend": backend}
 
     @classmethod
     def load_config(

--- a/sentence_transformers/models/Transformer.py
+++ b/sentence_transformers/models/Transformer.py
@@ -509,44 +509,10 @@ class Transformer(ModuleWithTokenizer):
         )
         return output
 
-    """
-    def get_config_dict(self) -> dict[str, Any]:
-        return {key: self.__dict__[key] for key in self.config_keys}
-    """
-
-    def save(self, output_path: str, safe_serialization: bool = True) -> None:
+    def save(self, output_path: str, safe_serialization: bool = True, **kwargs) -> None:
         self.auto_model.save_pretrained(output_path, safe_serialization=safe_serialization)
         self.tokenizer.save_pretrained(output_path)
         self.save_config(output_path)
-
-    """
-    @classmethod
-    def load(cls, input_path: str) -> Transformer:
-        # Old classes used other config names than 'sentence_bert_config.json'
-        for config_name in [
-            "sentence_bert_config.json",
-            "sentence_roberta_config.json",
-            "sentence_distilbert_config.json",
-            "sentence_camembert_config.json",
-            "sentence_albert_config.json",
-            "sentence_xlm-roberta_config.json",
-            "sentence_xlnet_config.json",
-        ]:
-            sbert_config_path = os.path.join(input_path, config_name)
-            if os.path.exists(sbert_config_path):
-                break
-
-        with open(sbert_config_path) as fIn:
-            config = json.load(fIn)
-        # Don't allow configs to set trust_remote_code
-        if "model_args" in config and "trust_remote_code" in config["model_args"]:
-            config["model_args"].pop("trust_remote_code")
-        if "tokenizer_args" in config and "trust_remote_code" in config["tokenizer_args"]:
-            config["tokenizer_args"].pop("trust_remote_code")
-        if "config_args" in config and "trust_remote_code" in config["config_args"]:
-            config["config_args"].pop("trust_remote_code")
-        return cls(model_name_or_path=input_path, **config)
-    """
 
     @classmethod
     def load(

--- a/sentence_transformers/models/Transformer.py
+++ b/sentence_transformers/models/Transformer.py
@@ -13,7 +13,7 @@ from transformers import AutoConfig, AutoModel, AutoTokenizer, MT5Config, Pretra
 from transformers.utils.import_utils import is_peft_available
 from transformers.utils.peft_utils import find_adapter_config_file
 
-from sentence_transformers.models.ModuleWithTokenizer import ModuleWithTokenizer
+from sentence_transformers.models.InputModule import InputModule
 
 logger = logging.getLogger(__name__)
 
@@ -29,7 +29,7 @@ def _save_pretrained_wrapper(_save_pretrained_fn: Callable, subfolder: str) -> C
     return wrapper
 
 
-class Transformer(ModuleWithTokenizer):
+class Transformer(InputModule):
     """Hugging Face AutoModel to generate token embeddings.
     Loads the correct class, e.g. BERT / RoBERTa etc.
 

--- a/sentence_transformers/models/Transformer.py
+++ b/sentence_transformers/models/Transformer.py
@@ -518,8 +518,8 @@ class Transformer(ModuleWithTokenizer):
     def load(
         cls,
         model_name_or_path: str,
-        directory: str = "",
         # Loading arguments
+        subfolder: str = "",
         token: bool | str | None = None,
         cache_folder: str | None = None,
         revision: str | None = None,
@@ -534,7 +534,7 @@ class Transformer(ModuleWithTokenizer):
     ) -> Self:
         config = cls.load_config(
             model_name_or_path=model_name_or_path,
-            directory=directory,
+            subfolder=subfolder,
             token=token,
             cache_folder=cache_folder,
             revision=revision,
@@ -542,11 +542,13 @@ class Transformer(ModuleWithTokenizer):
         )
 
         hub_kwargs = {
+            "subfolder": subfolder,
             "token": token,
-            "trust_remote_code": trust_remote_code,
             "revision": revision,
             "local_files_only": local_files_only,
+            "trust_remote_code": trust_remote_code,
         }
+
         # 3rd priority: config file
         if "model_args" not in config:
             config["model_args"] = {}
@@ -568,23 +570,13 @@ class Transformer(ModuleWithTokenizer):
         if config_kwargs:
             config["config_args"].update(config_kwargs)
 
-        if directory:
-            config["model_args"]["subfolder"] = directory
-            config["tokenizer_args"]["subfolder"] = directory
-            config["config_args"]["subfolder"] = directory
-
-        return cls(
-            model_name_or_path=model_name_or_path,
-            **config,
-            cache_dir=cache_folder,
-            backend=backend,
-        )
+        return cls(model_name_or_path=model_name_or_path, **config, cache_dir=cache_folder, backend=backend)
 
     @classmethod
     def load_config(
         cls,
         model_name_or_path: str,
-        directory: str = "",
+        subfolder: str = "",
         config_filename: str | None = None,
         token: bool | str | None = None,
         cache_folder: str | None = None,
@@ -607,7 +599,7 @@ class Transformer(ModuleWithTokenizer):
         for config_filename in config_filenames:
             config = super().load_config(
                 model_name_or_path=model_name_or_path,
-                directory=directory,
+                subfolder=subfolder,
                 config_filename=config_filename,
                 token=token,
                 cache_folder=cache_folder,

--- a/sentence_transformers/models/WeightedLayerPooling.py
+++ b/sentence_transformers/models/WeightedLayerPooling.py
@@ -1,22 +1,22 @@
 from __future__ import annotations
 
-import json
-import os
+from typing import Self
 
 import torch
-from safetensors.torch import load_model as load_safetensors_model
-from safetensors.torch import save_model as save_safetensors_model
 from torch import Tensor, nn
 
+from sentence_transformers.models.Module import Module
 
-class WeightedLayerPooling(nn.Module):
+
+class WeightedLayerPooling(Module):
     """Token embeddings are weighted mean of their different hidden layer representations"""
+
+    config_keys: list[str] = ["word_embedding_dimension", "layer_start", "num_hidden_layers"]
 
     def __init__(
         self, word_embedding_dimension, num_hidden_layers: int = 12, layer_start: int = 4, layer_weights=None
     ):
         super().__init__()
-        self.config_keys = ["word_embedding_dimension", "layer_start", "num_hidden_layers"]
         self.word_embedding_dimension = word_embedding_dimension
         self.layer_start = layer_start
         self.num_hidden_layers = num_hidden_layers
@@ -41,30 +41,29 @@ class WeightedLayerPooling(nn.Module):
     def get_word_embedding_dimension(self):
         return self.word_embedding_dimension
 
-    def get_config_dict(self):
-        return {key: self.__dict__[key] for key in self.config_keys}
+    def save(self, output_path: str, *args, safe_serialization: bool = True, **kwargs) -> None:
+        self.save_config(output_path)
+        self.save_torch_weights(output_path, safe_serialization=safe_serialization)
 
-    def save(self, output_path: str, safe_serialization: bool = True):
-        with open(os.path.join(output_path, "config.json"), "w") as fOut:
-            json.dump(self.get_config_dict(), fOut, indent=2)
-
-        if safe_serialization:
-            save_safetensors_model(self, os.path.join(output_path, "model.safetensors"))
-        else:
-            torch.save(self.state_dict(), os.path.join(output_path, "pytorch_model.bin"))
-
-    @staticmethod
-    def load(input_path):
-        with open(os.path.join(input_path, "config.json")) as fIn:
-            config = json.load(fIn)
-
-        model = WeightedLayerPooling(**config)
-        if os.path.exists(os.path.join(input_path, "model.safetensors")):
-            load_safetensors_model(model, os.path.join(input_path, "model.safetensors"))
-        else:
-            model.load_state_dict(
-                torch.load(
-                    os.path.join(input_path, "pytorch_model.bin"), map_location=torch.device("cpu"), weights_only=True
-                )
-            )
+    @classmethod
+    def load(
+        cls,
+        model_name_or_path: str,
+        subfolder: str = "",
+        token: bool | str | None = None,
+        cache_folder: str | None = None,
+        revision: str | None = None,
+        local_files_only: bool = False,
+        **kwargs,
+    ) -> Self:
+        hub_kwargs = {
+            "subfolder": subfolder,
+            "token": token,
+            "cache_folder": cache_folder,
+            "revision": revision,
+            "local_files_only": local_files_only,
+        }
+        config = cls.load_config(model_name_or_path=model_name_or_path, **hub_kwargs)
+        model = cls(**config)
+        model = cls.load_torch_weights(model_name_or_path=model_name_or_path, model=model, **hub_kwargs)
         return model

--- a/sentence_transformers/models/WeightedLayerPooling.py
+++ b/sentence_transformers/models/WeightedLayerPooling.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
-from typing import Self
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 import torch
 from torch import Tensor, nn

--- a/sentence_transformers/models/WordEmbeddings.py
+++ b/sentence_transformers/models/WordEmbeddings.py
@@ -3,7 +3,11 @@ from __future__ import annotations
 import gzip
 import logging
 import os
-from typing import Self
+
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 import numpy as np
 import torch

--- a/sentence_transformers/models/WordEmbeddings.py
+++ b/sentence_transformers/models/WordEmbeddings.py
@@ -1,17 +1,16 @@
 from __future__ import annotations
 
 import gzip
-import json
 import logging
 import os
+from typing import Self
 
 import numpy as np
 import torch
-from safetensors.torch import load_file as load_safetensors_file
-from safetensors.torch import save_file as save_safetensors_file
 from torch import nn
 from tqdm import tqdm
 
+from sentence_transformers.models.Module import Module
 from sentence_transformers.util import fullname, http_get, import_from_string
 
 from .tokenizer import WhitespaceTokenizer, WordTokenizer
@@ -19,7 +18,10 @@ from .tokenizer import WhitespaceTokenizer, WordTokenizer
 logger = logging.getLogger(__name__)
 
 
-class WordEmbeddings(nn.Module):
+class WordEmbeddings(Module):
+    config_keys: list[str] = ["tokenizer_class", "update_embeddings", "max_seq_length"]
+    config_file_name: str = "wordembedding_config.json"
+
     def __init__(
         self,
         tokenizer: WordTokenizer,
@@ -79,13 +81,8 @@ class WordEmbeddings(nn.Module):
         return self.embeddings_dimension
 
     def save(self, output_path: str, safe_serialization: bool = True):
-        with open(os.path.join(output_path, "wordembedding_config.json"), "w") as fOut:
-            json.dump(self.get_config_dict(), fOut, indent=2)
-
-        if safe_serialization:
-            save_safetensors_file(self.state_dict(), os.path.join(output_path, "model.safetensors"))
-        else:
-            torch.save(self.state_dict(), os.path.join(output_path, "pytorch_model.bin"))
+        self.save_config(output_path)
+        self.save_torch_weights(output_path, safe_serialization=safe_serialization)
         self.tokenizer.save(output_path)
 
     def get_config_dict(self):
@@ -95,27 +92,36 @@ class WordEmbeddings(nn.Module):
             "max_seq_length": self.max_seq_length,
         }
 
-    @staticmethod
-    def load(input_path: str):
-        with open(os.path.join(input_path, "wordembedding_config.json")) as fIn:
-            config = json.load(fIn)
+    @classmethod
+    def load(
+        cls,
+        model_name_or_path: str,
+        subfolder: str = "",
+        token: bool | str | None = None,
+        cache_folder: str | None = None,
+        revision: str | None = None,
+        local_files_only: bool = False,
+        **kwargs,
+    ) -> Self:
+        hub_kwargs = {
+            "subfolder": subfolder,
+            "token": token,
+            "cache_folder": cache_folder,
+            "revision": revision,
+            "local_files_only": local_files_only,
+        }
+        config = cls.load_config(model_name_or_path=model_name_or_path, **hub_kwargs)
+        tokenizer_class = import_from_string(config.pop("tokenizer_class"))
+        tokenizer_local_path = cls.load_dir_path(model_name_or_path=model_name_or_path, **hub_kwargs)
+        tokenizer = tokenizer_class.load(tokenizer_local_path)
 
-        tokenizer_class = import_from_string(config["tokenizer_class"])
-        tokenizer = tokenizer_class.load(input_path)
-        if os.path.exists(os.path.join(input_path, "model.safetensors")):
-            weights = load_safetensors_file(os.path.join(input_path, "model.safetensors"))
-        else:
-            weights = torch.load(
-                os.path.join(input_path, "pytorch_model.bin"), map_location=torch.device("cpu"), weights_only=True
-            )
-        embedding_weights = weights["emb_layer.weight"]
-        model = WordEmbeddings(
-            tokenizer=tokenizer, embedding_weights=embedding_weights, update_embeddings=config["update_embeddings"]
-        )
+        weights = cls.load_torch_weights(model_name_or_path=model_name_or_path, **hub_kwargs)
+        model = cls(tokenizer=tokenizer, embedding_weights=weights["emb_layer.weight"], **config)
         return model
 
-    @staticmethod
+    @classmethod
     def from_text_file(
+        cls,
         embeddings_file_path: str,
         update_embeddings: bool = False,
         item_separator: str = " ",
@@ -174,6 +180,4 @@ class WordEmbeddings(nn.Module):
             embeddings = np.asarray(embeddings)
 
             tokenizer.set_vocab(vocab)
-            return WordEmbeddings(
-                tokenizer=tokenizer, embedding_weights=embeddings, update_embeddings=update_embeddings
-            )
+            return cls(tokenizer=tokenizer, embedding_weights=embeddings, update_embeddings=update_embeddings)

--- a/sentence_transformers/models/WordWeights.py
+++ b/sentence_transformers/models/WordWeights.py
@@ -1,17 +1,19 @@
 from __future__ import annotations
 
-import json
 import logging
-import os
 
 import torch
 from torch import Tensor, nn
 
+from sentence_transformers.models.Module import Module
+
 logger = logging.getLogger(__name__)
 
 
-class WordWeights(nn.Module):
+class WordWeights(Module):
     """This model can weight word embeddings, for example, with idf-values."""
+
+    config_keys: list[str] = ["vocab", "word_weights", "unknown_word_weight"]
 
     def __init__(self, vocab: list[str], word_weights: dict[str, float], unknown_word_weight: float = 1):
         """
@@ -25,7 +27,6 @@ class WordWeights(nn.Module):
                 These can be, for example, rare words in the vocab where no weight exists. Defaults to 1.
         """
         super().__init__()
-        self.config_keys = ["vocab", "word_weights", "unknown_word_weight"]
         self.vocab = vocab
         self.word_weights = word_weights
         self.unknown_word_weight = unknown_word_weight
@@ -65,16 +66,5 @@ class WordWeights(nn.Module):
         features.update({"token_embeddings": token_embeddings, "token_weights_sum": token_weights_sum})
         return features
 
-    def get_config_dict(self):
-        return {key: self.__dict__[key] for key in self.config_keys}
-
-    def save(self, output_path):
-        with open(os.path.join(output_path, "config.json"), "w") as fOut:
-            json.dump(self.get_config_dict(), fOut, indent=2)
-
-    @staticmethod
-    def load(input_path):
-        with open(os.path.join(input_path, "config.json")) as fIn:
-            config = json.load(fIn)
-
-        return WordWeights(**config)
+    def save(self, output_path: str, *args, safe_serialization: bool = True, **kwargs) -> None:
+        self.save_config(output_path)

--- a/sentence_transformers/models/__init__.py
+++ b/sentence_transformers/models/__init__.py
@@ -6,10 +6,10 @@ from .CLIPModel import CLIPModel
 from .CNN import CNN
 from .Dense import Dense
 from .Dropout import Dropout
+from .InputModule import InputModule
 from .LayerNorm import LayerNorm
 from .LSTM import LSTM
 from .Module import Module
-from .ModuleWithTokenizer import ModuleWithTokenizer
 from .Normalize import Normalize
 from .Pooling import Pooling
 from .StaticEmbedding import StaticEmbedding
@@ -35,5 +35,5 @@ __all__ = [
     "WordWeights",
     "CLIPModel",
     "Module",
-    "ModuleWithTokenizer",
+    "InputModule",
 ]

--- a/sentence_transformers/models/__init__.py
+++ b/sentence_transformers/models/__init__.py
@@ -8,6 +8,8 @@ from .Dense import Dense
 from .Dropout import Dropout
 from .LayerNorm import LayerNorm
 from .LSTM import LSTM
+from .Module import Module
+from .ModuleWithTokenizer import ModuleWithTokenizer
 from .Normalize import Normalize
 from .Pooling import Pooling
 from .StaticEmbedding import StaticEmbedding
@@ -32,4 +34,6 @@ __all__ = [
     "WordEmbeddings",
     "WordWeights",
     "CLIPModel",
+    "Module",
+    "ModuleWithTokenizer",
 ]

--- a/sentence_transformers/util.py
+++ b/sentence_transformers/util.py
@@ -10,6 +10,7 @@ import random
 import sys
 from contextlib import contextmanager
 from importlib.metadata import PackageNotFoundError, metadata
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Literal, overload
 
 import numpy as np
@@ -1455,7 +1456,7 @@ def is_sentence_transformer_model(
 
 def load_file_path(
     model_name_or_path: str,
-    filename: str,
+    filename: str | Path,
     token: bool | str | None = None,
     cache_folder: str | None = None,
     revision: str | None = None,
@@ -1476,15 +1477,15 @@ def load_file_path(
         Optional[str]: The path to the loaded file, or None if the file could not be found or loaded.
     """
     # If file is local
-    file_path = os.path.join(model_name_or_path, filename)
-    if os.path.exists(file_path):
-        return file_path
+    file_path = Path(model_name_or_path, filename)
+    if file_path.exists():
+        return str(file_path)
 
     # If file is remote
     try:
         return hf_hub_download(
             model_name_or_path,
-            filename=filename,
+            filename=str(filename),
             revision=revision,
             library_name="sentence-transformers",
             token=token,
@@ -1517,10 +1518,13 @@ def load_dir_path(
     Returns:
         Optional[str]: The directory path if it exists, otherwise None.
     """
+    if isinstance(directory, Path):
+        directory = directory.as_posix()
+
     # If file is local
-    dir_path = os.path.join(model_name_or_path, directory)
-    if os.path.exists(dir_path):
-        return dir_path
+    dir_path = Path(model_name_or_path, directory)
+    if dir_path.exists():
+        return str(dir_path)
 
     download_kwargs = {
         "repo_id": model_name_or_path,
@@ -1539,7 +1543,7 @@ def load_dir_path(
         # Otherwise, try local (i.e. cache) only
         download_kwargs["local_files_only"] = True
         repo_path = snapshot_download(**download_kwargs)
-    return os.path.join(repo_path, directory)
+    return Path(repo_path, directory)
 
 
 def save_to_hub_args_decorator(func):

--- a/sentence_transformers/util.py
+++ b/sentence_transformers/util.py
@@ -1457,7 +1457,7 @@ def is_sentence_transformer_model(
 def load_file_path(
     model_name_or_path: str,
     filename: str | Path,
-    subfolder: str = "",  # <- Should this be 'subfolder' instead? To match huggingface_hub
+    subfolder: str = "",
     token: bool | str | None = None,
     cache_folder: str | None = None,
     revision: str | None = None,

--- a/sentence_transformers/util.py
+++ b/sentence_transformers/util.py
@@ -1485,7 +1485,8 @@ def load_file_path(
     try:
         return hf_hub_download(
             model_name_or_path,
-            filename=str(filename),
+            filename=Path(filename).name,
+            subfolder=Path(filename).parent.as_posix(),
             revision=revision,
             library_name="sentence-transformers",
             token=token,

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import torch
+from datasets import load_dataset
+
+from sentence_transformers import SentenceTransformer
+
+
+@pytest.mark.custom
+def test_cde_small_v2():
+    # 1. Load the Sentence Transformer model
+    model = SentenceTransformer("jxm/cde-small-v2", trust_remote_code=True)
+    context_docs_size = model[0].config.transductive_corpus_size  # 512
+
+    # 2. Load the dataset: context dataset, docs, and queries
+    dataset = load_dataset("sentence-transformers/natural-questions", split="train")
+    dataset.shuffle(seed=42)
+    # 2 queries, 512 context docs, 5 docs
+    queries = dataset["query"][:2]
+    docs = dataset["answer"][:5]
+    context_docs = dataset["answer"][-context_docs_size:]  # Last 512 docs
+
+    # 3. First stage: embed the context docs
+    dataset_embeddings = model.encode(
+        context_docs,
+        prompt_name="document",
+        convert_to_tensor=True,
+    )
+
+    # 4. Second stage: embed the docs and queries
+    doc_embeddings = model.encode(
+        docs,
+        prompt_name="document",
+        dataset_embeddings=dataset_embeddings,
+        convert_to_tensor=True,
+    )
+    query_embeddings = model.encode(
+        queries,
+        prompt_name="query",
+        dataset_embeddings=dataset_embeddings,
+        convert_to_tensor=True,
+    )
+
+    # 5. Compute the similarity between the queries and docs
+    similarities = model.similarity(query_embeddings, doc_embeddings)
+    assert similarities.shape == (2, 5), f"Expected shape (2, 5), but got {similarities.shape}"
+    expected = torch.tensor(
+        [[0.8778, 0.7851, 0.7810, 0.7781, 0.7966], [0.7916, 0.8648, 0.7845, 0.7865, 0.8136]],
+        device=similarities.device,
+    )
+    assert torch.isclose(similarities, expected, atol=1e-3).all()
+
+
+@pytest.mark.custom
+def test_jina_embeddings_v3():
+    model = SentenceTransformer("jinaai/jina-embeddings-v3", trust_remote_code=True)
+    task = "retrieval.query"
+    embeddings = model.encode(
+        ["What is the weather like in Berlin today?"],
+        task=task,
+        prompt_name=task,
+    )
+    assert embeddings.shape == (1, 1024), f"Expected shape (1, 1024), but got {embeddings.shape}"
+    assert embeddings[0][0] == pytest.approx(
+        -0.08203125, abs=0.01
+    ), f"Expected value close to 0.08203125, but got {embeddings[0][0]}"
+
+
+@pytest.mark.custom
+def test_jina_clip():
+    # Choose a matryoshka dimension
+    truncate_dim = 512
+
+    # Initialize the model
+    model = SentenceTransformer(
+        "jinaai/jina-clip-v2",
+        trust_remote_code=True,
+        truncate_dim=truncate_dim,
+        config_kwargs={"use_vision_xformers": False},
+    )
+
+    # Corpus
+    sentences = [
+        "غروب جميل على الشاطئ",  # Arabic
+        "海滩上美丽的日落",  # Chinese
+        "Un beau coucher de soleil sur la plage",  # French
+        "Ein wunderschöner Sonnenuntergang am Strand",  # German
+        "Ένα όμορφο ηλιοβασίλεμα πάνω από την παραλία",  # Greek
+        "समुद्र तट पर एक खूबसूरत सूर्यास्त",  # Hindi
+        "Un bellissimo tramonto sulla spiaggia",  # Italian
+        "浜辺に沈む美しい夕日",  # Japanese
+        "해변 위로 아름다운 일몰",  # Korean
+    ]
+
+    # Public image URLs or PIL Images
+    image_urls = ["https://i.ibb.co/nQNGqL0/beach1.jpg", "https://i.ibb.co/r5w8hG8/beach2.jpg"]
+
+    # Encode text and images
+    text_embeddings = model.encode(sentences, normalize_embeddings=True)
+    image_embeddings = model.encode(image_urls, normalize_embeddings=True)
+    embeddings = np.concatenate((text_embeddings, image_embeddings), axis=0)
+
+    # Encode query text
+    query = "beautiful sunset over the beach"  # English
+    query_embeddings = model.encode(query, prompt_name="retrieval.query", normalize_embeddings=True)
+
+    similarities = model.similarity(query_embeddings, embeddings)
+    assert similarities.shape == (
+        1,
+        len(sentences) + len(image_urls),
+    ), f"Expected shape (1, {len(sentences) + len(image_urls)}), but got {similarities.shape}"
+    expected = torch.tensor([0.5342, 0.6753, 0.6130, 0.6234, 0.5823, 0.6351, 0.5950, 0.5691, 0.6070, 0.3101, 0.3291])
+    assert torch.isclose(similarities, expected, atol=1e-3).all()


### PR DESCRIPTION
Hello!

## Pull Request overview
* Attempt to refactor the module loading, notably:
  * Introduce a base Module and ModuleWithTokenizer class (working names) that inform the class methods
  * Extend `load` parameters for the modules

## Details
The primary changes here is that `load` now gets more parameters, so that it's more convenient to load modules, especially nested modules. This is just a draft for now, not really sure if there's problems with the current approach. Notably, `_load_sbert_model` is also simplified by moving the Transformer-specific code to the `load` of that module.

cc @arthurbr11

- Tom Aarsen