### PR TITLE
Update rasyosef/splade-mini MSMARCO and BEIR-13 benchmark scores in pretrained_models.md

### DIFF
--- a/docs/sparse_encoder/pretrained_models.md
+++ b/docs/sparse_encoder/pretrained_models.md
@@ -55,7 +55,7 @@ Note that all the numbers of below are extracted information from different pape
 | [naver/splade-v3-lexical](https://huggingface.co/naver/splade-v3-lexical)                                                                                 | 40.0            | 49.1                | 109M       |
 | [prithivida/Splade_PP_en_v1](https://huggingface.co/prithivida/Splade_PP_en_v1)                                                                           | 37.2            | 48.7                | 109M       |
 | [naver/splade_v2_max](https://huggingface.co/naver/splade_v2_max)                                                                                         | 34.0            | 46.4                | 67M        |
-| [rasyosef/splade-mini](https://huggingface.co/rasyosef/splade-mini)                                                                                       | 33.2            | 42.5                | 11M        |
+| [rasyosef/splade-mini](https://huggingface.co/rasyosef/splade-mini)                                                                                       | 34.1            | 44.5                | 11M        |
 | [rasyosef/splade-tiny](https://huggingface.co/rasyosef/splade-tiny)                                                                                       | 30.9            | 40.6                | 4M         |
 | BM25 (Baseline)                                                                                                                                           | 18.4            | 45.6                | NA         |
 


### PR DESCRIPTION
Hi @tomaarsen,

I have updated the MSMARCO and BEIR-13 scores for [rasyosef/splade-mini](https://huggingface.co/rasyosef/splade-mini) in `pretrained_models.md`. It now beats [naver/splade_v2_max](https://huggingface.co/naver/splade_v2_max) on the MSMARCO benchmark.

|   |Size (# Params)|MSMARCO MRR@10|BEIR-13 avg nDCG@10|Corpus Active Dims (msmarco)|
|:--|:-----------------|:----------------------|:-------------------------|:---------------------------------|
|[rasyosef/splade-mini](https://huggingface.co/rasyosef/splade-mini)|11.2M|34.1|44.5|186.6|
|[rasyosef/splade-small](https://huggingface.co/rasyosef/splade-small)|28.8M|35.4|46.6|176.9|


Here is a table that contains **NDCG@10** scores of [rasyosef/splade-mini](https://huggingface.co/rasyosef/splade-mini) and [rasyosef/splade-small](https://huggingface.co/rasyosef/splade-small) on each of the 13 datasets in **BEIR-13**.

|                                             | rasyosef/splade-mini  | rasyosef/splade-small|
|:------------------------------|:-------------------------|:------------------------|
| TRECCOVID_ndcg@10        | 0.6141                         | 0.61183                       |
| NFCorpus_ndcg@10           | 0.32444                       | 0.33197                       |
| NQ_ndcg@10                      | 0.44797                       | 0.47761                       |
| HotpotQA_ndcg@10           | 0.58772                       | 0.62384                       |
| FiQA2018_ndcg@10            | 0.26163                       | 0.29805                       |
| DBPedia_ndcg@10              | 0.35631                       | 0.38858                       |
| ArguAna_ndcg@10             | 0.34157                       | 0.43647                       |
| Touche2020_ndcg@10        | 0.31878                       | 0.31065                       |
| QuoraRetrieval_ndcg@10   | 0.77854                       | 0.78591                       |
| SCIDOCS_ndcg@10            | 0.13452                       | 0.13823                       |
| SciFact_ndcg@10                | 0.65647                       | 0.6633                         |
| FEVER_ndcg@10                 | 0.75417                       | 0.77566                       |
| ClimateFEVER_ndcg@10     | 0.21024                       | 0.21584                       |
| **NDCG@10 (average)**    | **0.4451**                   | **0.4660**                    |