### PR TITLE
Future-proof tests for upcoming transformers version

### DIFF
--- a/tests/sparse_encoder/test_sparse_encoder.py
+++ b/tests/sparse_encoder/test_sparse_encoder.py
@@ -642,7 +642,7 @@ def test_get_model_kwargs(splade_bert_tiny_model: SparseEncoder) -> None:
     model.encode_query("Test sentence")
     with pytest.raises(
         TypeError,
-        match=r"(MLMTransformer\.)?forward\(\) got an unexpected keyword argument 'foo'",
+        match=r"(MLMTransformer\.)?forward\(\) got an unexpected keyword argument '(foo|bar)'",
     ):
         # This would run fine, except the model can't actually accept these arguments (we monkeypatched the modules'
         # forward_kwargs for this test, after all). The model does send the args down to the underlying modules, though!
@@ -674,7 +674,7 @@ def test_get_model_kwargs(splade_bert_tiny_model: SparseEncoder) -> None:
     model.encode_query("Test sentence")
     with pytest.raises(
         TypeError,
-        match=r"(MLMTransformer\.)?forward\(\) got an unexpected keyword argument 'foo'",
+        match=r"(MLMTransformer\.)?forward\(\) got an unexpected keyword argument '(foo|document_arg_1)'",
     ):
         # This would run fine, except the model can't actually accept these arguments (we monkeypatched the modules'
         # forward_kwargs for this test, after all). The model does send the args down to the underlying modules, though!

--- a/tests/test_sentence_transformer.py
+++ b/tests/test_sentence_transformer.py
@@ -1223,7 +1223,7 @@ def test_get_model_kwargs(stsb_bert_tiny_model: SentenceTransformer) -> None:
     model.encode_query("Test sentence")
     with pytest.raises(
         TypeError,
-        match=".*?" + re.escape("forward() got an unexpected keyword argument 'foo'"),
+        match=r".*?forward\(\) got an unexpected keyword argument '(foo|bar)'",
     ):
         # This would run fine, except the model can't actually accept these arguments (we monkeypatched the modules'
         # forward_kwargs for this test, after all). The model does send the args down to the underlying modules, though!
@@ -1255,7 +1255,7 @@ def test_get_model_kwargs(stsb_bert_tiny_model: SentenceTransformer) -> None:
     model.encode_query("Test sentence")
     with pytest.raises(
         TypeError,
-        match=".*?" + re.escape("forward() got an unexpected keyword argument 'foo'"),
+        match=r".*?forward\(\) got an unexpected keyword argument '(foo|document_arg_1)'",
     ):
         # This would run fine, except the model can't actually accept these arguments (we monkeypatched the modules'
         # forward_kwargs for this test, after all). The model does send the args down to the underlying modules, though!


### PR DESCRIPTION
Hello!

## Pull Request overview
* Future-proof tests for upcoming transformers version

## Details
For which keyword an error is thrown is not necessarily the first one, and the test failure shouldn't depend on that. 

- Tom Aarsen