### PR TITLE
bug: fix state bug in trainer

### DIFF
--- a/sentence_transformers/trainer.py
+++ b/sentence_transformers/trainer.py
@@ -185,7 +185,9 @@ class SentenceTransformerTrainer(Trainer):
 
         # Get a dictionary of the default training arguments, so we can determine which arguments have been changed
         # for the model card
-        default_args_dict = SentenceTransformerTrainingArguments(output_dir="unused", accelerator_config={"use_configured_state": True}).to_dict()
+        default_args_dict = SentenceTransformerTrainingArguments(
+            output_dir="unused", accelerator_config={"use_configured_state": True}
+        ).to_dict()
 
         # If the model ID is set via the SentenceTransformerTrainingArguments, but not via the SentenceTransformerModelCardData,
         # then we can set it here for the model card regardless

--- a/sentence_transformers/trainer.py
+++ b/sentence_transformers/trainer.py
@@ -185,7 +185,7 @@ class SentenceTransformerTrainer(Trainer):
 
         # Get a dictionary of the default training arguments, so we can determine which arguments have been changed
         # for the model card
-        default_args_dict = SentenceTransformerTrainingArguments(output_dir="unused").to_dict()
+        default_args_dict = SentenceTransformerTrainingArguments(output_dir="unused", accelerator_config={"use_configured_state": True}).to_dict()
 
         # If the model ID is set via the SentenceTransformerTrainingArguments, but not via the SentenceTransformerModelCardData,
         # then we can set it here for the model card regardless


### PR DESCRIPTION
This PR fixes a state bug in the trainer. It was impossible to train on CPU because of this bug. I think it also could have caused a bunch of other (hidden) issues, because the whole global state was actually always the default state.

It's a bit complicated, but this is the gist: creating a `SentenceTransformerTrainingArguments` calls the `post_init` of its super class, `TransformerTrainingArguments`. This, in turn, sets some flags in a global mutable state object, `Accelerator.state.PartialState`. 

In the `SentenceTransformersTrainer`, a dummy `SentenceTransformerTrainingArguments` is created to figure out the default arguments that would have come out of an object without any specific arguments. This is done to list the arguments that are different from the default. But the creation of this `SentenceTransformersTrainingArguments` dummy resets the global state. As the default in the `TransformersTrainingArguments` is to take the best device, e.g., `mps` if it is available, it was impossible to actually train on `cpu`. 

The solution is very simple: make the dummy call use the already configured state instead of overwriting it.