### PR TITLE
[`fix`] Fix the number of missing negatives in mine_hard_negatives

### DIFF
--- a/sentence_transformers/util/hard_negatives.py
+++ b/sentence_transformers/util/hard_negatives.py
@@ -636,6 +636,7 @@ def mine_hard_negatives(
             dataset_data[positive_column_name].append(corpus[positive_idx])
             dataset_data["negative"].append(corpus[negative_idx])
         difference_scores = positive_scores.repeat(num_negatives, 1).T[indices_to_keep] - negative_scores
+        maximum_possible_samples = indices_to_keep.numel()
 
     elif output_format == "labeled-pair":
         indices_to_keep = negative_scores != -float("inf")
@@ -660,6 +661,7 @@ def mine_hard_negatives(
 
         negative_scores = negative_scores[indices_to_keep]
         difference_scores = positive_scores.repeat(num_negatives, 1).T[indices_to_keep] - negative_scores
+        maximum_possible_samples = n_queries * num_negatives + len(dataset)
 
     elif output_format in ("n-tuple", "n-tuple-scores"):
         # Keep only indices where num_negative negatives were found
@@ -681,6 +683,7 @@ def mine_hard_negatives(
             ).tolist()
         negative_scores = negative_scores.flatten()
         difference_scores = positive_scores.repeat(num_negatives, 1).T[indices_to_keep].flatten() - negative_scores
+        maximum_possible_samples = indices_to_keep.size(0)
 
     elif output_format == "labeled-list":
         indices_to_keep = negative_scores != -float("inf")
@@ -696,6 +699,7 @@ def mine_hard_negatives(
         }
         negative_scores = negative_scores[indices_to_keep]
         difference_scores = positive_scores.repeat(num_negatives, 1).T[indices_to_keep] - negative_scores
+        maximum_possible_samples = indices_to_keep.size(0)
 
     if len(dataset_data) == 0:
         raise ValueError("No triplets could be generated. Please check the parameters and dataset.")
@@ -746,8 +750,8 @@ def mine_hard_negatives(
                     f"Skipped {skipped:,} potential negatives ({ratio:.2%}) due to the {param_name} of {param_value}."
                 )
 
-        missing_negatives = (num_negatives * len(dataset)) - len(negative_scores)
-        if missing_negatives > 0:
+        missing_samples = maximum_possible_samples - len(output_dataset)
+        if missing_samples > 0:
             solutions = ["range_max"]
             if range_min > 0:
                 solutions.append("range_min")
@@ -760,9 +764,9 @@ def mine_hard_negatives(
             considerations = ", ".join(solutions[:-1])
             if len(solutions) > 1:
                 considerations += " and " + solutions[-1]
-            missing_negatives_ratio = missing_negatives / (num_negatives * len(dataset))
+            missing_samples_ratio = missing_samples / maximum_possible_samples
             print(
-                f"Could not find enough negatives for {missing_negatives} samples ({missing_negatives_ratio:.2%})."
+                f"Could not find enough negatives for {missing_samples} samples ({missing_samples_ratio:.2%})."
                 f" Consider adjusting the {considerations} parameter{'s' if len(solutions) > 1 else ''} if you'd like to find more valid negatives."
             )
 


### PR DESCRIPTION
Hello!

## Pull Request overview
* Fix the number of missing negatives in mine_hard_negatives

## Details
There were a handful of issues with it, especially with higher num_negatives. For example, I got
```
Metric       Positive       Negative     Difference
Count         532,751      7,964,520               
Mean           0.7888         0.7233         0.0663
Median         0.7976         0.7290         0.0502
Std            0.0686         0.0608         0.0404
Min            0.2752         0.4056        -0.3588
25%            0.7500         0.6856         0.0411
50%            0.7976         0.7290         0.0502
75%            0.8377         0.7669         0.0801
Max            0.9654         0.9071         0.4145
Skipped 214,189,259 potential negatives (1.06%) due to the relative_margin of 0.05.
Could not find enough negatives for 26745 samples (0.33%). Consider adjusting the range_max and relative_margin parameters if you'd like to find more valid negatives.
```
But in reality, `26745 samples (0.33%)` was incorrect, it should have been `1783 samples (0.33%)`. It said 15x too many as num_negatives=15.

- Tom Aarsen