### PR TITLE
[`tests`] Update test based on M2V version

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -63,6 +63,8 @@ jobs:
 
       - name: Install dependencies
         run: |
+          # The --break-system-packages flag is used to allow pip to upgrade or install packages
+          # even in environments where system-managed packages might otherwise block such operations.
           python -m pip install --upgrade pip --break-system-packages
           python -m pip install '.[train, onnx, openvino, dev]'
           python -m pip install --upgrade 'huggingface_hub[hf_xet]'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip --break-system-packages
           python -m pip install '.[train, onnx, openvino, dev]'
           python -m pip install --upgrade 'huggingface_hub[hf_xet]'
 

--- a/tests/models/test_static_embedding.py
+++ b/tests/models/test_static_embedding.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import numpy as np
 import pytest
+from packaging.version import Version, parse
 from tokenizers import Tokenizer
 
 from sentence_transformers import SentenceTransformer
@@ -12,6 +13,7 @@ from sentence_transformers.models.StaticEmbedding import StaticEmbedding
 
 try:
     import model2vec
+    from model2vec import __version__ as M2V_VERSION
 except ImportError:
     model2vec = None
 
@@ -69,7 +71,7 @@ def test_save_and_load(tmp_path: Path, static_embedding: StaticEmbedding) -> Non
 @skip_if_no_model2vec()
 def test_from_distillation() -> None:
     model = StaticEmbedding.from_distillation("sentence-transformers-testing/stsb-bert-tiny-safetensors", pca_dims=32)
-    assert model.embedding.weight.shape == (29528, 32)
+    assert model.embedding.weight.shape == (29525 if parse(M2V_VERSION) >= Version("0.5.0") else 29528, 32)
 
 
 @skip_if_no_model2vec()

--- a/tests/models/test_static_embedding.py
+++ b/tests/models/test_static_embedding.py
@@ -71,7 +71,8 @@ def test_save_and_load(tmp_path: Path, static_embedding: StaticEmbedding) -> Non
 @skip_if_no_model2vec()
 def test_from_distillation() -> None:
     model = StaticEmbedding.from_distillation("sentence-transformers-testing/stsb-bert-tiny-safetensors", pca_dims=32)
-    assert model.embedding.weight.shape == (29525 if parse(M2V_VERSION) >= Version("0.5.0") else 29528, 32)
+    expected_shape = (29525 if parse(M2V_VERSION) >= Version("0.5.0") else 29528, 32)
+    assert model.embedding.weight.shape == expected_shape
 
 
 @skip_if_no_model2vec()


### PR DESCRIPTION
Hello!

## Pull Request overview
* Update test based on M2V version

## Details
A quick PR to resolve a failing test case due to an update of the `model2vec` package recently. Cherry-picked from https://github.com/UKPLab/sentence-transformers/pull/3349

- Tom Aarsen