### PR TITLE
[`fix`] FIPS compatibility - use SHA256 with usedforsecurity=False in hard negatives caching

### DIFF
--- a/sentence_transformers/util/hard_negatives.py
+++ b/sentence_transformers/util/hard_negatives.py
@@ -346,8 +346,8 @@ def mine_hard_negatives(
         os.makedirs(cache_folder, exist_ok=True)
 
         model_name = model.model_card_data.base_model or ""
-        query_hash = hashlib.md5((model_name + "".join(queries)).encode()).hexdigest()
-        corpus_hash = hashlib.md5((model_name + "".join(corpus)).encode()).hexdigest()
+        query_hash = hashlib.sha256((model_name + "".join(queries)).encode(), usedforsecurity=False).hexdigest()
+        corpus_hash = hashlib.sha256((model_name + "".join(corpus)).encode(), usedforsecurity=False).hexdigest()
 
         query_cache_file = os.path.join(cache_folder, f"query_embeddings_{query_hash}.npy")
         corpus_cache_file = os.path.join(cache_folder, f"corpus_embeddings_{corpus_hash}.npy")


### PR DESCRIPTION
Resolves #2234 

Hello!

## Pull Request overview
* use SHA256 with usedforsecurity=False in hard negatives caching

## Details
As detailed by @kobaan in https://github.com/UKPLab/sentence-transformers/issues/2234#issuecomment-3145475040, I introduced a non-FIPS-compatible md5 hashing in the `mine_hard_negatives` for caching. I've now replaced the MD5 with SHA-256 with `usedforsecurity=False` (as it's not used for security in the slightest here). 

This does not resolve a security issue, but simply introduces FIPS compatibility so users can be confident that there's indeed no hashing-related vulnerabilities here.

@jayteaftw @kobaan
If either of you can experiment with this branch by installing it like so:
```
pip install git+https://github.com/tomaarsen/sentence-transformers@fix/fips_compatibility
```
Assuming this is permissible on your systems. 

cc @apetersonflc as you once also experienced issues with FIPS compatibility.

- Tom Aarsen