### PR TITLE
Propagate local_files_only to model card to avoid verifying dataset/base model

### DIFF
--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -189,7 +189,7 @@ class SentenceTransformer(nn.Sequential, FitMixin, PeftAdapterMixin):
         self.similarity_fn_name = similarity_fn_name
         self.trust_remote_code = trust_remote_code
         self.truncate_dim = truncate_dim
-        self.model_card_data = model_card_data or SentenceTransformerModelCardData()
+        self.model_card_data = model_card_data or SentenceTransformerModelCardData(local_files_only=local_files_only)
         self.module_kwargs = None
         self._model_card_vars = {}
         self._model_card_text = None

--- a/sentence_transformers/cross_encoder/CrossEncoder.py
+++ b/sentence_transformers/cross_encoder/CrossEncoder.py
@@ -143,7 +143,7 @@ class CrossEncoder(nn.Module, PushToHubMixin, FitMixin):
             model_kwargs = {}
         if config_kwargs is None:
             config_kwargs = {}
-        self.model_card_data = model_card_data or CrossEncoderModelCardData()
+        self.model_card_data = model_card_data or CrossEncoderModelCardData(local_files_only=local_files_only)
         self.trust_remote_code = trust_remote_code
         self._model_card_text = None
         self.backend = backend

--- a/sentence_transformers/cross_encoder/model_card.py
+++ b/sentence_transformers/cross_encoder/model_card.py
@@ -44,6 +44,8 @@ class CrossEncoderModelCardData(SentenceTransformerModelCardData):
             e.g. "semantic search and paraphrase mining".
         tags (`Optional[List[str]]`): A list of tags for the model,
             e.g. ["sentence-transformers", "cross-encoder"].
+        local_files_only (`bool`): If True, don't attempt to find dataset or base model information on the Hub.
+            Defaults to False.
 
     .. tip::
 

--- a/sentence_transformers/model_card.py
+++ b/sentence_transformers/model_card.py
@@ -268,6 +268,8 @@ class SentenceTransformerModelCardData(CardData):
             e.g. "semantic textual similarity, semantic search, paraphrase mining, text classification, clustering, and more".
         tags (`Optional[List[str]]`): A list of tags for the model,
             e.g. ["sentence-transformers", "sentence-similarity", "feature-extraction"].
+        local_files_only (`bool`): If True, don't attempt to find dataset or base model information on the Hub.
+            Defaults to False.
 
     .. tip::
 
@@ -305,6 +307,7 @@ class SentenceTransformerModelCardData(CardData):
             "feature-extraction",
         ]
     )
+    local_files_only: bool = (False,)
     generate_widget_examples: Literal["deprecated"] = "deprecated"
 
     # Automatically filled by `SentenceTransformerModelCardCallback` and the Trainer directly
@@ -360,7 +363,7 @@ class SentenceTransformerModelCardData(CardData):
                 if "id" in dataset:
                     dataset["name"] = dataset["id"]
 
-            if "id" in dataset:
+            if "id" in dataset and not self.local_files_only:
                 # Try to determine the language from the dataset on the Hub
                 try:
                     info = get_dataset_info(dataset["id"])
@@ -753,6 +756,10 @@ class SentenceTransformerModelCardData(CardData):
         self.model_id = model_id
 
     def set_base_model(self, model_id: str, revision: str | None = None) -> None:
+        # We only set the base model if we can verify that it exists on the Hub
+        if self.local_files_only:
+            # Don't try to get the model info if we are not allowed to access the Hub
+            return False
         try:
             model_info = get_model_info(model_id)
         except Exception:

--- a/sentence_transformers/model_card.py
+++ b/sentence_transformers/model_card.py
@@ -307,7 +307,7 @@ class SentenceTransformerModelCardData(CardData):
             "feature-extraction",
         ]
     )
-    local_files_only: bool = (False,)
+    local_files_only: bool = False
     generate_widget_examples: Literal["deprecated"] = "deprecated"
 
     # Automatically filled by `SentenceTransformerModelCardCallback` and the Trainer directly


### PR DESCRIPTION
Resolves #3346

Hello!

## Pull Request overview
* Propagate local_files_only to model card to avoid verifying dataset/base model

## Details
As I suspected here (https://github.com/UKPLab/sentence-transformers/issues/3346#issuecomment-2837857271), the model card was still making requests to check:
1. languages of the given dataset(s)
2. whether the base model exists on the Hub

Now, if a SentenceTransformer or CrossEncoder model is loaded with `local_files_only`, it will not make any requests. Experiment with it here:
```python
from sentence_transformers import CrossEncoder
import logging

# Set up logging for requests and urllib3
logging.basicConfig(level=logging.DEBUG)
logging.getLogger('urllib3').setLevel(logging.DEBUG)
logging.getLogger('requests').setLevel(logging.DEBUG)

model = CrossEncoder(
    "cross-encoder/ms-marco-MiniLM-L6-v2",
    local_files_only=True
)
predictions = model.predict([["What is the capital of France?", "Paris"], ["What is the capital of Germany?", "Berlin"]])
print(predictions)
```
```
Batches: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00,  7.53it/s]
[-3.0106606 -1.509597 ]
```
On `master`, this same script returns this, i.e. it makes the base-model checking request that it shouldn't:
```python
INFO:sentence_transformers.cross_encoder.CrossEncoder:Use pytorch device: cuda:0
DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): huggingface.co:443
DEBUG:urllib3.connectionpool:https://huggingface.co:443 "GET /api/models/cross-encoder/ms-marco-MiniLM-L6-v2 HTTP/11" 200 5189
Batches: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00,  7.66it/s]
[-3.0106606 -1.509597 ]
```

- Tom Aarsen