### PR TITLE
[`tests`] Reuse models more where possible

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,6 +28,18 @@ def stsb_bert_tiny_model(_stsb_bert_tiny_model: SentenceTransformer) -> Sentence
     return deepcopy(_stsb_bert_tiny_model)
 
 
+@pytest.fixture(scope="session")
+def _avg_word_embeddings_levy() -> SentenceTransformer:
+    model = SentenceTransformer("sentence-transformers/average_word_embeddings_levy_dependency")
+    model.model_card_data.generate_widget_examples = False  # Disable widget examples generation for testing
+    return model
+
+
+@pytest.fixture()
+def avg_word_embeddings_levy(_avg_word_embeddings_levy: SentenceTransformer) -> SentenceTransformer:
+    return deepcopy(_avg_word_embeddings_levy)
+
+
 @pytest.fixture()
 def stsb_bert_tiny_model_onnx() -> SentenceTransformer:
     return SentenceTransformer("sentence-transformers-testing/stsb-bert-tiny-onnx")

--- a/tests/test_pretrained_stsb.py
+++ b/tests/test_pretrained_stsb.py
@@ -111,6 +111,7 @@ def test_sentence_t5_slow() -> None:
     pretrained_model_score_slow("sentence-t5-base", 85.52)
 
 
+@pytest.mark.slow  # Also marked as slow to avoid running it with CI: results in too many requests to the Hugging Face Hub
 @pytest.mark.parametrize(
     ["model_name", "expected_score"],
     [

--- a/tests/test_sentence_transformer.py
+++ b/tests/test_sentence_transformer.py
@@ -258,9 +258,9 @@ def test_push_to_hub(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureF
 
 
 @pytest.mark.parametrize("safe_serialization", [True, False, None])
-def test_safe_serialization(safe_serialization: bool) -> None:
+def test_safe_serialization(stsb_bert_tiny_model: SentenceTransformer, safe_serialization: bool) -> None:
+    model = stsb_bert_tiny_model
     with SafeTemporaryDirectory() as cache_folder:
-        model = SentenceTransformer("sentence-transformers-testing/stsb-bert-tiny-safetensors")
         if safe_serialization:
             model.save(cache_folder, safe_serialization=safe_serialization)
             model_files = list(Path(cache_folder).glob("**/model.safetensors"))
@@ -466,8 +466,8 @@ def test_prompt_length_calculation(
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA must be available to test float16 support.")
-def test_load_with_torch_dtype() -> None:
-    model = SentenceTransformer("sentence-transformers-testing/stsb-bert-tiny-safetensors")
+def test_load_with_torch_dtype(stsb_bert_tiny_model: SentenceTransformer) -> None:
+    model = stsb_bert_tiny_model
 
     assert model.encode(["Hello there!"], convert_to_tensor=True).dtype == torch.float32
 
@@ -508,7 +508,8 @@ def test_load_with_model_kwargs(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.mark.skipif(not is_peft_available(), reason="PEFT must be available to test PEFT support.")
-def test_load_checkpoint_with_peft_and_lora() -> None:
+def test_load_checkpoint_with_peft_and_lora(stsb_bert_tiny_model: SentenceTransformer) -> None:
+    model = stsb_bert_tiny_model
     from peft import LoraConfig, TaskType
 
     peft_config = LoraConfig(
@@ -521,7 +522,6 @@ def test_load_checkpoint_with_peft_and_lora() -> None:
     )
 
     with SafeTemporaryDirectory() as tmp_folder:
-        model = SentenceTransformer("sentence-transformers-testing/stsb-bert-tiny-safetensors")
         model.add_adapter(peft_config)
         model.save(tmp_folder)
         expecteds = model.encode(["Hello there!", "How are you?"], convert_to_tensor=True)
@@ -537,8 +537,8 @@ def test_load_checkpoint_with_peft_and_lora() -> None:
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA must be available to test float16 support.")
-def test_encode_fp16() -> None:
-    tiny_model = SentenceTransformer("sentence-transformers-testing/stsb-bert-tiny-safetensors")
+def test_encode_fp16(stsb_bert_tiny_model: SentenceTransformer) -> None:
+    tiny_model = stsb_bert_tiny_model
     tiny_model.half()
     embeddings = tiny_model.encode(["Hello there!"], convert_to_tensor=True)
     assert embeddings.dtype == torch.float16
@@ -763,36 +763,40 @@ def test_override_config_versions(stsb_bert_tiny_model: SentenceTransformer) -> 
 @pytest.mark.parametrize(
     "modules",
     [
-        lambda: [
-            Transformer("sentence-transformers-testing/stsb-bert-tiny-safetensors"),
+        lambda bert_model, word_model: [
+            bert_model[0],
             Pooling(128, "mean"),
             Dense(128, 128),
         ],
-        lambda: [
-            Transformer("sentence-transformers-testing/stsb-bert-tiny-safetensors"),
+        lambda bert_model, word_model: [
+            bert_model[0],
             CNN(128, 128),
             Pooling(128, "mean"),
         ],
-        lambda: [
-            Transformer("sentence-transformers-testing/stsb-bert-tiny-safetensors"),
+        lambda bert_model, word_model: [
+            bert_model[0],
             Pooling(128, "mean"),
             LayerNorm(128),
         ],
-        lambda: [
-            SentenceTransformer("sentence-transformers/average_word_embeddings_levy_dependency")[0],
+        lambda bert_model, word_model: [
+            word_model[0],
             LSTM(300, 128),
             Pooling(128, "mean"),
         ],
-        lambda: [
-            Transformer("sentence-transformers-testing/stsb-bert-tiny-safetensors"),
+        lambda bert_model, word_model: [
+            bert_model[0],
             WeightedLayerPooling(128, num_hidden_layers=2, layer_start=1),
             Pooling(128, "mean"),
         ],
-        lambda: SentenceTransformer("sentence-transformers/average_word_embeddings_levy_dependency"),
+        lambda bert_model, word_model: word_model,
     ],
 )
-def test_safetensors(modules: Callable[[], list[nn.Module] | SentenceTransformer]) -> None:
-    modules = modules()  # Call the lambda to get the actual modules
+def test_safetensors(
+    stsb_bert_tiny_model: SentenceTransformer,
+    avg_word_embeddings_levy: SentenceTransformer,
+    modules: Callable[[], list[nn.Module] | SentenceTransformer],
+) -> None:
+    modules = modules(stsb_bert_tiny_model, avg_word_embeddings_levy)  # Call the lambda to get the actual modules
     if isinstance(modules, SentenceTransformer):
         model = modules
     else:
@@ -824,9 +828,11 @@ def test_empty_encode(stsb_bert_tiny_model: SentenceTransformer) -> None:
 @pytest.mark.skipif(
     is_ci(), reason="huggingface_hub & PEFT incorrectly set the user agent in the CI, leading to failures."
 )
-def test_multiple_adapters() -> None:
+def test_multiple_adapters(
+    stsb_bert_tiny_model: SentenceTransformer, avg_word_embeddings_levy: SentenceTransformer
+) -> None:
     text = "Hello, World!"
-    model = SentenceTransformer("sentence-transformers-testing/stsb-bert-tiny-safetensors")
+    model = stsb_bert_tiny_model
     vec_initial = model.encode(text)
     from peft import LoraConfig, TaskType, get_model_status
 
@@ -883,7 +889,7 @@ def test_multiple_adapters() -> None:
     assert np.allclose(vec_initial, vec_no_adapter)
 
     # Check that for non Transformer-based models we have an error
-    model = SentenceTransformer("sentence-transformers/average_word_embeddings_levy_dependency")
+    model = avg_word_embeddings_levy
     with pytest.raises(ValueError, match="PEFT methods are only supported"):
         model.add_adapter(peft_config)
 


### PR DESCRIPTION
Hello!

## Pull Request overview
* Reuse models more where possible in tests
* Mark some download-intense tests as slow

## Details
The test suite on GitHub actions is currently struggling due to the large number of requests to the Hugging Face hub. This PR aims to reduce that number slightly, hopefully allowing the test suite to pass more easily.

- Tom Aarsen