### PR TITLE
Sync `prompts` type with documentation

### DIFF
--- a/sentence_transformers/training_args.py
+++ b/sentence_transformers/training_args.py
@@ -193,7 +193,7 @@ class SentenceTransformerTrainingArguments(TransformersTrainingArguments):
             with different learning rates.
     """
 
-    prompts: Optional[str] = field(  # noqa: UP007
+    prompts: Optional[Union[Dict[str, Dict[str, str]], Dict[str, str], str]] = field(  # noqa: UP007
         default=None,
         metadata={
             "help": "The prompts to use for each column in the datasets. "


### PR DESCRIPTION
`Union[Dict[str, Dict[str, str]], Dict[str, str], str]` instead of `str`

(no idea if this compiles, just made this change while looking at the github)