### PR TITLE
fix: pass `batch_size` args to CE evaluators

### DIFF
--- a/sentence_transformers/cross_encoder/evaluation/classification.py
+++ b/sentence_transformers/cross_encoder/evaluation/classification.py
@@ -108,7 +108,10 @@ class CrossEncoderClassificationEvaluator(SentenceEvaluator):
 
         logger.info(f"CrossEncoderClassificationEvaluator: Evaluating the model on {self.name} dataset{out_txt}:")
         pred_scores = model.predict(
-            self.sentence_pairs, convert_to_numpy=True, show_progress_bar=self.show_progress_bar
+            self.sentence_pairs,
+            batch_size=self.batch_size,
+            convert_to_numpy=True,
+            show_progress_bar=self.show_progress_bar,
         )
 
         if model.num_labels == 1:

--- a/sentence_transformers/cross_encoder/evaluation/correlation.py
+++ b/sentence_transformers/cross_encoder/evaluation/correlation.py
@@ -105,7 +105,12 @@ class CrossEncoderCorrelationEvaluator(SentenceEvaluator):
             out_txt = ""
 
         logger.info(f"CrossEncoderCorrelationEvaluator: Evaluating the model on {self.name} dataset{out_txt}:")
-        pred_scores = model.predict(self.sentence_pairs, convert_to_numpy=True, show_progress_bar=False)
+        pred_scores = model.predict(
+            self.sentence_pairs,
+            batch_size=self.batch_size,
+            convert_to_numpy=True,
+            show_progress_bar=False,
+        )
 
         eval_pearson, _ = pearsonr(self.scores, pred_scores)
         eval_spearman, _ = spearmanr(self.scores, pred_scores)


### PR DESCRIPTION
`batch_size` args are taken as input but not being passed to 2 of the CE evaluators. This PR fixes that.  

**Duplicate PRs that can be closed**
#2284 led me to this. It can probably be closed now?  
#1085, related to this, can be closed as well I think..
#1092, adds gradient accumulation for CE, i think this can be done thru `gradient_accumulation_steps` [Training Argument](https://sbert.net/docs/sentence_transformer/training_overview.html#training-arguments)