### PR TITLE
[`fix`] correct dataset link in training scripts

### DIFF
--- a/examples/sentence_transformer/training/ms_marco/train_bi-encoder_margin-mse.py
+++ b/examples/sentence_transformer/training/ms_marco/train_bi-encoder_margin-mse.py
@@ -129,7 +129,7 @@ ce_scores_file = os.path.join(data_folder, "cross-encoder-ms-marco-MiniLM-L6-v2-
 if not os.path.exists(ce_scores_file):
     logging.info("Download cross-encoder scores file")
     util.http_get(
-        "https://huggingface.co/datasets/sentence-transformers/msmarco-hard-negatives/resolve/main/cross-encoder-ms-marco-MiniLM-L6-v2-scores.pkl.gz",
+        "https://huggingface.co/datasets/sentence-transformers/msmarco-hard-negatives/resolve/main/cross-encoder-ms-marco-MiniLM-L-6-v2-scores.pkl.gz",
         ce_scores_file,
     )
 

--- a/examples/sentence_transformer/training/ms_marco/train_bi-encoder_mnrl.py
+++ b/examples/sentence_transformer/training/ms_marco/train_bi-encoder_mnrl.py
@@ -139,7 +139,7 @@ ce_scores_file = os.path.join(data_folder, "cross-encoder-ms-marco-MiniLM-L6-v2-
 if not os.path.exists(ce_scores_file):
     logging.info("Download cross-encoder scores file")
     util.http_get(
-        "https://huggingface.co/datasets/sentence-transformers/msmarco-hard-negatives/resolve/main/cross-encoder-ms-marco-MiniLM-L6-v2-scores.pkl.gz",
+        "https://huggingface.co/datasets/sentence-transformers/msmarco-hard-negatives/resolve/main/cross-encoder-ms-marco-MiniLM-L-6-v2-scores.pkl.gz",
         ce_scores_file,
     )
 


### PR DESCRIPTION
This link: https://huggingface.co/datasets/sentence-transformers/msmarco-hard-negatives/resolve/main/cross-encoder-ms-marco-MiniLM-L6-v2-scores.pkl.gz does not exist, resulting in an error when trying to run affected training scripts. 

Looking at https://huggingface.co/datasets/sentence-transformers/msmarco-hard-negatives/tree/main I see that https://huggingface.co/datasets/sentence-transformers/msmarco-hard-negatives/resolve/main/cross-encoder-ms-marco-MiniLM-L-6-v2-scores.pkl.gz does exist. So assuming that's the correct one. The training runs when correcting these. 
