### PR TITLE
[`fix`] Ensure multi-process embeddings are moved to CPU for concatenation

### DIFF
--- a/examples/sentence_transformer/applications/computing-embeddings/README.rst
+++ b/examples/sentence_transformer/applications/computing-embeddings/README.rst
@@ -172,7 +172,7 @@ You can use :meth:`SentenceTransformer.encode() <sentence_transformers.SentenceT
         def main():
             model = SentenceTransformer("all-MiniLM-L6-v2")
             # Start a multi-process pool with multiple GPUs
-            pool = model.start_multi_process_pool(devices=["cuda:0", "cuda:1"])
+            pool = model.start_multi_process_pool(target_devices=["cuda:0", "cuda:1"])
             # Encode with multiple GPUs
             embeddings = model.encode(inputs, pool=pool)
             # Don't forget to stop the pool after usage

--- a/examples/sparse_encoder/applications/computing_embeddings/README.rst
+++ b/examples/sparse_encoder/applications/computing_embeddings/README.rst
@@ -238,7 +238,7 @@ You can use :meth:`SparseEncoder.encode() <sentence_transformers.sparse_encoder.
         def main():
             model = SparseEncoder("naver/splade-cocondenser-ensembledistil")
             # Start a multi-process pool with multiple GPUs
-            pool = model.start_multi_process_pool(devices=["cuda:0", "cuda:1"])
+            pool = model.start_multi_process_pool(target_devices=["cuda:0", "cuda:1"])
             # Encode with multiple GPUs
             embeddings = model.encode(inputs, pool=pool)
             # Don't forget to stop the pool after usage

--- a/sentence_transformers/sparse_encoder/SparseEncoder.py
+++ b/sentence_transformers/sparse_encoder/SparseEncoder.py
@@ -526,7 +526,7 @@ class SparseEncoder(SentenceTransformer):
                 batch_size=batch_size,
                 convert_to_tensor=convert_to_tensor,
                 convert_to_sparse_tensor=convert_to_sparse_tensor,
-                save_to_cpu=save_to_cpu,
+                save_to_cpu=True,  # Move all embeddings to CPU to allow for concatenation
                 max_active_dims=max_active_dims,
                 **kwargs,
             )


### PR DESCRIPTION
Resolves #3486

Hello!

## Pull Request overview
* Ensure multi-process embeddings are moved to CPU for concatenation.
* Fix incorrect `devices` in documentation, should be `target_devices`.
* Add 2 slow tests checking that multi-device multi-processing works with tensors as output.

## Details
This PR updates the SentenceTransformer and SparseEncoder multi-processing/multi-gpu so that it always moves embeddings to CPU when `convert_to_tensor=True`. Otherwise, e.g. devices `cuda:0` and `cuda:1` will produce embeddings with those devices, and they can't be concatenated together. 

## Bug reproduction
This script should allow you to reproduce the bug from #3486 with just 1 GPU:
```python
import torch
from sentence_transformers import SentenceTransformer

def main():
    model = SentenceTransformer("all-mpnet-base-v2")

    # pool = model.start_multi_process_pool(target_devices=["cuda:0", "cuda:1"])
    pool = model.start_multi_process_pool(target_devices=["cuda", "cpu"])
    embeddings = model.encode_query(["hello", "how are you"], convert_to_tensor=True, show_progress_bar=True, pool=pool)
    model.stop_multi_process_pool(pool)

    if isinstance(embeddings, torch.Tensor):
        print(embeddings.shape, embeddings.device)
    else:
        print(embeddings.shape)

if __name__ == "__main__":
    main()
```

After this fix, the result is:
```
Chunks: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:00<00:00,  5.22it/s]
torch.Size([2, 768]) cpu
```

- Tom Aarsen