### PR TITLE
[`fix`] Patch Router training with Cached losses

### DIFF
--- a/sentence_transformers/losses/CachedGISTEmbedLoss.py
+++ b/sentence_transformers/losses/CachedGISTEmbedLoss.py
@@ -58,6 +58,9 @@ def _backward_hook(
                 ),
                 grad,
             ):
+                # TODO: This if-statement is for if the model does not require gradients, which may happen if the model
+                # contains a Router where one of the routes is frozen. It should be possible to not have to call
+                # embed_minibatch_iter in that case, as it's unnecessarily expensive.
                 if reps_mb.requires_grad:
                     surrogate = torch.dot(reps_mb.flatten(), grad_mb.flatten()) * grad_output
                     surrogate.backward()

--- a/sentence_transformers/losses/CachedGISTEmbedLoss.py
+++ b/sentence_transformers/losses/CachedGISTEmbedLoss.py
@@ -58,8 +58,9 @@ def _backward_hook(
                 ),
                 grad,
             ):
-                surrogate = torch.dot(reps_mb.flatten(), grad_mb.flatten()) * grad_output
-                surrogate.backward()
+                if reps_mb.requires_grad:
+                    surrogate = torch.dot(reps_mb.flatten(), grad_mb.flatten()) * grad_output
+                    surrogate.backward()
 
 
 class CachedGISTEmbedLoss(nn.Module):
@@ -220,7 +221,10 @@ class CachedGISTEmbedLoss(nn.Module):
         """Do forward pass on a minibatch of the input features and return corresponding embeddings."""
         grad_context = nullcontext if with_grad else torch.no_grad
         random_state_context = nullcontext() if random_state is None else random_state
-        sentence_feature_minibatch = {k: v[begin:end] for k, v in sentence_feature.items()}
+        sentence_feature_minibatch = {
+            key: value[begin:end] if isinstance(value, torch.Tensor) else value
+            for key, value in sentence_feature.items()
+        }
         with random_state_context:
             with grad_context():
                 random_state = RandContext(*sentence_feature_minibatch.values()) if copy_random_state else None

--- a/sentence_transformers/losses/CachedMultipleNegativesRankingLoss.py
+++ b/sentence_transformers/losses/CachedMultipleNegativesRankingLoss.py
@@ -58,6 +58,9 @@ def _backward_hook(
                 ),
                 grad,
             ):
+                # TODO: This if-statement is for if the model does not require gradients, which may happen if the model
+                # contains a Router where one of the routes is frozen. It should be possible to not have to call
+                # embed_minibatch_iter in that case, as it's unnecessarily expensive.
                 if reps_mb.requires_grad:
                     surrogate = torch.dot(reps_mb.flatten(), grad_mb.flatten()) * grad_output
                     surrogate.backward()

--- a/sentence_transformers/losses/CachedMultipleNegativesRankingLoss.py
+++ b/sentence_transformers/losses/CachedMultipleNegativesRankingLoss.py
@@ -58,8 +58,9 @@ def _backward_hook(
                 ),
                 grad,
             ):
-                surrogate = torch.dot(reps_mb.flatten(), grad_mb.flatten()) * grad_output
-                surrogate.backward()
+                if reps_mb.requires_grad:
+                    surrogate = torch.dot(reps_mb.flatten(), grad_mb.flatten()) * grad_output
+                    surrogate.backward()
 
 
 class CachedMultipleNegativesRankingLoss(nn.Module):
@@ -185,7 +186,10 @@ class CachedMultipleNegativesRankingLoss(nn.Module):
         """Do forward pass on a minibatch of the input features and return corresponding embeddings."""
         grad_context = nullcontext if with_grad else torch.no_grad
         random_state_context = nullcontext() if random_state is None else random_state
-        sentence_feature_minibatch = {k: v[begin:end] for k, v in sentence_feature.items()}
+        sentence_feature_minibatch = {
+            key: value[begin:end] if isinstance(value, torch.Tensor) else value
+            for key, value in sentence_feature.items()
+        }
         with random_state_context:
             with grad_context():
                 random_state = RandContext(*sentence_feature_minibatch.values()) if copy_random_state else None

--- a/sentence_transformers/losses/CachedMultipleNegativesSymmetricRankingLoss.py
+++ b/sentence_transformers/losses/CachedMultipleNegativesSymmetricRankingLoss.py
@@ -35,8 +35,9 @@ def _backward_hook(
                 ),
                 grad,
             ):
-                surrogate = torch.dot(reps_mb.flatten(), grad_mb.flatten()) * grad_output
-                surrogate.backward()
+                if reps_mb.requires_grad:
+                    surrogate = torch.dot(reps_mb.flatten(), grad_mb.flatten()) * grad_output
+                    surrogate.backward()
 
 
 class CachedMultipleNegativesSymmetricRankingLoss(nn.Module):
@@ -154,7 +155,10 @@ class CachedMultipleNegativesSymmetricRankingLoss(nn.Module):
         """Embed a mini-batch of sentences."""
         grad_context = nullcontext if with_grad else torch.no_grad
         random_state_context = nullcontext() if random_state is None else random_state
-        sentence_feature_minibatch = {k: v[begin:end] for k, v in sentence_feature.items()}
+        sentence_feature_minibatch = {
+            key: value[begin:end] if isinstance(value, torch.Tensor) else value
+            for key, value in sentence_feature.items()
+        }
         with random_state_context:
             with grad_context():
                 random_state = RandContext(*sentence_feature_minibatch.values()) if copy_random_state else None

--- a/sentence_transformers/losses/CachedMultipleNegativesSymmetricRankingLoss.py
+++ b/sentence_transformers/losses/CachedMultipleNegativesSymmetricRankingLoss.py
@@ -35,6 +35,9 @@ def _backward_hook(
                 ),
                 grad,
             ):
+                # TODO: This if-statement is for if the model does not require gradients, which may happen if the model
+                # contains a Router where one of the routes is frozen. It should be possible to not have to call
+                # embed_minibatch_iter in that case, as it's unnecessarily expensive.
                 if reps_mb.requires_grad:
                     surrogate = torch.dot(reps_mb.flatten(), grad_mb.flatten()) * grad_output
                     surrogate.backward()


### PR DESCRIPTION
Hello!

## Pull Request overview
1. Fix Router not working with Cached losses
2. Fix Router not working with Cached losses if one of the Routes doesn't have requires_grad

## Details
For issue 1: the tensor slicing also accidentally sliced the `task` parameter fed to the loss. This should have just been passed exactly down to the underlying model.
Then, for issue 2, it's possible to disable gradients for one of the routes (e.g. if you only want to train 1 route), but this crashed as the Cached hacking requires each of the embeddings to require gradients. This isn't the case if the route used to compute the embedding doesn't require gradients. A simple `if reps_mb.requires_grad` should fix it, although it's a shame that the `mini_batch_embed` has to be called again to begin with. Most likely, a cleaner solution is possible and would be recommended.

- Tom Aarsen