### PR TITLE
Replace `model.fit` in test files

### DIFF
--- a/tests/cross_encoder/test_train_stsb.py
+++ b/tests/cross_encoder/test_train_stsb.py
@@ -1,15 +1,17 @@
 from __future__ import annotations
 
 import os
+import tempfile
 from collections.abc import Generator
 
 import pytest
-from datasets import load_dataset
-from torch.utils.data import DataLoader
+from datasets import Dataset, load_dataset
 
 from sentence_transformers import CrossEncoder
 from sentence_transformers.cross_encoder.evaluation import CrossEncoderCorrelationEvaluator
-from sentence_transformers.readers import InputExample
+from sentence_transformers.cross_encoder.losses.BinaryCrossEntropyLoss import BinaryCrossEntropyLoss
+from sentence_transformers.cross_encoder.trainer import CrossEncoderTrainer
+from sentence_transformers.cross_encoder.training_args import CrossEncoderTrainingArguments
 from sentence_transformers.util import is_training_available
 
 if not is_training_available():
@@ -20,27 +22,25 @@ if not is_training_available():
 
 
 @pytest.fixture()
-def sts_resource() -> Generator[tuple[list[InputExample], list[InputExample]], None, None]:
+def sts_resource() -> Generator[tuple[Dataset, Dataset], None, None]:
     sts_dataset = load_dataset("sentence-transformers/stsb")
-
-    stsb_train_samples = []
-    stsb_test_samples = []
-    for row in sts_dataset["test"]:
-        stsb_test_samples.append(InputExample(texts=[row["sentence1"], row["sentence2"]], label=row["score"]))
-
-    for row in sts_dataset["train"]:
-        stsb_train_samples.append(InputExample(texts=[row["sentence1"], row["sentence2"]], label=row["score"]))
-    yield stsb_train_samples, stsb_test_samples
+    yield sts_dataset["train"], sts_dataset["test"]
 
 
 def evaluate_stsb_test(
-    distilroberta_base_ce_model: CrossEncoder,
+    model: CrossEncoder,
     expected_score: float,
-    test_samples: list[InputExample],
+    test_dataset: Dataset,
     num_test_samples: int = -1,
 ) -> None:
-    model = distilroberta_base_ce_model
-    evaluator = CrossEncoderCorrelationEvaluator.from_input_examples(test_samples[:num_test_samples], name="sts-test")
+    if num_test_samples > 0:
+        test_dataset = test_dataset.select(range(num_test_samples))
+    sentence_pairs = list(zip(test_dataset["sentence1"], test_dataset["sentence2"]))
+    evaluator = CrossEncoderCorrelationEvaluator(
+        sentence_pairs=sentence_pairs,
+        scores=test_dataset["score"],
+        name="sts-test",
+    )
     scores = evaluator(model)
     score = scores[evaluator.primary_metric] * 100
     print(f"STS-Test Performance: {score:.2f} vs. exp: {expected_score:.2f}")
@@ -48,37 +48,52 @@ def evaluate_stsb_test(
 
 
 @pytest.mark.skipif("CI" in os.environ, reason="This test triggers rate limits too often in the CI")
-def test_pretrained_stsb(sts_resource: tuple[list[InputExample], list[InputExample]]):
-    _, sts_test_samples = sts_resource
+def test_pretrained_stsb(sts_resource: tuple[Dataset, Dataset]) -> None:
+    _, test_dataset = sts_resource
     model = CrossEncoder("cross-encoder/stsb-distilroberta-base")
-    evaluate_stsb_test(model, 87.92, sts_test_samples)
+    evaluate_stsb_test(model, 87.92, test_dataset)
 
 
 @pytest.mark.slow
-def test_train_stsb_slow(
-    distilroberta_base_ce_model: CrossEncoder, sts_resource: tuple[list[InputExample], list[InputExample]]
-) -> None:
+def test_train_stsb_slow(distilroberta_base_ce_model: CrossEncoder, sts_resource: tuple[Dataset, Dataset]) -> None:
     model = distilroberta_base_ce_model
-    sts_train_samples, sts_test_samples = sts_resource
-    train_dataloader = DataLoader(sts_train_samples, shuffle=True, batch_size=16)
-    model.fit(
-        train_dataloader=train_dataloader,
-        epochs=1,
-        warmup_steps=int(len(train_dataloader) * 0.1),
-    )
-    evaluate_stsb_test(model, 75, sts_test_samples)
+    train_dataset, test_dataset = sts_resource
+    loss = BinaryCrossEntropyLoss(model=model)
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        args = CrossEncoderTrainingArguments(
+            output_dir=tmp_dir,
+            num_train_epochs=1,
+            per_device_train_batch_size=16,
+            warmup_ratio=0.1,
+        )
+        trainer = CrossEncoderTrainer(
+            model=model,
+            args=args,
+            train_dataset=train_dataset,
+            loss=loss,
+        )
+        trainer.train()
+    evaluate_stsb_test(model, 75, test_dataset)
 
 
 @pytest.mark.skipif("CI" in os.environ, reason="This test triggers rate limits too often in the CI")
-def test_train_stsb(
-    distilroberta_base_ce_model: CrossEncoder, sts_resource: tuple[list[InputExample], list[InputExample]]
-) -> None:
+def test_train_stsb(distilroberta_base_ce_model: CrossEncoder, sts_resource: tuple[Dataset, Dataset]) -> None:
     model = distilroberta_base_ce_model
-    sts_train_samples, sts_test_samples = sts_resource
-    train_dataloader = DataLoader(sts_train_samples[:500], shuffle=True, batch_size=16)
-    model.fit(
-        train_dataloader=train_dataloader,
-        epochs=1,
-        warmup_steps=int(len(train_dataloader) * 0.1),
-    )
-    evaluate_stsb_test(model, 50, sts_test_samples, num_test_samples=100)
+    train_dataset, test_dataset = sts_resource
+    train_dataset = train_dataset.select(range(500))
+    loss = BinaryCrossEntropyLoss(model=model)
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        args = CrossEncoderTrainingArguments(
+            output_dir=tmp_dir,
+            num_train_epochs=1,
+            per_device_train_batch_size=16,
+            warmup_ratio=0.1,
+        )
+        trainer = CrossEncoderTrainer(
+            model=model,
+            args=args,
+            train_dataset=train_dataset,
+            loss=loss,
+        )
+        trainer.train()
+    evaluate_stsb_test(model, 50, test_dataset, num_test_samples=100)

--- a/tests/sparse_encoder/test_train_stsb.py
+++ b/tests/sparse_encoder/test_train_stsb.py
@@ -4,16 +4,12 @@ import os
 from collections.abc import Generator
 
 import pytest
-from datasets import load_dataset
+from datasets import Dataset, load_dataset
 
 from sentence_transformers import SparseEncoder, SparseEncoderTrainer, SparseEncoderTrainingArguments
-from sentence_transformers.readers import InputExample
 from sentence_transformers.sparse_encoder import losses
 from sentence_transformers.sparse_encoder.evaluation import SparseEmbeddingSimilarityEvaluator
-from sentence_transformers.util import is_datasets_available, is_training_available
-
-if is_datasets_available():
-    from datasets import Dataset, load_dataset
+from sentence_transformers.util import is_training_available
 
 if not is_training_available():
     pytest.skip(
@@ -23,17 +19,9 @@ if not is_training_available():
 
 
 @pytest.fixture()
-def sts_resource() -> Generator[tuple[list[InputExample], list[InputExample]], None, None]:
+def sts_resource() -> Generator[tuple[Dataset, Dataset], None, None]:
     sts_dataset = load_dataset("sentence-transformers/stsb")
-
-    stsb_train_samples = []
-    stsb_test_samples = []
-    for row in sts_dataset["test"]:
-        stsb_test_samples.append(InputExample(texts=[row["sentence1"], row["sentence2"]], label=row["score"]))
-
-    for row in sts_dataset["train"]:
-        stsb_train_samples.append(InputExample(texts=[row["sentence1"], row["sentence2"]], label=row["score"]))
-    yield stsb_train_samples, stsb_test_samples
+    yield sts_dataset["train"], sts_dataset["test"]
 
 
 @pytest.fixture()
@@ -44,12 +32,14 @@ def dummy_sparse_encoder_model() -> SparseEncoder:
 def evaluate_stsb_test(
     model: SparseEncoder,
     expected_score: float,
-    test_samples: list[InputExample],
+    test_dataset: Dataset,
     num_test_samples: int = -1,
 ) -> None:
-    test_s1 = [s.texts[0] for s in test_samples[:num_test_samples]]
-    test_s2 = [s.texts[1] for s in test_samples[:num_test_samples]]
-    test_labels = [s.label for s in test_samples[:num_test_samples]]
+    if num_test_samples > 0:
+        test_dataset = test_dataset.select(range(num_test_samples))
+    test_s1 = test_dataset["sentence1"]
+    test_s2 = test_dataset["sentence2"]
+    test_labels = test_dataset["score"]
 
     evaluator = SparseEmbeddingSimilarityEvaluator(
         sentences1=test_s1,
@@ -63,28 +53,15 @@ def evaluate_stsb_test(
 
     score = scores_dict[evaluator.primary_metric] * 100
     print(f"STS-Test Performance: {score:.2f} vs. exp: {expected_score:.2f}")
-    assert score > expected_score or abs(score - expected_score) < 0.5  # Looser tolerance for sparse models initially
+    assert score > expected_score or abs(score - expected_score) < 0.5
 
 
 @pytest.mark.slow
 def test_train_stsb_slow(
-    dummy_sparse_encoder_model: SparseEncoder, sts_resource: tuple[list[InputExample], list[InputExample]], tmp_path
+    dummy_sparse_encoder_model: SparseEncoder, sts_resource: tuple[Dataset, Dataset], tmp_path
 ) -> None:
     model = dummy_sparse_encoder_model
-    sts_train_samples, sts_test_samples = sts_resource
-
-    train_dataset = (
-        load_dataset("sentence-transformers/stsb", split="train")
-        .map(
-            lambda batch: {
-                "sentence1": batch["sentence1"],
-                "sentence2": batch["sentence2"],
-                "score": [s / 5.0 for s in batch["score"]],
-            },
-            batched=True,
-        )
-        .select(range(len(sts_train_samples)))
-    )
+    train_dataset, test_dataset = sts_resource
 
     loss = losses.SpladeLoss(
         model=model,
@@ -112,25 +89,16 @@ def test_train_stsb_slow(
         loss=loss,
     )
     trainer.train()
-    evaluate_stsb_test(model, 10, sts_test_samples)  # Lower expected score for a short training
+    evaluate_stsb_test(model, 50, test_dataset, num_test_samples=50)  # Lower expected score for a short training
 
 
 @pytest.mark.skipif("CI" in os.environ, reason="This test triggers rate limits too often in the CI")
 def test_train_stsb(
-    dummy_sparse_encoder_model: SparseEncoder, sts_resource: tuple[list[InputExample], list[InputExample]]
+    dummy_sparse_encoder_model: SparseEncoder, sts_resource: tuple[Dataset, Dataset], tmp_path
 ) -> None:
     model = dummy_sparse_encoder_model
-    sts_train_samples, sts_test_samples = sts_resource
-
-    train_samples_subset = sts_train_samples[:100]
-
-    train_dict = {"sentence1": [], "sentence2": [], "score": []}
-    for example in train_samples_subset:
-        train_dict["sentence1"].append(example.texts[0])
-        train_dict["sentence2"].append(example.texts[1])
-        train_dict["score"].append(example.label)
-
-    train_dataset = Dataset.from_dict(train_dict)
+    train_dataset, test_dataset = sts_resource
+    train_dataset = train_dataset.select(range(100))
 
     loss = losses.SpladeLoss(
         model=model,
@@ -140,7 +108,7 @@ def test_train_stsb(
     )
 
     training_args = SparseEncoderTrainingArguments(
-        output_dir="runs/sparse_stsb_test_output",
+        output_dir=tmp_path,
         num_train_epochs=1,
         per_device_train_batch_size=8,  # Even smaller batch
         warmup_ratio=0.1,
@@ -160,4 +128,4 @@ def test_train_stsb(
         loss=loss,
     )
     trainer.train()
-    evaluate_stsb_test(model, 5, sts_test_samples, num_test_samples=50)  # Very low expectation
+    evaluate_stsb_test(model, 50, test_dataset, num_test_samples=50)  # Very low expectation


### PR DESCRIPTION
Test file 1 -  
<img width="916" height="457" alt="Screenshot 2026-02-03 at 6 20 40 PM" src="https://github.com/user-attachments/assets/1160fcff-13d8-4443-9a4c-2d651d563afe" />  

Test file 2 -   
<img width="927" height="528" alt="Screenshot 2026-02-03 at 6 14 37 PM" src="https://github.com/user-attachments/assets/d62dd6c3-d18d-4114-8549-62ed2ca77a3a" />   

> I noticed that `model.fit` still needs to be replaced in the MS-Marco examples (open PRs), this loss file, and the tests (`tests/test_train_stsb.py` and `tests/cross_encoder/test_train_stsb.py`). I think that would complete this work.
> 
> If that sounds good, I’m happy to take this on. I could also help with replacing `InputExample` or any other remaining pieces if needed. 

 _Originally posted by @omkar-334 in [#3650](https://github.com/huggingface/sentence-transformers/issues/3650#issuecomment-3837458557)_
 
Part of #3621 