### PR TITLE
Fix:Import SentenceTransformer class explicitly in losses module

### DIFF
--- a/sentence_transformers/losses/AnglELoss.py
+++ b/sentence_transformers/losses/AnglELoss.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from sentence_transformers import SentenceTransformer, losses, util
+from sentence_transformers import losses, util
+from sentence_transformers.SentenceTransformer import SentenceTransformer
 
 
 class AnglELoss(losses.CoSENTLoss):

--- a/sentence_transformers/losses/CachedGISTEmbedLoss.py
+++ b/sentence_transformers/losses/CachedGISTEmbedLoss.py
@@ -11,8 +11,8 @@ from torch import Tensor, nn
 from torch.utils.checkpoint import get_device_states, set_device_states
 from transformers import PreTrainedTokenizerBase
 
-from sentence_transformers import SentenceTransformer
 from sentence_transformers.models import StaticEmbedding
+from sentence_transformers.SentenceTransformer import SentenceTransformer
 from sentence_transformers.util import all_gather_with_grad
 
 

--- a/sentence_transformers/losses/CachedMultipleNegativesRankingLoss.py
+++ b/sentence_transformers/losses/CachedMultipleNegativesRankingLoss.py
@@ -10,8 +10,9 @@ import tqdm
 from torch import Tensor, nn
 from torch.utils.checkpoint import get_device_states, set_device_states
 
-from sentence_transformers import SentenceTransformer, util
+from sentence_transformers import util
 from sentence_transformers.models import StaticEmbedding
+from sentence_transformers.SentenceTransformer import SentenceTransformer
 from sentence_transformers.util import all_gather_with_grad
 
 

--- a/sentence_transformers/losses/CachedMultipleNegativesSymmetricRankingLoss.py
+++ b/sentence_transformers/losses/CachedMultipleNegativesSymmetricRankingLoss.py
@@ -9,9 +9,10 @@ import torch
 import tqdm
 from torch import Tensor, nn
 
-from sentence_transformers import SentenceTransformer, util
+from sentence_transformers import util
 from sentence_transformers.losses.CachedMultipleNegativesRankingLoss import RandContext
 from sentence_transformers.models import StaticEmbedding
+from sentence_transformers.SentenceTransformer import SentenceTransformer
 from sentence_transformers.util import all_gather_with_grad
 
 

--- a/sentence_transformers/losses/DenoisingAutoEncoderLoss.py
+++ b/sentence_transformers/losses/DenoisingAutoEncoderLoss.py
@@ -6,8 +6,8 @@ from collections.abc import Iterable
 from torch import Tensor, nn
 from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer, PreTrainedModel
 
-from sentence_transformers import SentenceTransformer
 from sentence_transformers.models import StaticEmbedding
+from sentence_transformers.SentenceTransformer import SentenceTransformer
 
 logger = logging.getLogger(__name__)
 
@@ -85,9 +85,9 @@ class DenoisingAutoEncoderLoss(nn.Module):
 
         encoder_name_or_path = model.transformers_model.config._name_or_path
         if decoder_name_or_path is None:
-            assert (
-                tie_encoder_decoder
-            ), "Must indicate the decoder_name_or_path argument when tie_encoder_decoder=False!"
+            assert tie_encoder_decoder, (
+                "Must indicate the decoder_name_or_path argument when tie_encoder_decoder=False!"
+            )
         if tie_encoder_decoder:
             if decoder_name_or_path:
                 logger.warning("When tie_encoder_decoder=True, the decoder_name_or_path will be invalid.")

--- a/sentence_transformers/losses/DistillKLDivLoss.py
+++ b/sentence_transformers/losses/DistillKLDivLoss.py
@@ -5,7 +5,8 @@ from collections.abc import Iterable
 import torch
 from torch import Tensor, nn
 
-from sentence_transformers import SentenceTransformer, util
+from sentence_transformers import util
+from sentence_transformers.SentenceTransformer import SentenceTransformer
 
 
 class DistillKLDivLoss(nn.Module):

--- a/sentence_transformers/losses/MSELoss.py
+++ b/sentence_transformers/losses/MSELoss.py
@@ -5,7 +5,7 @@ from collections.abc import Iterable
 import torch
 from torch import Tensor, nn
 
-from sentence_transformers import SentenceTransformer
+from sentence_transformers.SentenceTransformer import SentenceTransformer
 
 
 class MSELoss(nn.Module):

--- a/sentence_transformers/losses/MarginMSELoss.py
+++ b/sentence_transformers/losses/MarginMSELoss.py
@@ -5,7 +5,8 @@ from collections.abc import Iterable
 import torch
 from torch import Tensor, nn
 
-from sentence_transformers import SentenceTransformer, util
+from sentence_transformers import util
+from sentence_transformers.SentenceTransformer import SentenceTransformer
 
 
 class MarginMSELoss(nn.Module):

--- a/sentence_transformers/losses/Matryoshka2dLoss.py
+++ b/sentence_transformers/losses/Matryoshka2dLoss.py
@@ -4,7 +4,7 @@ from typing import Any
 
 from torch.nn import Module
 
-from sentence_transformers import SentenceTransformer
+from sentence_transformers.SentenceTransformer import SentenceTransformer
 
 from .AdaptiveLayerLoss import AdaptiveLayerLoss
 from .MatryoshkaLoss import MatryoshkaLoss

--- a/sentence_transformers/losses/MatryoshkaLoss.py
+++ b/sentence_transformers/losses/MatryoshkaLoss.py
@@ -8,12 +8,12 @@ import torch
 import torch.nn.functional as F
 from torch import Tensor, nn
 
-from sentence_transformers import SentenceTransformer
 from sentence_transformers.losses import (
     CachedGISTEmbedLoss,
     CachedMultipleNegativesRankingLoss,
     CachedMultipleNegativesSymmetricRankingLoss,
 )
+from sentence_transformers.SentenceTransformer import SentenceTransformer
 
 
 def shrink(tensor: Tensor, dim: int) -> Tensor:

--- a/sentence_transformers/losses/MegaBatchMarginLoss.py
+++ b/sentence_transformers/losses/MegaBatchMarginLoss.py
@@ -6,7 +6,8 @@ import torch
 import torch.nn.functional as F
 from torch import Tensor, nn
 
-from sentence_transformers import SentenceTransformer, util
+from sentence_transformers import util
+from sentence_transformers.SentenceTransformer import SentenceTransformer
 
 
 class MegaBatchMarginLoss(nn.Module):


### PR DESCRIPTION
## What

Fix import statements in losses module:
`from sentence_transformers import SentenceTransformer` → `from sentence_transformers.SentenceTransformer import SentenceTransformer`

## Why

I found that some loss modules do not import `SentencdeTransformer` class:

```python
>>> import importlib
>>> mod = importlib.import_module("sentence_transformers.losses.MatryoshkaLoss")
>>> mod.SentenceTransformer   #  sentence_transformers/losses/MatryoshkaLoss.py imports SentenceTransformer via `from sentence_transformers import SentenceTransformer`
<module 'sentence_transformers.SentenceTransformer' from '.../sentence_transformers/SentenceTransformer.py'>
```

In this case, `SentencdeTransformer` **module** is imported, not a class.

This can cause an error in some situations such as when utilizing type hints:

```python
>>> typing.get_type_hints(MatryoshkaLoss.__init__)
Traceback (most recent call last):
  ...
TypeError: Forward references must evaluate to types. Got <module 'sentence_transformers.SentenceTransformer'  from '.../sentence_transformers/SentenceTransformer.py'>
```

It would be nice to import the class explicitly.