### PR TITLE
[Fix] Add padding for odd embedding dimensions in tensors (sparse encoders)

### DIFF
--- a/sentence_transformers/util/similarity.py
+++ b/sentence_transformers/util/similarity.py
@@ -213,12 +213,11 @@ def pairwise_angle_sim(x: Tensor, y: Tensor) -> Tensor:
 
     x = _convert_to_tensor(x)
     y = _convert_to_tensor(y)
-    
-    # Pad tensors if the embedding dimension is odd
+
+    # Pad tensors if the embedding dimension is odd, as torch.chunk requires even dimensions
     if x.shape[1] % 2 != 0:
-        x = torch.nn.functional.pad(x, (0, 1), mode='constant', value=0)
-        y = torch.nn.functional.pad(y, (0, 1), mode='constant', value=0)
-    
+        x = torch.nn.functional.pad(x, (0, 1), mode="constant", value=0)
+        y = torch.nn.functional.pad(y, (0, 1), mode="constant", value=0)
 
     # modified from https://github.com/SeanLee97/AnglE/blob/main/angle_emb/angle.py
     # chunk both tensors to obtain complex components

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,7 @@ from tokenizers import Tokenizer
 from sentence_transformers import SentenceTransformer
 from sentence_transformers.cross_encoder import CrossEncoder
 from sentence_transformers.models import Pooling, StaticEmbedding, Transformer
+from sentence_transformers.sparse_encoder import SparseEncoder
 from sentence_transformers.util import is_datasets_available
 
 if is_datasets_available():
@@ -108,6 +109,30 @@ def _reranker_bert_tiny_model() -> CrossEncoder:
 @pytest.fixture()
 def reranker_bert_tiny_model(_reranker_bert_tiny_model) -> CrossEncoder:
     return deepcopy(_reranker_bert_tiny_model)
+
+
+@pytest.fixture(scope="session")
+def _splade_bert_tiny_model() -> SparseEncoder:
+    model = SparseEncoder("sparse-encoder-testing/splade-bert-tiny-nq")
+    model.model_card_data.generate_widget_examples = False  # Disable widget examples generation for testing
+    return model
+
+
+@pytest.fixture()
+def splade_bert_tiny_model(_splade_bert_tiny_model: SparseEncoder) -> SparseEncoder:
+    return deepcopy(_splade_bert_tiny_model)
+
+
+@pytest.fixture(scope="session")
+def _inference_free_splade_bert_tiny_model() -> SparseEncoder:
+    model = SparseEncoder("sparse-encoder-testing/inference-free-splade-bert-tiny-nq")
+    model.model_card_data.generate_widget_examples = False  # Disable widget examples generation for testing
+    return model
+
+
+@pytest.fixture()
+def inference_free_splade_bert_tiny_model(_inference_free_splade_bert_tiny_model: SparseEncoder) -> SparseEncoder:
+    return deepcopy(_inference_free_splade_bert_tiny_model)
 
 
 @pytest.fixture()

--- a/tests/sparse_encoder/conftest.py
+++ b/tests/sparse_encoder/conftest.py
@@ -8,30 +8,6 @@ from sentence_transformers import SparseEncoder
 
 
 @pytest.fixture(scope="session")
-def _splade_bert_tiny_model() -> SparseEncoder:
-    model = SparseEncoder("sparse-encoder-testing/splade-bert-tiny-nq")
-    model.model_card_data.generate_widget_examples = False  # Disable widget examples generation for testing
-    return model
-
-
-@pytest.fixture()
-def splade_bert_tiny_model(_splade_bert_tiny_model: SparseEncoder) -> SparseEncoder:
-    return deepcopy(_splade_bert_tiny_model)
-
-
-@pytest.fixture(scope="session")
-def _inference_free_splade_bert_tiny_model() -> SparseEncoder:
-    model = SparseEncoder("sparse-encoder-testing/inference-free-splade-bert-tiny-nq")
-    model.model_card_data.generate_widget_examples = False  # Disable widget examples generation for testing
-    return model
-
-
-@pytest.fixture()
-def inference_free_splade_bert_tiny_model(_inference_free_splade_bert_tiny_model: SparseEncoder) -> SparseEncoder:
-    return deepcopy(_inference_free_splade_bert_tiny_model)
-
-
-@pytest.fixture(scope="session")
 def _csr_bert_tiny_model() -> SparseEncoder:
     model = SparseEncoder("sentence-transformers-testing/stsb-bert-tiny-safetensors")
     model[-1].k = 16


### PR DESCRIPTION
Fix pairwise_angle_sim to handle odd embedding dimensions

The function uses `torch.chunk(x, 2, dim=1)` to split embeddings into real and imaginary components for complex angle calculations. This fails when the embedding dimension is odd since it cannot be evenly divided by 2.
```python
# y.size() == (32, 30503) (batch, vocabulary size, e.g., splade)

a, b = torch.chunk(x, 2, dim=1)
c, d = torch.chunk(y, 2, dim=1)
# c.size() == (32, 15252)
# d.size() == (32, 15251) ^^^ mismatch
z = torch.sum(c**2 + d**2, dim=1, keepdim=True) # size of c and d mismatches returning ERROR
```


I added a check for odd embedding dimensions and applied zero-padding (`torch.nn.functional.pad`) to both x and y tensors before chunking. The padding adds a single zero to the right side of the embedding dimension, which has minimal impact on the angle similarity computation while ensuring `torch.chunk` can split the tensors evenly.