### PR TITLE
Add OpenSearch-based semantic search example

### DIFF
--- a/examples/sentence_transformer/applications/semantic-search/README.md
+++ b/examples/sentence_transformer/applications/semantic-search/README.md
@@ -92,6 +92,10 @@ To get the optimal speed for the :func:`util.semantic_search <sentence_transform
 
 For further details, see [semantic_search_quora_elasticsearch.py](semantic_search_quora_elasticsearch.py).
 
+## OpenSearch
+[OpenSearch](https://opensearch.org/) is a community-driven, open-source search engine that supports vector search capabilities. It allows you to index dense vectors and perform efficient similarity search using approximate nearest neighbor algorithms. OpenSearch can be used to implement both traditional keyword-based search (BM25) and semantic search, making it possible to compare and combine both approaches.
+
+For an example implementation, see [semantic_search_nq_opensearch.py](semantic_search_nq_opensearch.py), which shows how to use OpenSearch with the Natural Questions dataset, demonstrating both semantic search and BM25 search capabilities.
 
 ## Approximate Nearest Neighbor
 ```{eval-rst}

--- a/examples/sentence_transformer/applications/semantic-search/semantic_search_nq_opensearch.py
+++ b/examples/sentence_transformer/applications/semantic-search/semantic_search_nq_opensearch.py
@@ -1,0 +1,138 @@
+"""
+This script contains an example how to perform semantic search with OpenSearch.
+
+As dataset, we use the Natural Questions dataset: https://ai.google.com/research/NaturalQuestions/
+
+The answers are indexed to OpenSearch together with their respective sentence embeddings.
+
+You need OpenSearch up and running locally:
+https://docs.opensearch.org/docs/latest/getting-started/quickstart/
+
+Further, you need the Python OpenSearch Client installed:
+https://docs.opensearch.org/docs/latest/clients/python-low-level/, e.g.:
+```
+pip install opensearch-py
+```
+
+This script was created for `opensearch` v2.17.0+.
+
+As embeddings model, we use the SBERT model 'nq-distilbert-base-v1',
+which is specifically trained for question answering on the Natural Questions dataset.
+"""
+
+import time
+
+from datasets import load_dataset
+from opensearchpy import OpenSearch, helpers
+from tqdm import tqdm
+
+from sentence_transformers import SentenceTransformer
+
+# 1. Load the natural-questions dataset with 100K answers
+dataset = load_dataset("sentence-transformers/natural-questions", split="train")
+num_docs = 10_000  # We use 10k documents for this example
+corpus = dataset["answer"][:num_docs]
+print(f"Finish loading data. Corpus size: {len(corpus)}")
+
+# 2. Come up with some initial queries
+queries = dataset["query"][:2]
+
+# 3. Load the model
+model = SentenceTransformer("nq-distilbert-base-v1")
+
+# 4. Encode the corpus
+print("Start encoding corpus...")
+start_time = time.time()
+corpus_embeddings = model.encode(corpus, batch_size=32, show_progress_bar=True)
+print(f"Corpus encoding time: {time.time() - start_time:.6f} seconds")
+
+
+# Function to create index and ingest documents
+def create_and_ingest_index(os_client, index_name, corpus, embeddings):
+    if os_client.indices.exists(index=index_name):
+        os_client.indices.delete(index=index_name)
+
+    os_index = {
+        "settings": {"index.knn": True},
+        "mappings": {
+            "properties": {
+                "answer": {"type": "text"},  # For BM25 search
+                "answer_vector": {
+                    "type": "knn_vector",
+                    "dimension": 768,
+                    "space_type": "cosinesimil",
+                    "mode": "on_disk",
+                },
+            }
+        },
+    }
+
+    os_client.indices.create(index=index_name, body=os_index)
+
+    # Ingest documents in batches
+    batch_size = 500
+    for start_idx in tqdm(range(0, len(corpus), batch_size)):
+        end_idx = start_idx + batch_size
+        bulk_data = []
+
+        for idx, (answer, embedding) in enumerate(zip(corpus[start_idx:end_idx], embeddings[start_idx:end_idx])):
+            doc_id = str(start_idx + idx)
+            bulk_data.append(
+                {
+                    "_index": index_name,
+                    "_id": doc_id,
+                    "_source": {
+                        "answer": answer,
+                        "answer_vector": embedding.tolist(),
+                    },
+                }
+            )
+
+        helpers.bulk(os_client, bulk_data)
+
+    os_client.indices.refresh(index=index_name)
+    return os_client, index_name
+
+
+# Initialize variables
+os_client = OpenSearch("http://localhost:9200")
+corpus_index = None
+
+while True:
+    # 5. Encode the queries
+    start_time = time.time()
+    query_embeddings = model.encode(queries)
+    encode_time = time.time() - start_time
+    print(f"Query encoding time: {encode_time:.6f} seconds")
+
+    # 6. Perform semantic search using OpenSearch
+    if corpus_index is None:
+        # Create index and ingest documents on first query
+        print("Creating index and ingesting documents...")
+        os_client, index_name = create_and_ingest_index(os_client, "nq", corpus, corpus_embeddings)
+        corpus_index = (os_client, index_name)
+
+    # Perform search
+    start_time = time.time()
+    results = []
+    os_client, index_name = corpus_index
+
+    for query_embedding in query_embeddings:
+        search_result = os_client.search(
+            index=index_name,
+            body={"size": 5, "query": {"knn": {"answer_vector": {"vector": query_embedding.tolist(), "k": 5}}}},
+        )
+        results.append(search_result["hits"]["hits"])
+
+    search_time = time.time() - start_time
+
+    # 7. Output the results
+    print(f"Search time: {search_time:.6f} seconds")
+    for query, hits in zip(queries, results):
+        print(f"Query: {query}")
+        for hit in hits:
+            print(f"(Score: {hit['_score']:.4f}) {hit['_source']['answer']}, corpus_id: {hit['_id']}")
+        print("")
+
+    # 8. Prompt for more queries
+    queries = [input("Please enter a question: ")]


### PR DESCRIPTION
Add code examples to do semantic search using OpenSearch engine. 

As dataset, we use the Natural Questions dataset: https://ai.google.com/research/NaturalQuestions/

The answers are indexed to OpenSearch together with their respective sentence embeddings. And we show the comparison between semantic search and BM25 search.