### PR TITLE
feat: expose new model2vec parameters

### DIFF
--- a/sentence_transformers/models/StaticEmbedding.py
+++ b/sentence_transformers/models/StaticEmbedding.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import math
 import os
 from pathlib import Path
+from typing import Any
 
 import numpy as np
 import torch
@@ -141,10 +142,14 @@ class StaticEmbedding(nn.Module):
         vocabulary: list[str] | None = None,
         device: str | None = None,
         pca_dims: int | None = 256,
-        apply_zipf: bool = True,
-        use_subword: bool = True,
+        apply_zipf: bool | None = None,
+        use_subword: bool | None = None,
+        sif_coefficient: float | None = 1e-4,
+        quantize_to: str = "float32",
+        token_remove_pattern: str | None = r"\[unused\d+\]",
+        **kwargs: Any,
     ) -> StaticEmbedding:
-        """
+        r"""
         Creates a StaticEmbedding instance from a distillation process using the `model2vec` package.
 
         Args:
@@ -155,6 +160,10 @@ class StaticEmbedding(nn.Module):
             pca_dims (int | None, optional): The number of dimensions for PCA reduction. Defaults to 256.
             apply_zipf (bool): Whether to apply Zipf's law during distillation. Defaults to True.
             use_subword (bool): Whether to use subword tokenization. Defaults to True.
+            sif_coefficient (float | None, optional): The coefficient for SIF weighting. Defaults to 1e-4.
+            quantize_to (str): The data type to quantize the weights to. Defaults to 'float32'.
+            token_remove_pattern (str | None, optional): A regex pattern to remove tokens from the vocabulary.
+                Defaults to r"\[unused\d+\]".
 
         Returns:
             StaticEmbedding: An instance of StaticEmbedding initialized with the distilled model's
@@ -179,6 +188,10 @@ class StaticEmbedding(nn.Module):
             pca_dims=pca_dims,
             apply_zipf=apply_zipf,
             use_subword=use_subword,
+            quantize_to=quantize_to,
+            sif_coefficient=sif_coefficient,
+            token_remove_pattern=token_remove_pattern,
+            **kwargs,
         )
         if isinstance(static_model.embedding, np.ndarray):
             embedding_weights = torch.from_numpy(static_model.embedding)

--- a/tests/models/test_static_embedding.py
+++ b/tests/models/test_static_embedding.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import numpy as np
 import pytest
+from packaging.version import Version, parse
 from tokenizers import Tokenizer
 
 from sentence_transformers import SentenceTransformer
@@ -12,6 +13,7 @@ from sentence_transformers.models.StaticEmbedding import StaticEmbedding
 
 try:
     import model2vec
+    from model2vec import __version__ as M2V_VERSION
 except ImportError:
     model2vec = None
 
@@ -69,7 +71,7 @@ def test_save_and_load(tmp_path: Path, static_embedding: StaticEmbedding) -> Non
 @skip_if_no_model2vec()
 def test_from_distillation() -> None:
     model = StaticEmbedding.from_distillation("sentence-transformers-testing/stsb-bert-tiny-safetensors", pca_dims=32)
-    assert model.embedding.weight.shape == (29525, 32)
+    assert model.embedding.weight.shape == (29525 if parse(M2V_VERSION) >= Version("0.5.0") else 29528, 32)
 
 
 @skip_if_no_model2vec()

--- a/tests/models/test_static_embedding.py
+++ b/tests/models/test_static_embedding.py
@@ -69,7 +69,7 @@ def test_save_and_load(tmp_path: Path, static_embedding: StaticEmbedding) -> Non
 @skip_if_no_model2vec()
 def test_from_distillation() -> None:
     model = StaticEmbedding.from_distillation("sentence-transformers-testing/stsb-bert-tiny-safetensors", pca_dims=32)
-    assert model.embedding.weight.shape == (29528, 32)
+    assert model.embedding.weight.shape == (29525, 32)
 
 
 @skip_if_no_model2vec()


### PR DESCRIPTION
Hello!

We're releasing a new model2vec version tomorrow. It has some shiny new parameters. This PR updates the spec of the `from_distillation` function to include the new parameters.

One issue is that this means that the `from_distillation` function is no longer backwards compatible with any model2vec version. So for example, if someone uses `model2vec 0.4.1` with the code in this PR, this will no longer work, and they will have to upgrade. One solution could be to actually pin model2vec in the sentence-transformers dependencies (in an extra).

Let me know what you think.