### PR TITLE
[`docs`] Add splade_index semantic search example

### DIFF
--- a/docs/sparse_encoder/pretrained_models.md
+++ b/docs/sparse_encoder/pretrained_models.md
@@ -55,8 +55,8 @@ Note that all the numbers of below are extracted information from different pape
 | [naver/splade-v3-lexical](https://huggingface.co/naver/splade-v3-lexical)                                                                                 | 40.0            | 49.1                | 109M       |
 | [prithivida/Splade_PP_en_v1](https://huggingface.co/prithivida/Splade_PP_en_v1)                                                                           | 37.2            | 48.7                | 109M       |
 | [naver/splade_v2_max](https://huggingface.co/naver/splade_v2_max)                                                                                         | 34.0            | 46.4                | 67M        |
-| [rasyosef/splade-mini](https://huggingface.co/rasyosef/splade-mini)                                                                                       | 32.8            | 42.9                | 11M        |
-| [rasyosef/splade-tiny](https://huggingface.co/rasyosef/splade-tiny)                                                                                       | 30.8            | 40.5                | 4M         |
+| [rasyosef/splade-mini](https://huggingface.co/rasyosef/splade-mini)                                                                                       | 33.2            | 42.5                | 11M        |
+| [rasyosef/splade-tiny](https://huggingface.co/rasyosef/splade-tiny)                                                                                       | 30.9            | 40.6                | 4M         |
 | BM25 (Baseline)                                                                                                                                           | 18.4            | 45.6                | NA         |
 
 ## Inference-Free SPLADE Models

--- a/docs/sparse_encoder/pretrained_models.md
+++ b/docs/sparse_encoder/pretrained_models.md
@@ -55,8 +55,8 @@ Note that all the numbers of below are extracted information from different pape
 | [naver/splade-v3-lexical](https://huggingface.co/naver/splade-v3-lexical)                                                                                 | 40.0            | 49.1                | 109M       |
 | [prithivida/Splade_PP_en_v1](https://huggingface.co/prithivida/Splade_PP_en_v1)                                                                           | 37.2            | 48.7                | 109M       |
 | [naver/splade_v2_max](https://huggingface.co/naver/splade_v2_max)                                                                                         | 34.0            | 46.4                | 67M        |
-| [rasyosef/splade-mini](https://huggingface.co/rasyosef/splade-mini)                                                                                       | 32.8            | NA                  | 11M        |
-| [rasyosef/splade-tiny](https://huggingface.co/rasyosef/splade-tiny)                                                                                       | 30.8            | NA                  | 4M         |
+| [rasyosef/splade-mini](https://huggingface.co/rasyosef/splade-mini)                                                                                       | 32.8            | 42.9                | 11M        |
+| [rasyosef/splade-tiny](https://huggingface.co/rasyosef/splade-tiny)                                                                                       | 30.8            | 40.5                | 4M         |
 | BM25 (Baseline)                                                                                                                                           | 18.4            | 45.6                | NA         |
 
 ## Inference-Free SPLADE Models

--- a/docs/sparse_encoder/pretrained_models.md
+++ b/docs/sparse_encoder/pretrained_models.md
@@ -55,6 +55,8 @@ Note that all the numbers of below are extracted information from different pape
 | [naver/splade-v3-lexical](https://huggingface.co/naver/splade-v3-lexical)                                                                                 | 40.0            | 49.1                | 109M       |
 | [prithivida/Splade_PP_en_v1](https://huggingface.co/prithivida/Splade_PP_en_v1)                                                                           | 37.2            | 48.7                | 109M       |
 | [naver/splade_v2_max](https://huggingface.co/naver/splade_v2_max)                                                                                         | 34.0            | 46.4                | 67M        |
+| [rasyosef/splade-mini](https://huggingface.co/rasyosef/splade-mini)                                                                                       | 32.8            | NA                  | 11M        |
+| [rasyosef/splade-tiny](https://huggingface.co/rasyosef/splade-tiny)                                                                                       | 30.8            | NA                  | 4M         |
 
 
 ## Inference-Free SPLADE Models

--- a/docs/sparse_encoder/pretrained_models.md
+++ b/docs/sparse_encoder/pretrained_models.md
@@ -57,7 +57,7 @@ Note that all the numbers of below are extracted information from different pape
 | [naver/splade_v2_max](https://huggingface.co/naver/splade_v2_max)                                                                                         | 34.0            | 46.4                | 67M        |
 | [rasyosef/splade-mini](https://huggingface.co/rasyosef/splade-mini)                                                                                       | 32.8            | NA                  | 11M        |
 | [rasyosef/splade-tiny](https://huggingface.co/rasyosef/splade-tiny)                                                                                       | 30.8            | NA                  | 4M         |
-
+| BM25 (Baseline)                                                                                                                                           | 18.4            | 45.6                | NA         |
 
 ## Inference-Free SPLADE Models
 

--- a/examples/sparse_encoder/applications/semantic_search/README.md
+++ b/examples/sparse_encoder/applications/semantic_search/README.md
@@ -386,7 +386,7 @@ This example demonstrates how to use [Seismic](https://github.com/TusKANNy/seism
 
 ## SPLADE-index Integration
 
-This example demonstrates how to use [splade-index](https://github.com/rasyosef/splade-index) for very fast sparse vector search powered by Scipy sparse matrices, built on top of the excellent [bm25s](https://github.com/xhluca/bm25s), a fast BM25 implementation. It does not require running a separate client, but instead performs search directly in memory. See [semantic_search_splade_index.py](semantic_search_splade_index.py) or below:
+This example demonstrates how to use [splade-index](https://github.com/rasyosef/splade-index) for very fast sparse vector search powered by SciPy sparse matrices, built on top of the excellent [bm25s](https://github.com/xhluca/bm25s), a fast BM25 implementation. It does not require running a separate client, but instead performs search directly in memory. See [semantic_search_splade_index.py](semantic_search_splade_index.py) or below:
 
 ### Prerequisites:
 - The SPLADE-index Python package must be installed:

--- a/examples/sparse_encoder/applications/semantic_search/README.md
+++ b/examples/sparse_encoder/applications/semantic_search/README.md
@@ -136,7 +136,7 @@ This example demonstrates how to set up Qdrant for sparse vector search by showi
 
 ### Prerequisites:
 - Qdrant running locally (or accessible), see the [Qdrant Quickstart](https://qdrant.tech/documentation/quickstart/) for more details.
-- Python Qdrant Client installed:
+- The Qdrant Python client must be installed:
   ```bash
   pip install qdrant-client
   ```
@@ -211,7 +211,7 @@ This example demonstrates how to set up OpenSearch for sparse vector search by s
 
 ### Prerequisites:
 - OpenSearch running locally (or accessible), see [OpenSearch locally](https://docs.opensearch.org/docs/latest/getting-started/quickstart/) for more details.
-- Further, you need the Python OpenSearch Client installed: https://docs.opensearch.org/docs/latest/clients/python-low-level/, e.g.:
+- Further, the OpenSearch Python client must be installed: https://docs.opensearch.org/docs/latest/clients/python-low-level/, e.g.:
   ```bash
     pip install opensearch-py
   ```
@@ -310,7 +310,7 @@ This example demonstrates how to set up OpenSearch for sparse vector search by s
 This example demonstrates how to use [Seismic](https://github.com/TusKANNy/seismic) for extremely performant sparse vector search. It does not require running a separate client, but instead performs search directly in memory. The Seismic library was introduced in [Bruch et al. (2024)](https://arxiv.org/abs/2404.18812), where it's shown to outperform the common inverted file (IVF) approach by an order of magnitude. For more information on building your Seismic Index you can look at the [Seismic Guidelines](https://github.com/TusKANNy/seismic/blob/main/docs/Guidelines.md). See [semantic_search_seismic.py](semantic_search_seismic.py) or below:
 
 ### Prerequisites:
-- The Seismic Python package installed:
+- The Seismic Python package must be installed:
   ```bash
   pip install pyseismic-lsr
   ```
@@ -384,13 +384,76 @@ This example demonstrates how to use [Seismic](https://github.com/TusKANNy/seism
         queries = [input("Please enter a question: ")]
 ```
 
+## SPLADE-index Integration
+
+This example demonstrates how to use [splade-index](https://github.com/rasyosef/splade-index) for very fast sparse vector search powered by Scipy sparse matrices, built on top of the excellent [bm25s](https://github.com/xhluca/bm25s), a fast BM25 implementation. It does not require running a separate client, but instead performs search directly in memory. See [semantic_search_splade_index.py](semantic_search_splade_index.py) or below:
+
+### Prerequisites:
+- The SPLADE-index Python package must be installed:
+  ```bash
+  pip install splade-index
+  ```
+
+```{eval-rst}
+
+.. sidebar:: Documentation
+
+   #. :class:`SparseEncoder <sentence_transformers.sparse_encoder.SparseEncoder>`
+   #. `rasyosef/splade-tiny <https://huggingface.co/rasyosef/splade-tiny>`_
+   #. `rasyosef/splade-mini <https://huggingface.co/rasyosef/splade-mini>`_
+   #. `sentence-transformers/natural-questions <https://huggingface.co/datasets/sentence-transformers/natural-questions>`_
+
+::
+   
+   import time
+   
+   from datasets import load_dataset
+   from splade_index import SPLADE
+   
+   from sentence_transformers import SparseEncoder
+   
+   # 1. Load the natural-questions dataset with 100K answers
+   dataset = load_dataset("sentence-transformers/natural-questions", split="train")
+   num_docs = 10_000
+   corpus = dataset["answer"][:num_docs]
+   
+   # 2. Come up with some queries
+   queries = dataset["query"][:2]
+   
+   # 3. Load the model
+   sparse_model = SparseEncoder("rasyosef/splade-tiny")
+   
+   # 4. Encode the corpus & create the index
+   print("Start encoding corpus and creating index...")
+   start_time = time.time()
+   corpus_index = SPLADE()
+   corpus_index.index(model=sparse_model, documents=corpus, batch_size=16,    show_progress=True)
+   print(f"Encoded corpus and created index in {time.time() - start_time:.6f} seconds")
+   
+   while True:
+       # 5. Encode the queries using the full precision
+       start_time = time.time()
+       all_doc_ids, all_documents, all_scores = corpus_index.retrieve(queries, k=5)
+       print(f"Encoding & Search time: {time.time() - start_time:.6f} seconds")
+   
+       # 7. Output the results
+       for query, doc_ids, documents, scores in zip(queries, all_doc_ids, all_documents,    all_scores):
+           print(f"Query: {query}")
+           for doc_id, document, score in zip(doc_ids, documents, scores):
+               print(f"(Score: {score:.4f}) {document}, corpus_id: {doc_id}")
+           print("")
+   
+       # 8. Prompt for more queries
+       queries = [input("Please enter a question: ")]
+```
+
 ## Elasticsearch Integration
 
 This example demonstrates how to set up Elasticsearch for sparse vector search by showing how to efficiently encode and index documents with sparse encoders, formulating search queries with sparse vectors, and providing an interactive query interface. See [semantic_search_elasticsearch.py](semantic_search_elasticsearch.py) or below:
 
 ### Prerequisites:
 - Elasticsearch running locally (or accessible), see [Elasticsearch locally](https://www.elastic.co/guide/en/elasticsearch/reference/current/run-elasticsearch-locally.html) for more details.
-- Python Elasticsearch client installed:
+- The Elasticsearch Python client must be installed:
   ```bash
   pip install elasticsearch
   ```

--- a/examples/sparse_encoder/applications/semantic_search/README.md
+++ b/examples/sparse_encoder/applications/semantic_search/README.md
@@ -305,6 +305,86 @@ This example demonstrates how to set up OpenSearch for sparse vector search by s
         queries = [input("Please enter a question: ")]
 ```
 
+## Elasticsearch Integration
+
+This example demonstrates how to set up Elasticsearch for sparse vector search by showing how to efficiently encode and index documents with sparse encoders, formulating search queries with sparse vectors, and providing an interactive query interface. See [semantic_search_elasticsearch.py](semantic_search_elasticsearch.py) or below:
+
+### Prerequisites:
+- Elasticsearch running locally (or accessible), see [Elasticsearch locally](https://www.elastic.co/guide/en/elasticsearch/reference/current/run-elasticsearch-locally.html) for more details.
+- The Elasticsearch Python client must be installed:
+  ```bash
+  pip install elasticsearch
+  ```
+
+```{eval-rst}
+
+.. sidebar:: Documentation
+
+   #. :class:`SparseEncoder <sentence_transformers.sparse_encoder.SparseEncoder>`
+   #. :meth:`SparseEncoder.encode_query <sentence_transformers.sparse_encoder.SparseEncoder.encode_query>`
+   #. :meth:`SparseEncoder.encode_document <sentence_transformers.sparse_encoder.SparseEncoder.encode_document>`
+   #. :meth:`semantic_search_elasticsearch <sentence_transformers.sparse_encoder.search_engines.semantic_search_elasticsearch>`
+   #. `naver/splade-cocondenser-ensembledistil <https://huggingface.co/naver/splade-cocondenser-ensembledistil>`_
+   #. `sentence-transformers/natural-questions <https://huggingface.co/datasets/sentence-transformers/natural-questions>`_
+
+::
+
+    import time
+
+    from datasets import load_dataset
+
+    from sentence_transformers import SparseEncoder
+    from sentence_transformers.sparse_encoder.search_engines import semantic_search_elasticsearch
+
+    # 1. Load the natural-questions dataset with 100K answers
+    dataset = load_dataset("sentence-transformers/natural-questions", split="train")
+    num_docs = 10_000
+    corpus = dataset["answer"][:num_docs]
+
+    # 2. Come up with some queries
+    queries = dataset["query"][:2]
+
+    # 3. Load the model
+    sparse_model = SparseEncoder("naver/splade-cocondenser-ensembledistil")
+
+    # 4. Encode the corpus
+    print("Start encoding corpus...")
+    start_time = time.time()
+    corpus_embeddings = sparse_model.encode_document(
+        corpus, convert_to_sparse_tensor=True, batch_size=16, show_progress_bar=True
+    )
+    corpus_embeddings_decoded = sparse_model.decode(corpus_embeddings)
+    print(f"Corpus encoding time: {time.time() - start_time:.6f} seconds")
+
+    corpus_index = None
+    while True:
+        # 5. Encode the queries using the full precision
+        start_time = time.time()
+        query_embeddings = sparse_model.encode_query(queries, convert_to_sparse_tensor=True)
+        query_embeddings_decoded = sparse_model.decode(query_embeddings)
+        print(f"Encoding time: {time.time() - start_time:.6f} seconds")
+
+        # 6. Perform semantic search using Elasticsearch
+        results, search_time, corpus_index = semantic_search_elasticsearch(
+            query_embeddings_decoded,
+            corpus_embeddings_decoded=corpus_embeddings_decoded if corpus_index is None else None,
+            corpus_index=corpus_index,
+            top_k=5,
+            output_index=True,
+        )
+
+        # 7. Output the results
+        print(f"Search time: {search_time:.6f} seconds")
+        for query, result in zip(queries, results):
+            print(f"Query: {query}")
+            for entry in result:
+                print(f"(Score: {entry['score']:.4f}) {corpus[entry['corpus_id']]}, corpus_id: {entry['corpus_id']}")
+            print("")
+
+        # 8. Prompt for more queries
+        queries = [input("Please enter a question: ")]
+```
+
 ## Seismic Integration
 
 This example demonstrates how to use [Seismic](https://github.com/TusKANNy/seismic) for extremely performant sparse vector search. It does not require running a separate client, but instead performs search directly in memory. The Seismic library was introduced in [Bruch et al. (2024)](https://arxiv.org/abs/2404.18812), where it's shown to outperform the common inverted file (IVF) approach by an order of magnitude. For more information on building your Seismic Index you can look at the [Seismic Guidelines](https://github.com/TusKANNy/seismic/blob/main/docs/Guidelines.md). See [semantic_search_seismic.py](semantic_search_seismic.py) or below:
@@ -445,84 +525,4 @@ This example demonstrates how to use [splade-index](https://github.com/rasyosef/
    
        # 8. Prompt for more queries
        queries = [input("Please enter a question: ")]
-```
-
-## Elasticsearch Integration
-
-This example demonstrates how to set up Elasticsearch for sparse vector search by showing how to efficiently encode and index documents with sparse encoders, formulating search queries with sparse vectors, and providing an interactive query interface. See [semantic_search_elasticsearch.py](semantic_search_elasticsearch.py) or below:
-
-### Prerequisites:
-- Elasticsearch running locally (or accessible), see [Elasticsearch locally](https://www.elastic.co/guide/en/elasticsearch/reference/current/run-elasticsearch-locally.html) for more details.
-- The Elasticsearch Python client must be installed:
-  ```bash
-  pip install elasticsearch
-  ```
-
-```{eval-rst}
-
-.. sidebar:: Documentation
-
-   #. :class:`SparseEncoder <sentence_transformers.sparse_encoder.SparseEncoder>`
-   #. :meth:`SparseEncoder.encode_query <sentence_transformers.sparse_encoder.SparseEncoder.encode_query>`
-   #. :meth:`SparseEncoder.encode_document <sentence_transformers.sparse_encoder.SparseEncoder.encode_document>`
-   #. :meth:`semantic_search_elasticsearch <sentence_transformers.sparse_encoder.search_engines.semantic_search_elasticsearch>`
-   #. `naver/splade-cocondenser-ensembledistil <https://huggingface.co/naver/splade-cocondenser-ensembledistil>`_
-   #. `sentence-transformers/natural-questions <https://huggingface.co/datasets/sentence-transformers/natural-questions>`_
-
-::
-
-    import time
-
-    from datasets import load_dataset
-
-    from sentence_transformers import SparseEncoder
-    from sentence_transformers.sparse_encoder.search_engines import semantic_search_elasticsearch
-
-    # 1. Load the natural-questions dataset with 100K answers
-    dataset = load_dataset("sentence-transformers/natural-questions", split="train")
-    num_docs = 10_000
-    corpus = dataset["answer"][:num_docs]
-
-    # 2. Come up with some queries
-    queries = dataset["query"][:2]
-
-    # 3. Load the model
-    sparse_model = SparseEncoder("naver/splade-cocondenser-ensembledistil")
-
-    # 4. Encode the corpus
-    print("Start encoding corpus...")
-    start_time = time.time()
-    corpus_embeddings = sparse_model.encode_document(
-        corpus, convert_to_sparse_tensor=True, batch_size=16, show_progress_bar=True
-    )
-    corpus_embeddings_decoded = sparse_model.decode(corpus_embeddings)
-    print(f"Corpus encoding time: {time.time() - start_time:.6f} seconds")
-
-    corpus_index = None
-    while True:
-        # 5. Encode the queries using the full precision
-        start_time = time.time()
-        query_embeddings = sparse_model.encode_query(queries, convert_to_sparse_tensor=True)
-        query_embeddings_decoded = sparse_model.decode(query_embeddings)
-        print(f"Encoding time: {time.time() - start_time:.6f} seconds")
-
-        # 6. Perform semantic search using Elasticsearch
-        results, search_time, corpus_index = semantic_search_elasticsearch(
-            query_embeddings_decoded,
-            corpus_embeddings_decoded=corpus_embeddings_decoded if corpus_index is None else None,
-            corpus_index=corpus_index,
-            top_k=5,
-            output_index=True,
-        )
-
-        # 7. Output the results
-        print(f"Search time: {search_time:.6f} seconds")
-        for query, result in zip(queries, results):
-            print(f"Query: {query}")
-            for entry in result:
-                print(f"(Score: {entry['score']:.4f}) {corpus[entry['corpus_id']]}, corpus_id: {entry['corpus_id']}")
-            print("")
-
-        # 8. Prompt for more queries
-        queries = [input("Please enter a question: ")]
 ```

--- a/examples/sparse_encoder/applications/semantic_search/README.md
+++ b/examples/sparse_encoder/applications/semantic_search/README.md
@@ -507,7 +507,7 @@ This example demonstrates how to use [splade-index](https://github.com/rasyosef/
    print("Start encoding corpus and creating index...")
    start_time = time.time()
    corpus_index = SPLADE()
-   corpus_index.index(model=sparse_model, documents=corpus, batch_size=16,    show_progress=True)
+   corpus_index.index(model=sparse_model, documents=corpus, batch_size=16, show_progress=True)
    print(f"Encoded corpus and created index in {time.time() - start_time:.6f} seconds")
    
    while True:
@@ -517,7 +517,7 @@ This example demonstrates how to use [splade-index](https://github.com/rasyosef/
        print(f"Encoding & Search time: {time.time() - start_time:.6f} seconds")
    
        # 7. Output the results
-       for query, doc_ids, documents, scores in zip(queries, all_doc_ids, all_documents,    all_scores):
+       for query, doc_ids, documents, scores in zip(queries, all_doc_ids, all_documents, all_scores):
            print(f"Query: {query}")
            for doc_id, document, score in zip(doc_ids, documents, scores):
                print(f"(Score: {score:.4f}) {document}, corpus_id: {doc_id}")

--- a/examples/sparse_encoder/applications/semantic_search/semantic_search_splade_index.py
+++ b/examples/sparse_encoder/applications/semantic_search/semantic_search_splade_index.py
@@ -1,0 +1,51 @@
+"""
+This script contains an example how to perform semantic search with splade_index.
+For more information, please refer to the documentation:
+https://github.com/rasyosef/splade-index
+
+All you need is installing the `splade-index` package:
+```
+pip install splade-index
+```
+"""
+
+import time
+
+from datasets import load_dataset
+from splade_index import SPLADE
+
+from sentence_transformers import SparseEncoder
+
+# 1. Load the natural-questions dataset with 100K answers
+dataset = load_dataset("sentence-transformers/natural-questions", split="train")
+num_docs = 10_000
+corpus = dataset["answer"][:num_docs]
+
+# 2. Come up with some queries
+queries = dataset["query"][:2]
+
+# 3. Load the model
+sparse_model = SparseEncoder("rasyosef/splade-tiny")
+
+# 4. Encode the corpus & create the index
+print("Start encoding corpus and creating index...")
+start_time = time.time()
+corpus_index = SPLADE()
+corpus_index.index(model=sparse_model, documents=corpus, batch_size=16, show_progress=True)
+print(f"Encoded corpus and created index in {time.time() - start_time:.6f} seconds")
+
+while True:
+    # 5. Encode the queries using the full precision
+    start_time = time.time()
+    all_doc_ids, all_documents, all_scores = corpus_index.retrieve(queries, k=5)
+    print(f"Encoding & Search time: {time.time() - start_time:.6f} seconds")
+
+    # 7. Output the results
+    for query, doc_ids, documents, scores in zip(queries, all_doc_ids, all_documents, all_scores):
+        print(f"Query: {query}")
+        for doc_id, document, score in zip(doc_ids, documents, scores):
+            print(f"(Score: {score:.4f}) {document}, corpus_id: {doc_id}")
+        print("")
+
+    # 8. Prompt for more queries
+    queries = [input("Please enter a question: ")]


### PR DESCRIPTION
Hello!

## Pull Request overview
* Add semantic search example using [splade_index](https://github.com/rasyosef/splade-index) 

## Details
As a follow-up of #3472, this PR adds a documentation example of how to use the splade-index project for efficient retrieval with SPLADE. Unlike the other integrations in this documentation page, splade-index is so nicely integrated that there's no need for a `semantic_search_splade_index` function. Instead, the usage script is extremely straight-forward, and it's extremely efficient as well. I used 100k docs with naver/splade-v3 as an experiment, and my average latency for query inference + top 5 search only takes 0.05 seconds on my local GPU.

cc @xhluca @rasyosef

P.s. would it be interesting to upstream this into bm25s?

- Tom Aarsen