### PR TITLE
[`deps`] Replace requests dependency with optional httpx dependency

### DIFF
--- a/sentence_transformers/util/file_io.py
+++ b/sentence_transformers/util/file_io.py
@@ -198,10 +198,10 @@ def http_get(url: str, path: str) -> None:
                     if chunk:
                         progress.update(len(chunk))
                         file_binary.write(chunk)
+            os.replace(download_filepath, path)
         except Exception:
             if os.path.exists(download_filepath):
                 os.remove(download_filepath)
             raise
         finally:
             progress.close()
-    os.replace(download_filepath, path)


### PR DESCRIPTION
Resolves #3617

Hello!

## Pull Request overview
* Replace requests dependency with optional httpx dependency

## Details
The `http_get` function is quite old, and not really used outside of a few tests, so I'm fine with keeping the dependency totally optional. Plus, it'll be installed via `transformers`/`huggingface_hub`. The primary goal is to avoid #3617.

I'm not sure if this httpx approach is optimal, I'm not very familiar with it yet. 

- Tom Aarsen