### PR TITLE
[`fix`] Use transformers Peft integration instead of manual get_peft_model call

### DIFF
--- a/sentence_transformers/models/Transformer.py
+++ b/sentence_transformers/models/Transformer.py
@@ -188,22 +188,12 @@ class Transformer(InputModule):
                 self.auto_model = AutoModel.from_pretrained(
                     model_name_or_path, config=config, cache_dir=cache_dir, **model_args
                 )
-
-            if is_peft_model:
-                self._load_peft_model(model_name_or_path, config, cache_dir, **model_args, **adapter_only_kwargs)
         elif backend == "onnx":
             self._load_onnx_model(model_name_or_path, config, cache_dir, **model_args)
         elif backend == "openvino":
             self._load_openvino_model(model_name_or_path, config, cache_dir, **model_args)
         else:
             raise ValueError(f"Unsupported backend '{backend}'. `backend` should be `torch`, `onnx`, or `openvino`.")
-
-    def _load_peft_model(self, model_name_or_path: str, config: PeftConfig, cache_dir: str, **model_args) -> None:
-        from peft import PeftModel
-
-        self.auto_model = PeftModel.from_pretrained(
-            self.auto_model, model_name_or_path, config=config, cache_dir=cache_dir, **model_args
-        )
 
     def _load_openvino_model(
         self, model_name_or_path: str, config: PretrainedConfig, cache_dir: str, **model_args

--- a/tests/test_sentence_transformer.py
+++ b/tests/test_sentence_transformer.py
@@ -10,13 +10,14 @@ import os
 import re
 from functools import partial
 from pathlib import Path
-from typing import Literal, cast
+from typing import Callable, Literal, cast
 
 import numpy as np
 import pytest
 import torch
 from huggingface_hub import CommitInfo, HfApi, RepoUrl
 from torch import nn
+from transformers import BertModel
 from transformers.utils import is_peft_available
 
 from sentence_transformers import SentenceTransformer, util
@@ -441,7 +442,7 @@ def test_load_with_model_kwargs(monkeypatch: pytest.MonkeyPatch) -> None:
 
 @pytest.mark.skipif(not is_peft_available(), reason="PEFT must be available to test PEFT support.")
 def test_load_checkpoint_with_peft_and_lora() -> None:
-    from peft import LoraConfig, PeftModel, TaskType
+    from peft import LoraConfig, TaskType
 
     peft_config = LoraConfig(
         target_modules=["query", "key", "value"],
@@ -461,8 +462,10 @@ def test_load_checkpoint_with_peft_and_lora() -> None:
         loaded_peft_model = SentenceTransformer(tmp_folder)
         actuals = loaded_peft_model.encode(["Hello there!", "How are you?"], convert_to_tensor=True)
 
-        assert isinstance(model._modules["0"].auto_model, nn.Module)
-        assert isinstance(loaded_peft_model._modules["0"].auto_model, PeftModel)
+        assert isinstance(model[0].auto_model, nn.Module)
+        assert isinstance(loaded_peft_model[0].auto_model, BertModel)
+        assert loaded_peft_model[0].auto_model._hf_peft_config_loaded
+        assert loaded_peft_model[0].auto_model.active_adapters() == ["default"]
         assert torch.equal(expecteds, actuals)
 
 
@@ -688,31 +691,36 @@ def test_override_config_versions(stsb_bert_tiny_model: SentenceTransformer) -> 
 @pytest.mark.parametrize(
     "modules",
     [
-        [
+        lambda: [
             Transformer("sentence-transformers-testing/stsb-bert-tiny-safetensors"),
             Pooling(128, "mean"),
             Dense(128, 128),
         ],
-        [Transformer("sentence-transformers-testing/stsb-bert-tiny-safetensors"), CNN(128, 128), Pooling(128, "mean")],
-        [
+        lambda: [
+            Transformer("sentence-transformers-testing/stsb-bert-tiny-safetensors"),
+            CNN(128, 128),
+            Pooling(128, "mean"),
+        ],
+        lambda: [
             Transformer("sentence-transformers-testing/stsb-bert-tiny-safetensors"),
             Pooling(128, "mean"),
             LayerNorm(128),
         ],
-        [
+        lambda: [
             SentenceTransformer("sentence-transformers/average_word_embeddings_levy_dependency")[0],
             LSTM(300, 128),
             Pooling(128, "mean"),
         ],
-        [
+        lambda: [
             Transformer("sentence-transformers-testing/stsb-bert-tiny-safetensors"),
             WeightedLayerPooling(128, num_hidden_layers=2, layer_start=1),
             Pooling(128, "mean"),
         ],
-        SentenceTransformer("sentence-transformers/average_word_embeddings_levy_dependency"),
+        lambda: SentenceTransformer("sentence-transformers/average_word_embeddings_levy_dependency"),
     ],
 )
-def test_safetensors(modules: list[nn.Module] | SentenceTransformer) -> None:
+def test_safetensors(modules: Callable[[], list[nn.Module] | SentenceTransformer]) -> None:
+    modules = modules()  # Call the lambda to get the actual modules
     if isinstance(modules, SentenceTransformer):
         model = modules
     else:


### PR DESCRIPTION
Resolves #3402

Hello!

## Pull Request overview
* Use transformers Peft integration instead of manual get_peft_model call

## Details
This resolves the issue from #3402. In short, I actually fixed this via https://github.com/arthurbr11/sentence-transformers/pull/47, which ended up really changing up the `_load_from_checkpoint` on the trainers. However, it wasn't until #3403 by @bg-l2norm that I discovered the discrepancy between 1) loading a model with an Adapter and 2) adding an adapter with e.g. `add_adapter`. In short, the former calls `get_peft_model` and turns the base model into a `PeftModelFor...`, whereas the latter keeps the model as a e.g. `BertModel`, but with LoRA layers.

@bg-l2norm 's PR updates the latter so that both cases use `PeftModelFor...`. However, I think my preference for now is to use the `transformers` implementation as much as possible. That's why I've made this PR - to align them so that both use e.g. `BertModel` but with e.g. LoRA layers.

I tested a training script with both #3403 and this PR, and both work, but my preference is this PR. Thank you @bg-l2norm and @mjstel for helping me get this resolved nicely!

- Tom Aarsen