### PR TITLE
always pass `input_ids`, `attention_mask`, `token_type_ids`, `inputs_embeds` to forward

### DIFF
--- a/sentence_transformers/models/Transformer.py
+++ b/sentence_transformers/models/Transformer.py
@@ -228,6 +228,8 @@ class Transformer(InputModule):
         """Returns token_embeddings, cls_token"""
         # Get the signature of the auto_model's forward method to pass only the expected arguments from `features`
         model_forward_params = list(inspect.signature(self.auto_model.forward).parameters)
+        # always pass ["input_ids", "attention_mask", "token_type_ids", "inputs_embeds"] to the forward
+        model_forward_params = list(set(model_forward_params + ["input_ids", "attention_mask", "token_type_ids", "inputs_embeds"]))
         trans_features = {key: value for key, value in features.items() if key in model_forward_params}
 
         outputs = self.auto_model(**trans_features, **kwargs, return_dict=True)


### PR DESCRIPTION
I think that using `inspect.signature` can be a breaking change, because custom model implementaion could have in  forward with `*args, **kwargs`?
```python
import inspect

def func(*args, **kwargs):
    pass
print(list(inspect.signature(func).parameters))
# ['args', 'kwargs']
```

E. g. `mme5` have just `features: Dict[str, torch.Tensor], **kwargs` in their implementaion and this can break it. 

https://huggingface.co/intfloat/mmE5-mllama-11b-instruct/blob/main/custom_st.py#L42

I think you can always pass `["input_ids", "attention_mask", "token_type_ids", "inputs_embeds"]`