### PR TITLE
Add Support for Knowledgeable Passage Retriever (KPR)

### DIFF
--- a/sentence_transformers/models/Transformer.py
+++ b/sentence_transformers/models/Transformer.py
@@ -228,7 +228,16 @@ class Transformer(InputModule):
         trans_features = {
             key: value
             for key, value in features.items()
-            if key in ["input_ids", "attention_mask", "token_type_ids", "inputs_embeds"]
+            if key
+            in [
+                "input_ids",
+                "attention_mask",
+                "token_type_ids",
+                "inputs_embeds",
+                "entity_ids",
+                "entity_position_ids",
+                "entity_embeds",
+            ]
         }
 
         outputs = self.auto_model(**trans_features, **kwargs, return_dict=True)


### PR DESCRIPTION
Hello,  

This pull request adds support for our new **Knowledgeable Passage Retriever (KPR)** model, which will be presented at the upcoming EMNLP conference.  
KPR improves embedding models on queries involving less-frequent entities by injecting external entity knowledge through an attention mechanism.

Paper: https://arxiv.org/abs/2507.03922  
Code: https://github.com/knowledgeable-embedding/knowledgeable-embedding  

This change is necessary because our model requires additional inputs: `entity_ids`, `entity_position_ids`, and `entity_embeds`, in addition to the standard features such as `input_ids` and `attention_mask`.  

Thanks in advance for reviewing this PR!