### PR TITLE
[`docs`] Fix link in README for training script name

### DIFF
--- a/examples/sparse_encoder/training/sts/README.md
+++ b/examples/sparse_encoder/training/sts/README.md
@@ -2,7 +2,7 @@
 
 Semantic Textual Similarity (STS) assigns a score on the similarity of two texts. In this example, we use the [stsb](https://huggingface.co/datasets/sentence-transformers/stsb) dataset as training data to fine-tune our sparse encoder model. See the following example scripts how to tune a SparseEncoder, and espacially fine-tune a splade model on STS data:
 
-- **[train_splade_stsbenchmark_sparse.py](train_splade_stsbenchmark_sparse.py)** - This example shows how to fine-tune a splade model already pre-trained by using a pre-trained splade model (e.g. [`splade-cocondenser-ensembledistil`](https://huggingface.co/naver/splade-cocondenser-ensembledistil)) and fine tuning it to get better result on this specific task.
+- **[train_splade_stsbenchmark.py](train_splade_stsbenchmark.py)** - This example shows how to fine-tune a splade model already pre-trained by using a pre-trained splade model (e.g. [`splade-cocondenser-ensembledistil`](https://huggingface.co/naver/splade-cocondenser-ensembledistil)) and fine tuning it to get better result on this specific task.
 
 ## Training data
 ```{eval-rst}


### PR DESCRIPTION
Hello!

## Pull Request overview
* Fix link in README for training script name

## Details
We renamed the file from `train_splade_stsbenchmark_sparse.py` to `train_splade_stsbenchmark.py`, but forgot to update this reference.

- Tom Aarsen