### PR TITLE
[`feat`] Add gather_across_devices parameter to some contrastive losses

### DIFF
--- a/sentence_transformers/losses/CachedMultipleNegativesRankingLoss.py
+++ b/sentence_transformers/losses/CachedMultipleNegativesRankingLoss.py
@@ -12,6 +12,7 @@ from torch.utils.checkpoint import get_device_states, set_device_states
 
 from sentence_transformers import SentenceTransformer, util
 from sentence_transformers.models import StaticEmbedding
+from sentence_transformers.util import all_gather_with_grad
 
 
 class RandContext:
@@ -67,6 +68,7 @@ class CachedMultipleNegativesRankingLoss(nn.Module):
         scale: float = 20.0,
         similarity_fct: callable[[Tensor, Tensor], Tensor] = util.cos_sim,
         mini_batch_size: int = 32,
+        gather_across_devices: bool = False,
         show_progress_bar: bool = False,
     ) -> None:
         """
@@ -90,13 +92,18 @@ class CachedMultipleNegativesRankingLoss(nn.Module):
 
         Args:
             model: SentenceTransformer model
-            scale: Output of similarity function is multiplied by scale value
+            scale: Output of similarity function is multiplied by scale value. In some literature, the scaling parameter
+                is referred to as temperature, which is the inverse of the scale. In short: scale = 1 / temperature, so
+                scale=20.0 is equivalent to temperature=0.05.
             similarity_fct: similarity function between sentence embeddings. By default, cos_sim. Can also be set to dot
                 product (and then set scale to 1)
             mini_batch_size: Mini-batch size for the forward pass, this denotes how much memory is actually used during
                 training and evaluation. The larger the mini-batch size, the more memory efficient the training is, but
                 the slower the training will be. It's recommended to set it as high as your GPU memory allows. The default
                 value is 32.
+            gather_across_devices: If True, gather the embeddings across all devices before computing the loss.
+                Recommended when training on multiple GPUs, as it allows for larger batch sizes, but it may slow down
+                training due to communication overhead, and can potentially lead to out-of-memory errors.
             show_progress_bar: If True, a progress bar for the mini-batches is shown during training. The default is False.
 
         References:
@@ -157,11 +164,13 @@ class CachedMultipleNegativesRankingLoss(nn.Module):
         self.model = model
         self.scale = scale
         self.similarity_fct = similarity_fct
-        self.cross_entropy_loss = nn.CrossEntropyLoss()
         self.mini_batch_size = mini_batch_size
+        self.gather_across_devices = gather_across_devices
+        self.show_progress_bar = show_progress_bar
+
+        self.cross_entropy_loss = nn.CrossEntropyLoss()
         self.cache: list[list[Tensor]] | None = None
         self.random_states: list[list[RandContext]] | None = None
-        self.show_progress_bar = show_progress_bar
 
     def embed_minibatch(
         self,
@@ -223,13 +232,25 @@ class CachedMultipleNegativesRankingLoss(nn.Module):
 
     def calculate_loss(self, reps: list[list[Tensor]], with_backward: bool = False) -> Tensor:
         """Calculate the cross-entropy loss. No need to cache the gradients."""
-        embeddings_a = torch.cat(reps[0])  # (bsz, hdim)
-        embeddings_b = torch.cat([torch.cat(r) for r in reps[1:]])  # ((1 + nneg) * bsz, hdim)
+        anchors = torch.cat(reps[0])  # (bsz, hdim)
+        candidates = torch.cat([torch.cat(r) for r in reps[1:]])  # ((1 + nneg) * bsz, hdim)
+        batch_size = len(anchors)
 
-        batch_size = len(embeddings_a)
-        labels = torch.tensor(
-            range(batch_size), dtype=torch.long, device=embeddings_a.device
-        )  # (bsz, (1 + nneg) * bsz)  Example a[i] should match with b[i]
+        labels = torch.tensor(range(batch_size), dtype=torch.long, device=anchors.device)
+        # (bsz, (1 + nneg) * bsz)  Example a[i] should match with b[i]
+
+        if self.gather_across_devices:
+            # Gather the candidates across all devices, with gradients, but not the anchors. We compute only this
+            # device's anchors with all candidates from all devices, such that the backward pass on the document
+            # embeddings can flow back to the original devices.
+            candidates = all_gather_with_grad(candidates)
+            # (batch_size * world_size * (1 + num_negatives), embedding_dim)
+
+            # Adjust the range_labels to account for the gathered candidates
+            if torch.distributed.is_initialized():
+                rank = torch.distributed.get_rank()
+                labels = labels + rank * batch_size
+
         losses: list[torch.Tensor] = []
         for b in tqdm.trange(
             0,
@@ -239,7 +260,7 @@ class CachedMultipleNegativesRankingLoss(nn.Module):
             disable=not self.show_progress_bar,
         ):
             e = b + self.mini_batch_size
-            scores: Tensor = self.similarity_fct(embeddings_a[b:e], embeddings_b) * self.scale
+            scores: Tensor = self.similarity_fct(anchors[b:e], candidates) * self.scale
             loss_mbatch: torch.Tensor = self.cross_entropy_loss(scores, labels[b:e]) * len(scores) / batch_size
             if with_backward:
                 loss_mbatch.backward()
@@ -283,6 +304,7 @@ class CachedMultipleNegativesRankingLoss(nn.Module):
             "scale": self.scale,
             "similarity_fct": self.similarity_fct.__name__,
             "mini_batch_size": self.mini_batch_size,
+            "gather_across_devices": self.gather_across_devices,
         }
 
     @property

--- a/sentence_transformers/losses/CachedMultipleNegativesRankingLoss.py
+++ b/sentence_transformers/losses/CachedMultipleNegativesRankingLoss.py
@@ -236,7 +236,7 @@ class CachedMultipleNegativesRankingLoss(nn.Module):
         candidates = torch.cat([torch.cat(r) for r in reps[1:]])  # ((1 + nneg) * bsz, hdim)
         batch_size = len(anchors)
 
-        labels = torch.tensor(range(batch_size), dtype=torch.long, device=anchors.device)
+        labels = torch.arange(batch_size, dtype=torch.long, device=anchors.device)
         # (bsz, (1 + nneg) * bsz)  Example a[i] should match with b[i]
 
         if self.gather_across_devices:

--- a/sentence_transformers/losses/CachedMultipleNegativesSymmetricRankingLoss.py
+++ b/sentence_transformers/losses/CachedMultipleNegativesSymmetricRankingLoss.py
@@ -12,6 +12,7 @@ from torch import Tensor, nn
 from sentence_transformers import SentenceTransformer, util
 from sentence_transformers.losses.CachedMultipleNegativesRankingLoss import RandContext
 from sentence_transformers.models import StaticEmbedding
+from sentence_transformers.util import all_gather_with_grad
 
 
 def _backward_hook(
@@ -44,6 +45,7 @@ class CachedMultipleNegativesSymmetricRankingLoss(nn.Module):
         scale: float = 20.0,
         similarity_fct: callable[[Tensor, Tensor], Tensor] = util.cos_sim,
         mini_batch_size: int = 32,
+        gather_across_devices: bool = False,
         show_progress_bar: bool = False,
     ) -> None:
         """
@@ -64,13 +66,19 @@ class CachedMultipleNegativesSymmetricRankingLoss(nn.Module):
 
         Args:
             model: SentenceTransformer model
-            scale: Output of similarity function is multiplied by scale value
-            similarity_fct: similarity function between sentence embeddings. By default, cos_sim.
-                Can also be set to dot product (and then set scale to 1)
+            scale: Output of similarity function is multiplied by scale value. In some literature, the scaling parameter
+                is referred to as temperature, which is the inverse of the scale. In short: scale = 1 / temperature, so
+                scale=20.0 is equivalent to temperature=0.05.
+            similarity_fct: similarity function between sentence embeddings. By default, cos_sim. Can also be set to dot
+                product (and then set scale to 1)
             mini_batch_size: Mini-batch size for the forward pass, this denotes how much memory is actually used during
                 training and evaluation. The larger the mini-batch size, the more memory efficient the training is, but
-                the slower the training will be.
-            show_progress_bar: If True, shows progress bar during processing
+                the slower the training will be. It's recommended to set it as high as your GPU memory allows. The default
+                value is 32.
+            gather_across_devices: If True, gather the embeddings across all devices before computing the loss.
+                Recommended when training on multiple GPUs, as it allows for larger batch sizes, but it may slow down
+                training due to communication overhead, and can potentially lead to out-of-memory errors.
+            show_progress_bar: If True, a progress bar for the mini-batches is shown during training. The default is False.
 
         Requirements:
             1. (anchor, positive) pairs
@@ -125,11 +133,13 @@ class CachedMultipleNegativesSymmetricRankingLoss(nn.Module):
         self.model = model
         self.scale = scale
         self.similarity_fct = similarity_fct
-        self.cross_entropy_loss = nn.CrossEntropyLoss()
         self.mini_batch_size = mini_batch_size
+        self.gather_across_devices = gather_across_devices
+        self.show_progress_bar = show_progress_bar
+
+        self.cross_entropy_loss = nn.CrossEntropyLoss()
         self.cache: list[list[Tensor]] | None = None
         self.random_states: list[list[RandContext]] | None = None
-        self.show_progress_bar = show_progress_bar
 
     def embed_minibatch(
         self,
@@ -159,21 +169,21 @@ class CachedMultipleNegativesSymmetricRankingLoss(nn.Module):
     ) -> Iterator[tuple[Tensor, RandContext | None]]:
         """Iterate over mini-batches of sentences for embedding."""
         input_ids: Tensor = sentence_feature["input_ids"]
-        bsz, _ = input_ids.shape
-        for i, b in enumerate(
+        batch_size, _ = input_ids.shape
+        for i, begin in enumerate(
             tqdm.trange(
                 0,
-                bsz,
+                batch_size,
                 self.mini_batch_size,
                 desc="Embed mini-batches",
                 disable=not self.show_progress_bar,
             )
         ):
-            e = b + self.mini_batch_size
+            end = begin + self.mini_batch_size
             reps, random_state = self.embed_minibatch(
                 sentence_feature=sentence_feature,
-                begin=b,
-                end=e,
+                begin=begin,
+                end=end,
                 with_grad=with_grad,
                 copy_random_state=copy_random_state,
                 random_state=None if random_states is None else random_states[i],
@@ -191,34 +201,52 @@ class CachedMultipleNegativesSymmetricRankingLoss(nn.Module):
 
     def calculate_loss(self, reps: list[list[Tensor]], with_backward: bool = False) -> Tensor:
         """Calculate the symmetric loss without caching gradients (for evaluation)."""
-        embeddings_a = torch.cat(reps[0])  # (bsz, hdim)
-        embeddings_b = torch.cat([torch.cat(r) for r in reps[1:]])  # ((1 + nneg) * bsz, hdim)
+        anchors = torch.cat(reps[0])  # (bsz, hdim)
+        candidates = torch.cat([torch.cat(r) for r in reps[1:]])  # ((1 + nneg) * bsz, hdim)
+        batch_size = len(anchors)
+        offset = 0
 
-        batch_size = len(embeddings_a)
-        labels = torch.arange(batch_size, device=embeddings_a.device)
+        if self.gather_across_devices:
+            # Gather the anchors and candidates across all devices, with gradients. We compute only this device's anchors
+            # with all candidates from all devices, and only this device's candidates with all anchors from all devices.
+            # We do this in such a way that the backward pass on the embeddings can flow back to the original devices.
+            anchors = all_gather_with_grad(anchors)
+            candidates = all_gather_with_grad(candidates)
+            # Both are (batch_size * world_size, embedding_dim)
+
+            # Adjust the range_labels to account for the gathered candidates
+            if torch.distributed.is_initialized():
+                rank = torch.distributed.get_rank()
+                offset = rank * batch_size
+
+        labels = torch.arange(offset, offset + batch_size, device=anchors.device)
+        # (bsz, (1 + nneg) * bsz)  Example a[i] should match with b[i]
 
         losses: list[torch.Tensor] = []
-        for b in tqdm.trange(
+        for begin in tqdm.trange(
             0,
             batch_size,
             self.mini_batch_size,
             desc="Calculating loss",
             disable=not self.show_progress_bar,
         ):
-            e = min(b + self.mini_batch_size, batch_size)
-            scores: Tensor = self.similarity_fct(embeddings_a[b:e], embeddings_b) * self.scale
-            forward_loss: torch.Tensor = self.cross_entropy_loss(scores, labels[b:e])
+            end = min(begin + self.mini_batch_size, batch_size)
+            forward_scores: Tensor = (
+                self.similarity_fct(anchors[offset + begin : offset + end], candidates) * self.scale
+            )
+            forward_loss: torch.Tensor = self.cross_entropy_loss(forward_scores, labels[begin:end])
 
-            positive_scores = scores[:, b:e]
-            backward_loss: torch.Tensor = self.cross_entropy_loss(positive_scores.t(), labels[: len(positive_scores)])
+            backward_scores = self.similarity_fct(candidates[offset + begin : offset + end], anchors) * self.scale
+            backward_loss: torch.Tensor = self.cross_entropy_loss(backward_scores, labels[begin:end])
 
             loss_mbatch = (forward_loss + backward_loss) / 2
+            loss_mbatch = loss_mbatch * (len(forward_scores) / batch_size)
             if with_backward:
                 loss_mbatch.backward()
                 loss_mbatch = loss_mbatch.detach()
             losses.append(loss_mbatch)
 
-        loss = sum(losses) / len(losses)
+        loss = sum(losses)
         return loss
 
     def forward(self, sentence_features: Iterable[dict[str, Tensor]], labels: Tensor) -> Tensor:
@@ -252,4 +280,5 @@ class CachedMultipleNegativesSymmetricRankingLoss(nn.Module):
             "scale": self.scale,
             "similarity_fct": self.similarity_fct.__name__,
             "mini_batch_size": self.mini_batch_size,
+            "gather_across_devices": self.gather_across_devices,
         }

--- a/sentence_transformers/losses/CachedMultipleNegativesSymmetricRankingLoss.py
+++ b/sentence_transformers/losses/CachedMultipleNegativesSymmetricRankingLoss.py
@@ -240,7 +240,7 @@ class CachedMultipleNegativesSymmetricRankingLoss(nn.Module):
             backward_loss: torch.Tensor = self.cross_entropy_loss(backward_scores, labels[begin:end])
 
             loss_mbatch = (forward_loss + backward_loss) / 2
-            loss_mbatch = loss_mbatch * (len(forward_scores) / batch_size)
+            loss_mbatch = loss_mbatch * len(forward_scores) / batch_size
             if with_backward:
                 loss_mbatch.backward()
                 loss_mbatch = loss_mbatch.detach()

--- a/sentence_transformers/losses/ContrastiveTensionLoss.py
+++ b/sentence_transformers/losses/ContrastiveTensionLoss.py
@@ -179,7 +179,7 @@ class ContrastiveTensionLossInBatchNegatives(nn.Module):
         embeddings_b = self.model2(sentence_features2)["sentence_embedding"]
 
         scores = self.similarity_fct(embeddings_a, embeddings_b) * self.logit_scale.exp()  # self.scale
-        labels = torch.tensor(range(len(scores)), dtype=torch.long, device=scores.device)
+        labels = torch.arange(len(scores), dtype=torch.long, device=scores.device)
         return (self.cross_entropy_loss(scores, labels) + self.cross_entropy_loss(scores.t(), labels)) / 2
 
     @property

--- a/sentence_transformers/losses/GISTEmbedLoss.py
+++ b/sentence_transformers/losses/GISTEmbedLoss.py
@@ -9,6 +9,7 @@ from transformers import PreTrainedTokenizerBase
 
 from sentence_transformers.models import StaticEmbedding
 from sentence_transformers.SentenceTransformer import SentenceTransformer
+from sentence_transformers.util import all_gather_with_grad
 
 
 class GISTEmbedLoss(nn.Module):
@@ -19,6 +20,9 @@ class GISTEmbedLoss(nn.Module):
         temperature: float = 0.01,
         margin_strategy: Literal["absolute", "relative"] = "absolute",
         margin: float = 0.0,
+        contrast_anchors: bool = True,
+        contrast_positives: bool = True,
+        gather_across_devices: bool = False,
     ) -> None:
         """
         This loss is used to train a SentenceTransformer model using the GISTEmbed algorithm.
@@ -35,10 +39,19 @@ class GISTEmbedLoss(nn.Module):
         Args:
             model: SentenceTransformer model based on a `transformers` model.
             guide: SentenceTransformer model to guide the in-batch negative sample selection.
-            temperature: Temperature parameter to scale the cosine similarities.
+            temperature: Temperature parameter to scale the cosine similarities. Inverse of the ``scale`` parameter
+                in :class:`MultipleNegativesRankingLoss`.
             margin_strategy: Strategy used for false negative filtering. One of {"absolute", "relative"}.
             margin: The margin value for filtering negatives. Defaults to 0.0, together with the "absolute" strategy,
                 this only removes negatives that are more similar to the query than the positive is to the query.
+            contrast_anchors: If True, include anchor-anchor pairs in the loss computation, resulting in the embeddings
+                of the anchors being pushed further apart. Defaults to True, following the original GISTEmbed paper.
+            contrast_positives: If True, include positive-positive pairs in the loss computation, resulting in the embeddings
+                of the positives being pushed further apart. Defaults to True, following the original GISTEmbed paper,
+                but setting to False may yield better results in some retrieval tasks.
+            gather_across_devices: If True, gather the embeddings across all devices before computing the loss.
+                Recommended when training on multiple GPUs, as it allows for larger batch sizes, but it may slow down
+                training due to communication overhead, and can potentially lead to out-of-memory errors.
 
         References:
             - For further details, see: https://arxiv.org/abs/2402.16829
@@ -115,6 +128,10 @@ class GISTEmbedLoss(nn.Module):
             raise ValueError("margin_strategy must be 'absolute' or 'relative'.")
         self.margin_strategy = margin_strategy
         self.margin = margin
+        self.contrast_anchors = contrast_anchors
+        self.contrast_positives = contrast_positives
+        self.gather_across_devices = gather_across_devices
+        self.cross_entropy_loss = nn.CrossEntropyLoss()
 
     def sim_matrix(self, embed1: Tensor, embed2: Tensor) -> Tensor:
         return self.similarity_fct(embed1.unsqueeze(1), embed2.unsqueeze(0))
@@ -148,19 +165,40 @@ class GISTEmbedLoss(nn.Module):
             anchor_guide, positive_guide, negative_guide = guide_embeddings
         else:
             raise ValueError(f"Expected 2 or 3 embeddings, got {len(embeddings)}")
+        batch_size = anchor.size(0)
+        offset = 0
+
+        if self.gather_across_devices:
+            # Gather the candidates across all devices, with gradients, but not the anchors. We compute only this
+            # device's anchors with all candidates from all devices, such that the backward pass on the document
+            # embeddings can flow back to the original devices.
+            positive = all_gather_with_grad(positive)
+            positive_guide = all_gather_with_grad(positive_guide)
+            if negative is not None:
+                negative = all_gather_with_grad(negative)
+                negative_guide = all_gather_with_grad(negative_guide)
+            # All have this shape: (batch_size * world_size * (1 + num_negatives), embedding_dim)
+
+            if torch.distributed.is_initialized():
+                rank = torch.distributed.get_rank()
+                offset = rank * batch_size
 
         # Compute the model's similarities
         ap_sim = self.sim_matrix(anchor, positive)
-        aa_sim = self.sim_matrix(anchor, anchor)
-        pp_sim = self.sim_matrix(positive, positive)
+        if self.contrast_anchors:
+            aa_sim = self.sim_matrix(anchor, anchor)
+        if self.contrast_positives:
+            pp_sim = self.sim_matrix(positive[offset : offset + batch_size], positive)
 
         # Let's compute the similarity matrices for the combinations of anchor and positive samples.
         guided_ap_sim = self.sim_matrix(anchor_guide, positive_guide)
-        guided_aa_sim = self.sim_matrix(anchor_guide, anchor_guide)
-        guided_pp_sim = self.sim_matrix(positive_guide, positive_guide)
+        if self.contrast_anchors:
+            guided_aa_sim = self.sim_matrix(anchor_guide, anchor_guide)
+        if self.contrast_positives:
+            guided_pp_sim = self.sim_matrix(positive_guide[offset : offset + batch_size], positive_guide)
 
         # Define the anchor threshold
-        guided_sim = guided_ap_sim.diagonal().view(-1, 1)
+        guided_sim = guided_ap_sim.diagonal(offset=offset).view(-1, 1)
 
         # This uses guided (teacher) similarity as a dynamic threshold to identify and suppress false negatives
         def mask_false_negatives(guided_sim_mat, sim_mat, positive_mask: Tensor | None = None):
@@ -182,26 +220,32 @@ class GISTEmbedLoss(nn.Module):
 
         # Apply false negative suppression to each similarity matrix using guided similarity as anchor
         ap_sim = mask_false_negatives(guided_ap_sim, ap_sim, positive_mask=positive_mask)  # anchor-positive
-        aa_sim = mask_false_negatives(guided_aa_sim, aa_sim)  # anchor-anchor
-        pp_sim = mask_false_negatives(guided_pp_sim, pp_sim)  # positive-positive
+        if self.contrast_anchors:
+            aa_sim = mask_false_negatives(guided_aa_sim, aa_sim)  # anchor-anchor
+        if self.contrast_positives:
+            pp_sim = mask_false_negatives(guided_pp_sim, pp_sim)  # positive-positive
 
-        scores = [ap_sim, aa_sim, pp_sim]
+        scores = [ap_sim]
+        if self.contrast_anchors:
+            scores.append(aa_sim)
+        if self.contrast_positives:
+            scores.append(pp_sim)
 
         # Handle the case where we have a negative sample
         if negative is not None:
             an_sim = self.sim_matrix(anchor, negative)
             guided_an_sim = self.sim_matrix(anchor_guide, negative_guide)
-            an_sim = mask_false_negatives(guided_an_sim, an_sim)
+            an_sim = mask_false_negatives(guided_an_sim, an_sim)  # anchor-negative
 
             scores.append(an_sim)
 
         scores = torch.cat(scores, dim=1) / self.temperature
 
-        # NOTE: We use arange here since the ap_sim matrix contains the anchor-positive
-        # similarities along the diagonal.
-        labels = torch.arange(scores.size(0)).long().to(scores.device)
+        # anchor[i] should be most similar to candidates[i], as that is the paired positive,
+        # so the label for anchor[i] is i. This means that we can just use arange
+        range_labels = torch.arange(offset, offset + batch_size, device=anchor.device)
 
-        return nn.CrossEntropyLoss()(scores, labels)
+        return self.cross_entropy_loss(scores, range_labels)
 
     def get_config_dict(self) -> dict[str, Any]:
         return {
@@ -209,6 +253,9 @@ class GISTEmbedLoss(nn.Module):
             "temperature": self.temperature,
             "margin_strategy": self.margin_strategy,
             "margin": self.margin,
+            "contrast_anchors": self.contrast_anchors,
+            "contrast_positives": self.contrast_positives,
+            "gather_across_devices": self.gather_across_devices,
         }
 
     @property

--- a/sentence_transformers/losses/MultipleNegativesRankingLoss.py
+++ b/sentence_transformers/losses/MultipleNegativesRankingLoss.py
@@ -8,10 +8,17 @@ from torch import Tensor, nn
 
 from sentence_transformers import util
 from sentence_transformers.SentenceTransformer import SentenceTransformer
+from sentence_transformers.util import all_gather_with_grad
 
 
 class MultipleNegativesRankingLoss(nn.Module):
-    def __init__(self, model: SentenceTransformer, scale: float = 20.0, similarity_fct=util.cos_sim) -> None:
+    def __init__(
+        self,
+        model: SentenceTransformer,
+        scale: float = 20.0,
+        similarity_fct=util.cos_sim,
+        gather_across_devices: bool = False,
+    ) -> None:
         """
         Given a list of (anchor, positive) pairs or (anchor, positive, negative) triplets, this loss optimizes the following:
 
@@ -30,11 +37,14 @@ class MultipleNegativesRankingLoss(nn.Module):
 
         Args:
             model: SentenceTransformer model
-            scale: Output of similarity function is multiplied by scale
-                value
-            similarity_fct: similarity function between sentence
-                embeddings. By default, cos_sim. Can also be set to dot
-                product (and then set scale to 1)
+            scale: Output of similarity function is multiplied by scale value. In some literature, the scaling parameter
+                is referred to as temperature, which is the inverse of the scale. In short: scale = 1 / temperature, so
+                scale=20.0 is equivalent to temperature=0.05.
+            similarity_fct: similarity function between sentence embeddings. By default, cos_sim. Can also be set to
+                dot product (and then set scale to 1)
+            gather_across_devices: If True, gather the embeddings across all devices before computing the loss.
+                Recommended when training on multiple GPUs, as it allows for larger batch sizes, but it may slow down
+                training due to communication overhead, and can potentially lead to out-of-memory errors.
 
         References:
             - Efficient Natural Language Response Suggestion for Smart Reply, Section 4.4: https://arxiv.org/pdf/1705.00652.pdf
@@ -95,6 +105,7 @@ class MultipleNegativesRankingLoss(nn.Module):
         self.model = model
         self.scale = scale
         self.similarity_fct = similarity_fct
+        self.gather_across_devices = gather_across_devices
         self.cross_entropy_loss = nn.CrossEntropyLoss()
 
     def forward(self, sentence_features: Iterable[dict[str, Tensor]], labels: Tensor) -> Tensor:
@@ -116,20 +127,37 @@ class MultipleNegativesRankingLoss(nn.Module):
 
         anchors = embeddings[0]  # (batch_size, embedding_dim)
         candidates = torch.cat(embeddings[1:])  # (batch_size * (1 + num_negatives), embedding_dim)
+        batch_size = anchors.size(0)
+
+        # anchor[i] should be most similar to candidates[i], as that is the paired positive,
+        # so the label for anchor[i] is i
+        range_labels = torch.arange(0, batch_size, device=anchors.device)
+
+        if self.gather_across_devices:
+            # Gather the candidates across all devices, with gradients, but not the anchors. We compute only this
+            # device's anchors with all candidates from all devices, such that the backward pass on the document
+            # embeddings can flow back to the original devices.
+            candidates = all_gather_with_grad(candidates)
+            # (batch_size * world_size * (1 + num_negatives), embedding_dim)
+
+            # Adjust the range_labels to account for the gathered candidates
+            if torch.distributed.is_initialized():
+                rank = torch.distributed.get_rank()
+                range_labels = range_labels + rank * batch_size
 
         # For every anchor, we compute the similarity to all other candidates (positives and negatives),
         # also from other anchors. This gives us a lot of in-batch negatives.
         scores = self.similarity_fct(anchors, candidates) * self.scale
-        # (batch_size, batch_size * (1 + num_negatives))
-
-        # anchor[i] should be most similar to candidates[i], as that is the paired positive,
-        # so the label for anchor[i] is i
-        range_labels = torch.arange(0, scores.size(0), device=scores.device)
+        # (batch_size, world_size * batch_size * (1 + num_negatives))
 
         return self.cross_entropy_loss(scores, range_labels)
 
     def get_config_dict(self) -> dict[str, Any]:
-        return {"scale": self.scale, "similarity_fct": self.similarity_fct.__name__}
+        return {
+            "scale": self.scale,
+            "similarity_fct": self.similarity_fct.__name__,
+            "gather_across_devices": self.gather_across_devices,
+        }
 
     @property
     def citation(self) -> str:

--- a/sentence_transformers/losses/MultipleNegativesSymmetricRankingLoss.py
+++ b/sentence_transformers/losses/MultipleNegativesSymmetricRankingLoss.py
@@ -8,10 +8,17 @@ from torch import Tensor, nn
 
 from sentence_transformers import util
 from sentence_transformers.SentenceTransformer import SentenceTransformer
+from sentence_transformers.util import all_gather_with_grad
 
 
 class MultipleNegativesSymmetricRankingLoss(nn.Module):
-    def __init__(self, model: SentenceTransformer, scale: float = 20.0, similarity_fct=util.cos_sim) -> None:
+    def __init__(
+        self,
+        model: SentenceTransformer,
+        scale: float = 20.0,
+        similarity_fct=util.cos_sim,
+        gather_across_devices: bool = False,
+    ) -> None:
         """
         Given a list of (anchor, positive) pairs, this loss sums the following two losses:
 
@@ -27,11 +34,14 @@ class MultipleNegativesSymmetricRankingLoss(nn.Module):
 
         Args:
             model: SentenceTransformer model
-            scale: Output of similarity function is multiplied by scale
-                value
-            similarity_fct: similarity function between sentence
-                embeddings. By default, cos_sim. Can also be set to dot
-                product (and then set scale to 1)
+            scale: Output of similarity function is multiplied by scale value. In some literature, the scaling parameter
+                is referred to as temperature, which is the inverse of the scale. In short: scale = 1 / temperature, so
+                scale=20.0 is equivalent to temperature=0.05.
+            similarity_fct: similarity function between sentence embeddings. By default, cos_sim. Can also be set to
+                dot product (and then set scale to 1)
+            gather_across_devices: If True, gather the embeddings across all devices before computing the loss.
+                Recommended when training on multiple GPUs, as it allows for larger batch sizes, but it may slow down
+                training due to communication overhead, and can potentially lead to out-of-memory errors.
 
         Requirements:
             1. (anchor, positive) pairs
@@ -77,22 +87,53 @@ class MultipleNegativesSymmetricRankingLoss(nn.Module):
         self.model = model
         self.scale = scale
         self.similarity_fct = similarity_fct
+        self.gather_across_devices = gather_across_devices
         self.cross_entropy_loss = nn.CrossEntropyLoss()
 
     def forward(self, sentence_features: Iterable[dict[str, Tensor]], labels: Tensor) -> Tensor:
-        reps = [self.model(sentence_feature)["sentence_embedding"] for sentence_feature in sentence_features]
-        anchor = reps[0]
-        candidates = torch.cat(reps[1:])
+        embeddings = [self.model(sentence_feature)["sentence_embedding"] for sentence_feature in sentence_features]
 
-        scores = self.similarity_fct(anchor, candidates) * self.scale
-        labels = torch.tensor(
-            range(len(scores)), dtype=torch.long, device=scores.device
-        )  # Example a[i] should match with b[i]
+        return self.compute_loss_from_embeddings(embeddings, labels)
 
-        anchor_positive_scores = scores[:, 0 : len(reps[1])]
-        forward_loss = self.cross_entropy_loss(scores, labels)
-        backward_loss = self.cross_entropy_loss(anchor_positive_scores.transpose(0, 1), labels)
+    def compute_loss_from_embeddings(self, embeddings: list[Tensor], labels: Tensor) -> Tensor:
+        anchors = embeddings[0]
+        candidates = embeddings[1]
+        batch_size = anchors.size(0)
+        offset = 0
+
+        if self.gather_across_devices:
+            # Gather the candidates across all devices, with gradients, but not the anchors. We compute only this
+            # device's anchors with all candidates from all devices, such that the backward pass on the document
+            # embeddings can flow back to the original devices.
+            anchors = all_gather_with_grad(anchors)
+            candidates = all_gather_with_grad(candidates)
+            # Both are (batch_size * world_size, embedding_dim)
+
+            # Adjust the range_labels to account for the gathered candidates
+            if torch.distributed.is_initialized():
+                rank = torch.distributed.get_rank()
+                offset = rank * batch_size
+
+        # anchor[i] should be most similar to candidates[i], as that is the paired positive,
+        # so the label for anchor[i] is i
+        range_labels = torch.arange(offset, offset + batch_size, device=anchors.device)
+
+        # Compute the scores for "given anchor, find the most similar candidate" and vice versa
+        # If gathered across devices, take anchors/candidates from the same device against all candidates/anchors
+        forward_scores = self.similarity_fct(anchors[range_labels], candidates) * self.scale
+        # If we're not gathering across devices, we can just transpose the scores, otherwise we need to compute scores
+        if offset == 0:
+            backward_scores = forward_scores.T
+        else:
+            backward_scores = self.similarity_fct(candidates[range_labels], anchors) * self.scale
+
+        forward_loss = self.cross_entropy_loss(forward_scores, range_labels)
+        backward_loss = self.cross_entropy_loss(backward_scores, range_labels)
         return (forward_loss + backward_loss) / 2
 
     def get_config_dict(self) -> dict[str, Any]:
-        return {"scale": self.scale, "similarity_fct": self.similarity_fct.__name__}
+        return {
+            "scale": self.scale,
+            "similarity_fct": self.similarity_fct.__name__,
+            "gather_across_devices": self.gather_across_devices,
+        }

--- a/sentence_transformers/util.py
+++ b/sentence_transformers/util.py
@@ -5,7 +5,6 @@ import functools
 import hashlib
 import heapq
 import importlib
-import logging
 import os
 import queue
 import random
@@ -18,6 +17,7 @@ from typing import TYPE_CHECKING, Any, Callable, Literal, overload
 import numpy as np
 import requests
 import torch
+import torch.distributed as dist
 from huggingface_hub import hf_hub_download, snapshot_download
 from scipy.sparse import coo_matrix
 from sklearn.metrics import pairwise_distances
@@ -25,8 +25,10 @@ from torch import Tensor, device
 from tqdm import trange
 from tqdm.autonotebook import tqdm
 from transformers import is_torch_npu_available
+from transformers.utils import logging
 
-logger = logging.getLogger(__name__)
+# NOTE: transformers wraps the regular logging module for e.g. warning_once
+logger = logging.get_logger(__name__)
 
 if TYPE_CHECKING:
     from datasets import Dataset
@@ -1914,3 +1916,56 @@ def append_to_last_row(csv_path, additional_data):
             writer.writerows(rows)
         return True
     return False
+
+
+def all_gather(tensor: torch.Tensor, with_grad: bool = False) -> torch.Tensor:
+    """
+    Gathers a tensor from each distributed rank into a list. Always retains gradients for the local rank's tensor,
+    and optionally retains gradients for the gathered tensors if `with_grad` is True.
+
+    Args:
+        tensor (torch.Tensor): The tensor to gather from each rank.
+        with_grad (bool, optional): If True, the local rank's tensor retains its gradients. Defaults to False.
+
+    Returns:
+        torch.Tensor: A tensor containing the gathered tensors from all ranks, concatenated along the first dimension.
+        If torch.distributed is not available or not initialized, returns the original tensor.
+    """
+
+    if dist.is_available() and dist.is_initialized():
+        if with_grad:
+            gathered_tensors = torch.distributed.nn.all_gather(tensor)
+        else:
+            world_size = dist.get_world_size()
+            gathered_tensors = [torch.zeros_like(tensor) for _ in range(world_size)]
+
+            # Perform all_gather.
+            dist.all_gather(gathered_tensors, tensor)
+
+            # Replace local rank's tensor with the original (retaining gradients).
+            local_rank = dist.get_rank()
+            gathered_tensors[local_rank] = tensor
+        return torch.cat(gathered_tensors, dim=0)
+
+    # Warn once about uninitialized or single-GPU usage.
+    warning = (
+        "Trying to gather while torch.distributed is not available or has not been initialized, "
+        "returning the original (local) tensor. This is expected if you are "
+        "only using one GPU; consider not using gathering to remove this warning."
+    )
+    logger.warning_once(warning)
+    return tensor
+
+
+def all_gather_with_grad(tensor: torch.Tensor) -> torch.Tensor:
+    """
+    Gathers a tensor from each distributed rank into a list, retaining gradients for the local rank's tensor.
+
+    Args:
+        tensor (torch.Tensor): The tensor to gather from each rank.
+
+    Returns:
+        torch.Tensor: A tensor containing the gathered tensors from all ranks, concatenated along the first dimension.
+        If torch.distributed is not available or not initialized, returns the original tensor.
+    """
+    return all_gather(tensor, with_grad=True)

--- a/sentence_transformers/util.py
+++ b/sentence_transformers/util.py
@@ -1651,25 +1651,6 @@ class disabled_tqdm(tqdm):
                 raise
 
 
-@contextmanager
-def disable_logging(highest_level=logging.CRITICAL):
-    """
-    A context manager that will prevent any logging messages
-    triggered during the body from being processed.
-
-    Args:
-        highest_level: the maximum logging level allowed.
-    """
-    previous_level = logging._get_library_root_logger().manager.disable
-
-    logging.disable(highest_level)
-
-    try:
-        yield
-    finally:
-        logging.disable(previous_level)
-
-
 def is_sentence_transformer_model(
     model_name_or_path: str,
     token: bool | str | None = None,

--- a/sentence_transformers/util.py
+++ b/sentence_transformers/util.py
@@ -1660,8 +1660,7 @@ def disable_logging(highest_level=logging.CRITICAL):
     Args:
         highest_level: the maximum logging level allowed.
     """
-
-    previous_level = logging.root.manager.disable
+    previous_level = logging._get_library_root_logger().manager.disable
 
     logging.disable(highest_level)
 

--- a/tests/sparse_encoder/test_model_card.py
+++ b/tests/sparse_encoder/test_model_card.py
@@ -58,7 +58,7 @@ def dummy_dataset():
                 "| details | <ul><li>min: 4 tokens</li><li>mean: 4.0 tokens</li><li>max: 4 tokens</li></ul> | <ul><li>min: 4 tokens</li><li>mean: 4.0 tokens</li><li>max: 4 tokens</li></ul> | <ul><li>min: 4 tokens</li><li>mean: 4.0 tokens</li><li>max: 4 tokens</li></ul> |",
                 " | <code>anchor 1</code> | <code>positive 1</code> | <code>negative 1</code> |",
                 "* Loss: [<code>SpladeLoss</code>](https://sbert.net/docs/package_reference/sparse_encoder/losses.html#spladeloss) with these parameters:",
-                '  ```json\n  {\n      "loss": "SparseMultipleNegativesRankingLoss(scale=1.0, similarity_fct=\'dot_score\')",\n      "document_regularizer_weight": 3e-05,\n      "query_regularizer_weight": 5e-05\n  }\n  ```',
+                '  ```json\n  {\n      "loss": "SparseMultipleNegativesRankingLoss(scale=1.0, similarity_fct=\'dot_score\', gather_across_devices=False)",\n      "document_regularizer_weight": 3e-05,\n      "query_regularizer_weight": 5e-05\n  }\n  ```',
             ],
         ),
         (
@@ -68,7 +68,7 @@ def dummy_dataset():
                 "This is a [SPLADE Sparse Encoder](https://www.sbert.net/docs/sparse_encoder/usage/usage.html) model finetuned from [sparse-encoder-testing/splade-bert-tiny-nq](https://huggingface.co/sparse-encoder-testing/splade-bert-tiny-nq) on the train_0 dataset using the [sentence-transformers](https://www.SBERT.net) library.",
                 "#### train_0",
                 "* Loss: [<code>SpladeLoss</code>](https://sbert.net/docs/package_reference/sparse_encoder/losses.html#spladeloss) with these parameters:",
-                '  ```json\n  {\n      "loss": "SparseMultipleNegativesRankingLoss(scale=1.0, similarity_fct=\'dot_score\')",\n      "document_regularizer_weight": 3e-05,\n      "query_regularizer_weight": 5e-05\n  }\n  ```',
+                '  ```json\n  {\n      "loss": "SparseMultipleNegativesRankingLoss(scale=1.0, similarity_fct=\'dot_score\', gather_across_devices=False)",\n      "document_regularizer_weight": 3e-05,\n      "query_regularizer_weight": 5e-05\n  }\n  ```',
             ],
         ),
         (
@@ -79,7 +79,7 @@ def dummy_dataset():
                 "#### train_0",
                 "#### train_1",
                 "* Loss: [<code>SpladeLoss</code>](https://sbert.net/docs/package_reference/sparse_encoder/losses.html#spladeloss) with these parameters:",
-                '  ```json\n  {\n      "loss": "SparseMultipleNegativesRankingLoss(scale=1.0, similarity_fct=\'dot_score\')",\n      "document_regularizer_weight": 3e-05,\n      "query_regularizer_weight": 5e-05\n  }\n  ```',
+                '  ```json\n  {\n      "loss": "SparseMultipleNegativesRankingLoss(scale=1.0, similarity_fct=\'dot_score\', gather_across_devices=False)",\n      "document_regularizer_weight": 3e-05,\n      "query_regularizer_weight": 5e-05\n  }\n  ```',
             ],
         ),
         (
@@ -92,7 +92,7 @@ def dummy_dataset():
                 "</details>\n<details><summary>train_9</summary>",
                 "#### train_9",
                 "* Loss: [<code>SpladeLoss</code>](https://sbert.net/docs/package_reference/sparse_encoder/losses.html#spladeloss) with these parameters:",
-                '  ```json\n  {\n      "loss": "SparseMultipleNegativesRankingLoss(scale=1.0, similarity_fct=\'dot_score\')",\n      "document_regularizer_weight": 3e-05,\n      "query_regularizer_weight": 5e-05\n  }\n  ```',
+                '  ```json\n  {\n      "loss": "SparseMultipleNegativesRankingLoss(scale=1.0, similarity_fct=\'dot_score\', gather_across_devices=False)",\n      "document_regularizer_weight": 3e-05,\n      "query_regularizer_weight": 5e-05\n  }\n  ```',
             ],
         ),
         # We start using "50 datasets" when the ", "-joined dataset name exceed 200 characters
@@ -106,7 +106,7 @@ def dummy_dataset():
                 "</details>\n<details><summary>train_49</summary>",
                 "#### train_49",
                 "* Loss: [<code>SpladeLoss</code>](https://sbert.net/docs/package_reference/sparse_encoder/losses.html#spladeloss) with these parameters:",
-                '  ```json\n  {\n      "loss": "SparseMultipleNegativesRankingLoss(scale=1.0, similarity_fct=\'dot_score\')",\n      "document_regularizer_weight": 3e-05,\n      "query_regularizer_weight": 5e-05\n  }\n  ```',
+                '  ```json\n  {\n      "loss": "SparseMultipleNegativesRankingLoss(scale=1.0, similarity_fct=\'dot_score\', gather_across_devices=False)",\n      "document_regularizer_weight": 3e-05,\n      "query_regularizer_weight": 5e-05\n  }\n  ```',
             ],
         ),
         (
@@ -125,7 +125,7 @@ def dummy_dataset():
                 "| details | <ul><li>min: 4 tokens</li><li>mean: 4.0 tokens</li><li>max: 4 tokens</li></ul> | <ul><li>min: 4 tokens</li><li>mean: 4.0 tokens</li><li>max: 4 tokens</li></ul> | <ul><li>min: 4 tokens</li><li>mean: 4.0 tokens</li><li>max: 4 tokens</li></ul> |",
                 " | <code>anchor 1</code> | <code>positive 1</code> | <code>negative 1</code> |",
                 "* Loss: [<code>SpladeLoss</code>](https://sbert.net/docs/package_reference/sparse_encoder/losses.html#spladeloss) with these parameters:",
-                '  ```json\n  {\n      "loss": "SparseMultipleNegativesRankingLoss(scale=1.0, similarity_fct=\'dot_score\')",\n      "document_regularizer_weight": 3e-05,\n      "query_regularizer_weight": 5e-05\n  }\n  ```',
+                '  ```json\n  {\n      "loss": "SparseMultipleNegativesRankingLoss(scale=1.0, similarity_fct=\'dot_score\', gather_across_devices=False)",\n      "document_regularizer_weight": 3e-05,\n      "query_regularizer_weight": 5e-05\n  }\n  ```',
             ],
         ),
         (
@@ -146,7 +146,7 @@ def dummy_dataset():
                 "| details | <ul><li>min: 4 tokens</li><li>mean: 4.0 tokens</li><li>max: 4 tokens</li></ul> | <ul><li>min: 4 tokens</li><li>mean: 4.0 tokens</li><li>max: 4 tokens</li></ul> | <ul><li>min: 4 tokens</li><li>mean: 4.0 tokens</li><li>max: 4 tokens</li></ul> |",
                 " | <code>anchor 1</code> | <code>positive 1</code> | <code>negative 1</code> |",
                 "* Loss: [<code>SpladeLoss</code>](https://sbert.net/docs/package_reference/sparse_encoder/losses.html#spladeloss) with these parameters:",
-                '  ```json\n  {\n      "loss": "SparseMultipleNegativesRankingLoss(scale=1.0, similarity_fct=\'dot_score\')",\n      "document_regularizer_weight": 3e-05,\n      "query_regularizer_weight": 5e-05\n  }\n  ```',
+                '  ```json\n  {\n      "loss": "SparseMultipleNegativesRankingLoss(scale=1.0, similarity_fct=\'dot_score\', gather_across_devices=False)",\n      "document_regularizer_weight": 3e-05,\n      "query_regularizer_weight": 5e-05\n  }\n  ```',
             ],
         ),
     ],

--- a/tests/test_model_card.py
+++ b/tests/test_model_card.py
@@ -50,7 +50,7 @@ def dummy_dataset():
                 "| details | <ul><li>min: 4 tokens</li><li>mean: 4.0 tokens</li><li>max: 4 tokens</li></ul> | <ul><li>min: 4 tokens</li><li>mean: 4.0 tokens</li><li>max: 4 tokens</li></ul> | <ul><li>min: 4 tokens</li><li>mean: 4.0 tokens</li><li>max: 4 tokens</li></ul> |",
                 " | <code>anchor 1</code> | <code>positive 1</code> | <code>negative 1</code> |",
                 "* Loss: [<code>GISTEmbedLoss</code>](https://sbert.net/docs/package_reference/sentence_transformer/losses.html#gistembedloss) with these parameters:",
-                '  ```json\n  {\n      "guide": "SentenceTransformer(\'sentence-transformers/all-MiniLM-L6-v2\', trust_remote_code=True)",\n      "temperature": 0.05,\n      "margin_strategy": "relative",\n      "margin": 0.05\n  }\n  ```',
+                '  ```json\n  {\n      "guide": "SentenceTransformer(\'sentence-transformers/all-MiniLM-L6-v2\', trust_remote_code=True)",\n      "temperature": 0.05,\n      "margin_strategy": "relative",\n      "margin": 0.05,\n      "contrast_anchors": true,\n      "contrast_positives": true,\n      "gather_across_devices": false\n  }\n  ```',
             ],
         ),
         (
@@ -59,7 +59,7 @@ def dummy_dataset():
                 "This is a [sentence-transformers](https://www.SBERT.net) model finetuned from [sentence-transformers-testing/stsb-bert-tiny-safetensors](https://huggingface.co/sentence-transformers-testing/stsb-bert-tiny-safetensors) on the train_0 dataset.",
                 "#### train_0",
                 "* Loss: [<code>GISTEmbedLoss</code>](https://sbert.net/docs/package_reference/sentence_transformer/losses.html#gistembedloss) with these parameters:",
-                '  ```json\n  {\n      "guide": "SentenceTransformer(\'sentence-transformers/all-MiniLM-L6-v2\', trust_remote_code=True)",\n      "temperature": 0.05,\n      "margin_strategy": "relative",\n      "margin": 0.05\n  }\n  ```',
+                '  ```json\n  {\n      "guide": "SentenceTransformer(\'sentence-transformers/all-MiniLM-L6-v2\', trust_remote_code=True)",\n      "temperature": 0.05,\n      "margin_strategy": "relative",\n      "margin": 0.05,\n      "contrast_anchors": true,\n      "contrast_positives": true,\n      "gather_across_devices": false\n  }\n  ```',
             ],
         ),
         (
@@ -69,7 +69,7 @@ def dummy_dataset():
                 "#### train_0",
                 "#### train_1",
                 "* Loss: [<code>GISTEmbedLoss</code>](https://sbert.net/docs/package_reference/sentence_transformer/losses.html#gistembedloss) with these parameters:",
-                '  ```json\n  {\n      "guide": "SentenceTransformer(\'sentence-transformers/all-MiniLM-L6-v2\', trust_remote_code=True)",\n      "temperature": 0.05,\n      "margin_strategy": "relative",\n      "margin": 0.05\n  }\n  ```',
+                '  ```json\n  {\n      "guide": "SentenceTransformer(\'sentence-transformers/all-MiniLM-L6-v2\', trust_remote_code=True)",\n      "temperature": 0.05,\n      "margin_strategy": "relative",\n      "margin": 0.05,\n      "contrast_anchors": true,\n      "contrast_positives": true,\n      "gather_across_devices": false\n  }\n  ```',
             ],
         ),
         (
@@ -81,7 +81,7 @@ def dummy_dataset():
                 "</details>\n<details><summary>train_9</summary>",
                 "#### train_9",
                 "* Loss: [<code>GISTEmbedLoss</code>](https://sbert.net/docs/package_reference/sentence_transformer/losses.html#gistembedloss) with these parameters:",
-                '  ```json\n  {\n      "guide": "SentenceTransformer(\'sentence-transformers/all-MiniLM-L6-v2\', trust_remote_code=True)",\n      "temperature": 0.05,\n      "margin_strategy": "relative",\n      "margin": 0.05\n  }\n  ```',
+                '  ```json\n  {\n      "guide": "SentenceTransformer(\'sentence-transformers/all-MiniLM-L6-v2\', trust_remote_code=True)",\n      "temperature": 0.05,\n      "margin_strategy": "relative",\n      "margin": 0.05,\n      "contrast_anchors": true,\n      "contrast_positives": true,\n      "gather_across_devices": false\n  }\n  ```',
             ],
         ),
         # We start using "50 datasets" when the ", "-joined dataset name exceed 200 characters
@@ -94,7 +94,7 @@ def dummy_dataset():
                 "</details>\n<details><summary>train_49</summary>",
                 "#### train_49",
                 "* Loss: [<code>GISTEmbedLoss</code>](https://sbert.net/docs/package_reference/sentence_transformer/losses.html#gistembedloss) with these parameters:",
-                '  ```json\n  {\n      "guide": "SentenceTransformer(\'sentence-transformers/all-MiniLM-L6-v2\', trust_remote_code=True)",\n      "temperature": 0.05,\n      "margin_strategy": "relative",\n      "margin": 0.05\n  }\n  ```',
+                '  ```json\n  {\n      "guide": "SentenceTransformer(\'sentence-transformers/all-MiniLM-L6-v2\', trust_remote_code=True)",\n      "temperature": 0.05,\n      "margin_strategy": "relative",\n      "margin": 0.05,\n      "contrast_anchors": true,\n      "contrast_positives": true,\n      "gather_across_devices": false\n  }\n  ```',
             ],
         ),
     ],


### PR DESCRIPTION
Hello!

## Pull Request overview
* Add `gather_across_devices` to MNRL and CMNRL, etc.
* Add `contrast_anchors` and `contrast_positives` to GIST and CGIST losses
* Add utility functions for distributed all-gathers

## Details
This is a work-in-progress. The goal of this PR is to introduce gathering across devices, as @NohTow showed that it was still worthwhile despite the same also being possible with GradCache. Also thanks to @NohTow for writing the code that this PR is based on & for helping debugging.

## TODOs:
- [x] Update all other contrastive losses that benefit from in-batch negatives.
	- [x] For Dense
    	- [x] Implement and test for MNRL
    	- [x] Implement and test for CMNRL
    	- [x] Implement and test for MNSRL
    	- [x] Implement and test for CMNSRL
    	- [x] Implement and test for GIST
    	- [x] Implement and test for CGIST
	- [x] ~~For Reranker~~: Rerankers don't benefit from cross-device gathering as they require computing per pair.
	- [x] For Sparse
    	- [x] Implement for SparseMNRL
- [ ] Turn `util.py` into a `util` folder with files for separate components, e.g. `negative_mining.py`, `distributed.py`, `similarity_functions.py`, `huggingface.py`, etc. It's getting too big.

---

- Tom Aarsen