### PR TITLE
[`tests`] Reduce the number of hub requests for the model card tests

### DIFF
--- a/tests/cross_encoder/test_model_card.py
+++ b/tests/cross_encoder/test_model_card.py
@@ -137,15 +137,15 @@ def test_model_card_base(
 ) -> None:
     model = CrossEncoder("prajjwal1/bert-tiny", num_labels=num_labels)
 
+    # Let's avoid requesting the Hub for e.g. checking if a base model exists there
+    model.model_card_data.local_files_only = True
+
     train_dataset = dummy_dataset
     if num_datasets:
         train_dataset = DatasetDict({f"train_{i}": train_dataset for i in range(num_datasets)})
 
     # This adds data to model.model_card_data
-    CrossEncoderTrainer(
-        model,
-        train_dataset=train_dataset,
-    )
+    CrossEncoderTrainer(model, train_dataset=train_dataset)
 
     model_card = generate_model_card(model)
 

--- a/tests/sparse_encoder/test_model_card.py
+++ b/tests/sparse_encoder/test_model_card.py
@@ -161,6 +161,9 @@ def test_model_card_base(
 ) -> None:
     model = request.getfixturevalue(model_fixture_name)
 
+    # Let's avoid requesting the Hub for e.g. checking if a base model exists there
+    model.model_card_data.local_files_only = True
+
     train_dataset = dummy_dataset
     if num_datasets:
         train_dataset = DatasetDict({f"train_{i}": train_dataset for i in range(num_datasets)})

--- a/tests/test_model_card.py
+++ b/tests/test_model_card.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from copy import deepcopy
+
 import pytest
 
 from sentence_transformers import SentenceTransformer, SentenceTransformerTrainer, losses
@@ -50,7 +52,7 @@ def dummy_dataset():
                 "| details | <ul><li>min: 4 tokens</li><li>mean: 4.0 tokens</li><li>max: 4 tokens</li></ul> | <ul><li>min: 4 tokens</li><li>mean: 4.0 tokens</li><li>max: 4 tokens</li></ul> | <ul><li>min: 4 tokens</li><li>mean: 4.0 tokens</li><li>max: 4 tokens</li></ul> |",
                 " | <code>anchor 1</code> | <code>positive 1</code> | <code>negative 1</code> |",
                 "* Loss: [<code>GISTEmbedLoss</code>](https://sbert.net/docs/package_reference/sentence_transformer/losses.html#gistembedloss) with these parameters:",
-                '  ```json\n  {\n      "guide": "SentenceTransformer(\'sentence-transformers/all-MiniLM-L6-v2\', trust_remote_code=True)",\n      "temperature": 0.05,\n      "margin_strategy": "relative",\n      "margin": 0.05,\n      "contrast_anchors": true,\n      "contrast_positives": true,\n      "gather_across_devices": false\n  }\n  ```',
+                '  ```json\n  {\n      "guide": "SentenceTransformer(\'sentence-transformers-testing/stsb-bert-tiny-safetensors\', trust_remote_code=True)",\n      "temperature": 0.05,\n      "margin_strategy": "relative",\n      "margin": 0.05,\n      "contrast_anchors": true,\n      "contrast_positives": true,\n      "gather_across_devices": false\n  }\n  ```',
             ],
         ),
         (
@@ -59,7 +61,7 @@ def dummy_dataset():
                 "This is a [sentence-transformers](https://www.SBERT.net) model finetuned from [sentence-transformers-testing/stsb-bert-tiny-safetensors](https://huggingface.co/sentence-transformers-testing/stsb-bert-tiny-safetensors) on the train_0 dataset.",
                 "#### train_0",
                 "* Loss: [<code>GISTEmbedLoss</code>](https://sbert.net/docs/package_reference/sentence_transformer/losses.html#gistembedloss) with these parameters:",
-                '  ```json\n  {\n      "guide": "SentenceTransformer(\'sentence-transformers/all-MiniLM-L6-v2\', trust_remote_code=True)",\n      "temperature": 0.05,\n      "margin_strategy": "relative",\n      "margin": 0.05,\n      "contrast_anchors": true,\n      "contrast_positives": true,\n      "gather_across_devices": false\n  }\n  ```',
+                '  ```json\n  {\n      "guide": "SentenceTransformer(\'sentence-transformers-testing/stsb-bert-tiny-safetensors\', trust_remote_code=True)",\n      "temperature": 0.05,\n      "margin_strategy": "relative",\n      "margin": 0.05,\n      "contrast_anchors": true,\n      "contrast_positives": true,\n      "gather_across_devices": false\n  }\n  ```',
             ],
         ),
         (
@@ -69,7 +71,7 @@ def dummy_dataset():
                 "#### train_0",
                 "#### train_1",
                 "* Loss: [<code>GISTEmbedLoss</code>](https://sbert.net/docs/package_reference/sentence_transformer/losses.html#gistembedloss) with these parameters:",
-                '  ```json\n  {\n      "guide": "SentenceTransformer(\'sentence-transformers/all-MiniLM-L6-v2\', trust_remote_code=True)",\n      "temperature": 0.05,\n      "margin_strategy": "relative",\n      "margin": 0.05,\n      "contrast_anchors": true,\n      "contrast_positives": true,\n      "gather_across_devices": false\n  }\n  ```',
+                '  ```json\n  {\n      "guide": "SentenceTransformer(\'sentence-transformers-testing/stsb-bert-tiny-safetensors\', trust_remote_code=True)",\n      "temperature": 0.05,\n      "margin_strategy": "relative",\n      "margin": 0.05,\n      "contrast_anchors": true,\n      "contrast_positives": true,\n      "gather_across_devices": false\n  }\n  ```',
             ],
         ),
         (
@@ -81,7 +83,7 @@ def dummy_dataset():
                 "</details>\n<details><summary>train_9</summary>",
                 "#### train_9",
                 "* Loss: [<code>GISTEmbedLoss</code>](https://sbert.net/docs/package_reference/sentence_transformer/losses.html#gistembedloss) with these parameters:",
-                '  ```json\n  {\n      "guide": "SentenceTransformer(\'sentence-transformers/all-MiniLM-L6-v2\', trust_remote_code=True)",\n      "temperature": 0.05,\n      "margin_strategy": "relative",\n      "margin": 0.05,\n      "contrast_anchors": true,\n      "contrast_positives": true,\n      "gather_across_devices": false\n  }\n  ```',
+                '  ```json\n  {\n      "guide": "SentenceTransformer(\'sentence-transformers-testing/stsb-bert-tiny-safetensors\', trust_remote_code=True)",\n      "temperature": 0.05,\n      "margin_strategy": "relative",\n      "margin": 0.05,\n      "contrast_anchors": true,\n      "contrast_positives": true,\n      "gather_across_devices": false\n  }\n  ```',
             ],
         ),
         # We start using "50 datasets" when the ", "-joined dataset name exceed 200 characters
@@ -94,7 +96,7 @@ def dummy_dataset():
                 "</details>\n<details><summary>train_49</summary>",
                 "#### train_49",
                 "* Loss: [<code>GISTEmbedLoss</code>](https://sbert.net/docs/package_reference/sentence_transformer/losses.html#gistembedloss) with these parameters:",
-                '  ```json\n  {\n      "guide": "SentenceTransformer(\'sentence-transformers/all-MiniLM-L6-v2\', trust_remote_code=True)",\n      "temperature": 0.05,\n      "margin_strategy": "relative",\n      "margin": 0.05,\n      "contrast_anchors": true,\n      "contrast_positives": true,\n      "gather_across_devices": false\n  }\n  ```',
+                '  ```json\n  {\n      "guide": "SentenceTransformer(\'sentence-transformers-testing/stsb-bert-tiny-safetensors\', trust_remote_code=True)",\n      "temperature": 0.05,\n      "margin_strategy": "relative",\n      "margin": 0.05,\n      "contrast_anchors": true,\n      "contrast_positives": true,\n      "gather_across_devices": false\n  }\n  ```',
             ],
         ),
     ],
@@ -107,12 +109,16 @@ def test_model_card_base(
 ) -> None:
     model = stsb_bert_tiny_model
 
+    # Let's avoid requesting the Hub for e.g. checking if a base model exists there
+    model.model_card_data.local_files_only = True
+
     train_dataset = dummy_dataset
     if num_datasets:
         train_dataset = DatasetDict({f"train_{i}": train_dataset for i in range(num_datasets)})
 
     # This adds data to model.model_card_data
-    guide_loss = SentenceTransformer("all-MiniLM-L6-v2", trust_remote_code=True)
+    guide_loss = deepcopy(stsb_bert_tiny_model)
+    guide_loss.trust_remote_code = True  # Let's test if we can see this again in the model card
     loss = losses.GISTEmbedLoss(
         model,
         guide=guide_loss,


### PR DESCRIPTION
Hello!

## Pull Request overview
* Reduce the number of hub requests for the model card tests

## Details
By setting `local_files_only=True` after loading the model, the model card should (IIRC) not check if the base model exists on the Hub, or whether the training dataset exists on the Hub.
Additionally, instead of using a separate guide model in the SentenceTransformer model card tests, I'm just reusing the model being trained, as that one is cached. It should help lower the 429 errors a little bit.

- Tom Aarsen