### PR TITLE
Correcting TripletEvaluator.py Docstring

### DIFF
--- a/sentence_transformers/evaluation/TripletEvaluator.py
+++ b/sentence_transformers/evaluation/TripletEvaluator.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 class TripletEvaluator(SentenceEvaluator):
     """
     Evaluate a model based on a triplet: (sentence, positive_example, negative_example).
-    Checks if ``similarity(sentence, positive_example) < similarity(sentence, negative_example) + margin``.
+    Checks if ``similarity(sentence, positive_example) > similarity(sentence, negative_example) + margin``.
 
     Args:
         anchors (List[str]): Sentences to check similarity to. (e.g. a query)


### PR DESCRIPTION
## Resolves issue #3377 


## Pull Request overview

- Fixes an error in the docstring for the TripletEvaluator class.

## Details:

In issue #3377, @alexiaALLAL noted that in the [TripletEvaluator class](https://github.com/UKPLab/sentence-transformers/blob/163258f16cc0fa75639fd6e2b58bdc42921178f0/sentence_transformers/evaluation/TripletEvaluator.py), the docstring states:
"Checks if similarity(sentence, positive_example) < similarity(sentence, negative_example) + margin."

However, the implementation performs the following:
`accuracy = (positive_scores > negative_scores + self.margin[fn_name])`

It looks like what happened was when TripletEvaluator was changed to use [similarities instead of distances](https://github.com/UKPLab/sentence-transformers/commit/b055b5d502bbe297131f13ad04503ea4c92c5abd), the docstring was changed to replace distance() with similarity(), without changing the less than sign to a greater than sign.