### PR TITLE
Adjust label shape handling in MarginMSELoss for single score inputs

### DIFF
--- a/sentence_transformers/losses/MarginMSELoss.py
+++ b/sentence_transformers/losses/MarginMSELoss.py
@@ -187,6 +187,11 @@ class MarginMSELoss(nn.Module):
             # we need to adjust the labels to be the difference between positive and negatives
             labels = labels[:, 0].unsqueeze(1) - labels[:, 1:]
 
+        if labels.shape == (batch_size,):
+            # If labels are given as a single score for positive and multiple negatives,
+            # we need to adjust the labels to be the difference between positive and negatives
+            labels = labels.unsqueeze(1)
+
         if labels.shape != (batch_size, len(embeddings_negs)):
             raise ValueError(
                 f"Labels shape {labels.shape} does not match expected shape {(batch_size, len(embeddings_negs))}. "


### PR DESCRIPTION
Hello!

## Pull Request overview
* Adjust label shape handling in MarginMSELoss for single score inputs

## Details
Some recent changes to allow for separate scores for query-positive and query-negative in MarginMSELoss (instead of just query-positive minus query-negative scores) introduced an issue preventing single-score inputs. This resolves that.

In the meantime, please use a list of scores, even if you just have 1 score (e.g. in the triplet case).

cc @arthurbr11 

- Tom Aarsen