### PR TITLE
fix: static model saving fails because weights are not contiguous

### DIFF
--- a/sentence_transformers/models/StaticEmbedding.py
+++ b/sentence_transformers/models/StaticEmbedding.py
@@ -229,7 +229,7 @@ class StaticEmbedding(InputModule):
         device = get_device_name()
         static_model = distill(model_name, **kwargs)
         if isinstance(static_model.embedding, np.ndarray):
-            embedding_weights = torch.from_numpy(static_model.embedding)
+            embedding_weights = torch.from_numpy(static_model.embedding).contiguous()
         else:
             embedding_weights = static_model.embedding.weight
         tokenizer: Tokenizer = static_model.tokenizer

--- a/sentence_transformers/models/StaticEmbedding.py
+++ b/sentence_transformers/models/StaticEmbedding.py
@@ -260,7 +260,7 @@ class StaticEmbedding(InputModule):
 
         static_model = StaticModel.from_pretrained(model_id_or_path)
         if isinstance(static_model.embedding, np.ndarray):
-            embedding_weights = torch.from_numpy(static_model.embedding)
+            embedding_weights = torch.from_numpy(static_model.embedding).contiguous()
         else:
             embedding_weights = static_model.embedding.weight
         tokenizer: Tokenizer = static_model.tokenizer


### PR DESCRIPTION
When saving a `StaticModel` with a weight tensor that has been converted from a numpy array, saving will fail with the following error. 

```
ValueError: You are trying to save a non contiguous tensor: `embedding.weight` which is not allowed. It either means you are trying to save tensors which are reference of each other in which case it's recommended to save only the full tensors, and reslice at load time, or simply call `.contiguous()` on your tensor to pack it before saving.
```

This also happens during training, so the non-contiguity of the array is not resolved by updating the weights. The following snippets demonstrates how this crashes on the current master branch:

```python
from sentence_transformers import (
    SentenceTransformer,
)
from sentence_transformers.models.StaticEmbedding import StaticEmbedding

model_dim = 256
static_embedding = StaticEmbedding.from_distillation("BAAI/bge-base-en-v1.5", pca_dims=model_dim)
model = SentenceTransformer(
    modules=[static_embedding],
)

model.save("test-static-embedding")
```

After applying contiguous after converting from numpy, the error goes away. I wasn't able to test this on other systems; I only have access to a macbook with MPS, so this could be a hardware/MPS-specific issue.