### PR TITLE
Improve MatryoshkaLoss warning guidance for matryoshka_dims settings

### DIFF
--- a/sentence_transformers/losses/MatryoshkaLoss.py
+++ b/sentence_transformers/losses/MatryoshkaLoss.py
@@ -211,6 +211,18 @@ class MatryoshkaLoss(nn.Module):
                     "when using the model without specifying a lower truncation dimension. It is strongly recommended to include "
                     f"{model_embedding_dim} in matryoshka_dims."
                 )
+        sorted_dims = sorted(matryoshka_dims, reverse=True)
+        if len(sorted_dims) >= 2:
+            # Warn when dims do not follow a strict halving schedule, e.g. d, d/2, d/4, ...
+            # This matches the "consistent halving" guidance from the Matryoshka paper (2205.13147).
+            non_halving = any(sorted_dims[i] != 2 * sorted_dims[i + 1] for i in range(len(sorted_dims) - 1))
+            if non_halving:
+                logger.warning(
+                    "matryoshka_dims do not follow the recommended consistent halving schedule after sorting: %s. "
+                    "This configuration is allowed, but a typical schedule is [d, d/2, d/4, ...]. "
+                    "Refer to the MRL paper, Section 3: https://arxiv.org/html/2205.13147v4#S3",
+                    sorted_dims,
+                )
 
         # Sort the dimensions and weights in descending order
         dims_weights = zip(matryoshka_dims, matryoshka_weights)


### PR DESCRIPTION
Hello!

## Pull Request overview
- This PR adds clearer guidance in `MatryoshkaLoss` for `matryoshka_dims` settings that are not aligned with the recommended consistent halving pattern described in the Matryoshka paper (Section 3).
- The goal is to make this setup issue easier to notice during training configuration while keeping such configurations allowed.

## Details
- Kept the existing warning when the model’s full embedding dimension is not included in `matryoshka_dims`.
- Added a separate warning when `matryoshka_dims` do not follow the recommended consistent halving schedule after sorting.
- Added a direct reference to the MRL paper Section 3 in the warning message:
  `https://arxiv.org/html/2205.13147v4#S3`
- Added/updated tests to validate:
  - warning emission for non-halving settings
  - warning behavior when both warning conditions are met
  - warning behavior when only one condition is met
  - non-halving behavior for two-dimension settings

- As written in Section 3 of the [Matryoshka Representation Learning paper](https://arxiv.org/html/2205.13147v4#S3):

> The usual set ℳ consists of consistent halving until the representation size hits a low information bottleneck.

## Testing
- `uv run pytest tests/losses/test_MatryoshkaLoss.py -k "warn or warning or halving"`

## Note
- In local training runs, MRL performance was slightly worse without consistent halving, but improved after switching to a consistent halving schedule.
