### PR TITLE
[`docs`] Fix formatting of docstring arguments in SpladeRegularizerWeightSchedulerCallback

### DIFF
--- a/sentence_transformers/sparse_encoder/callbacks/splade_callbacks.py
+++ b/sentence_transformers/sparse_encoder/callbacks/splade_callbacks.py
@@ -32,10 +32,10 @@ class SpladeRegularizerWeightSchedulerCallback(TrainerCallback):
         The scheduler gradually increases the weight values from 0 to their max value
         within the specified warmup ratio of the total training steps.
 
-         Args:
-                loss: SpladeLoss instance to be updated
-                scheduler_type: Type of scheduler ('linear' or 'quadratic')
-                warmup_ratio: Ratio of total steps to reach max weight values (default: 1/3)
+        Args:
+            loss (SpladeLoss): SpladeLoss instance to be updated
+            scheduler_type (str): Type of scheduler ('linear' or 'quadratic')
+            warmup_ratio (float): Ratio of total steps to reach max weight values (default: 1/3)
         """
         super().__init__()
 


### PR DESCRIPTION
Hello!

## Pull Request overview
* Fix formatting of docstring arguments in SpladeRegularizerWeightSchedulerCallback

## Details
Currently, the docs look like this:
![image](https://github.com/user-attachments/assets/46fe5ecb-0598-4719-a0f7-31f967fe4a4f)

Afterwards, like this:
![image](https://github.com/user-attachments/assets/be31b69a-167a-4b6a-bbb3-adc3e070bad6)

- Tom Aarsen