### PR TITLE
Fix: Add Image.Image support to encode() overloads to resolve mypy error (#3462)

### DIFF
--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -22,6 +22,7 @@ from typing import Any, Callable, Literal, overload
 
 import numpy as np
 import numpy.typing as npt
+from PIL import Image
 import torch
 import torch.multiprocessing as mp
 import transformers
@@ -678,7 +679,7 @@ class SentenceTransformer(nn.Sequential, FitMixin, PeftAdapterMixin):
     @overload
     def encode(
         self,
-        sentences: str,
+        sentences: str | Image.Image,
         prompt_name: str | None = ...,
         prompt: str | None = ...,
         batch_size: int = ...,
@@ -700,7 +701,7 @@ class SentenceTransformer(nn.Sequential, FitMixin, PeftAdapterMixin):
     @overload
     def encode(
         self,
-        sentences: str | list[str] | np.ndarray,
+        sentences: str | list[str] | np.ndarray | Image.Image | list[Image.Image],
         prompt_name: str | None = ...,
         prompt: str | None = ...,
         batch_size: int = ...,
@@ -722,7 +723,7 @@ class SentenceTransformer(nn.Sequential, FitMixin, PeftAdapterMixin):
     @overload
     def encode(
         self,
-        sentences: str | list[str] | np.ndarray,
+        sentences: str | list[str] | np.ndarray | Image.Image | list[Image.Image],
         prompt_name: str | None = ...,
         prompt: str | None = ...,
         batch_size: int = ...,
@@ -743,7 +744,7 @@ class SentenceTransformer(nn.Sequential, FitMixin, PeftAdapterMixin):
     @overload
     def encode(
         self,
-        sentences: list[str] | np.ndarray,
+        sentences: list[str] | np.ndarray | list[Image.Image],
         prompt_name: str | None = ...,
         prompt: str | None = ...,
         batch_size: int = ...,
@@ -764,7 +765,7 @@ class SentenceTransformer(nn.Sequential, FitMixin, PeftAdapterMixin):
     @overload
     def encode(
         self,
-        sentences: list[str] | np.ndarray,
+        sentences: list[str] | np.ndarray | list[Image.Image],
         prompt_name: str | None = ...,
         prompt: str | None = ...,
         batch_size: int = ...,
@@ -785,7 +786,7 @@ class SentenceTransformer(nn.Sequential, FitMixin, PeftAdapterMixin):
     @overload
     def encode(
         self,
-        sentences: str,
+        sentences: str | Image.Image,
         prompt_name: str | None = ...,
         prompt: str | None = ...,
         batch_size: int = ...,
@@ -806,7 +807,7 @@ class SentenceTransformer(nn.Sequential, FitMixin, PeftAdapterMixin):
     @overload
     def encode(
         self,
-        sentences: str,
+        sentences: str | Image.Image,
         prompt_name: str | None = ...,
         prompt: str | None = ...,
         batch_size: int = ...,
@@ -826,7 +827,7 @@ class SentenceTransformer(nn.Sequential, FitMixin, PeftAdapterMixin):
     @torch.inference_mode()
     def encode(
         self,
-        sentences: str | list[str] | np.ndarray,
+        sentences: str | list[str] | np.ndarray | Image.Image | list[Image.Image],
         prompt_name: str | None = None,
         prompt: str | None = None,
         batch_size: int = 32,


### PR DESCRIPTION
Hi @tomaarsen 

In this PR I have tried #3462 by updating the `encode()` method's type hints (including all relevant overload variants) to support `PIL.Image.Image` and `list[PIL.Image.Image]`.

Summary of Changes:
- Imported `Image` from `PIL`
- Updated all `encode()` overloads to include `Image.Image` and `list[Image.Image]`
- Also updated the main `encode()` function signature accordingly

This ensures that tools like `mypy` no longer raise type errors when calling `encode()` with image inputs. As it is working correctly at inference time — the issue was limited to type checking.
