### PR TITLE
fix: add makedirs to informationretrievalevaluator

### DIFF
--- a/examples/sentence_transformer/applications/parallel-sentence-mining/bitext_mining.py
+++ b/examples/sentence_transformer/applications/parallel-sentence-mining/bitext_mining.py
@@ -4,7 +4,7 @@ This scripts show how to mine parallel (translated) sentences from two list of m
 As input, you specific two text files that have sentences in every line. Then, the
 LaBSE model is used to find parallel (translated) across these two files.
 
-The result is written to disc.
+The result is written to disk.
 
 A large source for monolingual sentences in different languages is:
 http://data.statmt.org/cc-100/
@@ -154,7 +154,7 @@ scores = np.concatenate([fwd_scores.max(axis=1), bwd_scores.max(axis=1)])
 seen_src, seen_trg = set(), set()
 
 # Extract list of parallel sentences
-print("Write sentences to disc")
+print("Write sentences to disk")
 sentences_written = 0
 with gzip.open("parallel-sentences-out.tsv.gz", "wt", encoding="utf8") as fOut:
     for i in np.argsort(-scores):

--- a/examples/sentence_transformer/applications/parallel-sentence-mining/bucc2018.py
+++ b/examples/sentence_transformer/applications/parallel-sentence-mining/bucc2018.py
@@ -53,7 +53,7 @@ ann_num_cluster_probe = 5
 use_pca = False
 pca_dimensions = 128
 
-# We store the embeddings on disc, so that they can later be loaded from disc
+# We store the embeddings on disc, so that they can later be loaded from disk
 source_embedding_file = f"{model_name}_{os.path.basename(source_file)}_{pca_dimensions if use_pca else model.get_sentence_embedding_dimension()}.emb"
 target_embedding_file = f"{model_name}_{os.path.basename(target_file)}_{pca_dimensions if use_pca else model.get_sentence_embedding_dimension()}.emb"
 

--- a/examples/sentence_transformer/applications/parallel-sentence-mining/bucc2018.py
+++ b/examples/sentence_transformer/applications/parallel-sentence-mining/bucc2018.py
@@ -53,7 +53,7 @@ ann_num_cluster_probe = 5
 use_pca = False
 pca_dimensions = 128
 
-# We store the embeddings on disc, so that they can later be loaded from disk
+# We store the embeddings on disk, so that they can later be loaded from disk
 source_embedding_file = f"{model_name}_{os.path.basename(source_file)}_{pca_dimensions if use_pca else model.get_sentence_embedding_dimension()}.emb"
 target_embedding_file = f"{model_name}_{os.path.basename(target_file)}_{pca_dimensions if use_pca else model.get_sentence_embedding_dimension()}.emb"
 

--- a/examples/sentence_transformer/applications/semantic-search/semantic_search_quora_annoy.py
+++ b/examples/sentence_transformer/applications/semantic-search/semantic_search_quora_annoy.py
@@ -78,11 +78,11 @@ if not os.path.exists(embedding_cache_path):
     print("Encode the corpus. This might take a while")
     corpus_embeddings = model.encode(corpus_sentences, show_progress_bar=True, convert_to_numpy=True)
 
-    print("Store file on disc")
+    print("Store file on disk")
     with open(embedding_cache_path, "wb") as fOut:
         pickle.dump({"sentences": corpus_sentences, "embeddings": corpus_embeddings}, fOut)
 else:
-    print("Load pre-computed embeddings from disc")
+    print("Load pre-computed embeddings from disk")
     with open(embedding_cache_path, "rb") as fIn:
         cache_data = pickle.load(fIn)
         corpus_sentences = cache_data["sentences"]

--- a/examples/sentence_transformer/applications/semantic-search/semantic_search_quora_annoy.py
+++ b/examples/sentence_transformer/applications/semantic-search/semantic_search_quora_annoy.py
@@ -99,7 +99,7 @@ if not os.path.exists(annoy_index_path):
     annoy_index.build(n_trees)
     annoy_index.save(annoy_index_path)
 else:
-    # Load Annoy Index from disc
+    # Load Annoy Index from disk
     annoy_index = AnnoyIndex(embedding_size, "angular")
     annoy_index.load(annoy_index_path)
 

--- a/examples/sentence_transformer/applications/semantic-search/semantic_search_quora_faiss.py
+++ b/examples/sentence_transformer/applications/semantic-search/semantic_search_quora_faiss.py
@@ -82,11 +82,11 @@ if not os.path.exists(embedding_cache_path):
     print("Encode the corpus. This might take a while")
     corpus_embeddings = model.encode(corpus_sentences, show_progress_bar=True, convert_to_numpy=True)
 
-    print("Store file on disc")
+    print("Store file on disk")
     with open(embedding_cache_path, "wb") as fOut:
         pickle.dump({"sentences": corpus_sentences, "embeddings": corpus_embeddings}, fOut)
 else:
-    print("Load pre-computed embeddings from disc")
+    print("Load pre-computed embeddings from disk")
     with open(embedding_cache_path, "rb") as fIn:
         cache_data = pickle.load(fIn)
         corpus_sentences = cache_data["sentences"]

--- a/examples/sentence_transformer/applications/semantic-search/semantic_search_quora_hnswlib.py
+++ b/examples/sentence_transformer/applications/semantic-search/semantic_search_quora_hnswlib.py
@@ -68,11 +68,11 @@ if not os.path.exists(embedding_cache_path):
     print("Encode the corpus. This might take a while")
     corpus_embeddings = model.encode(corpus_sentences, show_progress_bar=True, convert_to_numpy=True)
 
-    print("Store file on disc")
+    print("Store file on disk")
     with open(embedding_cache_path, "wb") as fOut:
         pickle.dump({"sentences": corpus_sentences, "embeddings": corpus_embeddings}, fOut)
 else:
-    print("Load pre-computed embeddings from disc")
+    print("Load pre-computed embeddings from disk")
     with open(embedding_cache_path, "rb") as fIn:
         cache_data = pickle.load(fIn)
         corpus_sentences = cache_data["sentences"]

--- a/examples/sentence_transformer/applications/semantic-search/semantic_search_quora_pytorch.py
+++ b/examples/sentence_transformer/applications/semantic-search/semantic_search_quora_pytorch.py
@@ -56,11 +56,11 @@ if not os.path.exists(embedding_cache_path):
     print("Encode the corpus. This might take a while")
     corpus_embeddings = model.encode(corpus_sentences, show_progress_bar=True, convert_to_tensor=True)
 
-    print("Store file on disc")
+    print("Store file on disk")
     with open(embedding_cache_path, "wb") as fOut:
         pickle.dump({"sentences": corpus_sentences, "embeddings": corpus_embeddings}, fOut)
 else:
-    print("Load pre-computed embeddings from disc")
+    print("Load pre-computed embeddings from disk")
     with open(embedding_cache_path, "rb") as fIn:
         cache_data = pickle.load(fIn)
         corpus_sentences = cache_data["sentences"][0:max_corpus_size]

--- a/examples/sentence_transformer/training/distillation/dimensionality_reduction.py
+++ b/examples/sentence_transformer/training/distillation/dimensionality_reduction.py
@@ -81,7 +81,7 @@ logging.info(f"Model with {new_dimension} dimensions:")
 stsb_evaluator(model)
 
 
-# If you like, you can store the model on disc by uncommenting the following line
+# If you like, you can store the model on diskby uncommenting the following line
 model_name = model_name if "/" not in model_name else model_name.split("/")[-1]
 model.save(f"{model_name}-128dim")
 

--- a/examples/sentence_transformer/training/distillation/dimensionality_reduction.py
+++ b/examples/sentence_transformer/training/distillation/dimensionality_reduction.py
@@ -81,7 +81,7 @@ logging.info(f"Model with {new_dimension} dimensions:")
 stsb_evaluator(model)
 
 
-# If you like, you can store the model on diskby uncommenting the following line
+# If you like, you can store the model on disk by uncommenting the following line
 model_name = model_name if "/" not in model_name else model_name.split("/")[-1]
 model.save(f"{model_name}-128dim")
 

--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -1652,7 +1652,7 @@ class SentenceTransformer(nn.Sequential, FitMixin, PeftAdapterMixin):
         with ``SentenceTransformer(path)`` again.
 
         Args:
-            path (str): Path on disc where the model will be saved.
+            path (str): Path on diskwhere the model will be saved.
             model_name (str, optional): Optional model name.
             create_model_card (bool, optional): If True, create a README.md with basic information about this model.
             train_datasets (List[str], optional): Optional list with the names of the datasets used to train the model.
@@ -1745,7 +1745,7 @@ class SentenceTransformer(nn.Sequential, FitMixin, PeftAdapterMixin):
         with ``SentenceTransformer(path)`` again.
 
         Args:
-            path (str): Path on disc where the model will be saved.
+            path (str): Path on diskwhere the model will be saved.
             model_name (str, optional): Optional model name.
             create_model_card (bool, optional): If True, create a README.md with basic information about this model.
             train_datasets (List[str], optional): Optional list with the names of the datasets used to train the model.

--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -63,7 +63,7 @@ class SentenceTransformer(nn.Sequential, FitMixin, PeftAdapterMixin):
     Loads or creates a SentenceTransformer model that can be used to map sentences / text to embeddings.
 
     Args:
-        model_name_or_path (str, optional): If it is a filepath on disc, it loads the model from that path. If it is not a path,
+        model_name_or_path (str, optional): If it is a filepath on disk, it loads the model from that path. If it is not a path,
             it first tries to download a pre-trained SentenceTransformer model. If that fails, tries to construct a model
             from the Hugging Face Hub with that name.
         modules (Iterable[nn.Module], optional): A list of torch Modules that should be called sequentially, can be used to create custom
@@ -1652,7 +1652,7 @@ class SentenceTransformer(nn.Sequential, FitMixin, PeftAdapterMixin):
         with ``SentenceTransformer(path)`` again.
 
         Args:
-            path (str): Path on diskwhere the model will be saved.
+            path (str): Path on disk where the model will be saved.
             model_name (str, optional): Optional model name.
             create_model_card (bool, optional): If True, create a README.md with basic information about this model.
             train_datasets (List[str], optional): Optional list with the names of the datasets used to train the model.
@@ -1745,7 +1745,7 @@ class SentenceTransformer(nn.Sequential, FitMixin, PeftAdapterMixin):
         with ``SentenceTransformer(path)`` again.
 
         Args:
-            path (str): Path on diskwhere the model will be saved.
+            path (str): Path on disk where the model will be saved.
             model_name (str, optional): Optional model name.
             create_model_card (bool, optional): If True, create a README.md with basic information about this model.
             train_datasets (List[str], optional): Optional list with the names of the datasets used to train the model.

--- a/sentence_transformers/cross_encoder/evaluation/classification.py
+++ b/sentence_transformers/cross_encoder/evaluation/classification.py
@@ -166,6 +166,7 @@ class CrossEncoderClassificationEvaluator(SentenceEvaluator):
             self.primary_metric = "f1_macro"
 
         if output_path is not None and self.write_csv:
+            os.makedirs(output_path, exist_ok=True)
             csv_path = os.path.join(output_path, self.csv_file)
             output_file_exists = os.path.isfile(csv_path)
             with open(csv_path, mode="a" if output_file_exists else "w", encoding="utf-8") as f:

--- a/sentence_transformers/cross_encoder/evaluation/correlation.py
+++ b/sentence_transformers/cross_encoder/evaluation/correlation.py
@@ -113,6 +113,7 @@ class CrossEncoderCorrelationEvaluator(SentenceEvaluator):
         logger.info(f"Correlation:\tPearson: {eval_pearson:.4f}\tSpearman: {eval_spearman:.4f}")
 
         if output_path is not None and self.write_csv:
+            os.makedirs(output_path, exist_ok=True)
             csv_path = os.path.join(output_path, self.csv_file)
             output_file_exists = os.path.isfile(csv_path)
             with open(csv_path, mode="a" if output_file_exists else "w", encoding="utf-8") as f:

--- a/sentence_transformers/cross_encoder/evaluation/nano_beir.py
+++ b/sentence_transformers/cross_encoder/evaluation/nano_beir.py
@@ -240,6 +240,7 @@ class CrossEncoderNanoBEIREvaluator(SentenceEvaluator):
             agg_results[metric] = self.aggregate_fn(per_metric_results[metric])
 
         if output_path is not None and self.write_csv:
+            os.makedirs(output_path, exist_ok=True)
             csv_path = os.path.join(output_path, self.csv_file)
             if not os.path.isfile(csv_path):
                 fOut = open(csv_path, mode="w", encoding="utf-8")

--- a/sentence_transformers/cross_encoder/evaluation/reranking.py
+++ b/sentence_transformers/cross_encoder/evaluation/reranking.py
@@ -270,6 +270,7 @@ class CrossEncoderRerankingEvaluator(SentenceEvaluator):
             self.store_metrics_in_model_card_data(model, metrics, epoch, steps)
 
         if output_path is not None and self.write_csv:
+            os.makedirs(output_path, exist_ok=True)
             csv_path = os.path.join(output_path, self.csv_file)
             output_file_exists = os.path.isfile(csv_path)
             with open(csv_path, mode="a" if output_file_exists else "w", encoding="utf-8") as f:

--- a/sentence_transformers/evaluation/BinaryClassificationEvaluator.py
+++ b/sentence_transformers/evaluation/BinaryClassificationEvaluator.py
@@ -189,6 +189,7 @@ class BinaryClassificationEvaluator(SentenceEvaluator):
                     file_output_data.append(scores[sim_fct][metric])
 
         if output_path is not None and self.write_csv:
+            os.makedirs(output_path, exist_ok=True)
             csv_path = os.path.join(output_path, self.csv_file)
             if not os.path.isfile(csv_path):
                 with open(csv_path, newline="", mode="w", encoding="utf-8") as f:

--- a/sentence_transformers/evaluation/EmbeddingSimilarityEvaluator.py
+++ b/sentence_transformers/evaluation/EmbeddingSimilarityEvaluator.py
@@ -201,6 +201,7 @@ class EmbeddingSimilarityEvaluator(SentenceEvaluator):
                 )
 
         if output_path is not None and self.write_csv:
+            os.makedirs(output_path, exist_ok=True)
             csv_path = os.path.join(output_path, self.csv_file)
             output_file_exists = os.path.isfile(csv_path)
             with open(csv_path, newline="", mode="a" if output_file_exists else "w", encoding="utf-8") as f:

--- a/sentence_transformers/evaluation/InformationRetrievalEvaluator.py
+++ b/sentence_transformers/evaluation/InformationRetrievalEvaluator.py
@@ -236,8 +236,9 @@ class InformationRetrievalEvaluator(SentenceEvaluator):
 
         scores = self.compute_metrices(model, output_path=output_path, *args, **kwargs)
 
-        # Write results to disc
+        # Write results to disk
         if output_path is not None and self.write_csv:
+            os.makedirs(output_path, exist_ok=True)
             csv_path = os.path.join(output_path, self.csv_file)
             if not os.path.isfile(csv_path):
                 fOut = open(csv_path, mode="w", encoding="utf-8")

--- a/sentence_transformers/evaluation/LabelAccuracyEvaluator.py
+++ b/sentence_transformers/evaluation/LabelAccuracyEvaluator.py
@@ -78,6 +78,7 @@ class LabelAccuracyEvaluator(SentenceEvaluator):
         logger.info(f"Accuracy: {accuracy:.4f} ({correct}/{total})\n")
 
         if output_path is not None and self.write_csv:
+            os.makedirs(output_path, exist_ok=True)
             csv_path = os.path.join(output_path, self.csv_file)
             if not os.path.isfile(csv_path):
                 with open(csv_path, newline="", mode="w", encoding="utf-8") as f:

--- a/sentence_transformers/evaluation/MSEEvaluator.py
+++ b/sentence_transformers/evaluation/MSEEvaluator.py
@@ -116,6 +116,7 @@ class MSEEvaluator(SentenceEvaluator):
         logger.info(f"MSE (*100):\t{mse:4f}")
 
         if output_path is not None and self.write_csv:
+            os.makedirs(output_path, exist_ok=True)
             csv_path = os.path.join(output_path, self.csv_file)
             output_file_exists = os.path.isfile(csv_path)
             with open(csv_path, newline="", mode="a" if output_file_exists else "w", encoding="utf-8") as f:

--- a/sentence_transformers/evaluation/MSEEvaluatorFromDataFrame.py
+++ b/sentence_transformers/evaluation/MSEEvaluatorFromDataFrame.py
@@ -104,6 +104,7 @@ class MSEEvaluatorFromDataFrame(SentenceEvaluator):
             logger.info(f"MSE (*100):\t{mse:4f}")
 
         if output_path is not None and self.write_csv:
+            os.makedirs(output_path, exist_ok=True)
             csv_path = os.path.join(output_path, self.csv_file)
             output_file_exists = os.path.isfile(csv_path)
             with open(csv_path, newline="", mode="a" if output_file_exists else "w", encoding="utf-8") as f:

--- a/sentence_transformers/evaluation/NanoBEIREvaluator.py
+++ b/sentence_transformers/evaluation/NanoBEIREvaluator.py
@@ -324,6 +324,7 @@ class NanoBEIREvaluator(SentenceEvaluator):
             agg_results[metric] = self.aggregate_fn(per_metric_results[metric])
 
         if output_path is not None and self.write_csv:
+            os.makedirs(output_path, exist_ok=True)
             csv_path = os.path.join(output_path, self.csv_file)
             if not os.path.isfile(csv_path):
                 fOut = open(csv_path, mode="w", encoding="utf-8")

--- a/sentence_transformers/evaluation/ParaphraseMiningEvaluator.py
+++ b/sentence_transformers/evaluation/ParaphraseMiningEvaluator.py
@@ -218,6 +218,7 @@ class ParaphraseMiningEvaluator(SentenceEvaluator):
         logger.info(f"F1: {best_f1 * 100:.2f}\n")
 
         if output_path is not None and self.write_csv:
+            os.makedirs(output_path, exist_ok=True)
             csv_path = os.path.join(output_path, self.csv_file)
             if not os.path.isfile(csv_path):
                 with open(csv_path, newline="", mode="w", encoding="utf-8") as f:

--- a/sentence_transformers/evaluation/RerankingEvaluator.py
+++ b/sentence_transformers/evaluation/RerankingEvaluator.py
@@ -177,8 +177,9 @@ class RerankingEvaluator(SentenceEvaluator):
         logger.info(f"MRR@{self.at_k}: {mean_mrr * 100:.2f}")
         logger.info(f"NDCG@{self.at_k}: {mean_ndcg * 100:.2f}")
 
-        #### Write results to disc
+        #### Write results to disk
         if output_path is not None and self.write_csv:
+            os.makedirs(output_path, exist_ok=True)
             csv_path = os.path.join(output_path, self.csv_file)
             output_file_exists = os.path.isfile(csv_path)
             with open(csv_path, newline="", mode="a" if output_file_exists else "w", encoding="utf-8") as f:

--- a/sentence_transformers/evaluation/TranslationEvaluator.py
+++ b/sentence_transformers/evaluation/TranslationEvaluator.py
@@ -151,6 +151,7 @@ class TranslationEvaluator(SentenceEvaluator):
         logger.info(f"Accuracy trg2src: {acc_trg2src * 100:.2f}")
 
         if output_path is not None and self.write_csv:
+            os.makedirs(output_path, exist_ok=True)
             csv_path = os.path.join(output_path, self.csv_file)
             output_file_exists = os.path.isfile(csv_path)
             with open(csv_path, newline="", mode="a" if output_file_exists else "w", encoding="utf-8") as f:

--- a/sentence_transformers/evaluation/TripletEvaluator.py
+++ b/sentence_transformers/evaluation/TripletEvaluator.py
@@ -214,6 +214,7 @@ class TripletEvaluator(SentenceEvaluator):
                 logger.info(f"Accuracy {fn_name.capitalize()} Similarity:\t{accuracy:.2%}")
 
         if output_path is not None and self.write_csv:
+            os.makedirs(output_path, exist_ok=True)
             csv_path = os.path.join(output_path, self.csv_file)
             if not os.path.isfile(csv_path):
                 with open(csv_path, newline="", mode="w", encoding="utf-8") as f:

--- a/sentence_transformers/fit_mixin.py
+++ b/sentence_transformers/fit_mixin.py
@@ -503,7 +503,7 @@ class FitMixin:
             evaluator: An evaluator (sentence_transformers.evaluation)
                 evaluates the model performance during training on held-
                 out dev data. It is used to determine the best model
-                that is saved to disc.
+                that is saved to disk.
             epochs: Number of epochs for training
             steps_per_epoch: Number of training steps per epoch. If set
                 to None (default), one epoch is equal the DataLoader

--- a/sentence_transformers/sparse_encoder/SparseEncoder.py
+++ b/sentence_transformers/sparse_encoder/SparseEncoder.py
@@ -845,7 +845,7 @@ class SparseEncoder(SentenceTransformer):
         with ``SparseEncoder(path)`` again.
 
         Args:
-            path (str): Path on disc where the model will be saved.
+            path (str): Path on diskwhere the model will be saved.
             model_name (str, optional): Optional model name.
             create_model_card (bool, optional): If True, create a README.md with basic information about this model.
             train_datasets (List[str], optional): Optional list with the names of the datasets used to train the model.
@@ -873,7 +873,7 @@ class SparseEncoder(SentenceTransformer):
         with ``SparseEncoder(path)`` again.
 
         Args:
-            path (str): Path on disc where the model will be saved.
+            path (str): Path on diskwhere the model will be saved.
             model_name (str, optional): Optional model name.
             create_model_card (bool, optional): If True, create a README.md with basic information about this model.
             train_datasets (List[str], optional): Optional list with the names of the datasets used to train the model.

--- a/sentence_transformers/sparse_encoder/SparseEncoder.py
+++ b/sentence_transformers/sparse_encoder/SparseEncoder.py
@@ -29,7 +29,7 @@ class SparseEncoder(SentenceTransformer):
     Loads or creates a SparseEncoder model that can be used to map sentences / text to sparse embeddings.
 
     Args:
-        model_name_or_path (str, optional): If it is a filepath on disc, it loads the model from that path. If it is not a path,
+        model_name_or_path (str, optional): If it is a filepath on disk, it loads the model from that path. If it is not a path,
             it first tries to download a pre-trained SparseEncoder model. If that fails, tries to construct a model
             from the Hugging Face Hub with that name.
         modules (Iterable[nn.Module], optional): A list of torch Modules that should be called sequentially, can be used to create custom
@@ -845,7 +845,7 @@ class SparseEncoder(SentenceTransformer):
         with ``SparseEncoder(path)`` again.
 
         Args:
-            path (str): Path on diskwhere the model will be saved.
+            path (str): Path on disk where the model will be saved.
             model_name (str, optional): Optional model name.
             create_model_card (bool, optional): If True, create a README.md with basic information about this model.
             train_datasets (List[str], optional): Optional list with the names of the datasets used to train the model.
@@ -873,7 +873,7 @@ class SparseEncoder(SentenceTransformer):
         with ``SparseEncoder(path)`` again.
 
         Args:
-            path (str): Path on diskwhere the model will be saved.
+            path (str): Path on disk where the model will be saved.
             model_name (str, optional): Optional model name.
             create_model_card (bool, optional): If True, create a README.md with basic information about this model.
             train_datasets (List[str], optional): Optional list with the names of the datasets used to train the model.


### PR DESCRIPTION
The Information Retrieval Evaluator crashes if a csv path has been passed for which the directory does not yet exists. This is fine, but it only crashes _after_ an experiment is done and the csv writer tries to write to the path.

This PR fixes that by creating the directories before writing it. An alternative could be to check if it exists before starting an experiment and then crashing before starting the experiment. Also fixes a typo.