### PR TITLE
Mention TSDAE incompatibility with transformers v5, update TSDAE snippet

### DIFF
--- a/examples/sentence_transformer/unsupervised_learning/TSDAE/train_stsb_tsdae.py
+++ b/examples/sentence_transformer/unsupervised_learning/TSDAE/train_stsb_tsdae.py
@@ -32,8 +32,8 @@ model = SentenceTransformer(modules=[word_embedding_model, pooling_model])
 # model.max_seq_length = max_seq_length
 
 # 2. We use 1 Million sentences from Wikipedia to train our model:
-# https://huggingface.co/datasets/princeton-nlp/datasets-for-simcse
-dataset = load_dataset("princeton-nlp/datasets-for-simcse", split="train")
+# https://huggingface.co/datasets/sentence-transformers/wiki1m-for-simcse
+dataset = load_dataset("sentence-transformers/wiki1m-for-simcse", split="train")
 
 
 def noise_transform(batch, del_ratio=0.6):

--- a/sentence_transformers/losses/DenoisingAutoEncoderLoss.py
+++ b/sentence_transformers/losses/DenoisingAutoEncoderLoss.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 import logging
 from collections.abc import Iterable
 
+from packaging.version import Version, parse
 from torch import Tensor, nn
 from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer, PreTrainedModel
+from transformers import __version__ as transformers_version
 
 from sentence_transformers.models import StaticEmbedding
 from sentence_transformers.SentenceTransformer import SentenceTransformer
@@ -119,6 +121,12 @@ class DenoisingAutoEncoderLoss(nn.Module):
             )
 
         if tie_encoder_decoder:
+            if parse(transformers_version) >= Version("5.0.0"):
+                raise RuntimeError(
+                    "Tying encoder and decoder weights is not currently supported for transformers version >= 5.0.0. "
+                    "Please either install transformers<5.0.0 or set tie_encoder_decoder=False."
+                )
+
             assert not self.need_retokenization, "The tokenizers should be the same when tie_encoder_decoder=True."
             if len(self.tokenizer_encoder) != len(self.tokenizer_decoder):  # The vocabulary has been changed.
                 self.tokenizer_decoder = self.tokenizer_encoder


### PR DESCRIPTION
Hello!

## Pull Request overview
* Mention TSDAE incompatibility with transformers v5
* update TSDAE snippet in docs to avoid `model.fit`
* Avoid princeton-nlp/datasets-for-simcse as it no longer works with modern `datasets` versions

## Details
TSDAE won't work nicely with transformers v5 with `tie_encoder_decoder` as it refactored weight ties. They're now a bit harder to do without all weights being inside of the same `PreTrainedModel` instance. So, for now it's just not supported with an error to warn users. 

- Tom Aarsen