### PR TITLE
Fix ONNX/OV export; Avoid .transformers_model

### DIFF
--- a/sentence_transformers/backend.py
+++ b/sentence_transformers/backend.py
@@ -83,7 +83,8 @@ def export_optimized_onnx_model(
     viable_st_model = (
         isinstance(model, SentenceTransformer)
         and len(model)
-        and isinstance(model.transformers_model, ORTModelForFeatureExtraction)
+        and hasattr(model[0], "auto_model")
+        and isinstance(model[0].auto_model, ORTModelForFeatureExtraction)
     )
     viable_ce_model = isinstance(model, CrossEncoder) and isinstance(model.model, ORTModelForSequenceClassification)
     if not (viable_st_model or viable_ce_model):
@@ -92,7 +93,7 @@ def export_optimized_onnx_model(
         )
 
     if viable_st_model:
-        ort_model: ORTModelForFeatureExtraction = model.transformers_model
+        ort_model: ORTModelForFeatureExtraction = model[0].auto_model
     else:
         ort_model: ORTModelForSequenceClassification = model.model
     optimizer = ORTOptimizer.from_pretrained(ort_model)
@@ -174,7 +175,8 @@ def export_dynamic_quantized_onnx_model(
     viable_st_model = (
         isinstance(model, SentenceTransformer)
         and len(model)
-        and isinstance(model.transformers_model, ORTModelForFeatureExtraction)
+        and hasattr(model[0], "auto_model")
+        and isinstance(model[0].auto_model, ORTModelForFeatureExtraction)
     )
     viable_ce_model = isinstance(model, CrossEncoder) and isinstance(model.model, ORTModelForSequenceClassification)
     if not (viable_st_model or viable_ce_model):
@@ -183,7 +185,7 @@ def export_dynamic_quantized_onnx_model(
         )
 
     if viable_st_model:
-        ort_model: ORTModelForFeatureExtraction = model.transformers_model
+        ort_model: ORTModelForFeatureExtraction = model[0].auto_model
     else:
         ort_model: ORTModelForSequenceClassification = model.model
     quantizer = ORTQuantizer.from_pretrained(ort_model)
@@ -283,7 +285,8 @@ def export_static_quantized_openvino_model(
     viable_st_model = (
         isinstance(model, SentenceTransformer)
         and len(model)
-        and isinstance(model.transformers_model, OVModelForFeatureExtraction)
+        and hasattr(model[0], "auto_model")
+        and isinstance(model[0].auto_model, OVModelForFeatureExtraction)
     )
     viable_ce_model = isinstance(model, CrossEncoder) and isinstance(model.model, OVModelForSequenceClassification)
     if not (viable_st_model or viable_ce_model):
@@ -295,7 +298,7 @@ def export_static_quantized_openvino_model(
         quantization_config = OVQuantizationConfig()
 
     if viable_st_model:
-        ov_model: OVModelForFeatureExtraction = model.transformers_model
+        ov_model: OVModelForFeatureExtraction = model[0].auto_model
     else:
         ov_model: OVModelForSequenceClassification = model.model
     ov_config = OVConfig(quantization_config=quantization_config)

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -4,16 +4,20 @@ import gc
 import json
 import os
 import tempfile
+from contextlib import nullcontext
 from pathlib import Path
 
 import numpy as np
 import pytest
+from packaging.version import Version, parse
 
 from tests.utils import is_ci
 
 try:
     from optimum.intel import OVModelForFeatureExtraction
+    from optimum.intel.version import __version__ as optimum_intel_version
     from optimum.onnxruntime import ORTModelForFeatureExtraction
+    from optimum.version import __version__ as optimum_version
 except ImportError:
     pytest.skip("OpenVINO and ONNX backends are not available", allow_module_level=True)
 
@@ -39,24 +43,29 @@ def test_backend_export(backend, expected_auto_model_class, model_kwargs) -> Non
         "sentence-transformers-testing/stsb-bert-tiny-safetensors", backend=backend, model_kwargs=model_kwargs
     )
     assert model.get_backend() == backend
-    assert isinstance(model.transformers_model, expected_auto_model_class)
+    assert isinstance(model[0].auto_model, expected_auto_model_class)
     embedding = model.encode("Hello, World!")
     assert embedding.shape == (model.get_sentence_embedding_dimension(),)
 
 
 def test_backend_no_export_crash():
-    # ONNX Crashes when it can't export & the model repo/path doesn't contain an exported model
-    with pytest.raises(OSError):
-        SentenceTransformer(
+    # Prior to optimum v1.25.0, ONNX Crashes when it can't export & the model repo/path doesn't contain an exported model
+    # Since then, it auto-updates export to True
+    with pytest.raises(OSError) if parse(optimum_version) < Version("1.25.0") else nullcontext():
+        model = SentenceTransformer(
             "sentence-transformers-testing/stsb-bert-tiny-safetensors", backend="onnx", model_kwargs={"export": False}
         )
+        assert isinstance(model[0].auto_model, ORTModelForFeatureExtraction)
 
     # OpenVINO will forcibly override the export=False if the model repo/path doesn't contain an exported model
-    # But only starting from v1.19.0
-    model = SentenceTransformer(
-        "sentence-transformers-testing/stsb-bert-tiny-safetensors", backend="openvino", model_kwargs={"export": False}
-    )
-    assert isinstance(model.transformers_model, OVModelForFeatureExtraction)
+    # But only starting from optimum-intel=v1.19.0
+    with pytest.raises(OSError) if parse(optimum_intel_version) < Version("1.19.0") else nullcontext():
+        model = SentenceTransformer(
+            "sentence-transformers-testing/stsb-bert-tiny-safetensors",
+            backend="openvino",
+            model_kwargs={"export": False},
+        )
+        assert isinstance(model[0].auto_model, OVModelForFeatureExtraction)
 
 
 ## Testing loading exported models:
@@ -101,7 +110,7 @@ def test_openvino_provider() -> None:
         backend="openvino",
         model_kwargs={"ov_config": {"INFERENCE_PRECISION_HINT": "precision_1"}},
     )
-    assert model.transformers_model.ov_config == {
+    assert model[0].auto_model.ov_config == {
         "INFERENCE_PRECISION_HINT": "precision_1",
         "PERFORMANCE_HINT": "LATENCY",
     }
@@ -116,7 +125,7 @@ def test_openvino_provider() -> None:
             backend="openvino",
             model_kwargs={"ov_config": ov_config_path},
         )
-        assert model.transformers_model.ov_config == {
+        assert model[0].auto_model.ov_config == {
             "INFERENCE_PRECISION_HINT": "precision_2",
             "PERFORMANCE_HINT": "LATENCY",
         }
@@ -151,7 +160,7 @@ def test_openvino_backend() -> None:
             model_kwargs={"ov_config": config_file},
         )
         # The transformers model is an Optimum model with an OpenVINO inference request property
-        assert openvino_model_with_config.transformers_model.request.get_property("NUM_STREAMS") == 2
+        assert openvino_model_with_config[0].auto_model.request.get_property("NUM_STREAMS") == 2
 
         # Test that saving and loading local OpenVINO models works as expected
         openvino_model_with_config.save_pretrained(tmpdirname)


### PR DESCRIPTION
Hello!

## Pull Request overview
* Fix ONNX/OV export

## Details
I'm avoiding the `.transformers_model` for ONNX/OV exported models, as these models don't have modules that are `transformers` `PreTrainedModel` instances, but instead optimum models. This is an oversight on my end that I didn't catch as my local tests didn't run because I didn't have `optimum-intel` installed anymore.

It should help with #3437, but I believe that I've always had issues exporting bge-m3 as the ONNX file gets too big. It looks like @xenova was able to get it to work with https://huggingface.co/Xenova/bge-m3, however. 

- Tom Aarsen