### PR TITLE
Move precision format validation before training loop

### DIFF
--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -615,6 +615,10 @@ class SentenceTransformer(nn.Sequential, FitMixin, PeftAdapterMixin):
             sentences = [sentences]
             input_was_string = True
 
+        allowed_precisions = {"float32", "int8", "uint8", "binary", "ubinary"}
+        if precision is None or not isinstance(precision, str) or precision not in allowed_precisions:
+            raise ValueError(f"Precision {precision} is not supported")
+
         if prompt is None:
             if prompt_name is not None:
                 try:


### PR DESCRIPTION
Previously, the code checked if the precision was among the supported options only after the embeddings were computed. If an unsupported format was passed, it would raise a ValueError late in the process, potentially losing all prior work. This commit ensures that precision is validated as a string and among the supported options before any embedding computation begins. This also prevents AttributeError from the .endswith call in quantize_embedding if precision is not a string.