### PR TITLE
Add self-guide mode for CachedGISTEmbedLoss

### DIFF
--- a/sentence_transformers/callbacks/__init__.py
+++ b/sentence_transformers/callbacks/__init__.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+from sentence_transformers.callbacks.self_guide_callbacks import SelfGuideWarmupCallback
+
+__all__ = ["SelfGuideWarmupCallback"]

--- a/sentence_transformers/callbacks/self_guide_callbacks.py
+++ b/sentence_transformers/callbacks/self_guide_callbacks.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import logging
+
+from transformers.trainer_callback import TrainerCallback, TrainerControl, TrainerState
+from transformers.training_args import TrainingArguments
+
+logger = logging.getLogger(__name__)
+
+
+class SelfGuideWarmupCallback(TrainerCallback):
+    """Disables self-guide false-negative filtering during warmup, then enables it.
+
+    This callback holds a reference to a loss module that has a ``self_guide_filtering_active``
+    attribute and toggles it from ``False`` to ``True`` once the warmup phase is over.
+
+    Args:
+        loss: A loss module with a ``self_guide_filtering_active`` boolean attribute.
+        warmup_ratio: Fraction of total training steps during which filtering is disabled.
+            Defaults to 0.2 (i.e., filtering starts after the first 20% of training).
+    """
+
+    def __init__(self, loss, warmup_ratio: float = 0.2) -> None:
+        super().__init__()
+        self.loss = loss
+        self.warmup_ratio = warmup_ratio
+        self.warmup_steps: int | None = None
+
+    def on_train_begin(
+        self,
+        args: TrainingArguments,
+        state: TrainerState,
+        control: TrainerControl,
+        **kwargs,
+    ) -> None:
+        self.warmup_steps = int(state.max_steps * self.warmup_ratio)
+        self.loss.self_guide_filtering_active = False
+
+    def on_step_begin(
+        self,
+        args: TrainingArguments,
+        state: TrainerState,
+        control: TrainerControl,
+        **kwargs,
+    ) -> None:
+        if self.warmup_steps is None:
+            return
+        should_be_active = state.global_step >= self.warmup_steps
+        if should_be_active != self.loss.self_guide_filtering_active:
+            self.loss.self_guide_filtering_active = should_be_active
+
+    def on_log(
+        self,
+        args: TrainingArguments,
+        state: TrainerState,
+        control: TrainerControl,
+        logs: dict | None = None,
+        **kwargs,
+    ) -> None:
+        if logs is not None:
+            logs["self_guide_filtering_active"] = self.loss.self_guide_filtering_active

--- a/sentence_transformers/losses/CachedGISTEmbedLoss.py
+++ b/sentence_transformers/losses/CachedGISTEmbedLoss.py
@@ -79,6 +79,7 @@ class CachedGISTEmbedLoss(nn.Module):
         contrast_anchors: bool = True,
         contrast_positives: bool = True,
         gather_across_devices: bool = False,
+        self_guide_warmup_ratio: float = 0.0,
     ) -> None:
         """
         This loss is a combination of :class:`GISTEmbedLoss` and :class:`CachedMultipleNegativesRankingLoss`.
@@ -122,6 +123,10 @@ class CachedGISTEmbedLoss(nn.Module):
             gather_across_devices: If True, gather the embeddings across all devices before computing the loss.
                 Recommended when training on multiple GPUs, as it allows for larger batch sizes, but it may slow down
                 training due to communication overhead, and can potentially lead to out-of-memory errors.
+            self_guide_warmup_ratio: Fraction of total training steps during which self-guide filtering is
+                disabled (warmup phase). Only relevant when using self-guided mode (``guide=None``). When set to a
+                value > 0, the :class:`~sentence_transformers.callbacks.SelfGuideWarmupCallback` is automatically
+                added by the trainer. Defaults to 0.0 (no warmup, filtering is always active).
 
         References:
             - Efficient Natural Language Response Suggestion for Smart Reply, Section 4.4: https://huggingface.co/papers/1705.00652
@@ -254,6 +259,13 @@ class CachedGISTEmbedLoss(nn.Module):
         self.contrast_positives = contrast_positives
         self.gather_across_devices = gather_across_devices
         self.cross_entropy_loss = nn.CrossEntropyLoss()
+
+        self.self_guide_warmup_ratio = self_guide_warmup_ratio
+        if self.is_self_guided and self_guide_warmup_ratio > 0:
+            # Filtering starts disabled; the SelfGuideWarmupCallback enables it after warmup.
+            self.self_guide_filtering_active: bool = False
+        else:
+            self.self_guide_filtering_active: bool = True
 
     def sim_matrix(self, embed1: Tensor, embed2: Tensor) -> Tensor:
         return self.similarity_fct(embed1.unsqueeze(1), embed2.unsqueeze(0))
@@ -403,14 +415,20 @@ class CachedGISTEmbedLoss(nn.Module):
             positive_mask = torch.eye(*guided_ap_sim.shape, dtype=torch.bool, device=guided_ap_sim.device)
             positive_mask = positive_mask.roll(begin)
 
-            # Apply false negative suppression to each similarity matrix using guided similarity as anchor
-            ap_sim = mask_false_negatives(guided_ap_sim, ap_sim, positive_mask=positive_mask)  # anchor-positive
+            # Apply false negative suppression to each similarity matrix using guided similarity as anchor.
+            # For self-guided mode, respect the warmup: skip filtering while self_guide_filtering_active is False.
+            # For external guide mode, always filter (self_guide_filtering_active is always True).
+            apply_filtering = not self.is_self_guided or self.self_guide_filtering_active
+
+            if apply_filtering:
+                ap_sim = mask_false_negatives(guided_ap_sim, ap_sim, positive_mask=positive_mask)  # anchor-positive
             scores = [ap_sim]
 
             if self.contrast_anchors:
                 aa_sim = self.sim_matrix(anchors[begin:end], anchors)
                 guided_aa_sim = self.sim_matrix(anchors_guide[begin:end], anchors_guide)
-                aa_sim = mask_false_negatives(guided_aa_sim, aa_sim)  # anchor-anchor
+                if apply_filtering:
+                    aa_sim = mask_false_negatives(guided_aa_sim, aa_sim)  # anchor-anchor
                 scores.append(aa_sim)
 
             if self.contrast_positives:
@@ -420,7 +438,8 @@ class CachedGISTEmbedLoss(nn.Module):
                 guided_pp_sim = self.sim_matrix(
                     candidates_guide[0][offset + begin : min(offset + end, offset + batch_size)], candidates_guide[0]
                 )
-                pp_sim = mask_false_negatives(guided_pp_sim, pp_sim)  # positive-positive
+                if apply_filtering:
+                    pp_sim = mask_false_negatives(guided_pp_sim, pp_sim)  # positive-positive
                 scores.append(pp_sim)
 
             # If there are negatives (len(candidates) > 1), process them
@@ -428,7 +447,8 @@ class CachedGISTEmbedLoss(nn.Module):
                 for i in range(1, len(candidates)):  # Start from 1 since the first is the positive
                     neg_sim = self.sim_matrix(anchors[begin:end], candidates[i])
                     guided_neg_sim = self.sim_matrix(anchors_guide[begin:end], candidates_guide[i])
-                    neg_sim = mask_false_negatives(guided_neg_sim, neg_sim)
+                    if apply_filtering:
+                        neg_sim = mask_false_negatives(guided_neg_sim, neg_sim)
                     scores.append(neg_sim)  # anchor-negative
 
             # Concatenate all scores into a single tensor

--- a/sentence_transformers/losses/CachedMultipleNegativesRankingLoss.py
+++ b/sentence_transformers/losses/CachedMultipleNegativesRankingLoss.py
@@ -85,6 +85,10 @@ class CachedMultipleNegativesRankingLoss(nn.Module):
         show_progress_bar: bool = False,
         hardness_mode: Literal["in_batch_negatives", "hard_negatives", "all_negatives"] | None = None,
         hardness_strength: float = 0.0,
+        self_guide: bool = False,
+        self_guide_margin: float = 0.0,
+        self_guide_margin_strategy: Literal["absolute", "relative"] = "absolute",
+        self_guide_warmup_ratio: float = 0.0,
     ) -> None:
         """
         Boosted version of :class:`MultipleNegativesRankingLoss` (https://huggingface.co/papers/1705.00652) by GradCache (https://huggingface.co/papers/2101.06983).
@@ -155,6 +159,21 @@ class CachedMultipleNegativesRankingLoss(nn.Module):
                 - For ``"hard_negatives"``: acts as ``alpha`` in the hardness penalty, `Lan et al. 2025 <https://huggingface.co/papers/2509.20354>`_ uses 5.
 
                 Must be non-negative. Ignored when ``hardness_mode`` is ``None``.
+
+            self_guide: If True, enable self-guided false-negative filtering. The model's own similarity scores
+                are used to detect and suppress likely false negatives in the in-batch negatives before computing
+                the loss. This can improve training quality when the batch contains semantically similar samples
+                that are not explicitly paired. Only applied to the ``"query_to_doc"`` direction.
+            self_guide_margin: Margin for false-negative detection threshold. With ``self_guide_margin_strategy="absolute"``,
+                a negative with similarity above ``positive_sim - margin`` is considered a false negative. With
+                ``"relative"``, the threshold is ``positive_sim * (1 - margin)``. Defaults to 0.0.
+            self_guide_margin_strategy: Strategy for applying the margin. One of ``"absolute"`` or ``"relative"``.
+                Defaults to ``"absolute"``.
+            self_guide_warmup_ratio: Fraction of total training steps during which self-guide filtering is
+                disabled (warmup phase). Requires the :class:`~sentence_transformers.callbacks.SelfGuideWarmupCallback`
+                to be added to the trainer, which is done automatically by
+                :class:`~sentence_transformers.SentenceTransformerTrainer`. Defaults to 0.0 (no warmup, filtering
+                is always active).
 
         References:
             - Efficient Natural Language Response Suggestion for Smart Reply, Section 4.4: https://huggingface.co/papers/1705.00652
@@ -253,6 +272,17 @@ class CachedMultipleNegativesRankingLoss(nn.Module):
                 f"hardness_mode={hardness_mode!r} is set but hardness_strength=0.0, so hardness weighting has no "
                 "effect. Set hardness_strength to a positive value to enable hardness weighting."
             )
+
+        self.self_guide = self_guide
+        if self_guide:
+            if self_guide_margin_strategy not in ("absolute", "relative"):
+                raise ValueError("self_guide_margin_strategy must be 'absolute' or 'relative'.")
+            self.self_guide_margin = self_guide_margin
+            self.self_guide_margin_strategy = self_guide_margin_strategy
+            self.self_guide_warmup_ratio = self_guide_warmup_ratio
+            # If warmup_ratio == 0, filtering is always active (no warmup needed).
+            # Otherwise, it starts disabled and the SelfGuideWarmupCallback enables it.
+            self.self_guide_filtering_active: bool = self_guide_warmup_ratio == 0.0
 
         self.cache: list[list[Tensor]] | None = None
         self.random_states: list[list[RandContext]] | None = None
@@ -382,6 +412,21 @@ class CachedMultipleNegativesRankingLoss(nn.Module):
                 same_query_doc_mask = identity[local_batch].repeat(1, num_docs).bool()
                 sim_matrices["doc_to_doc"].masked_fill_(same_query_doc_mask, -torch.inf)
 
+            # Self-guide false-negative filtering: use the model's own similarity scores to detect
+            # and mask likely false negatives. Applied only to query_to_doc before temperature scaling.
+            if self.self_guide and self.self_guide_filtering_active:
+                guide_sim = sim_matrices["query_to_doc"].detach()
+                positive_sim = guide_sim[row_indices, local_batch].unsqueeze(1)  # (mbs, 1)
+
+                if self.self_guide_margin_strategy == "absolute":
+                    fn_mask = guide_sim > (positive_sim - self.self_guide_margin)
+                else:
+                    fn_mask = guide_sim > (positive_sim * (1 - self.self_guide_margin))
+
+                # Protect true positives from masking
+                fn_mask[row_indices, local_batch] = False
+                sim_matrices["query_to_doc"] = sim_matrices["query_to_doc"].masked_fill(fn_mask, -torch.inf)
+
             # Compute hardness penalties on the unscaled (raw cosine) similarities (Lan et al. 2025, Eq. 5).
             # penalty = alpha * stop_grad(cos_sim), making harder negatives contribute more to the
             # softmax denominator. Computed before temperature scaling so no rescaling is needed.
@@ -476,7 +521,7 @@ class CachedMultipleNegativesRankingLoss(nn.Module):
         return loss
 
     def get_config_dict(self) -> dict[str, Any]:
-        return {
+        config = {
             "scale": self.scale,
             "similarity_fct": self.similarity_fct.__name__,
             "mini_batch_size": self.mini_batch_size,
@@ -486,6 +531,12 @@ class CachedMultipleNegativesRankingLoss(nn.Module):
             "hardness_mode": self.hardness_mode,
             "hardness_strength": self.hardness_strength,
         }
+        if self.self_guide:
+            config["self_guide"] = self.self_guide
+            config["self_guide_margin"] = self.self_guide_margin
+            config["self_guide_margin_strategy"] = self.self_guide_margin_strategy
+            config["self_guide_warmup_ratio"] = self.self_guide_warmup_ratio
+        return config
 
     @property
     def temperature(self) -> float:

--- a/sentence_transformers/losses/GISTEmbedLoss.py
+++ b/sentence_transformers/losses/GISTEmbedLoss.py
@@ -23,6 +23,7 @@ class GISTEmbedLoss(nn.Module):
         contrast_anchors: bool = True,
         contrast_positives: bool = True,
         gather_across_devices: bool = False,
+        self_guide_warmup_ratio: float = 0.0,
     ) -> None:
         """
         This loss is used to train a SentenceTransformer model using the GISTEmbed algorithm.
@@ -56,6 +57,10 @@ class GISTEmbedLoss(nn.Module):
             gather_across_devices: If True, gather the embeddings across all devices before computing the loss.
                 Recommended when training on multiple GPUs, as it allows for larger batch sizes, but it may slow down
                 training due to communication overhead, and can potentially lead to out-of-memory errors.
+            self_guide_warmup_ratio: Fraction of total training steps during which self-guide filtering is
+                disabled (warmup phase). Only relevant when using self-guided mode (``guide=None``). When set to a
+                value > 0, the :class:`~sentence_transformers.callbacks.SelfGuideWarmupCallback` is automatically
+                added by the trainer. Defaults to 0.0 (no warmup, filtering is always active).
 
         References:
             - For further details, see: https://huggingface.co/papers/2402.16829
@@ -174,6 +179,13 @@ class GISTEmbedLoss(nn.Module):
         self.gather_across_devices = gather_across_devices
         self.cross_entropy_loss = nn.CrossEntropyLoss()
 
+        self.self_guide_warmup_ratio = self_guide_warmup_ratio
+        if self.is_self_guided and self_guide_warmup_ratio > 0:
+            # Filtering starts disabled; the SelfGuideWarmupCallback enables it after warmup.
+            self.self_guide_filtering_active: bool = False
+        else:
+            self.self_guide_filtering_active: bool = True
+
     def sim_matrix(self, embed1: Tensor, embed2: Tensor) -> Tensor:
         return self.similarity_fct(embed1.unsqueeze(1), embed2.unsqueeze(0))
 
@@ -254,27 +266,35 @@ class GISTEmbedLoss(nn.Module):
         # Create a mask to protect true positive pairs in the anchor-positive matrix (i.e., diagonal elements)
         positive_mask = torch.eye(*guided_ap_sim.shape, dtype=torch.bool, device=guided_ap_sim.device)
 
-        # Apply false negative suppression to each similarity matrix using guided similarity as anchor
-        ap_sim = mask_false_negatives(guided_ap_sim, ap_sim, positive_mask=positive_mask)  # anchor-positive
+        # Apply false negative suppression to each similarity matrix using guided similarity as anchor.
+        # For self-guided mode, respect the warmup: skip filtering while self_guide_filtering_active is False.
+        # For external guide mode, always filter (self_guide_filtering_active is always True).
+        apply_filtering = not self.is_self_guided or self.self_guide_filtering_active
+
+        if apply_filtering:
+            ap_sim = mask_false_negatives(guided_ap_sim, ap_sim, positive_mask=positive_mask)  # anchor-positive
         scores = [ap_sim]
 
         if self.contrast_anchors:
             aa_sim = self.sim_matrix(anchor, anchor)
             guided_aa_sim = self.sim_matrix(anchor_guide, anchor_guide)
-            aa_sim = mask_false_negatives(guided_aa_sim, aa_sim)  # anchor-anchor
+            if apply_filtering:
+                aa_sim = mask_false_negatives(guided_aa_sim, aa_sim)  # anchor-anchor
             scores.append(aa_sim)
 
         if self.contrast_positives:
             pp_sim = self.sim_matrix(positive[offset : offset + batch_size], positive)
             guided_pp_sim = self.sim_matrix(positive_guide[offset : offset + batch_size], positive_guide)
-            pp_sim = mask_false_negatives(guided_pp_sim, pp_sim)  # positive-positive
+            if apply_filtering:
+                pp_sim = mask_false_negatives(guided_pp_sim, pp_sim)  # positive-positive
             scores.append(pp_sim)
 
         # Handle the case where we have a negative sample
         if negative is not None:
             an_sim = self.sim_matrix(anchor, negative)
             guided_an_sim = self.sim_matrix(anchor_guide, negative_guide)
-            an_sim = mask_false_negatives(guided_an_sim, an_sim)  # anchor-negative
+            if apply_filtering:
+                an_sim = mask_false_negatives(guided_an_sim, an_sim)  # anchor-negative
             scores.append(an_sim)
 
         scores = torch.cat(scores, dim=1) / self.temperature

--- a/sentence_transformers/losses/MultipleNegativesRankingLoss.py
+++ b/sentence_transformers/losses/MultipleNegativesRankingLoss.py
@@ -28,6 +28,10 @@ class MultipleNegativesRankingLoss(nn.Module):
         partition_mode: Literal["joint", "per_direction"] = "joint",
         hardness_mode: Literal["in_batch_negatives", "hard_negatives", "all_negatives"] | None = None,
         hardness_strength: float = 0.0,
+        self_guide: bool = False,
+        self_guide_margin: float = 0.0,
+        self_guide_margin_strategy: Literal["absolute", "relative"] = "absolute",
+        self_guide_warmup_ratio: float = 0.0,
     ) -> None:
         """
         Given a dataset of (anchor, positive) pairs, (anchor, positive, negative) triplets, or (anchor, positive, negative_1, ..., negative_n)
@@ -104,6 +108,21 @@ class MultipleNegativesRankingLoss(nn.Module):
                 - For ``"hard_negatives"``: acts as ``alpha`` in the hardness penalty, `Lan et al. 2025 <https://huggingface.co/papers/2509.20354>`_ uses 5.
 
                 Must be non-negative. Ignored when ``hardness_mode`` is ``None``.
+
+            self_guide: If True, enable self-guided false-negative filtering. The model's own similarity scores
+                are used to detect and suppress likely false negatives in the in-batch negatives before computing
+                the loss. This can improve training quality when the batch contains semantically similar samples
+                that are not explicitly paired. Only applied to the ``"query_to_doc"`` direction.
+            self_guide_margin: Margin for false-negative detection threshold. With ``self_guide_margin_strategy="absolute"``,
+                a negative with similarity above ``positive_sim - margin`` is considered a false negative. With
+                ``"relative"``, the threshold is ``positive_sim * (1 - margin)``. Defaults to 0.0.
+            self_guide_margin_strategy: Strategy for applying the margin. One of ``"absolute"`` or ``"relative"``.
+                Defaults to ``"absolute"``.
+            self_guide_warmup_ratio: Fraction of total training steps during which self-guide filtering is
+                disabled (warmup phase). Requires the :class:`~sentence_transformers.callbacks.SelfGuideWarmupCallback`
+                to be added to the trainer, which is done automatically by
+                :class:`~sentence_transformers.SentenceTransformerTrainer`. Defaults to 0.0 (no warmup, filtering
+                is always active).
 
         Requirements:
             1. (anchor, positive) pairs, (anchor, positive, negative) triplets, or (anchor, positive, negative_1, ..., negative_n) n-tuples
@@ -227,6 +246,17 @@ class MultipleNegativesRankingLoss(nn.Module):
                 "effect. Set hardness_strength to a positive value to enable hardness weighting."
             )
 
+        self.self_guide = self_guide
+        if self_guide:
+            if self_guide_margin_strategy not in ("absolute", "relative"):
+                raise ValueError("self_guide_margin_strategy must be 'absolute' or 'relative'.")
+            self.self_guide_margin = self_guide_margin
+            self.self_guide_margin_strategy = self_guide_margin_strategy
+            self.self_guide_warmup_ratio = self_guide_warmup_ratio
+            # If warmup_ratio == 0, filtering is always active (no warmup needed).
+            # Otherwise, it starts disabled and the SelfGuideWarmupCallback enables it.
+            self.self_guide_filtering_active: bool = self_guide_warmup_ratio == 0.0
+
     def forward(self, sentence_features: Iterable[dict[str, Tensor]], labels: Tensor) -> Tensor:
         # Compute the embeddings and distribute them to anchor and candidates (positive and optionally negatives)
         embeddings = [self.model(sentence_feature)["sentence_embedding"] for sentence_feature in sentence_features]
@@ -281,6 +311,22 @@ class MultipleNegativesRankingLoss(nn.Module):
             same_query_doc_mask = torch.eye(world_batch_size, device=queries.device)[local_indices]
             same_query_doc_mask = same_query_doc_mask.repeat(1, len(docs)).bool()
             sim_matrices["doc_to_doc"].masked_fill_(same_query_doc_mask, -torch.inf)
+
+        # Self-guide false-negative filtering: use the model's own similarity scores to detect
+        # and mask likely false negatives (negatives that are more similar to the query than the
+        # positive). Applied only to the query_to_doc direction before temperature scaling.
+        if self.self_guide and self.self_guide_filtering_active:
+            guide_sim = sim_matrices["query_to_doc"].detach()
+            positive_sim = guide_sim[row_indices, local_indices].unsqueeze(1)  # (bs, 1)
+
+            if self.self_guide_margin_strategy == "absolute":
+                fn_mask = guide_sim > (positive_sim - self.self_guide_margin)
+            else:
+                fn_mask = guide_sim > (positive_sim * (1 - self.self_guide_margin))
+
+            # Protect true positives from masking
+            fn_mask[row_indices, local_indices] = False
+            sim_matrices["query_to_doc"] = sim_matrices["query_to_doc"].masked_fill(fn_mask, -torch.inf)
 
         # Compute hardness penalties on the unscaled (raw cosine) similarities (Lan et al. 2025, Eq. 5).
         # penalty = alpha * stop_grad(cos_sim), making harder negatives contribute more to the
@@ -337,7 +383,7 @@ class MultipleNegativesRankingLoss(nn.Module):
         return loss
 
     def get_config_dict(self) -> dict[str, Any]:
-        return {
+        config = {
             "scale": self.scale,
             "similarity_fct": self.similarity_fct.__name__,
             "gather_across_devices": self.gather_across_devices,
@@ -346,6 +392,12 @@ class MultipleNegativesRankingLoss(nn.Module):
             "hardness_mode": self.hardness_mode,
             "hardness_strength": self.hardness_strength,
         }
+        if self.self_guide:
+            config["self_guide"] = self.self_guide
+            config["self_guide_margin"] = self.self_guide_margin
+            config["self_guide_margin_strategy"] = self.self_guide_margin_strategy
+            config["self_guide_warmup_ratio"] = self.self_guide_warmup_ratio
+        return config
 
     @property
     def temperature(self) -> float:

--- a/sentence_transformers/trainer.py
+++ b/sentence_transformers/trainer.py
@@ -388,8 +388,23 @@ class SentenceTransformerTrainer(Trainer):
         model: SentenceTransformer,
     ) -> torch.nn.Module:
         if isinstance(loss, torch.nn.Module):
-            return loss.to(model.device)
-        return loss(model).to(model.device)
+            loss = loss.to(model.device)
+        else:
+            loss = loss(model).to(model.device)
+
+        # Auto-add SelfGuideWarmupCallback if the loss has self_guide_warmup_ratio > 0
+        warmup_ratio = getattr(loss, "self_guide_warmup_ratio", 0.0)
+        if warmup_ratio and warmup_ratio > 0:
+            from sentence_transformers.callbacks import SelfGuideWarmupCallback
+
+            has_callback = any(
+                isinstance(cb, SelfGuideWarmupCallback) and cb.loss is loss for cb in self.callback_handler.callbacks
+            )
+            if not has_callback:
+                callback = SelfGuideWarmupCallback(loss=loss, warmup_ratio=warmup_ratio)
+                self.add_callback(callback)
+
+        return loss
 
     def compute_loss(
         self,


### PR DESCRIPTION
## Summary

Hello ! This PR optimizes `CachedGISTEmbedLoss` for self-guided training scenarios where the student model serves as its own guide.

### Motivation

Recent embedding papers (e.g., [Qwen3-Embedding](https://arxiv.org/abs/2506.05176), [Diffusion-Pretrained Dense and Contextual Embeddings (a.k.a pplx-embed)](https://arxiv.org/abs/2602.11151)) have shown that using the model's own similarity scores with a margin (e.g., `margin=-1.0`) provides effective self-guide without requiring a separate guide model. 
#### [Qwen3-Embedding]

$$
m_{ij} = \begin{cases} 
0 & \text{if } s_{ij} > s(q_i, d_i^+) + 0.1 \text{ or } d_j == d_i^+, \\
1 & \text{otherwise,}
\end{cases}
$$

#### [pplx-embed]

$$
m_i(\mathbf{x}) = \mathbb{1}_{\{s(\mathbf{q}_i, \mathbf{x}) \le s(\mathbf{q}_i, \mathbf{d}_i) + 0.1\}}
$$

This approach:
- Filters negatives based on `student_score > positive_score - margin (0.1)`
- Eliminates the need for a separate teacher model

However, when using the model as its own guide, the previous implementation still required passing the same instance twice and performed **two forward passes** - one for student embeddings and one for guide embeddings. This is computationally wasteful since both would produce identical results.

### Changes

1. **`guide` parameter is now optional**: When `guide=None` (default), the model uses itself as the guide (self-guided mode)
2. **Skip redundant forward pass**: When self-guided, reuse `reps.detach()` as `guide_reps` instead of calling the guide model again
3. **Skip retokenization check**: When self-guided, `must_retokenize` is always `False` (same tokenizer)

### Code Changes

```python
# In __init__
if guide is None:
    self.guide = model
    self.is_self_guided = True
else:
    self.guide = guide
    self.is_self_guided = model is guide

# In embed_minibatch
if self.is_self_guided:
    guide_reps = reps.detach()  # Reuse student embeddings
else:
    guide_reps = self.guide(...)  # Separate forward pass
```

### Usage Example

```python
from sentence_transformers import SentenceTransformer, losses

model = SentenceTransformer("BAAI/bge-base-en-v1.5")

# Self-guided mode (recommended): simply omit the guide parameter
loss = losses.CachedGISTEmbedLoss(
    model,
    margin=-1.0,  # Recommended for self-guided training
)

# Or with explicit separate guide model
guide = SentenceTransformer("all-MiniLM-L6-v2")
loss = losses.CachedGISTEmbedLoss(
    model,
    guide=guide,
    margin=0.1,
)
```

### Benefits

| Scenario | Before | After |
|----------|--------|-------|
| Self-guided (`guide=None`) | N/A (required guide) | 1 forward pass |
| Self-guided (`guide=model`) | 2 forward passes | 1 forward pass |
| Separate guide | 2 forward passes | 2 forward passes (unchanged) |