### PR TITLE
[`deps`] Use optimum-onnx now that both optimum-onnx and optimum-intel can use optimum==2.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,9 +49,9 @@ Repository = "https://github.com/huggingface/sentence-transformers/"
 
 [project.optional-dependencies]
 train = ["datasets", "accelerate>=0.20.3"]
-onnx = ["optimum[onnxruntime]>=1.23.1"]
-onnx-gpu = ["optimum[onnxruntime-gpu]>=1.23.1"]
-openvino = ["optimum-intel[openvino]>=1.20.0"]
+onnx = ["optimum-onnx[onnxruntime]"]
+onnx-gpu = ["optimum-onnx[onnxruntime-gpu]"]
+openvino = ["optimum-intel[openvino]"]
 dev = ["datasets", "accelerate>=0.20.3", "pre-commit", "pytest", "pytest-cov", "peft"]
 
 [build-system]

--- a/sentence_transformers/backend/load.py
+++ b/sentence_transformers/backend/load.py
@@ -47,8 +47,8 @@ def load_onnx_model(model_name_or_path: str, config: PretrainedConfig, task_name
     except ModuleNotFoundError:
         raise Exception(
             "Using the ONNX backend requires installing Optimum and ONNX Runtime. "
-            "You can install them with pip: `pip install optimum[onnxruntime]` "
-            "or `pip install optimum[onnxruntime-gpu]`"
+            "You can install them with pip: `pip install sentence-transformers[onnx]` "
+            "or `pip install sentence-transformers[onnx-gpu]`"
         )
 
     # Default to the highest priority available provider if not specified
@@ -122,7 +122,7 @@ def load_openvino_model(model_name_or_path: str, config: PretrainedConfig, task_
     except ModuleNotFoundError:
         raise Exception(
             "Using the OpenVINO backend requires installing Optimum and OpenVINO. "
-            "You can install them with pip: `pip install optimum[openvino]`"
+            "You can install them with pip: `pip install sentence-transformers[openvino]`"
         )
 
     load_path = Path(model_name_or_path)

--- a/sentence_transformers/backend/optimize.py
+++ b/sentence_transformers/backend/optimize.py
@@ -67,8 +67,8 @@ def export_optimized_onnx_model(
     except ImportError:
         raise ImportError(
             "Please install Optimum and ONNX Runtime to use this function. "
-            "You can install them with pip: `pip install optimum[onnxruntime]` "
-            "or `pip install optimum[onnxruntime-gpu]`"
+            "You can install them with pip: `pip install sentence-transformers[onnx]` "
+            "or `pip install sentence-transformers[onnx-gpu]`"
         )
 
     viable_st_model = (

--- a/sentence_transformers/backend/quantize.py
+++ b/sentence_transformers/backend/quantize.py
@@ -67,8 +67,8 @@ def export_dynamic_quantized_onnx_model(
     except ImportError:
         raise ImportError(
             "Please install Optimum and ONNX Runtime to use this function. "
-            "You can install them with pip: `pip install optimum[onnxruntime]` "
-            "or `pip install optimum[onnxruntime-gpu]`"
+            "You can install them with pip: `pip install sentence-transformers[onnx]` "
+            "or `pip install sentence-transformers[onnx-gpu]`"
         )
 
     viable_st_model = (
@@ -180,7 +180,7 @@ def export_static_quantized_openvino_model(
     except ImportError:
         raise ImportError(
             "Please install datasets, optimum-intel and openvino to use this function. "
-            "You can install them with pip: `pip install datasets optimum[openvino]`"
+            "You can install them with pip: `pip install datasets sentence-transformers[openvino]`"
         )
     if not is_datasets_available():
         raise ImportError(


### PR DESCRIPTION
Hello!

## Pull Request overview
* Use optimum-onnx now that both optimum-onnx and optimum-intel can use optimum==2.0.0

## Details
The CI isn't enabled for backend tests anymore due to rate limits, but it does pass locally.

- Tom Aarsen