### PR TITLE
[`fix`] Fix Router torch initialization, fixes DP

### DIFF
--- a/sentence_transformers/models/Router.py
+++ b/sentence_transformers/models/Router.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import json
 import os
-from collections import OrderedDict
 from pathlib import Path
 
 try:
@@ -20,14 +19,14 @@ from sentence_transformers.util import import_from_string, load_dir_path
 logger = logging.get_logger(__name__)
 
 
-class Router(InputModule, nn.Sequential):
+class Router(InputModule):
     forward_kwargs = {"task"}
     config_keys: list[str] = ["default_route", "allow_empty_key"]
     config_file_name = "router_config.json"
 
     def __init__(
         self, sub_modules: dict[str, list[Module]], default_route: str | None = None, allow_empty_key: bool = True
-    ):
+    ) -> None:
         r"""
         This model allows to create asymmetric SentenceTransformer models that apply different modules depending on the specified route,
         such as "query" or "document". Especially useful for models that have different encoders for queries and documents.
@@ -169,9 +168,12 @@ class Router(InputModule, nn.Sequential):
             allow_empty_key: If True, allows the default route to be set to the first key in `sub_modules` if
                 ``default_route`` is None. Defaults to True.
         """
-        self.sub_modules = sub_modules
-        if self.sub_modules is None or len(self.sub_modules) == 0:
+        super().__init__()
+        if sub_modules is None or len(sub_modules) == 0:
             raise ValueError("The routes dictionary cannot be empty.")
+        self.sub_modules = nn.ModuleDict(
+            {route_name: nn.Sequential(*modules) for route_name, modules in sub_modules.items()}
+        )
 
         if default_route is not None and default_route not in sub_modules:
             raise ValueError(f"Default route '{default_route}' not found in route keys: {list(sub_modules.keys())}")
@@ -181,16 +183,6 @@ class Router(InputModule, nn.Sequential):
             default_route = next(iter(sub_modules.keys()))
         self.default_route = default_route
         self.allow_empty_key = allow_empty_key
-
-        ordered_dict = OrderedDict()
-        for name, models in sub_modules.items():
-            if not isinstance(models, list):
-                models = [models]
-
-            for idx, model in enumerate(models):
-                ordered_dict[f"{name}_{idx}_{type(model).__name__}"] = model
-
-        super().__init__(ordered_dict)
 
     @classmethod
     def for_query_document(


### PR DESCRIPTION
Resolves #3452

Hello!

## Pull Request overview
* Fix Router torch initialization
* Fix DataParallel inference and training of Router-based model

## Details
The `Router` module, inspired by the original `Asym` module, was a `nn.Sequential` subclass that used an `OrderedDict` to store the modules used in the `Router`. However, this `OrderedDict` is never used in inference. Instead, a `sub_modules` attribute is used, which is a dictionary mapping route names to a list of modules. The `OrderedDict` and `sub_modules` dictionaries both point to the same underlying modules.

However, there's two concerns:
1. `torch` doesn't seem to correctly understand this unusual linking. E.g., when wrapping the model in `DataParallel`, when the model is moved to the appropriate device, only the `OrderedDict` parameters are moved, whereas the `sub_modules` modules are kept. In short, the "link" between the two is lost.
2. It's deeply unusual to have a `nn.Sequential` with a properly initialized `OrderedDict` that is never actually used as a `Sequential` module. The modules in `OrderedDict` aren't used at all - they only seem to have existed so that `torch` will propagate function calls to them (e.g. `.to()`). When removed and only the `sub_modules` are kept, the parameters deep in the dictionary aren't considered part of the model.

In short, the structure of the `Router` (and the `Asym` before it) is fundamentally flawed, relying on an unusual "linking" between modules in the `OrderedDict` and in the `sub_modules`. This linking falls apart in certain scenarios (e.g. DataParallel), and is overall buggy.

In addition to #3452, this might also resolve #3441. I think it's very possible that DDP duplicates all of the parameters of the model during training, potentially with the actually used model not responding to e.g. `b16`/`fp16` conversions. cc @ccdv-ai

Model saving and loading of pretrained models should stay the same.

cc @zionsoumik @arthurbr11 

- Tom Aarsen