### PR TITLE
feat: matryoshka dims bounds checks and warning

### DIFF
--- a/sentence_transformers/losses/MatryoshkaLoss.py
+++ b/sentence_transformers/losses/MatryoshkaLoss.py
@@ -200,13 +200,13 @@ class MatryoshkaLoss(nn.Module):
 
         model_embedding_dim = model.get_sentence_embedding_dimension()
         if model_embedding_dim is not None:
+            if any(d <= 0 for d in self.matryoshka_dims):
+                raise ValueError(
+                    "All dimensions passed to a matryoshka loss must be > 0."
+                )
             if model_embedding_dim not in self.matryoshka_dims:
                 logger.warning(
-                    f"The model's own embedding dimension {model_embedding_dim} is not in the matryoshka_dims: {self.matryoshka_dims}. Although this works, it is recommended to add it."
-                )
-            if any(model_embedding_dim < d <= 0 for d in self.matryoshka_dims):
-                raise ValueError(
-                    f"All dimensions in matryoshka_dims must be > 0 and <= the model's embedding dimension: {model_embedding_dim}"
+                    f"The model's own embedding dimension, {model_embedding_dim}, is not in the matryoshka_dims: {self.matryoshka_dims}. Although this works, it is recommended to add it."
                 )
 
         # The Cached... losses require a special treatment as their backward pass is incompatible with the

--- a/sentence_transformers/losses/MatryoshkaLoss.py
+++ b/sentence_transformers/losses/MatryoshkaLoss.py
@@ -201,9 +201,7 @@ class MatryoshkaLoss(nn.Module):
         model_embedding_dim = model.get_sentence_embedding_dimension()
         if model_embedding_dim is not None:
             if any(d <= 0 for d in self.matryoshka_dims):
-                raise ValueError(
-                    "All dimensions passed to a matryoshka loss must be > 0."
-                )
+                raise ValueError("All dimensions passed to a matryoshka loss must be > 0.")
             if model_embedding_dim not in self.matryoshka_dims:
                 logger.warning(
                     f"The model's own embedding dimension, {model_embedding_dim}, is not in the matryoshka_dims: {self.matryoshka_dims}. Although this works, it is recommended to add it."

--- a/sentence_transformers/losses/MatryoshkaLoss.py
+++ b/sentence_transformers/losses/MatryoshkaLoss.py
@@ -202,6 +202,10 @@ class MatryoshkaLoss(nn.Module):
         if model_embedding_dim is not None:
             if any(d <= 0 for d in self.matryoshka_dims):
                 raise ValueError("All dimensions passed to a matryoshka loss must be > 0.")
+            if any(d > model_embedding_dim for d in self.matryoshka_dims):
+                raise ValueError(
+                    f"All dimensions in matryoshka_dims must <= the model's embedding dimension: {model_embedding_dim}"
+                )
             if model_embedding_dim not in self.matryoshka_dims:
                 logger.warning(
                     f"The model's own embedding dimension, {model_embedding_dim}, is not in the matryoshka_dims: {self.matryoshka_dims}. Although this works, it is recommended to add it."


### PR DESCRIPTION
This PR adds some checks for matryoshka dimensions. 

The upper out of bounds check is already done in the `shrink` function, but only triggers on the first call. I added a check in the `__init__` so it crashes earlier. In addition, I also added a > 0 check. In the current implementation, it is possible to add negative dimensions, which work like regular tensor operations (i.e., passing -100 for a 300-dim tensor would effectively add 200). I don't think this is desirable, however. It is also currently possible to pass 0, which crashes.

I also added a warning if the actual model dimension is not part of the passed dimension. I think this is always desirable, so I think the warning is warranted.

Finally, I fixed some typing issues (list -> tuple -> Sequence stuff)