### PR TITLE
fix: allow MSE to be used with matryoshka

### DIFF
--- a/sentence_transformers/losses/MSELoss.py
+++ b/sentence_transformers/losses/MSELoss.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Sequence
 
 import torch
 from torch import Tensor, nn
@@ -72,7 +72,7 @@ class MSELoss(nn.Module):
         self.model = model
         self.loss_fct = nn.MSELoss()
 
-    def forward(self, sentence_features: Iterable[dict[str, Tensor]], labels: Tensor) -> Tensor:
+    def forward(self, sentence_features: Sequence[dict[str, Tensor]], labels: Tensor) -> Tensor:
         # Concatenate multiple inputs on the batch dimension
         if len(sentence_features) > 1:
             embeddings = torch.cat([self.model(inputs)["sentence_embedding"] for inputs in sentence_features], dim=0)
@@ -80,6 +80,10 @@ class MSELoss(nn.Module):
             return self.loss_fct(embeddings, labels.repeat(len(sentence_features), 1))
 
         embeddings = self.model(sentence_features[0])["sentence_embedding"]
+        if isinstance(labels, Tensor):
+            embedding_dim = embeddings.shape[1]
+            labels = labels[:, :embedding_dim]
+
         return self.loss_fct(embeddings, labels)
 
     @property

--- a/tests/losses/test_MSELoss.py
+++ b/tests/losses/test_MSELoss.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import warnings
+from unittest.mock import Mock
+
+import pytest
+import torch
+
+from sentence_transformers import SentenceTransformer
+from sentence_transformers.losses import MatryoshkaLoss, MSELoss
+
+
+@pytest.fixture
+def mock_model():
+    """Create a mock SentenceTransformer model for testing."""
+    model = Mock(spec=SentenceTransformer)
+    model.get_sentence_embedding_dimension.return_value = 768
+    return model
+
+
+def test_mse_loss_with_matching_dimensions(mock_model):
+    """Test MSELoss with matching dimensions."""
+    loss = MSELoss(model=mock_model)
+    sentence_features = [{"input_ids": torch.tensor([[1, 2, 3]])}]
+    x = torch.randn(1, 768)
+
+    # Mock the model's forward method to return fixed embeddings
+    mock_model.return_value = {"sentence_embedding": x}
+
+    output = loss(sentence_features, x)
+    assert isinstance(output, torch.Tensor)
+    assert output.shape == torch.Size([])  # MSELoss returns a scalar
+    mock_model.assert_called_once()
+
+
+def test_mse_loss_with_dimension_mismatch(mock_model):
+    """Test MSELoss with dimension mismatch."""
+    loss = MSELoss(model=mock_model)
+    sentence_features = [{"input_ids": torch.tensor([[1, 2, 3]])}]
+    x = torch.randn(1, 768)  # Original dimension (teacher)
+
+    # Mock the model's forward method to return fixed embeddings
+    mock_model.return_value = {"sentence_embedding": torch.randn(1, 512)}
+
+    output = loss(sentence_features, x)
+    assert isinstance(output, torch.Tensor)
+    assert output.shape == torch.Size([])  # MSELoss returns a scalar
+    mock_model.assert_called_once()
+
+
+def test_mse_loss_with_dimension_mismatch_target(mock_model):
+    """Test MSELoss with teacher > student. This should crash"""
+    loss = MSELoss(model=mock_model)
+    sentence_features = [{"input_ids": torch.tensor([[1, 2, 3]])}]
+    x = torch.randn(1, 512)  # Original dimension (teacher)
+
+    # Mock the model's forward method to return fixed embeddings
+    mock_model.return_value = {"sentence_embedding": torch.randn(1, 768)}
+
+    with warnings.catch_warnings():
+        # This function errors, but before it does so, it shows a warning.
+        # We should not show it, as we handle the dimension mismatch internally.
+        warnings.simplefilter("ignore")
+        with pytest.raises(RuntimeError):
+            loss(sentence_features, x)
+
+
+def test_mse_loss_matryoshka(mock_model):
+    """Test MSELoss with multiple inputs (matryoshka)."""
+    orig_loss = MSELoss(model=mock_model)
+    loss = MatryoshkaLoss(model=mock_model, loss=orig_loss, matryoshka_dims=[32, 64, 128, 256, 512, 768])
+    sentence_features = [{"input_ids": torch.tensor([[1, 2, 3]])}]
+    x = torch.randn(1, 768)  # Original dimension (teacher)
+
+    # Mock the model's forward method to return fixed embeddings
+    mock_model.return_value = {"sentence_embedding": torch.randn(1, 768)}
+    output = loss(sentence_features, x)
+    assert isinstance(output, torch.Tensor)
+    assert output.shape == torch.Size([])  # MSELoss returns a scalar
+    assert mock_model.call_count == 6  # Called once for each matryoshka


### PR DESCRIPTION
The MSELoss is currently not usable with Matryoshka because the target embeddings are not truncated together with the model embeddings. This PR changes the MSELoss to automatically truncate the target to be the size of the model when the model size < the target size.

This allows the model to be used safely with Matryoshka.
We do it automatically, but this is safe, because we only truncate the target to the model dimension if the model dimension is smaller. This will never lead to the model not learning specific dimensions.

The worst that could happen is that a user creates a mismatch in, e.g., the teacher embeddings and student embeddings, and that this passes silently. To prevent this, we could set some kind of flag to disallow this behavior when the model is not used in a Matryoshka environment (?). Not sure if this is overengineering, however.

I also added tests this time.

I also fixed the typing of the MSELoss, which was incorrect.