### PR TITLE
docs: add MTEB evaluation guide and update usage.rst

### DIFF
--- a/docs/sentence_transformer/usage/mteb_evaluation.md
+++ b/docs/sentence_transformer/usage/mteb_evaluation.md
@@ -2,7 +2,7 @@
 
 The [Massive Text Embedding Benchmark (MTEB)](https://github.com/embeddings-benchmark/mteb) is a comprehensive benchmark suite for evaluating embedding models across diverse NLP tasks like retrieval, classification, clustering, reranking, and semantic similarity.
 
-This guide walks you through using MTEB with SentenceTransformer models for post-training evaluation. This is *not* designed for use during training loops, as this risks overfitting to public benchmarks. For evaluation during training, please see the [Evaluator section in the Training Overview](../training_overview.md#evaluator). To fully integrate your model to MTEB, you can follow the [Adding a model to the Leaderboard](https://github.com/embeddings-benchmark/mteb/blob/main/docs/adding_a_model.md) guide from the MTEB Documentation.
+This guide walks you through using MTEB with SentenceTransformer models for post-training evaluation. This is *not* designed for use during training, as this risks overfitting on public benchmarks. For evaluation during training, please see the [Evaluator section in the Training Overview](../training_overview.md#evaluator). To fully integrate your model to MTEB, you can follow the [Adding a model to the Leaderboard](https://github.com/embeddings-benchmark/mteb/blob/main/docs/adding_a_model.md) guide from the MTEB Documentation.
 
 ## Installation
 
@@ -67,7 +67,18 @@ For the full list of supported benchmarks, visit the [MTEB Benchmarks documentat
 
 ## Additional Arguments
 
-When running evaluations, you can pass arguments down to `model.encode()` using the `encode_kwargs` parameter on `evaluation.run()`. This allows you to customize how embeddings are generated, such as setting `batch_size`, `truncate_dim`, or `normalize_embeddings`.
+When running evaluations, you can pass arguments down to `model.encode()` using the `encode_kwargs` parameter on `evaluation.run()`. This allows you to customize how embeddings are generated, such as setting `batch_size`, `truncate_dim`, or `normalize_embeddings`. For example:
+
+```python
+...
+
+results = evaluation.run(
+    model,
+    verbosity=2,
+    output_folder="results/",
+    encode_kwargs={"batch_size": 64, "normalize_embeddings": True}
+)
+```
 
 Additionally, your SentenceTransformer model may have been configured to use `prompts`. MTEB will automatically detect and use these prompts if they are defined in your model's configuration. For task-specific or document/query-specific prompts, you should read the MTEB Documentation on [Running SentenceTransformer models with prompts](https://github.com/embeddings-benchmark/mteb/blob/main/docs/usage/usage.md#running-sentencetransformer-model-with-prompts).
 
@@ -102,7 +113,7 @@ for task_results in results:
 To add your model to the [MTEB Leaderboard](https://huggingface.co/spaces/mteb/leaderboard), you will need to follow the [Adding a Model](https://github.com/embeddings-benchmark/mteb/blob/main/docs/adding_a_model.md) MTEB Documentation.
 
 For the process, you'll need to follow these steps:
-1. Add your model metadata (name, languages, number of parameters, framework, training datasets, etc.) to the [MTEB Repository](https://github.com/embeddings-benchmark/mteb/tree/main/mteb/models)
+1. Add your model metadata (name, languages, number of parameters, framework, training datasets, etc.) to the [MTEB Repository](https://github.com/embeddings-benchmark/mteb/tree/main/mteb/models).
 2. Evaluate your model using MTEB on your desired tasks and save the results.
 2. Submit your results to the [MTEB Results Repository](https://github.com/embeddings-benchmark/results).
 

--- a/docs/sentence_transformer/usage/usage.rst
+++ b/docs/sentence_transformer/usage/usage.rst
@@ -57,6 +57,6 @@ Once you have `installed <../../installation.html>`_ Sentence Transformers, you 
    ../../../examples/sentence_transformer/applications/image-search/README
    ../../../examples/sentence_transformer/applications/embedding-quantization/README
    custom_models
-   efficiency
    mteb_evaluation
+   efficiency
 


### PR DESCRIPTION
This PR resolves [#3332](https://github.com/UKPLab/sentence-transformers/issues/3332).

### Summary

Adds a new documentation page for evaluating SentenceTransformer models using the [Massive Text Embedding Benchmark (MTEB)](https://github.com/embeddings-benchmark/mteb), along with relevant task examples and best practices.

### Changes

- `mteb_evaluation.md` in `docs/sentence_transformer/usage/`:
  - Installation steps
  - Minimal working example
  - Task-type breakdown (STS, Classification, Retrieval, etc.)
  - Notes on output handling
  - Warnings about *not* using MTEB during training
  - Leaderboard + export instructions

-  Linked from `usage.rst` to include in sidebar navigation

### Notes

Following the guidance in the discussion, MTEB is documented as a **post-training evaluation tool**, not integrated as an evaluator to avoid benchmark overfitting.

Let me know if you'd like any section adjusted. Thank you!
