### PR TITLE
[`tests`] Patch Regex expected output for Python 3.9

### DIFF
--- a/tests/sparse_encoder/test_sparse_encoder.py
+++ b/tests/sparse_encoder/test_sparse_encoder.py
@@ -642,7 +642,7 @@ def test_get_model_kwargs(splade_bert_tiny_model: SparseEncoder) -> None:
     model.encode_query("Test sentence")
     with pytest.raises(
         TypeError,
-        match=re.escape("MLMTransformer.forward() got an unexpected keyword argument 'foo'"),
+        match=r"(MLMTransformer\\.)?" + re.escape("forward() got an unexpected keyword argument 'foo'"),
     ):
         # This would run fine, except the model can't actually accept these arguments (we monkeypatched the modules'
         # forward_kwargs for this test, after all). The model does send the args down to the underlying modules, though!
@@ -674,7 +674,7 @@ def test_get_model_kwargs(splade_bert_tiny_model: SparseEncoder) -> None:
     model.encode_query("Test sentence")
     with pytest.raises(
         TypeError,
-        match=re.escape("MLMTransformer.forward() got an unexpected keyword argument 'foo'"),
+        match=r"(MLMTransformer\\.)?" + re.escape("forward() got an unexpected keyword argument 'foo'"),
     ):
         # This would run fine, except the model can't actually accept these arguments (we monkeypatched the modules'
         # forward_kwargs for this test, after all). The model does send the args down to the underlying modules, though!


### PR DESCRIPTION
Hello!

## Pull Request overview
* Patch Regex expected output for Python 3.9

## Details
The previous pattern seems to have failed in Python 3.9. This new pattern allows for more flexibility (with or without the class name).

- Tom Aarsen