### PR TITLE
fix: correct typo 'seperated' to 'separated'

### DIFF
--- a/examples/sentence_transformer/training/multilingual/make_multilingual.py
+++ b/examples/sentence_transformer/training/multilingual/make_multilingual.py
@@ -5,7 +5,7 @@ Given a (monolingual) teacher model you would like to extend to new languages, w
 variable. We train a multilingual student model to imitate the teacher model (variable student_model_name)
 on multiple languages.
 
-For training, you need parallel sentence data (machine translation training data). You need tab-seperated files (.tsv)
+For training, you need parallel sentence data (machine translation training data). You need tab-separated files (.tsv)
 with the first column a sentence in a language understood by the teacher model, e.g. English,
 and the further columns contain the according translations for languages you want to extend to.
 

--- a/sentence_transformers/datasets/ParallelSentencesDataset.py
+++ b/sentence_transformers/datasets/ParallelSentencesDataset.py
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 
 class ParallelSentencesDataset(Dataset):
     """
-    This dataset reader can be used to read-in parallel sentences, i.e., it reads in a file with tab-seperated sentences with the same
+    This dataset reader can be used to read-in parallel sentences, i.e., it reads in a file with tab-separated sentences with the same
     sentence in different languages. For example, the file can look like this (EN\tDE\tES):
     hello world     hallo welt  hola mundo
     second sentence zweiter satz    segunda oración
@@ -72,7 +72,7 @@ class ParallelSentencesDataset(Dataset):
         self, filepath: str, weight: int = 100, max_sentences: int = None, max_sentence_length: int = 128
     ) -> None:
         """
-        Reads in a tab-seperated .txt/.csv/.tsv or .gz file. The different columns contain the different translations of the sentence in the first column
+        Reads in a tab-separated .txt/.csv/.tsv or .gz file. The different columns contain the different translations of the sentence in the first column
 
         Args:
             filepath (str): Filepath to the file.


### PR DESCRIPTION
Fixed 3 occurrences of the typo 'seperated' in ParallelSentencesDataset.py and make_multilingual.py.