### PR TITLE
fix: device name in multi-node ddp

### DIFF
--- a/sentence_transformers/util.py
+++ b/sentence_transformers/util.py
@@ -1581,10 +1581,12 @@ def get_device_name() -> str:
         str: Device name, like 'cuda:2', 'mps', 'npu', 'hpu', or 'cpu'
     """
     if torch.cuda.is_available():
-        if torch.distributed.is_initialized():
+        if os.environ.get("LOCAL_RANK"):
+            local_rank = int(os.environ.get("LOCAL_RANK"))
+        elif torch.distributed.is_initialized() and torch.cuda.device_count() >= torch.distributed.get_rank():
             local_rank = torch.distributed.get_rank()
         else:
-            local_rank = int(os.environ.get("LOCAL_RANK", 0))
+            local_rank = 0
         return f"cuda:{local_rank}"
     elif torch.backends.mps.is_available():
         return "mps"

--- a/sentence_transformers/util.py
+++ b/sentence_transformers/util.py
@@ -1583,7 +1583,7 @@ def get_device_name() -> str:
     if torch.cuda.is_available():
         if os.environ.get("LOCAL_RANK"):
             local_rank = int(os.environ.get("LOCAL_RANK"))
-        elif torch.distributed.is_initialized() and torch.cuda.device_count() >= torch.distributed.get_rank():
+        elif torch.distributed.is_initialized() and torch.cuda.device_count() > torch.distributed.get_rank():
             local_rank = torch.distributed.get_rank()
         else:
             local_rank = 0

--- a/sentence_transformers/util.py
+++ b/sentence_transformers/util.py
@@ -1581,8 +1581,8 @@ def get_device_name() -> str:
         str: Device name, like 'cuda:2', 'mps', 'npu', 'hpu', or 'cpu'
     """
     if torch.cuda.is_available():
-        if os.environ.get("LOCAL_RANK"):
-            local_rank = int(os.environ.get("LOCAL_RANK"))
+        if "LOCAL_RANK" in os.environ:
+            local_rank = int(os.environ["LOCAL_RANK"])
         elif torch.distributed.is_initialized() and torch.cuda.device_count() > torch.distributed.get_rank():
             local_rank = torch.distributed.get_rank()
         else:


### PR DESCRIPTION
`torch.distributed.get_rank()` returns the global rank in a DDP training task. It should not be directly mapped to a CUDA device number.
In scenarios such as multi-node setups or k8s with the [NVIDIA device plugin](https://github.com/NVIDIA/k8s-device-plugin), the number of available devices on a node may be smaller than the global rank.
To avoid assigning an invalid device ordinal, it should prioritize `LOCAL_RANK` first, and then compare the number of available GPUs with the global rank.