### PR TITLE
[`model_card`] Don't override manually provided languages in model card

### DIFF
--- a/sentence_transformers/model_card.py
+++ b/sentence_transformers/model_card.py
@@ -359,12 +359,11 @@ class SentenceTransformerModelCardData(CardData):
 
     def __post_init__(self) -> None:
         # We don't want to save "ignore_metadata_errors" in our Model Card
-        infer_languages = not self.language
         if isinstance(self.language, str):
             self.language = [self.language]
 
-        self.train_datasets = self.validate_datasets(self.train_datasets, infer_languages=infer_languages)
-        self.eval_datasets = self.validate_datasets(self.eval_datasets, infer_languages=infer_languages)
+        self.train_datasets = self.validate_datasets(self.train_datasets)
+        self.eval_datasets = self.validate_datasets(self.eval_datasets)
 
         if self.model_id and self.model_id.count("/") != 1:
             logger.warning(
@@ -374,8 +373,11 @@ class SentenceTransformerModelCardData(CardData):
             self.model_id = None
 
     def validate_datasets(
-        self, dataset_list: list[dict[str, Any]], infer_languages: bool = True
+        self, dataset_list: list[dict[str, Any]], infer_languages: bool | None = None
     ) -> list[dict[str, Any]]:
+        if infer_languages is None:
+            # Infer languages if they're not already defined
+            infer_languages = not self.language
         output_dataset_list = []
         for dataset in dataset_list:
             if "name" not in dataset:


### PR DESCRIPTION
Hello!

## Pull Request overview
* Don't override manually provided languages in model card

## Details
Prior to this PR, if you manually specify a language of `en` in the `SentenceTransformerModelCardData`, it can still be overwritten if the training/eval dataset on the Hub has some languages defined.

- Tom Aarsen