### PR TITLE
[`fix`] Allow loading Dense modules not saved in fp32

### DIFF
--- a/sentence_transformers/models/Module.py
+++ b/sentence_transformers/models/Module.py
@@ -336,7 +336,16 @@ class Module(ABC, torch.nn.Module):
         if safetensors_path is not None:
             # Either load the weights into the model or return the weights
             if model is not None:
-                load_safetensors_model(model, safetensors_path)
+                missing, unexpected = load_safetensors_model(model, safetensors_path, strict=False)
+                missing_keys = ", ".join([f'"{k}"' for k in sorted(missing)])
+                unexpected_keys = ", ".join([f'"{k}"' for k in sorted(unexpected)])
+                error = f"Error(s) in loading state_dict for {model.__class__.__name__}:"
+                if missing:
+                    error += f"\n    Missing key(s) in state_dict: {missing_keys}"
+                if unexpected:
+                    error += f"\n    Unexpected key(s) in state_dict: {unexpected_keys}"
+                if missing or unexpected:
+                    raise RuntimeError(error)
                 return model
             else:
                 weights = load_safetensors_file(safetensors_path)

--- a/sentence_transformers/models/Module.py
+++ b/sentence_transformers/models/Module.py
@@ -337,15 +337,15 @@ class Module(ABC, torch.nn.Module):
             # Either load the weights into the model or return the weights
             if model is not None:
                 missing, unexpected = load_safetensors_model(model, safetensors_path, strict=False)
-                missing_keys = ", ".join([f'"{k}"' for k in sorted(missing)])
-                unexpected_keys = ", ".join([f'"{k}"' for k in sorted(unexpected)])
-                error = f"Error(s) in loading state_dict for {model.__class__.__name__}:"
+                missing_keys = ", ".join(f'"{k}"' for k in sorted(missing))
+                unexpected_keys = ", ".join(f'"{k}"' for k in sorted(unexpected))
+                error_lines = [f"Error(s) in loading state_dict for {model.__class__.__name__}:"]
                 if missing:
-                    error += f"\n    Missing key(s) in state_dict: {missing_keys}"
+                    error_lines.append(f"    Missing key(s) in state_dict: {missing_keys}")
                 if unexpected:
-                    error += f"\n    Unexpected key(s) in state_dict: {unexpected_keys}"
+                    error_lines.append(f"    Unexpected key(s) in state_dict: {unexpected_keys}")
                 if missing or unexpected:
-                    raise RuntimeError(error)
+                    raise RuntimeError("\n".join(error_lines))
                 return model
             else:
                 weights = load_safetensors_file(safetensors_path)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -78,7 +78,7 @@ def tokenizer() -> Tokenizer:
 
 @pytest.fixture
 def embedding_weights():
-    return np.random.rand(30522, 768)
+    return np.random.rand(30522, 768).astype(np.float32)
 
 
 @pytest.fixture

--- a/tests/models/test_dense.py
+++ b/tests/models/test_dense.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from pathlib import Path
+
+import torch
+from torch import nn
+
+from sentence_transformers import SentenceTransformer
+from sentence_transformers.models import Dense, StaticEmbedding
+
+
+def test_dense_load_and_save_in_other_precisions(static_embedding_model: StaticEmbedding, tmp_path: Path) -> None:
+    base_model = SentenceTransformer(modules=[static_embedding_model, Dense(768, 256, activation_function=nn.Tanh())])
+    test_text = ["This is a test"]
+    base_embedding = base_model.encode(test_text, convert_to_tensor=True)
+
+    base_path = str(tmp_path / "model")
+    base_model.save_pretrained(base_path)
+
+    loaded_model = SentenceTransformer(base_path)
+    assert loaded_model[1].linear.weight.dtype == torch.float32
+    assert loaded_model[1].linear.weight.shape == (256, 768)
+    loaded_embedding = loaded_model.encode(test_text, convert_to_tensor=True)
+    assert torch.allclose(base_embedding, loaded_embedding, atol=1e-6)
+
+    fp64_model = deepcopy(base_model).to(torch.float64)
+    fp64_path = str(tmp_path / "fp64")
+    fp64_model.save_pretrained(fp64_path)
+    loaded_fp64_model = SentenceTransformer(fp64_path)
+    assert loaded_fp64_model[1].linear.weight.dtype == torch.float64
+    assert loaded_fp64_model[1].linear.weight.shape == (256, 768)
+    loaded_fp64_embedding = loaded_fp64_model.encode(test_text, convert_to_tensor=True)
+    assert torch.allclose(base_embedding, loaded_fp64_embedding.to(torch.float32), atol=1e-6)
+
+    fp16_model = deepcopy(base_model).to(torch.float16)
+    fp16_path = str(tmp_path / "fp16")
+    fp16_model.save_pretrained(fp16_path)
+    loaded_fp16_model = SentenceTransformer(fp16_path)
+    assert loaded_fp16_model[1].linear.weight.dtype == torch.float16
+    assert loaded_fp16_model[1].linear.weight.shape == (256, 768)
+    loaded_fp16_embedding = loaded_fp16_model.encode(test_text, convert_to_tensor=True)
+    assert torch.allclose(base_embedding, loaded_fp16_embedding.to(torch.float32), atol=1e-3)
+
+    if torch.cuda.is_available() and torch.cuda.is_bf16_supported():
+        bf16_model = deepcopy(base_model).to(torch.bfloat16)
+        bf16_path = str(tmp_path / "bf16")
+        bf16_model.save_pretrained(bf16_path)
+        loaded_bf16_model = SentenceTransformer(bf16_path)
+        assert loaded_bf16_model[1].linear.weight.dtype == torch.bfloat16
+        assert loaded_bf16_model[1].linear.weight.shape == (256, 768)
+        loaded_bf16_embedding = loaded_bf16_model.encode(test_text, convert_to_tensor=True)
+        assert torch.allclose(base_embedding, loaded_bf16_embedding.to(torch.float32), atol=1e-2)


### PR DESCRIPTION
Hello!

## Pull Request overview
* Allow loading Dense modules not saved in fp32

## Details
With a new `safetensors` version, the tests start failing as there we're saving a model in fp64 and then loading a fp32 Dense module. Now we're using strict=False and ignoring issues of shape and dtype. The load_state_dict should take care of the conversions.

- Tom Aarsen