### PR TITLE
Specify numpy manually in dependencies, as it's directly used/imported

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,12 +33,13 @@ classifiers = [
 ]
 dependencies = [
     "transformers>=4.41.0,<6.0.0",
-    "tqdm",
+    "huggingface-hub>=0.20.0",
     "torch>=1.11.0",
+    "numpy",
     "scikit-learn",
     "scipy",
-    "huggingface-hub>=0.20.0",
     "typing_extensions>=4.5.0",
+    "tqdm",
 ]
 
 [project.urls]


### PR DESCRIPTION
Hello!

## Pull Request overview
* Specify numpy manually in dependencies, as it's directly used/imported

## Details
Numpy was already a required dependency, but only via `transformers`/`scipy` etc. I also reordered the dependencies somewhat.

- Tom Aarsen