### PR TITLE
[`tests`] Use 120s HF Hub timeout for tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ train = ["datasets", "accelerate>=0.20.3"]
 onnx = ["optimum-onnx[onnxruntime]"]
 onnx-gpu = ["optimum-onnx[onnxruntime-gpu]"]
 openvino = ["optimum-intel[openvino]"]
-dev = ["datasets", "accelerate>=0.20.3", "pre-commit", "pytest", "pytest-cov", "peft", "Pillow"]
+dev = ["datasets", "accelerate>=0.20.3", "pre-commit", "pytest", "pytest-cov", "pytest-env", "peft", "Pillow"]
 
 [build-system]
 requires = ["setuptools>=42", "wheel"]
@@ -102,4 +102,9 @@ addopts = "--strict-markers -m 'not slow and not custom'"
 markers = [
     "slow: marks tests as slow",
     "custom: marks tests for third-party models with custom modules"
+]
+env = [
+    # Avoid any ReadTimeout when making requests to the Hub (default is 10)
+    # Note: 'D:' means default value from laptop or CI won't be overwritten
+    "D:HF_HUB_DOWNLOAD_TIMEOUT=60",
 ]


### PR DESCRIPTION
Hello!

## Pull Request overview
* Use 120s HF Hub timeout for tests

## Details
This requires huggingface_hub v1.3.5, which should automatically be grabbed by the transformers v5.0.0+ tests. See also the sister-PR for this in transformers: https://github.com/huggingface/transformers/pull/43586, and the PR that adds this environment variable in huggingface_hub: https://github.com/huggingface/huggingface_hub/pull/3751.

Nice work @Wauplin.

- Tom Aarsen