### PR TITLE
[`feat`] Use encode_document and encode_query in mine_hard_negatives

### DIFF
--- a/sentence_transformers/util/hard_negatives.py
+++ b/sentence_transformers/util/hard_negatives.py
@@ -369,7 +369,7 @@ def mine_hard_negatives(
                 target_devices=None if isinstance(use_multi_process, bool) else use_multi_process
             )
             if corpus_embeddings is None:
-                corpus_embeddings = model.encode(
+                corpus_embeddings = model.encode_document(
                     corpus,
                     pool=pool,
                     batch_size=batch_size,
@@ -380,7 +380,7 @@ def mine_hard_negatives(
                     prompt=corpus_prompt,
                 )
             if query_embeddings is None:
-                query_embeddings = model.encode(
+                query_embeddings = model.encode_query(
                     queries,
                     pool=pool,
                     batch_size=batch_size,
@@ -393,7 +393,7 @@ def mine_hard_negatives(
             model.stop_multi_process_pool(pool)
         else:
             if corpus_embeddings is None:
-                corpus_embeddings = model.encode(
+                corpus_embeddings = model.encode_document(
                     corpus,
                     batch_size=batch_size,
                     normalize_embeddings=True,
@@ -403,7 +403,7 @@ def mine_hard_negatives(
                     prompt=corpus_prompt,
                 )
             if query_embeddings is None:
-                query_embeddings = model.encode(
+                query_embeddings = model.encode_query(
                     queries,
                     batch_size=batch_size,
                     normalize_embeddings=True,

--- a/tests/util/test_hard_negatives.py
+++ b/tests/util/test_hard_negatives.py
@@ -799,9 +799,9 @@ def test_mine_hard_negatives_with_prompt(paraphrase_distilroberta_base_v1_model:
     original_tokenize = model.tokenize
     tokenize_calls = []
 
-    def mock_tokenize(texts) -> dict[str, Tensor]:
+    def mock_tokenize(texts, **kwargs) -> dict[str, Tensor]:
         tokenize_calls.append(texts)
-        return original_tokenize(texts)
+        return original_tokenize(texts, **kwargs)
 
     # 2. Run without prompt - check that no prompt is added
     model.tokenize = mock_tokenize


### PR DESCRIPTION
Hello!

## Pull Request overview
* Use encode_document and encode_query in mine_hard_negatives

## Details
Currently, `model.encode` is used in `mine_hard_negatives`, with users able to provide `query_prompt`, `query_prompt_name`, `corpus_prompt_name`, and `corpus_prompt` to specify prompts. However, we can simply use the new `encode_query` and `encode_document` to optionally use the "query" and "document" default prompts if they're configured in the embedding model of choice.

- Tom Aarsen