### PR TITLE
[`fix`] cast indexing numpy int to Python int

### DIFF
--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -1013,7 +1013,7 @@ class SentenceTransformer(nn.Sequential, FitMixin, PeftAdapterMixin):
 
         all_embeddings = []
         length_sorted_idx = np.argsort([-self._text_length(sen) for sen in sentences])
-        sentences_sorted = [sentences[idx] for idx in length_sorted_idx]
+        sentences_sorted = [sentences[int(idx)] for idx in length_sorted_idx]
 
         for start_index in trange(0, len(sentences), batch_size, desc="Batches", disable=not show_progress_bar):
             sentences_batch = sentences_sorted[start_index : start_index + batch_size]

--- a/sentence_transformers/sparse_encoder/SparseEncoder.py
+++ b/sentence_transformers/sparse_encoder/SparseEncoder.py
@@ -572,7 +572,7 @@ class SparseEncoder(SentenceTransformer):
 
         all_embeddings = []
         length_sorted_idx = np.argsort([-self._text_length(sen) for sen in sentences])
-        sentences_sorted = [sentences[idx] for idx in length_sorted_idx]
+        sentences_sorted = [sentences[int(idx)] for idx in length_sorted_idx]
 
         for start_index in trange(0, len(sentences), batch_size, desc="Batches", disable=not show_progress_bar):
             sentences_batch = sentences_sorted[start_index : start_index + batch_size]

--- a/tests/cross_encoder/test_cross_encoder.py
+++ b/tests/cross_encoder/test_cross_encoder.py
@@ -599,3 +599,25 @@ def test_bge_reranker_max_length():
     model.max_length = 256
     assert model.max_length == 256
     assert model.tokenizer.model_max_length == 256
+
+
+def test_predict_with_dataset_column(reranker_bert_tiny_model: CrossEncoder) -> None:
+    """Test that predict can handle a dataset column as input."""
+    model = reranker_bert_tiny_model
+    from datasets import Dataset
+
+    # Create a simple dataset with a text column
+    dataset = Dataset.from_dict(
+        {
+            "text": [
+                ["This is the start of a pair.", "And this the end."],
+                ["This is a second pair.", "And this the end of the second pair."],
+            ]
+        }
+    )
+
+    # Encode the dataset column
+    embeddings = model.predict(dataset["text"], convert_to_tensor=True)
+
+    # Check the shape of the embeddings
+    assert embeddings.shape == (2,)

--- a/tests/sparse_encoder/test_sparse_encoder.py
+++ b/tests/sparse_encoder/test_sparse_encoder.py
@@ -546,3 +546,18 @@ def test_intersection(splade_bert_tiny_model: SparseEncoder):
 
     decoded_intersection_batch = model.decode(intersection_batch)
     assert len(decoded_intersection_batch) == len(documents)
+
+
+def test_encode_with_dataset_column(splade_bert_tiny_model: SparseEncoder) -> None:
+    """Test that encode can handle a dataset column as input."""
+    model = splade_bert_tiny_model
+    from datasets import Dataset
+
+    # Create a simple dataset with a text column
+    dataset = Dataset.from_dict({"text": ["This is a test.", "Another sentence."]})
+
+    # Encode the dataset column
+    embeddings = model.encode(dataset["text"], convert_to_tensor=True)
+
+    # Check the shape of the embeddings
+    assert embeddings.shape == (2, model.get_sentence_embedding_dimension())

--- a/tests/test_sentence_transformer.py
+++ b/tests/test_sentence_transformer.py
@@ -1134,3 +1134,18 @@ def test_encode_query_document_vs_encode(stsb_bert_tiny_model: SentenceTransform
         np.testing.assert_allclose(query_embeddings_without_prompt, query_embeddings)
     with pytest.raises(AssertionError):
         np.testing.assert_allclose(document_embeddings_without_prompt, document_embeddings)
+
+
+def test_encode_with_dataset_column(stsb_bert_tiny_model: SentenceTransformer) -> None:
+    """Test that encode can handle a dataset column as input."""
+    model = stsb_bert_tiny_model
+    from datasets import Dataset
+
+    # Create a simple dataset with a text column
+    dataset = Dataset.from_dict({"text": ["This is a test.", "Another sentence."]})
+
+    # Encode the dataset column
+    embeddings = model.encode(dataset["text"], convert_to_tensor=True)
+
+    # Check the shape of the embeddings
+    assert embeddings.shape == (2, model.get_sentence_embedding_dimension())


### PR DESCRIPTION
In datasets==4.0.0, arrow datasets raise a TypeError (`TypeError: Wrong key type: '5' of type '<class 'numpy.int64'>'. Expected one of int, slice, range, str or Iterable.`) when indexed with a numpy int.

This PR casts the index before indexing `sentences`.

[Traceback](https://github.com/emapco/chem-mrl/actions/runs/16437195797/job/46449425520?pr=5#step:5:187)