### PR TITLE
[`feat`] Add generic NanoEvaluator abstractions with NanoBEIR backward compatibility

### DIFF
--- a/examples/cross_encoder/evaluation/evaluation_nano_cross_encoder_bm25.py
+++ b/examples/cross_encoder/evaluation/evaluation_nano_cross_encoder_bm25.py
@@ -1,0 +1,52 @@
+"""Simple CrossEncoder NanoBEIR reranking example.
+
+Run:
+  uv run --with datasets python examples/cross_encoder/evaluation/evaluation_nano_cross_encoder_bm25.py
+"""
+
+import logging
+
+from sentence_transformers import CrossEncoder
+from sentence_transformers.cross_encoder.evaluation import CrossEncoderNanoBEIREvaluator
+
+logging.basicConfig(format="%(message)s", level=logging.INFO)
+
+MODEL_NAME = "cross-encoder/ms-marco-MiniLM-L6-v2"
+DATASET_ID = "sentence-transformers/NanoBEIR-en"
+DATASET_SPLITS = ["msmarco", "nq"]
+
+model = CrossEncoder(MODEL_NAME)
+evaluator = CrossEncoderNanoBEIREvaluator(
+    dataset_id=DATASET_ID,
+    dataset_names=DATASET_SPLITS,
+    candidate_subset_name="bm25",
+    rerank_k=100,
+    at_k=10,
+    batch_size=32,
+    show_progress_bar=False,
+)
+
+results = evaluator(model)
+if evaluator.primary_metric is None:
+    raise ValueError("Expected evaluator.primary_metric to be set after evaluation.")
+
+primary_metric = evaluator.primary_metric
+if primary_metric not in results:
+    primary_metric = f"{evaluator.name}_{primary_metric}"
+if primary_metric not in results:
+    raise ValueError(f"Primary metric key not found: {primary_metric}")
+
+"""
+Example output (actual run in this repo, to be updated if defaults change):
+  Model: cross-encoder/ms-marco-MiniLM-L6-v2
+  Dataset: sentence-transformers/NanoBEIR-en
+  Splits: ['msmarco', 'nq']
+  Primary metric key: NanoBEIR_R100_mean_ndcg@10
+  Primary metric value: 0.7142
+"""
+
+print(f"Model: {MODEL_NAME}")
+print(f"Dataset: {DATASET_ID}")
+print(f"Splits: {DATASET_SPLITS}")
+print(f"Primary metric key: {primary_metric}")
+print(f"Primary metric value: {float(results[primary_metric]):.4f}")

--- a/examples/cross_encoder/evaluation/evaluation_nano_cross_encoder_bm25.py
+++ b/examples/cross_encoder/evaluation/evaluation_nano_cross_encoder_bm25.py
@@ -8,19 +8,21 @@ import logging
 
 from sentence_transformers import CrossEncoder
 from sentence_transformers.cross_encoder.evaluation import CrossEncoderNanoBEIREvaluator
+from sentence_transformers.cross_encoder.evaluation.nano_beir import DATASET_NAME_TO_HUMAN_READABLE
 
 logging.basicConfig(format="%(message)s", level=logging.INFO)
 
 MODEL_NAME = "cross-encoder/ms-marco-MiniLM-L6-v2"
 DATASET_ID = "sentence-transformers/NanoBEIR-en"
 DATASET_SPLITS = ["msmarco", "nq"]
+RERANK_K = 100
 
 model = CrossEncoder(MODEL_NAME)
 evaluator = CrossEncoderNanoBEIREvaluator(
     dataset_id=DATASET_ID,
     dataset_names=DATASET_SPLITS,
     candidate_subset_name="bm25",
-    rerank_k=100,
+    rerank_k=RERANK_K,
     at_k=10,
     batch_size=32,
     show_progress_bar=False,
@@ -41,6 +43,9 @@ Example output (actual run in this repo, to be updated if defaults change):
   Model: cross-encoder/ms-marco-MiniLM-L6-v2
   Dataset: sentence-transformers/NanoBEIR-en
   Splits: ['msmarco', 'nq']
+  Split scores:
+  - NanoMSMARCO_R100_ndcg@10 = 0.6686
+  - NanoNQ_R100_ndcg@10 = 0.7599
   Primary metric key: NanoBEIR_R100_mean_ndcg@10
   Primary metric value: 0.7142
 """
@@ -48,5 +53,12 @@ Example output (actual run in this repo, to be updated if defaults change):
 print(f"Model: {MODEL_NAME}")
 print(f"Dataset: {DATASET_ID}")
 print(f"Splits: {DATASET_SPLITS}")
+metric_suffix = primary_metric.split("_mean_", maxsplit=1)[1]
+print("Split scores:")
+for split_name in DATASET_SPLITS:
+    human_readable = DATASET_NAME_TO_HUMAN_READABLE[split_name.lower()]
+    split_key = f"Nano{human_readable}_R{RERANK_K}_{metric_suffix}"
+    if split_key in results:
+        print(f"- {split_key} = {float(results[split_key]):.4f}")
 print(f"Primary metric key: {primary_metric}")
 print(f"Primary metric value: {float(results[primary_metric]):.4f}")

--- a/examples/cross_encoder/evaluation/evaluation_nano_cross_encoder_bm25.py
+++ b/examples/cross_encoder/evaluation/evaluation_nano_cross_encoder_bm25.py
@@ -21,7 +21,6 @@ model = CrossEncoder(MODEL_NAME)
 evaluator = CrossEncoderNanoBEIREvaluator(
     dataset_id=DATASET_ID,
     dataset_names=DATASET_SPLITS,
-    candidate_subset_name="bm25",
     rerank_k=RERANK_K,
     at_k=10,
     batch_size=32,

--- a/examples/sentence_transformer/evaluation/evaluation_nano_dense_miracl.py
+++ b/examples/sentence_transformer/evaluation/evaluation_nano_dense_miracl.py
@@ -1,0 +1,45 @@
+"""Simple NanoEvaluator example on NanoMIRACL.
+
+Run:
+  uv run --with datasets python examples/sentence_transformer/evaluation/evaluation_nano_dense_miracl.py
+"""
+
+import logging
+
+from sentence_transformers import SentenceTransformer
+from sentence_transformers.evaluation import NanoEvaluator
+
+logging.basicConfig(format="%(message)s", level=logging.INFO)
+
+# Keep this example light: evaluate two language splits.
+MODEL_NAME = "intfloat/multilingual-e5-small"
+DATASET_ID = "hotchpotch/NanoMIRACL"
+DATASET_SPLITS = ["en", "ja"]
+
+model = SentenceTransformer(MODEL_NAME)
+evaluator = NanoEvaluator(
+    dataset_id=DATASET_ID,
+    dataset_names=DATASET_SPLITS,
+    batch_size=32,
+    show_progress_bar=False,
+)
+
+results = evaluator(model)
+"""
+Example output (actual run in this repo, to be updated if defaults change):
+  Model: intfloat/multilingual-e5-small
+  Dataset: hotchpotch/NanoMIRACL
+  Splits: ['en', 'ja']
+  Primary metric key: NanoMIRACL_mean_cosine_ndcg@10
+  Primary metric value: 0.7034
+"""
+
+primary_metric = evaluator.primary_metric
+if primary_metric is None:
+    raise ValueError("Expected evaluator.primary_metric to be set after evaluation.")
+
+print(f"Model: {MODEL_NAME}")
+print(f"Dataset: {DATASET_ID}")
+print(f"Splits: {DATASET_SPLITS}")
+print(f"Primary metric key: {primary_metric}")
+print(f"Primary metric value: {results[primary_metric]:.4f}")

--- a/examples/sentence_transformer/evaluation/evaluation_nano_dense_miracl.py
+++ b/examples/sentence_transformer/evaluation/evaluation_nano_dense_miracl.py
@@ -30,6 +30,9 @@ Example output (actual run in this repo, to be updated if defaults change):
   Model: intfloat/multilingual-e5-small
   Dataset: hotchpotch/NanoMIRACL
   Splits: ['en', 'ja']
+  Split scores:
+  - NanoMIRACL_en_cosine_ndcg@10 = 0.6901
+  - NanoMIRACL_ja_cosine_ndcg@10 = 0.7168
   Primary metric key: NanoMIRACL_mean_cosine_ndcg@10
   Primary metric value: 0.7034
 """
@@ -41,5 +44,11 @@ if primary_metric is None:
 print(f"Model: {MODEL_NAME}")
 print(f"Dataset: {DATASET_ID}")
 print(f"Splits: {DATASET_SPLITS}")
+metric_suffix = primary_metric.split("_mean_", maxsplit=1)[1]
+print("Split scores:")
+for split_name in DATASET_SPLITS:
+    split_key = f"NanoMIRACL_{split_name}_{metric_suffix}"
+    if split_key in results:
+        print(f"- {split_key} = {results[split_key]:.4f}")
 print(f"Primary metric key: {primary_metric}")
 print(f"Primary metric value: {results[primary_metric]:.4f}")

--- a/examples/sentence_transformer/evaluation/evaluation_nano_dense_multidataset_macro.py
+++ b/examples/sentence_transformer/evaluation/evaluation_nano_dense_multidataset_macro.py
@@ -1,0 +1,59 @@
+"""Simple dense multi-dataset Nano macro example.
+
+Run:
+  uv run --with datasets python examples/sentence_transformer/evaluation/evaluation_nano_dense_multidataset_macro.py
+"""
+
+import logging
+
+import numpy as np
+
+from sentence_transformers import SentenceTransformer
+from sentence_transformers.evaluation import NanoEvaluator
+
+logging.basicConfig(format="%(message)s", level=logging.INFO)
+
+MODEL_NAME = "intfloat/multilingual-e5-small"
+MULTILINGUAL_NANOBEIR_DATASET_IDS = [
+    "sentence-transformers/NanoBEIR-en",
+    "LiquidAI/NanoBEIR-ja",
+]
+CUSTOM_DATASET_IDS = [
+    "hotchpotch/NanoCodeSearchNet",
+]
+
+
+def evaluate_dataset(model: SentenceTransformer, dataset_id: str) -> float:
+    evaluator = NanoEvaluator(
+        dataset_id=dataset_id,
+        dataset_names=None,
+        batch_size=32,
+        show_progress_bar=False,
+    )
+    results = evaluator(model)
+    if evaluator.primary_metric is None:
+        raise ValueError(f"Expected evaluator.primary_metric for dataset_id={dataset_id}")
+    return float(results[evaluator.primary_metric])
+
+
+model = SentenceTransformer(MODEL_NAME)
+
+multilingual_scores = [evaluate_dataset(model, dataset_id) for dataset_id in MULTILINGUAL_NANOBEIR_DATASET_IDS]
+custom_scores = [evaluate_dataset(model, dataset_id) for dataset_id in CUSTOM_DATASET_IDS]
+
+multilingual_macro = float(np.mean(multilingual_scores))
+custom_macro = float(np.mean(custom_scores))
+group_macro = float(np.mean([multilingual_macro, custom_macro]))
+
+"""
+Example output (actual run in this repo, to be updated if defaults change):
+  Model: intfloat/multilingual-e5-small
+  Multilingual macro mean: 0.5263
+  Custom macro mean: 0.7381
+  Group macro mean: 0.6322
+"""
+
+print(f"Model: {MODEL_NAME}")
+print(f"Multilingual macro mean: {multilingual_macro:.4f}")
+print(f"Custom macro mean: {custom_macro:.4f}")
+print(f"Group macro mean: {group_macro:.4f}")

--- a/examples/sentence_transformer/evaluation/evaluation_nano_dense_multidataset_macro.py
+++ b/examples/sentence_transformer/evaluation/evaluation_nano_dense_multidataset_macro.py
@@ -23,7 +23,7 @@ CUSTOM_DATASET_IDS = [
 ]
 
 
-def evaluate_dataset(model: SentenceTransformer, dataset_id: str) -> float:
+def evaluate_dataset(model: SentenceTransformer, dataset_id: str) -> tuple[str, str, float]:
     evaluator = NanoEvaluator(
         dataset_id=dataset_id,
         dataset_names=None,
@@ -33,13 +33,16 @@ def evaluate_dataset(model: SentenceTransformer, dataset_id: str) -> float:
     results = evaluator(model)
     if evaluator.primary_metric is None:
         raise ValueError(f"Expected evaluator.primary_metric for dataset_id={dataset_id}")
-    return float(results[evaluator.primary_metric])
+    return dataset_id, evaluator.primary_metric, float(results[evaluator.primary_metric])
 
 
 model = SentenceTransformer(MODEL_NAME)
 
-multilingual_scores = [evaluate_dataset(model, dataset_id) for dataset_id in MULTILINGUAL_NANOBEIR_DATASET_IDS]
-custom_scores = [evaluate_dataset(model, dataset_id) for dataset_id in CUSTOM_DATASET_IDS]
+multilingual_results = [evaluate_dataset(model, dataset_id) for dataset_id in MULTILINGUAL_NANOBEIR_DATASET_IDS]
+custom_results = [evaluate_dataset(model, dataset_id) for dataset_id in CUSTOM_DATASET_IDS]
+
+multilingual_scores = [score for _, _, score in multilingual_results]
+custom_scores = [score for _, _, score in custom_results]
 
 multilingual_macro = float(np.mean(multilingual_scores))
 custom_macro = float(np.mean(custom_scores))
@@ -48,12 +51,23 @@ group_macro = float(np.mean([multilingual_macro, custom_macro]))
 """
 Example output (actual run in this repo, to be updated if defaults change):
   Model: intfloat/multilingual-e5-small
+  Multilingual dataset scores:
+  - sentence-transformers/NanoBEIR-en | NanoBEIR-en_mean_cosine_ndcg@10 = 0.5542
+  - LiquidAI/NanoBEIR-ja | NanoBEIR-ja_mean_cosine_ndcg@10 = 0.4985
+  Custom dataset scores:
+  - hotchpotch/NanoCodeSearchNet | NanoCodeSearchNet_mean_cosine_ndcg@10 = 0.7381
   Multilingual macro mean: 0.5263
   Custom macro mean: 0.7381
   Group macro mean: 0.6322
 """
 
 print(f"Model: {MODEL_NAME}")
+print("Multilingual dataset scores:")
+for dataset_id, metric_key, score in multilingual_results:
+    print(f"- {dataset_id} | {metric_key} = {score:.4f}")
+print("Custom dataset scores:")
+for dataset_id, metric_key, score in custom_results:
+    print(f"- {dataset_id} | {metric_key} = {score:.4f}")
 print(f"Multilingual macro mean: {multilingual_macro:.4f}")
 print(f"Custom macro mean: {custom_macro:.4f}")
 print(f"Group macro mean: {group_macro:.4f}")

--- a/examples/sparse_encoder/evaluation/sparse_nano_multidataset_macro_evaluator.py
+++ b/examples/sparse_encoder/evaluation/sparse_nano_multidataset_macro_evaluator.py
@@ -1,0 +1,58 @@
+"""Simple sparse multi-dataset Nano macro example.
+
+Run:
+  uv run --with datasets python examples/sparse_encoder/evaluation/sparse_nano_multidataset_macro_evaluator.py
+"""
+
+import logging
+
+import numpy as np
+
+from sentence_transformers import SparseEncoder
+from sentence_transformers.sparse_encoder.evaluation import SparseNanoEvaluator
+
+logging.basicConfig(format="%(message)s", level=logging.INFO)
+
+MODEL_NAME = "sparse-encoder/example-inference-free-splade-distilbert-base-uncased-nq"
+MULTILINGUAL_NANOBEIR_DATASET_IDS = [
+    "sentence-transformers/NanoBEIR-en",
+]
+CUSTOM_DATASET_IDS = [
+    "hotchpotch/NanoCodeSearchNet",
+]
+
+
+def evaluate_dataset(model: SparseEncoder, dataset_id: str) -> float:
+    evaluator = SparseNanoEvaluator(
+        dataset_id=dataset_id,
+        dataset_names=None,
+        batch_size=32,
+        show_progress_bar=False,
+    )
+    results = evaluator(model)
+    if evaluator.primary_metric is None:
+        raise ValueError(f"Expected evaluator.primary_metric for dataset_id={dataset_id}")
+    return float(results[evaluator.primary_metric])
+
+
+model = SparseEncoder(MODEL_NAME)
+
+multilingual_scores = [evaluate_dataset(model, dataset_id) for dataset_id in MULTILINGUAL_NANOBEIR_DATASET_IDS]
+custom_scores = [evaluate_dataset(model, dataset_id) for dataset_id in CUSTOM_DATASET_IDS]
+
+multilingual_macro = float(np.mean(multilingual_scores))
+custom_macro = float(np.mean(custom_scores))
+group_macro = float(np.mean([multilingual_macro, custom_macro]))
+
+"""
+Example output (actual run in this repo, to be updated if defaults change):
+  Model: sparse-encoder/example-inference-free-splade-distilbert-base-uncased-nq
+  Multilingual macro mean: 0.5205
+  Custom macro mean: 0.5867
+  Group macro mean: 0.5536
+"""
+
+print(f"Model: {MODEL_NAME}")
+print(f"Multilingual macro mean: {multilingual_macro:.4f}")
+print(f"Custom macro mean: {custom_macro:.4f}")
+print(f"Group macro mean: {group_macro:.4f}")

--- a/examples/sparse_encoder/evaluation/sparse_nano_multidataset_macro_evaluator.py
+++ b/examples/sparse_encoder/evaluation/sparse_nano_multidataset_macro_evaluator.py
@@ -22,7 +22,7 @@ CUSTOM_DATASET_IDS = [
 ]
 
 
-def evaluate_dataset(model: SparseEncoder, dataset_id: str) -> float:
+def evaluate_dataset(model: SparseEncoder, dataset_id: str) -> tuple[str, str, float]:
     evaluator = SparseNanoEvaluator(
         dataset_id=dataset_id,
         dataset_names=None,
@@ -32,13 +32,16 @@ def evaluate_dataset(model: SparseEncoder, dataset_id: str) -> float:
     results = evaluator(model)
     if evaluator.primary_metric is None:
         raise ValueError(f"Expected evaluator.primary_metric for dataset_id={dataset_id}")
-    return float(results[evaluator.primary_metric])
+    return dataset_id, evaluator.primary_metric, float(results[evaluator.primary_metric])
 
 
 model = SparseEncoder(MODEL_NAME)
 
-multilingual_scores = [evaluate_dataset(model, dataset_id) for dataset_id in MULTILINGUAL_NANOBEIR_DATASET_IDS]
-custom_scores = [evaluate_dataset(model, dataset_id) for dataset_id in CUSTOM_DATASET_IDS]
+multilingual_results = [evaluate_dataset(model, dataset_id) for dataset_id in MULTILINGUAL_NANOBEIR_DATASET_IDS]
+custom_results = [evaluate_dataset(model, dataset_id) for dataset_id in CUSTOM_DATASET_IDS]
+
+multilingual_scores = [score for _, _, score in multilingual_results]
+custom_scores = [score for _, _, score in custom_results]
 
 multilingual_macro = float(np.mean(multilingual_scores))
 custom_macro = float(np.mean(custom_scores))
@@ -47,12 +50,22 @@ group_macro = float(np.mean([multilingual_macro, custom_macro]))
 """
 Example output (actual run in this repo, to be updated if defaults change):
   Model: sparse-encoder/example-inference-free-splade-distilbert-base-uncased-nq
+  Multilingual dataset scores:
+  - sentence-transformers/NanoBEIR-en | NanoBEIR-en_mean_dot_ndcg@10 = 0.5205
+  Custom dataset scores:
+  - hotchpotch/NanoCodeSearchNet | NanoCodeSearchNet_mean_dot_ndcg@10 = 0.5867
   Multilingual macro mean: 0.5205
   Custom macro mean: 0.5867
   Group macro mean: 0.5536
 """
 
 print(f"Model: {MODEL_NAME}")
+print("Multilingual dataset scores:")
+for dataset_id, metric_key, score in multilingual_results:
+    print(f"- {dataset_id} | {metric_key} = {score:.4f}")
+print("Custom dataset scores:")
+for dataset_id, metric_key, score in custom_results:
+    print(f"- {dataset_id} | {metric_key} = {score:.4f}")
 print(f"Multilingual macro mean: {multilingual_macro:.4f}")
 print(f"Custom macro mean: {custom_macro:.4f}")
 print(f"Group macro mean: {group_macro:.4f}")

--- a/sentence_transformers/cross_encoder/evaluation/__init__.py
+++ b/sentence_transformers/cross_encoder/evaluation/__init__.py
@@ -12,6 +12,7 @@ from .deprecated import (
     CERerankingEvaluator,
     CESoftmaxAccuracyEvaluator,
 )
+from .nano_evaluator import CrossEncoderNanoEvaluator
 from .nano_beir import CrossEncoderNanoBEIREvaluator
 from .reranking import CrossEncoderRerankingEvaluator
 
@@ -31,6 +32,7 @@ for module in deprecated_modules:
 __all__ = [
     "CrossEncoderClassificationEvaluator",
     "CrossEncoderCorrelationEvaluator",
+    "CrossEncoderNanoEvaluator",
     "CrossEncoderRerankingEvaluator",
     "CrossEncoderNanoBEIREvaluator",
     # Deprecated:

--- a/sentence_transformers/cross_encoder/evaluation/nano_beir.py
+++ b/sentence_transformers/cross_encoder/evaluation/nano_beir.py
@@ -41,42 +41,149 @@ DATASET_NAME_TO_HUMAN_READABLE: dict[str, str] = {
 
 
 class CrossEncoderNanoBEIREvaluator(CrossEncoderNanoEvaluator):
-    """Evaluate a CrossEncoder model on NanoBEIR datasets.
+    """
+    This class evaluates a CrossEncoder model on the NanoBEIR collection of Information Retrieval datasets.
 
-    This evaluator is designed for reranking over NanoBEIR datasets. Rather
-    than reranking the full corpus, it reranks only ``rerank_k`` first-stage
-    candidates (``bm25`` by default), and reports MAP / MRR@k / nDCG@k.
+    The collection is a set of datasets based on the BEIR collection, but with a significantly smaller size, so it can
+    be used for quickly evaluating the retrieval performance of a model before committing to a full evaluation.
+    The datasets are available on Hugging Face in the `NanoBEIR collection <https://huggingface.co/collections/sentence-transformers/nanobeir-datasets>`_.
+    This evaluator will return the same metrics as the :class:`~sentence_transformers.cross_encoder.evaluation.CrossEncoderRerankingEvaluator`
+    (i.e., MRR@k, nDCG@k, MAP), for each dataset and on average.
 
-    This class preserves the NanoBEIR short-name API while delegating shared
-    reranking dataset mechanics to
+    Rather than reranking all documents for each query, the evaluator will only rerank the ``rerank_k`` documents from
+    a BM25 ranking. When your logging is set to INFO, the evaluator will print the MAP, MRR@k, and nDCG@k for each dataset
+    and the average over all datasets.
+
+    Note that the maximum score is 1.0 by default, because all positive documents are included in the ranking. This
+    can be toggled off by setting ``always_rerank_positives=False``, at which point the maximum score will be bound by
+    the number of positive documents that BM25 ranks in the top ``rerank_k`` documents.
+
+    This class preserves the NanoBEIR short-name API and delegates shared, dataset-agnostic mechanics to
     :class:`~sentence_transformers.cross_encoder.evaluation.CrossEncoderNanoEvaluator`.
+    For generic non-NanoBEIR behavior and advanced subset options, see that base class.
 
     .. note::
-        Result keys follow the NanoBEIR convention:
-        ``NanoBEIR_R{rerank_k}_{aggregate_key}_{metric}``.
-        Per-dataset keys use ``Nano{DatasetName}_R{rerank_k}_{metric}``.
+        This evaluator outputs its results using keys in the format ``NanoBEIR_R{rerank_k}_{aggregate_key}_{metric}``,
+        where ``metric`` is one of ``map``, ``mrr@{at_k}``, or ``ndcg@{at_k}``, and ``rerank_k``, ``aggregate_key`` and
+        ``at_k`` are the parameters of the evaluator. The primary metric is ``ndcg@{at_k}``. By default, the name of
+        the primary metric is ``NanoBEIR_R100_mean_ndcg@10``.
+
+        For the results of each dataset, the keys are in the format ``Nano{dataset_name}_R{rerank_k}_{metric}``,
+        for example ``NanoMSMARCO_R100_mrr@10``.
+
+        These can be used as ``metric_for_best_model`` alongside ``load_best_model_at_end=True`` in the
+        :class:`~sentence_transformers.cross_encoder.training_args.CrossEncoderTrainingArguments` to automatically load the
+        best model based on a specific metric of interest.
 
     .. warning::
-        By default (when ``dataset_names`` is not provided), this evaluator
-        excludes ``arguana`` and ``touche2020`` because their argument-retrieval
-        setup differs from the other NanoBEIR subsets.
+
+        When not specifying the ``dataset_names`` manually, the evaluator will exclude the ``arguana`` and ``touche2020``
+        datasets as their Argument Retrieval task differs meaningfully from the other datasets. This differs from
+        :class:`~sentence_transformers.evaluation.NanoBEIREvaluator` and
+        :class:`~sentence_transformers.sparse_encoder.evaluation.SparseNanoBEIREvaluator`, which include all datasets
+        by default.
 
     Args:
-        dataset_names (List[str]): NanoBEIR short names to evaluate. If not
-            provided, defaults to all except ``arguana`` and ``touche2020``.
-        dataset_id (str): Hugging Face dataset ID. Must include ``corpus``,
-            ``queries``, ``qrels``, and candidate subset data.
-        rerank_k (int): Number of candidates to rerank per query.
-        at_k (int): Metric cutoff for MRR/nDCG.
-        always_rerank_positives (bool): Whether to enforce positives in rerank pool.
-        batch_size (int): Cross-encoder evaluation batch size.
-        show_progress_bar (bool): Whether to show progress bars.
-        write_csv (bool): Whether to write CSV metrics.
-        aggregate_fn (Callable[[list[float]], float]): Aggregation function across subsets.
-        aggregate_key (str): Aggregate metric key prefix.
-        candidate_subset_name (str): First-stage candidate subset name (default: ``bm25``).
-        bm25_subset_name (str, optional): Deprecated alias for ``candidate_subset_name``.
-        retrieved_corpus_ids_column (str): Column name containing candidate corpus IDs.
+        dataset_names (List[str]): The short names of the datasets to evaluate on (e.g., "climatefever", "msmarco").
+            If not specified, all predefined NanoBEIR datasets except arguana and touche2020 are used. The full list
+            of available datasets is: "climatefever", "dbpedia", "fever", "fiqa2018", "hotpotqa", "msmarco",
+            "nfcorpus", "nq", "quoraretrieval", "scidocs", "arguana", "scifact", and "touche2020".
+        dataset_id (str): The HuggingFace dataset ID to load the datasets from. Defaults to
+            "sentence-transformers/NanoBEIR-en". The dataset must contain "corpus", "queries", "qrels", and "bm25"
+            subsets for each NanoBEIR dataset, stored under splits named ``Nano{DatasetName}`` (for example,
+            ``NanoMSMARCO`` or ``NanoNFCorpus``).
+        rerank_k (int): The number of documents to rerank from the BM25 ranking. Defaults to 100.
+        at_k (int, optional): Only consider the top k most similar documents to each query for the evaluation. Defaults to 10.
+        always_rerank_positives (bool): If True, always evaluate with all positives included. If False, only include
+            the positives that are already in the documents list. Always set to True if your ``samples`` contain ``negative``
+            instead of ``documents``. When using ``documents``, setting this to True will result in a more useful evaluation
+            signal, but setting it to False will result in a more realistic evaluation. Defaults to True.
+        batch_size (int): Batch size to compute sentence embeddings. Defaults to 32.
+        show_progress_bar (bool): Show progress bar when computing embeddings. Defaults to False.
+        write_csv (bool): Write results to CSV file. Defaults to True.
+        aggregate_fn (Callable[[list[float]], float]): The function to aggregate the scores. Defaults to np.mean.
+        aggregate_key (str): The key to use for the aggregated score. Defaults to "mean".
+
+    .. tip::
+
+        See this `NanoBEIR datasets collection on Hugging Face <https://huggingface.co/collections/sentence-transformers/nanobeir-datasets>`_
+        with valid NanoBEIR ``dataset_id`` options for different languages. The datasets must contain a "bm25" subset
+        with BM25 rankings for the reranking evaluation to work.
+
+    Example:
+        ::
+
+            from sentence_transformers.cross_encoder import CrossEncoder
+            from sentence_transformers.cross_encoder.evaluation import CrossEncoderNanoBEIREvaluator
+            import logging
+
+            logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(message)s")
+
+            # Load a model
+            model = CrossEncoder("cross-encoder/ms-marco-MiniLM-L6-v2")
+
+            # Load & run the evaluator
+            dataset_names = ["msmarco", "nfcorpus", "nq"]
+            evaluator = CrossEncoderNanoBEIREvaluator(dataset_names)
+            results = evaluator(model)
+            '''
+            NanoBEIR Evaluation of the model on ['msmarco', 'nfcorpus', 'nq'] dataset:
+            Evaluating NanoMSMARCO
+            CrossEncoderRerankingEvaluator: Evaluating the model on the NanoMSMARCO dataset:
+                     Base  -> Reranked
+            MAP:     48.96 -> 60.35
+            MRR@10:  47.75 -> 59.63
+            NDCG@10: 54.04 -> 66.86
+
+            Evaluating NanoNFCorpus
+            CrossEncoderRerankingEvaluator: Evaluating the model on the NanoNFCorpus dataset:
+            Queries: 50   Positives: Min 1.0, Mean 50.4, Max 463.0        Negatives: Min 54.0, Mean 92.8, Max 100.0
+                     Base  -> Reranked
+            MAP:     26.10 -> 34.61
+            MRR@10:  49.98 -> 58.85
+            NDCG@10: 32.50 -> 39.30
+
+            Evaluating NanoNQ
+            CrossEncoderRerankingEvaluator: Evaluating the model on the NanoNQ dataset:
+            Queries: 50   Positives: Min 1.0, Mean 1.1, Max 2.0   Negatives: Min 98.0, Mean 99.0, Max 100.0
+                     Base  -> Reranked
+            MAP:     41.96 -> 70.98
+            MRR@10:  42.67 -> 73.55
+            NDCG@10: 50.06 -> 75.99
+
+            CrossEncoderNanoBEIREvaluator: Aggregated Results:
+                     Base  -> Reranked
+            MAP:     39.01 -> 55.31
+            MRR@10:  46.80 -> 64.01
+            NDCG@10: 45.54 -> 60.72
+            '''
+            print(evaluator.primary_metric)
+            # NanoBEIR_R100_mean_ndcg@10
+            print(results[evaluator.primary_metric])
+            # 0.60716840988382
+
+        Evaluating on custom/translated datasets::
+
+            import logging
+            from pprint import pprint
+
+            from sentence_transformers.cross_encoder import CrossEncoder
+            from sentence_transformers.cross_encoder.evaluation import CrossEncoderNanoBEIREvaluator
+
+            logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(message)s")
+
+            # Load a model
+            model = CrossEncoder("cross-encoder/mmarco-mMiniLMv2-L12-H384-v1")
+
+            # Load & run the evaluator
+            evaluator = CrossEncoderNanoBEIREvaluator(
+                ["msmarco", "nq"],
+                dataset_id="Serbian-AI-Society/NanoBEIR-sr",
+                batch_size=16,
+            )
+            results = evaluator(model)
+            print(results[evaluator.primary_metric])
+            pprint({key: value for key, value in results.items() if "ndcg@10" in key})
     """
 
     def __init__(

--- a/sentence_transformers/cross_encoder/evaluation/nano_beir.py
+++ b/sentence_transformers/cross_encoder/evaluation/nano_beir.py
@@ -1,21 +1,11 @@
 from __future__ import annotations
 
-import logging
-import os
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Literal
+from typing import Any, Literal
 
 import numpy as np
-from tqdm import tqdm
 
-from sentence_transformers.cross_encoder.evaluation.reranking import CrossEncoderRerankingEvaluator
-from sentence_transformers.evaluation.SentenceEvaluator import SentenceEvaluator
-from sentence_transformers.util import is_datasets_available
-
-if TYPE_CHECKING:
-    from sentence_transformers.cross_encoder.CrossEncoder import CrossEncoder
-
-logger = logging.getLogger(__name__)
+from sentence_transformers.cross_encoder.evaluation.nano_evaluator import CrossEncoderNanoEvaluator
 
 DatasetNameType = Literal[
     "climatefever",
@@ -33,7 +23,7 @@ DatasetNameType = Literal[
     "touche2020",
 ]
 
-DATASET_NAME_TO_HUMAN_READABLE = {
+DATASET_NAME_TO_HUMAN_READABLE: dict[str, str] = {
     "climatefever": "ClimateFEVER",
     "dbpedia": "DBPedia",
     "fever": "FEVER",
@@ -50,146 +40,43 @@ DATASET_NAME_TO_HUMAN_READABLE = {
 }
 
 
-class CrossEncoderNanoBEIREvaluator(SentenceEvaluator):
-    """
-    This class evaluates a CrossEncoder model on the NanoBEIR collection of Information Retrieval datasets.
+class CrossEncoderNanoBEIREvaluator(CrossEncoderNanoEvaluator):
+    """Evaluate a CrossEncoder model on NanoBEIR datasets.
 
-    The collection is a set of datasets based on the BEIR collection, but with a significantly smaller size, so it can
-    be used for quickly evaluating the retrieval performance of a model before committing to a full evaluation.
-    The datasets are available on Hugging Face in the `NanoBEIR collection <https://huggingface.co/collections/sentence-transformers/nanobeir-datasets>`_.
-    This evaluator will return the same metrics as the :class:`~sentence_transformers.cross_encoder.evaluation.CrossEncoderRerankingEvaluator`
-    (i.e., MRR@k, nDCG@k, MAP), for each dataset and on average.
+    This evaluator is designed for reranking over NanoBEIR datasets. Rather
+    than reranking the full corpus, it reranks only ``rerank_k`` first-stage
+    candidates (``bm25`` by default), and reports MAP / MRR@k / nDCG@k.
 
-    Rather than reranking all documents for each query, the evaluator will only rerank the ``rerank_k`` documents from
-    a BM25 ranking. When your logging is set to INFO, the evaluator will print the MAP, MRR@k, and nDCG@k for each dataset
-    and the average over all datasets.
-
-    Note that the maximum score is 1.0 by default, because all positive documents are included in the ranking. This
-    can be toggled off by setting ``always_rerank_positives=False``, at which point the maximum score will be bound by
-    the number of positive documents that BM25 ranks in the top ``rerank_k`` documents.
+    This class preserves the NanoBEIR short-name API while delegating shared
+    reranking dataset mechanics to
+    :class:`~sentence_transformers.cross_encoder.evaluation.CrossEncoderNanoEvaluator`.
 
     .. note::
-        This evaluator outputs its results using keys in the format ``NanoBEIR_R{rerank_k}_{aggregate_key}_{metric}``,
-        where ``metric`` is one of ``map``, ``mrr@{at_k}``, or ``ndcg@{at_k}``, and ``rerank_k``, ``aggregate_key`` and
-        ``at_k`` are the parameters of the evaluator. The primary metric is ``ndcg@{at_k}``. By default, the name of
-        the primary metric is ``NanoBEIR_R100_mean_ndcg@10``.
-
-        For the results of each dataset, the keys are in the format ``Nano{dataset_name}_R{rerank_k}_{metric}``,
-        for example ``NanoMSMARCO_R100_mrr@10``.
-
-        These can be used as ``metric_for_best_model`` alongside ``load_best_model_at_end=True`` in the
-        :class:`~sentence_transformers.cross_encoder.training_args.CrossEncoderTrainingArguments` to automatically load the
-        best model based on a specific metric of interest.
+        Result keys follow the NanoBEIR convention:
+        ``NanoBEIR_R{rerank_k}_{aggregate_key}_{metric}``.
+        Per-dataset keys use ``Nano{DatasetName}_R{rerank_k}_{metric}``.
 
     .. warning::
-
-        When not specifying the ``dataset_names`` manually, the evaluator will exclude the ``arguana`` and ``touche2020``
-        datasets as their Argument Retrieval task differs meaningfully from the other datasets. This differs from
-        :class:`~sentence_transformers.evaluation.NanoBEIREvaluator` and
-        :class:`~sentence_transformers.sparse_encoder.evaluation.SparseNanoBEIREvaluator`, which include all datasets
-        by default.
+        By default (when ``dataset_names`` is not provided), this evaluator
+        excludes ``arguana`` and ``touche2020`` because their argument-retrieval
+        setup differs from the other NanoBEIR subsets.
 
     Args:
-        dataset_names (List[str]): The short names of the datasets to evaluate on (e.g., "climatefever", "msmarco").
-            If not specified, all predefined NanoBEIR datasets except arguana and touche2020 are used. The full list
-            of available datasets is: "climatefever", "dbpedia", "fever", "fiqa2018", "hotpotqa", "msmarco",
-            "nfcorpus", "nq", "quoraretrieval", "scidocs", "arguana", "scifact", and "touche2020".
-        dataset_id (str): The HuggingFace dataset ID to load the datasets from. Defaults to
-            "sentence-transformers/NanoBEIR-en". The dataset must contain "corpus", "queries", "qrels", and "bm25"
-            subsets for each NanoBEIR dataset, stored under splits named ``Nano{DatasetName}`` (for example,
-            ``NanoMSMARCO`` or ``NanoNFCorpus``).
-        rerank_k (int): The number of documents to rerank from the BM25 ranking. Defaults to 100.
-        at_k (int, optional): Only consider the top k most similar documents to each query for the evaluation. Defaults to 10.
-        always_rerank_positives (bool): If True, always evaluate with all positives included. If False, only include
-            the positives that are already in the documents list. Always set to True if your ``samples`` contain ``negative``
-            instead of ``documents``. When using ``documents``, setting this to True will result in a more useful evaluation
-            signal, but setting it to False will result in a more realistic evaluation. Defaults to True.
-        batch_size (int): Batch size to compute sentence embeddings. Defaults to 64.
-        show_progress_bar (bool): Show progress bar when computing embeddings. Defaults to False.
-        write_csv (bool): Write results to CSV file. Defaults to True.
-        aggregate_fn (Callable[[list[float]], float]): The function to aggregate the scores. Defaults to np.mean.
-        aggregate_key (str): The key to use for the aggregated score. Defaults to "mean".
-
-    .. tip::
-
-        See this `NanoBEIR datasets collection on Hugging Face <https://huggingface.co/collections/sentence-transformers/nanobeir-datasets>`_
-        with valid NanoBEIR ``dataset_id`` options for different languages. The datasets must contain a "bm25" subset
-        with BM25 rankings for the reranking evaluation to work.
-
-    Example:
-        ::
-
-            from sentence_transformers.cross_encoder import CrossEncoder
-            from sentence_transformers.cross_encoder.evaluation import CrossEncoderNanoBEIREvaluator
-            import logging
-
-            logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(message)s")
-
-            # Load a model
-            model = CrossEncoder("cross-encoder/ms-marco-MiniLM-L6-v2")
-
-            # Load & run the evaluator
-            dataset_names = ["msmarco", "nfcorpus", "nq"]
-            evaluator = CrossEncoderNanoBEIREvaluator(dataset_names)
-            results = evaluator(model)
-            '''
-            NanoBEIR Evaluation of the model on ['msmarco', 'nfcorpus', 'nq'] dataset:
-            Evaluating NanoMSMARCO
-            CrossEncoderRerankingEvaluator: Evaluating the model on the NanoMSMARCO dataset:
-                     Base  -> Reranked
-            MAP:     48.96 -> 60.35
-            MRR@10:  47.75 -> 59.63
-            NDCG@10: 54.04 -> 66.86
-
-            Evaluating NanoNFCorpus
-            CrossEncoderRerankingEvaluator: Evaluating the model on the NanoNFCorpus dataset:
-            Queries: 50   Positives: Min 1.0, Mean 50.4, Max 463.0        Negatives: Min 54.0, Mean 92.8, Max 100.0
-                     Base  -> Reranked
-            MAP:     26.10 -> 34.61
-            MRR@10:  49.98 -> 58.85
-            NDCG@10: 32.50 -> 39.30
-
-            Evaluating NanoNQ
-            CrossEncoderRerankingEvaluator: Evaluating the model on the NanoNQ dataset:
-            Queries: 50   Positives: Min 1.0, Mean 1.1, Max 2.0   Negatives: Min 98.0, Mean 99.0, Max 100.0
-                     Base  -> Reranked
-            MAP:     41.96 -> 70.98
-            MRR@10:  42.67 -> 73.55
-            NDCG@10: 50.06 -> 75.99
-
-            CrossEncoderNanoBEIREvaluator: Aggregated Results:
-                     Base  -> Reranked
-            MAP:     39.01 -> 55.31
-            MRR@10:  46.80 -> 64.01
-            NDCG@10: 45.54 -> 60.72
-            '''
-            print(evaluator.primary_metric)
-            # NanoBEIR_R100_mean_ndcg@10
-            print(results[evaluator.primary_metric])
-            # 0.60716840988382
-
-        Evaluating on custom/translated datasets::
-
-            import logging
-            from pprint import pprint
-
-            from sentence_transformers.cross_encoder import CrossEncoder
-            from sentence_transformers.cross_encoder.evaluation import CrossEncoderNanoBEIREvaluator
-
-            logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(message)s")
-
-            # Load a model
-            model = CrossEncoder("cross-encoder/mmarco-mMiniLMv2-L12-H384-v1")
-
-            # Load & run the evaluator
-            evaluator = CrossEncoderNanoBEIREvaluator(
-                ["msmarco", "nq"],
-                dataset_id="Serbian-AI-Society/NanoBEIR-sr",
-                batch_size=16,
-            )
-            results = evaluator(model)
-            print(results[evaluator.primary_metric])
-            pprint({key: value for key, value in results.items() if "ndcg@10" in key})
+        dataset_names (List[str]): NanoBEIR short names to evaluate. If not
+            provided, defaults to all except ``arguana`` and ``touche2020``.
+        dataset_id (str): Hugging Face dataset ID. Must include ``corpus``,
+            ``queries``, ``qrels``, and candidate subset data.
+        rerank_k (int): Number of candidates to rerank per query.
+        at_k (int): Metric cutoff for MRR/nDCG.
+        always_rerank_positives (bool): Whether to enforce positives in rerank pool.
+        batch_size (int): Cross-encoder evaluation batch size.
+        show_progress_bar (bool): Whether to show progress bars.
+        write_csv (bool): Whether to write CSV metrics.
+        aggregate_fn (Callable[[list[float]], float]): Aggregation function across subsets.
+        aggregate_key (str): Aggregate metric key prefix.
+        candidate_subset_name (str): First-stage candidate subset name (default: ``bm25``).
+        bm25_subset_name (str, optional): Deprecated alias for ``candidate_subset_name``.
+        retrieved_corpus_ids_column (str): Column name containing candidate corpus IDs.
     """
 
     def __init__(
@@ -204,206 +91,40 @@ class CrossEncoderNanoBEIREvaluator(SentenceEvaluator):
         write_csv: bool = True,
         aggregate_fn: Callable[[list[float]], float] = np.mean,
         aggregate_key: str = "mean",
-    ):
-        super().__init__()
+        candidate_subset_name: str = "bm25",
+        bm25_subset_name: str | None = None,
+        retrieved_corpus_ids_column: str = "corpus-ids",
+    ) -> None:
         if dataset_names is None:
-            # We exclude arguana and touche2020 because their Argument Retrieval meaningfully task differs from the others
-            dataset_names = [key for key in DATASET_NAME_TO_HUMAN_READABLE if key not in ["arguana", "touche2020"]]
-        self.dataset_names = dataset_names
-        self.dataset_id = dataset_id
-        self.rerank_k = rerank_k
-        self.at_k = at_k
-        self.always_rerank_positives = always_rerank_positives
-        self.show_progress_bar = show_progress_bar
-        self.batch_size = batch_size
-        self.write_csv = write_csv
-        self.aggregate_fn = aggregate_fn
-        self.aggregate_key = aggregate_key
-
-        self.name = f"NanoBEIR_R{rerank_k:d}_{self.aggregate_key}"
-
-        self._validate_dataset_names()
-
-        reranking_kwargs = {
-            "at_k": self.at_k,
-            "always_rerank_positives": self.always_rerank_positives,
-            "show_progress_bar": self.show_progress_bar,
-            "batch_size": self.batch_size,
-            "write_csv": self.write_csv,
-        }
-
-        self.evaluators = [
-            self._load_dataset(name, **reranking_kwargs)
-            for name in tqdm(self.dataset_names, desc="Loading NanoBEIR datasets", leave=False)
-        ]
-
-        self.csv_file: str = f"NanoBEIR_evaluation_{aggregate_key}_results.csv"
-        self.csv_headers = ["epoch", "steps", "MAP", f"MRR@{self.at_k}", f"NDCG@{self.at_k}"]
-
-        self.primary_metric = f"ndcg@{self.at_k}"
-
-    def __call__(
-        self, model: CrossEncoder, output_path: str | None = None, epoch: int = -1, steps: int = -1, *args, **kwargs
-    ) -> dict[str, float]:
-        per_metric_results = {}
-        per_dataset_results = {}
-        if epoch != -1:
-            if steps == -1:
-                out_txt = f" after epoch {epoch}"
-            else:
-                out_txt = f" in epoch {epoch} after {steps} steps"
-        else:
-            out_txt = ""
-        logger.info(f"NanoBEIR Evaluation of the model on {self.dataset_names} dataset{out_txt}:")
-
-        for evaluator in tqdm(self.evaluators, desc="Evaluating datasets", disable=not self.show_progress_bar):
-            logger.info(f"Evaluating {evaluator.name}")
-            evaluation = evaluator(model, output_path, epoch, steps)
-            for k in evaluation:
-                dataset, _rerank_k, metric = k.split("_", maxsplit=2)
-                if metric not in per_metric_results:
-                    per_metric_results[metric] = []
-                per_dataset_results[f"{dataset}_R{self.rerank_k}_{metric}"] = evaluation[k]
-                per_metric_results[metric].append(evaluation[k])
-            logger.info("")
-
-        agg_results = {}
-        for metric in per_metric_results:
-            agg_results[metric] = self.aggregate_fn(per_metric_results[metric])
-
-        if output_path is not None and self.write_csv:
-            os.makedirs(output_path, exist_ok=True)
-            csv_path = os.path.join(output_path, self.csv_file)
-            if not os.path.isfile(csv_path):
-                fOut = open(csv_path, mode="w", encoding="utf-8")
-                fOut.write(",".join(self.csv_headers))
-                fOut.write("\n")
-
-            else:
-                fOut = open(csv_path, mode="a", encoding="utf-8")
-
-            output_data = [
-                epoch,
-                steps,
-                agg_results["map"],
-                agg_results[f"mrr@{self.at_k}"],
-                agg_results[f"ndcg@{self.at_k}"],
+            dataset_names = [
+                key for key in DATASET_NAME_TO_HUMAN_READABLE.keys() if key not in ["arguana", "touche2020"]
             ]
 
-            fOut.write(",".join(map(str, output_data)))
-            fOut.write("\n")
-            fOut.close()
-
-        logger.info("CrossEncoderNanoBEIREvaluator: Aggregated Results:")
-        logger.info(f"{' ' * len(str(self.at_k))}       Base  -> Reranked")
-        logger.info(
-            f"MAP:{' ' * len(str(self.at_k))}   {agg_results['base_map'] * 100:.2f} -> {agg_results['map'] * 100:.2f}"
-        )
-        logger.info(
-            f"MRR@{self.at_k}:  {agg_results[f'base_mrr@{self.at_k}'] * 100:.2f} -> {agg_results[f'mrr@{self.at_k}'] * 100:.2f}"
-        )
-        logger.info(
-            f"NDCG@{self.at_k}: {agg_results[f'base_ndcg@{self.at_k}'] * 100:.2f} -> {agg_results[f'ndcg@{self.at_k}'] * 100:.2f}"
-        )
-
-        model_card_metrics = {
-            "map": f"{agg_results['map']:.4f} ({agg_results['map'] - agg_results['base_map']:+.4f})",
-            f"mrr@{self.at_k}": f"{agg_results[f'mrr@{self.at_k}']:.4f} ({agg_results[f'mrr@{self.at_k}'] - agg_results[f'base_mrr@{self.at_k}']:+.4f})",
-            f"ndcg@{self.at_k}": f"{agg_results[f'ndcg@{self.at_k}']:.4f} ({agg_results[f'ndcg@{self.at_k}'] - agg_results[f'base_ndcg@{self.at_k}']:+.4f})",
-        }
-        model_card_metrics = self.prefix_name_to_metrics(model_card_metrics, self.name)
-        self.store_metrics_in_model_card_data(model, model_card_metrics, epoch, steps)
-
-        agg_results = self.prefix_name_to_metrics(agg_results, self.name)
-        per_dataset_results.update(agg_results)
-
-        return per_dataset_results
-
-    def _get_human_readable_name(self, dataset_name: DatasetNameType | str) -> str:
-        return f"Nano{DATASET_NAME_TO_HUMAN_READABLE[dataset_name.lower()]}_R{self.rerank_k}"
-
-    def _load_dataset(
-        self, dataset_name: DatasetNameType | str, **ir_evaluator_kwargs
-    ) -> CrossEncoderRerankingEvaluator:
-        if dataset_name.lower() not in DATASET_NAME_TO_HUMAN_READABLE:
-            raise ValueError(f"Dataset '{dataset_name}' is not a valid NanoBEIR dataset.")
-        human_readable = DATASET_NAME_TO_HUMAN_READABLE[dataset_name.lower()]
-        split_name = f"Nano{human_readable}"
-
-        corpus = self._load_dataset_subset_split("corpus", split=split_name, required_columns=["_id", "text"])
-        queries = self._load_dataset_subset_split("queries", split=split_name, required_columns=["_id", "text"])
-        qrels = self._load_dataset_subset_split("qrels", split=split_name, required_columns=["query-id", "corpus-id"])
-        bm25 = self._load_dataset_subset_split("bm25", split=split_name, required_columns=["query-id", "corpus-ids"])
-
-        corpus_mapping = dict(zip(corpus["_id"], corpus["text"]))
-        query_mapping = dict(zip(queries["_id"], queries["text"]))
-        qrels_mapping = {}
-        for sample in qrels:
-            corpus_ids = sample.get("corpus-id")
-            if sample["query-id"] not in qrels_mapping:
-                qrels_mapping[sample["query-id"]] = set()
-
-            if isinstance(corpus_ids, list):
-                qrels_mapping[sample["query-id"]].update(corpus_ids)
-            else:
-                qrels_mapping[sample["query-id"]].add(corpus_ids)
-
-        def mapper(
-            sample,
-            corpus_mapping: dict[str, str],
-            query_mapping: dict[str, str],
-            qrels_mapping: dict[str, set[str]],
-            rerank_k: int,
-        ):
-            query = query_mapping[sample["query-id"]]
-            positives = [corpus_mapping[positive_id] for positive_id in qrels_mapping[sample["query-id"]]]
-            documents = [corpus_mapping[document_id] for document_id in sample["corpus-ids"][:rerank_k]]
-            return {
-                "query": query,
-                "positive": positives,
-                "documents": documents,
-            }
-
-        relevance = bm25.map(
-            mapper,
-            fn_kwargs={
-                "corpus_mapping": corpus_mapping,
-                "query_mapping": query_mapping,
-                "qrels_mapping": qrels_mapping,
-                "rerank_k": self.rerank_k,
-            },
+        super().__init__(
+            dataset_names=[str(name) for name in dataset_names],
+            dataset_id=dataset_id,
+            rerank_k=rerank_k,
+            at_k=at_k,
+            always_rerank_positives=always_rerank_positives,
+            batch_size=batch_size,
+            show_progress_bar=show_progress_bar,
+            write_csv=write_csv,
+            aggregate_fn=aggregate_fn,
+            aggregate_key=aggregate_key,
+            dataset_name_to_human_readable=DATASET_NAME_TO_HUMAN_READABLE,
+            split_prefix="Nano",
+            strict_dataset_name_validation=True,
+            auto_expand_splits_when_dataset_names_none=False,
+            candidate_subset_name=candidate_subset_name,
+            bm25_subset_name=bm25_subset_name,
+            retrieved_corpus_ids_column=retrieved_corpus_ids_column,
+            name="NanoBEIR",
         )
 
-        human_readable_name = self._get_human_readable_name(dataset_name)
-        return CrossEncoderRerankingEvaluator(
-            samples=list(relevance),
-            name=human_readable_name,
-            **ir_evaluator_kwargs,
-        )
-
-    def _load_dataset_subset_split(self, subset: str, split: str, required_columns: list[str]):
-        if not is_datasets_available():
-            raise ValueError(
-                "datasets is not available. Please install it to use the CrossEncoderNanoBEIREvaluator via `pip install datasets`."
-            )
-        from datasets import load_dataset
-
-        try:
-            dataset = load_dataset(self.dataset_id, subset, split=split)
-        except Exception as e:
-            raise ValueError(
-                f"Could not load subset '{subset}' split '{split}' from dataset '{self.dataset_id}'."
-            ) from e
-
-        if missing_columns := set(required_columns) - set(dataset.column_names):
-            raise ValueError(
-                f"Subset '{subset}' split '{split}' from dataset '{self.dataset_id}' is missing required columns: {list(missing_columns)}."
-            )
-        return dataset
-
-    def _validate_dataset_names(self):
+    def _validate_dataset_names(self) -> None:
         if len(self.dataset_names) == 0:
             raise ValueError("dataset_names cannot be empty. Use None to evaluate on all datasets.")
+
         missing_datasets = [
             dataset_name
             for dataset_name in self.dataset_names
@@ -415,11 +136,16 @@ class CrossEncoderNanoBEIREvaluator(SentenceEvaluator):
                 f"Valid dataset names are: {list(DATASET_NAME_TO_HUMAN_READABLE.keys())}"
             )
 
-    def get_config_dict(self):
-        return {
+    def get_config_dict(self) -> dict[str, Any]:
+        config_dict: dict[str, Any] = {
             "dataset_names": self.dataset_names,
             "dataset_id": self.dataset_id,
             "rerank_k": self.rerank_k,
             "at_k": self.at_k,
             "always_rerank_positives": self.always_rerank_positives,
+            "candidate_subset_name": self.candidate_subset_name,
+            "retrieved_corpus_ids_column": self.retrieved_corpus_ids_column,
         }
+        if self._bm25_subset_name_alias_input is not None:
+            config_dict["bm25_subset_name"] = self.candidate_subset_name
+        return config_dict

--- a/sentence_transformers/cross_encoder/evaluation/nano_beir.py
+++ b/sentence_transformers/cross_encoder/evaluation/nano_beir.py
@@ -224,7 +224,6 @@ class CrossEncoderNanoBEIREvaluator(SentenceEvaluator):
         self.name = f"{self._get_evaluator_name_root()}_R{rerank_k:d}_{self.aggregate_key}"
 
         self._validate_dataset_names()
-        self._validate_mapping_splits()
 
         reranking_kwargs = {
             "at_k": self.at_k,
@@ -331,25 +330,13 @@ class CrossEncoderNanoBEIREvaluator(SentenceEvaluator):
     ) -> CrossEncoderRerankingEvaluator:
         split_name = self._get_split_name(dataset_name)
 
-        corpus = self._load_dataset_subset_split(
-            self._get_corpus_subset_name(),
-            split=split_name,
-            required_columns=["_id", "text"],
-        )
-        queries = self._load_dataset_subset_split(
-            self._get_queries_subset_name(),
-            split=split_name,
-            required_columns=["_id", "text"],
-        )
-        qrels = self._load_dataset_subset_split(
-            self._get_qrels_subset_name(),
-            split=split_name,
-            required_columns=["query-id", "corpus-id"],
-        )
+        corpus = self._load_dataset_subset_split("corpus", split=split_name, required_columns=["_id", "text"])
+        queries = self._load_dataset_subset_split("queries", split=split_name, required_columns=["_id", "text"])
+        qrels = self._load_dataset_subset_split("qrels", split=split_name, required_columns=["query-id", "corpus-id"])
         bm25 = self._load_dataset_subset_split(
-            self._get_candidate_subset_name(),
+            "bm25",
             split=split_name,
-            required_columns=["query-id", self._get_retrieved_corpus_ids_column()],
+            required_columns=["query-id", "corpus-ids"],
         )
 
         corpus_mapping = dict(zip(corpus["_id"], corpus["text"]))
@@ -374,11 +361,10 @@ class CrossEncoderNanoBEIREvaluator(SentenceEvaluator):
             query_mapping: dict[str, str],
             qrels_mapping: dict[str, set[str]],
             rerank_k: int,
-            retrieved_corpus_ids_column: str,
         ):
             query = query_mapping[sample["query-id"]]
             positives = [corpus_mapping[positive_id] for positive_id in qrels_mapping[sample["query-id"]]]
-            documents = [corpus_mapping[document_id] for document_id in sample[retrieved_corpus_ids_column][:rerank_k]]
+            documents = [corpus_mapping[document_id] for document_id in sample["corpus-ids"][:rerank_k]]
             return {
                 "query": query,
                 "positive": positives,
@@ -392,7 +378,6 @@ class CrossEncoderNanoBEIREvaluator(SentenceEvaluator):
                 "query_mapping": query_mapping,
                 "qrels_mapping": qrels_mapping,
                 "rerank_k": self.rerank_k,
-                "retrieved_corpus_ids_column": self._get_retrieved_corpus_ids_column(),
             },
         )
 
@@ -453,28 +438,10 @@ class CrossEncoderNanoBEIREvaluator(SentenceEvaluator):
     def _get_split_name(self, dataset_name: DatasetNameType | str) -> str:
         return f"Nano{DATASET_NAME_TO_HUMAN_READABLE[dataset_name.lower()]}"
 
-    def _get_corpus_subset_name(self) -> str:
-        return "corpus"
-
-    def _get_queries_subset_name(self) -> str:
-        return "queries"
-
-    def _get_qrels_subset_name(self) -> str:
-        return "qrels"
-
-    def _get_candidate_subset_name(self) -> str:
-        return "bm25"
-
-    def _get_retrieved_corpus_ids_column(self) -> str:
-        return "corpus-ids"
-
     def _parse_evaluation_key(self, evaluator_name: str, full_key: str) -> tuple[str, str]:
         del evaluator_name
         _dataset, _rerank_k, metric = full_key.split("_", maxsplit=2)
         return full_key, metric
-
-    def _validate_mapping_splits(self) -> None:
-        pass
 
     def _validate_retrieval_references(
         self,

--- a/sentence_transformers/cross_encoder/evaluation/nano_beir.py
+++ b/sentence_transformers/cross_encoder/evaluation/nano_beir.py
@@ -209,7 +209,7 @@ class CrossEncoderNanoBEIREvaluator(SentenceEvaluator):
     ):
         super().__init__()
         if dataset_names is None:
-            dataset_names = self._get_default_dataset_names()
+            dataset_names = [key for key in DATASET_NAME_TO_HUMAN_READABLE if key not in ["arguana", "touche2020"]]
         self.dataset_names = dataset_names
         self.dataset_id = dataset_id
         self.rerank_k = rerank_k
@@ -221,7 +221,7 @@ class CrossEncoderNanoBEIREvaluator(SentenceEvaluator):
         self.aggregate_fn = aggregate_fn
         self.aggregate_key = aggregate_key
 
-        self.name = f"{self._get_evaluator_name_root()}_R{rerank_k:d}_{self.aggregate_key}"
+        self.name = f"{self.description}_R{rerank_k:d}_{self.aggregate_key}"
 
         self._validate_dataset_names()
 
@@ -235,10 +235,10 @@ class CrossEncoderNanoBEIREvaluator(SentenceEvaluator):
 
         self.evaluators = [
             self._load_dataset(name, **reranking_kwargs)
-            for name in tqdm(self.dataset_names, desc=self._get_loading_description(), leave=False)
+            for name in tqdm(self.dataset_names, desc=f"Loading {self.description} datasets", leave=False)
         ]
 
-        self.csv_file: str = f"{self._get_evaluator_name_root()}_evaluation_{aggregate_key}_results.csv"
+        self.csv_file: str = f"{self.description}_evaluation_{aggregate_key}_results.csv"
         self.csv_headers = ["epoch", "steps", "MAP", f"MRR@{self.at_k}", f"NDCG@{self.at_k}"]
 
         self.primary_metric = f"ndcg@{self.at_k}"
@@ -255,9 +255,7 @@ class CrossEncoderNanoBEIREvaluator(SentenceEvaluator):
                 out_txt = f" in epoch {epoch} after {steps} steps"
         else:
             out_txt = ""
-        logger.info(
-            f"{self._get_evaluation_description()} Evaluation of the model on {self.dataset_names} dataset{out_txt}:"
-        )
+        logger.info(f"{self.description} Evaluation of the model on {self.dataset_names} dataset{out_txt}:")
 
         for evaluator in tqdm(self.evaluators, desc="Evaluating datasets", disable=not self.show_progress_bar):
             logger.info(f"Evaluating {evaluator.name}")
@@ -388,6 +386,10 @@ class CrossEncoderNanoBEIREvaluator(SentenceEvaluator):
             **ir_evaluator_kwargs,
         )
 
+    @property
+    def description(self) -> str:
+        return "NanoBEIR"
+
     def _load_dataset_subset_split(self, subset: str, split: str, required_columns: list[str]):
         if not is_datasets_available():
             raise ValueError(
@@ -421,19 +423,6 @@ class CrossEncoderNanoBEIREvaluator(SentenceEvaluator):
                 f"Dataset(s) {missing_datasets} are not valid NanoBEIR datasets. "
                 f"Valid dataset names are: {list(DATASET_NAME_TO_HUMAN_READABLE.keys())}"
             )
-
-    def _get_default_dataset_names(self) -> list[str]:
-        # We exclude arguana and touche2020 because their Argument Retrieval meaningfully task differs from the others
-        return [key for key in DATASET_NAME_TO_HUMAN_READABLE if key not in ["arguana", "touche2020"]]
-
-    def _get_evaluator_name_root(self) -> str:
-        return "NanoBEIR"
-
-    def _get_evaluation_description(self) -> str:
-        return "NanoBEIR"
-
-    def _get_loading_description(self) -> str:
-        return "Loading NanoBEIR datasets"
 
     def _get_split_name(self, dataset_name: DatasetNameType | str) -> str:
         return f"Nano{DATASET_NAME_TO_HUMAN_READABLE[dataset_name.lower()]}"

--- a/sentence_transformers/cross_encoder/evaluation/nano_beir.py
+++ b/sentence_transformers/cross_encoder/evaluation/nano_beir.py
@@ -427,8 +427,7 @@ class CrossEncoderNanoBEIREvaluator(SentenceEvaluator):
     def _get_split_name(self, dataset_name: DatasetNameType | str) -> str:
         return f"Nano{DATASET_NAME_TO_HUMAN_READABLE[dataset_name.lower()]}"
 
-    def _parse_evaluation_key(self, evaluator_name: str, full_key: str) -> tuple[str, str]:
-        del evaluator_name
+    def _parse_evaluation_key(self, _evaluator_name: str, full_key: str) -> tuple[str, str]:
         _dataset, _rerank_k, metric = full_key.split("_", maxsplit=2)
         return full_key, metric
 

--- a/sentence_transformers/cross_encoder/evaluation/nano_beir.py
+++ b/sentence_transformers/cross_encoder/evaluation/nano_beir.py
@@ -1,11 +1,21 @@
 from __future__ import annotations
 
+import logging
+import os
 from collections.abc import Callable
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Literal
 
 import numpy as np
+from tqdm import tqdm
 
-from sentence_transformers.cross_encoder.evaluation.nano_evaluator import CrossEncoderNanoEvaluator
+from sentence_transformers.cross_encoder.evaluation.reranking import CrossEncoderRerankingEvaluator
+from sentence_transformers.evaluation.SentenceEvaluator import SentenceEvaluator
+from sentence_transformers.util import is_datasets_available
+
+if TYPE_CHECKING:
+    from sentence_transformers.cross_encoder.CrossEncoder import CrossEncoder
+
+logger = logging.getLogger(__name__)
 
 DatasetNameType = Literal[
     "climatefever",
@@ -23,7 +33,7 @@ DatasetNameType = Literal[
     "touche2020",
 ]
 
-DATASET_NAME_TO_HUMAN_READABLE: dict[str, str] = {
+DATASET_NAME_TO_HUMAN_READABLE = {
     "climatefever": "ClimateFEVER",
     "dbpedia": "DBPedia",
     "fever": "FEVER",
@@ -40,7 +50,7 @@ DATASET_NAME_TO_HUMAN_READABLE: dict[str, str] = {
 }
 
 
-class CrossEncoderNanoBEIREvaluator(CrossEncoderNanoEvaluator):
+class CrossEncoderNanoBEIREvaluator(SentenceEvaluator):
     """
     This class evaluates a CrossEncoder model on the NanoBEIR collection of Information Retrieval datasets.
 
@@ -57,10 +67,6 @@ class CrossEncoderNanoBEIREvaluator(CrossEncoderNanoEvaluator):
     Note that the maximum score is 1.0 by default, because all positive documents are included in the ranking. This
     can be toggled off by setting ``always_rerank_positives=False``, at which point the maximum score will be bound by
     the number of positive documents that BM25 ranks in the top ``rerank_k`` documents.
-
-    This class preserves the NanoBEIR short-name API and delegates shared, dataset-agnostic mechanics to
-    :class:`~sentence_transformers.cross_encoder.evaluation.CrossEncoderNanoEvaluator`.
-    For generic non-NanoBEIR behavior and advanced subset options, see that base class.
 
     .. note::
         This evaluator outputs its results using keys in the format ``NanoBEIR_R{rerank_k}_{aggregate_key}_{metric}``,
@@ -98,7 +104,7 @@ class CrossEncoderNanoBEIREvaluator(CrossEncoderNanoEvaluator):
             the positives that are already in the documents list. Always set to True if your ``samples`` contain ``negative``
             instead of ``documents``. When using ``documents``, setting this to True will result in a more useful evaluation
             signal, but setting it to False will result in a more realistic evaluation. Defaults to True.
-        batch_size (int): Batch size to compute sentence embeddings. Defaults to 32.
+        batch_size (int): Batch size to compute sentence embeddings. Defaults to 64.
         show_progress_bar (bool): Show progress bar when computing embeddings. Defaults to False.
         write_csv (bool): Write results to CSV file. Defaults to True.
         aggregate_fn (Callable[[list[float]], float]): The function to aggregate the scores. Defaults to np.mean.
@@ -186,6 +192,8 @@ class CrossEncoderNanoBEIREvaluator(CrossEncoderNanoEvaluator):
             pprint({key: value for key, value in results.items() if "ndcg@10" in key})
     """
 
+    reranking_evaluator_class = CrossEncoderRerankingEvaluator
+
     def __init__(
         self,
         dataset_names: list[DatasetNameType | str] | None = None,
@@ -198,40 +206,226 @@ class CrossEncoderNanoBEIREvaluator(CrossEncoderNanoEvaluator):
         write_csv: bool = True,
         aggregate_fn: Callable[[list[float]], float] = np.mean,
         aggregate_key: str = "mean",
-        candidate_subset_name: str = "bm25",
-        bm25_subset_name: str | None = None,
-        retrieved_corpus_ids_column: str = "corpus-ids",
-    ) -> None:
+    ):
+        super().__init__()
         if dataset_names is None:
-            dataset_names = [
-                key for key in DATASET_NAME_TO_HUMAN_READABLE.keys() if key not in ["arguana", "touche2020"]
-            ]
+            dataset_names = self._get_default_dataset_names()
+        self.dataset_names = dataset_names
+        self.dataset_id = dataset_id
+        self.rerank_k = rerank_k
+        self.at_k = at_k
+        self.always_rerank_positives = always_rerank_positives
+        self.show_progress_bar = show_progress_bar
+        self.batch_size = batch_size
+        self.write_csv = write_csv
+        self.aggregate_fn = aggregate_fn
+        self.aggregate_key = aggregate_key
 
-        super().__init__(
-            dataset_names=[str(name) for name in dataset_names],
-            dataset_id=dataset_id,
-            rerank_k=rerank_k,
-            at_k=at_k,
-            always_rerank_positives=always_rerank_positives,
-            batch_size=batch_size,
-            show_progress_bar=show_progress_bar,
-            write_csv=write_csv,
-            aggregate_fn=aggregate_fn,
-            aggregate_key=aggregate_key,
-            dataset_name_to_human_readable=DATASET_NAME_TO_HUMAN_READABLE,
-            split_prefix="Nano",
-            strict_dataset_name_validation=True,
-            auto_expand_splits_when_dataset_names_none=False,
-            candidate_subset_name=candidate_subset_name,
-            bm25_subset_name=bm25_subset_name,
-            retrieved_corpus_ids_column=retrieved_corpus_ids_column,
-            name="NanoBEIR",
+        self.name = f"{self._get_evaluator_name_root()}_R{rerank_k:d}_{self.aggregate_key}"
+
+        self._validate_dataset_names()
+        self._validate_mapping_splits()
+
+        reranking_kwargs = {
+            "at_k": self.at_k,
+            "always_rerank_positives": self.always_rerank_positives,
+            "show_progress_bar": self.show_progress_bar,
+            "batch_size": self.batch_size,
+            "write_csv": self.write_csv,
+        }
+
+        self.evaluators = [
+            self._load_dataset(name, **reranking_kwargs)
+            for name in tqdm(self.dataset_names, desc=self._get_loading_description(), leave=False)
+        ]
+
+        self.csv_file: str = f"{self._get_evaluator_name_root()}_evaluation_{aggregate_key}_results.csv"
+        self.csv_headers = ["epoch", "steps", "MAP", f"MRR@{self.at_k}", f"NDCG@{self.at_k}"]
+
+        self.primary_metric = f"ndcg@{self.at_k}"
+
+    def __call__(
+        self, model: CrossEncoder, output_path: str | None = None, epoch: int = -1, steps: int = -1, *args, **kwargs
+    ) -> dict[str, float]:
+        per_metric_results = {}
+        per_dataset_results = {}
+        if epoch != -1:
+            if steps == -1:
+                out_txt = f" after epoch {epoch}"
+            else:
+                out_txt = f" in epoch {epoch} after {steps} steps"
+        else:
+            out_txt = ""
+        logger.info(
+            f"{self._get_evaluation_description()} Evaluation of the model on {self.dataset_names} dataset{out_txt}:"
         )
 
-    def _validate_dataset_names(self) -> None:
+        for evaluator in tqdm(self.evaluators, desc="Evaluating datasets", disable=not self.show_progress_bar):
+            logger.info(f"Evaluating {evaluator.name}")
+            evaluation = evaluator(model, output_path, epoch, steps)
+            for full_key, metric_value in evaluation.items():
+                result_key, metric = self._parse_evaluation_key(evaluator.name, full_key)
+                if metric not in per_metric_results:
+                    per_metric_results[metric] = []
+                per_dataset_results[result_key] = metric_value
+                per_metric_results[metric].append(metric_value)
+            logger.info("")
+
+        agg_results = {}
+        for metric in per_metric_results:
+            agg_results[metric] = self.aggregate_fn(per_metric_results[metric])
+
+        if output_path is not None and self.write_csv:
+            os.makedirs(output_path, exist_ok=True)
+            csv_path = os.path.join(output_path, self.csv_file)
+            if not os.path.isfile(csv_path):
+                fOut = open(csv_path, mode="w", encoding="utf-8")
+                fOut.write(",".join(self.csv_headers))
+                fOut.write("\n")
+
+            else:
+                fOut = open(csv_path, mode="a", encoding="utf-8")
+
+            output_data = [
+                epoch,
+                steps,
+                agg_results["map"],
+                agg_results[f"mrr@{self.at_k}"],
+                agg_results[f"ndcg@{self.at_k}"],
+            ]
+
+            fOut.write(",".join(map(str, output_data)))
+            fOut.write("\n")
+            fOut.close()
+
+        logger.info("CrossEncoderNanoBEIREvaluator: Aggregated Results:")
+        logger.info(f"{' ' * len(str(self.at_k))}       Base  -> Reranked")
+        logger.info(
+            f"MAP:{' ' * len(str(self.at_k))}   {agg_results['base_map'] * 100:.2f} -> {agg_results['map'] * 100:.2f}"
+        )
+        logger.info(
+            f"MRR@{self.at_k}:  {agg_results[f'base_mrr@{self.at_k}'] * 100:.2f} -> {agg_results[f'mrr@{self.at_k}'] * 100:.2f}"
+        )
+        logger.info(
+            f"NDCG@{self.at_k}: {agg_results[f'base_ndcg@{self.at_k}'] * 100:.2f} -> {agg_results[f'ndcg@{self.at_k}'] * 100:.2f}"
+        )
+
+        model_card_metrics = {
+            "map": f"{agg_results['map']:.4f} ({agg_results['map'] - agg_results['base_map']:+.4f})",
+            f"mrr@{self.at_k}": f"{agg_results[f'mrr@{self.at_k}']:.4f} ({agg_results[f'mrr@{self.at_k}'] - agg_results[f'base_mrr@{self.at_k}']:+.4f})",
+            f"ndcg@{self.at_k}": f"{agg_results[f'ndcg@{self.at_k}']:.4f} ({agg_results[f'ndcg@{self.at_k}'] - agg_results[f'base_ndcg@{self.at_k}']:+.4f})",
+        }
+        model_card_metrics = self.prefix_name_to_metrics(model_card_metrics, self.name)
+        self.store_metrics_in_model_card_data(model, model_card_metrics, epoch, steps)
+
+        agg_results = self.prefix_name_to_metrics(agg_results, self.name)
+        per_dataset_results.update(agg_results)
+
+        return per_dataset_results
+
+    def _get_human_readable_name(self, dataset_name: DatasetNameType | str) -> str:
+        return f"{self._get_split_name(dataset_name)}_R{self.rerank_k}"
+
+    def _load_dataset(
+        self, dataset_name: DatasetNameType | str, **ir_evaluator_kwargs
+    ) -> CrossEncoderRerankingEvaluator:
+        split_name = self._get_split_name(dataset_name)
+
+        corpus = self._load_dataset_subset_split(
+            self._get_corpus_subset_name(),
+            split=split_name,
+            required_columns=["_id", "text"],
+        )
+        queries = self._load_dataset_subset_split(
+            self._get_queries_subset_name(),
+            split=split_name,
+            required_columns=["_id", "text"],
+        )
+        qrels = self._load_dataset_subset_split(
+            self._get_qrels_subset_name(),
+            split=split_name,
+            required_columns=["query-id", "corpus-id"],
+        )
+        bm25 = self._load_dataset_subset_split(
+            self._get_candidate_subset_name(),
+            split=split_name,
+            required_columns=["query-id", self._get_retrieved_corpus_ids_column()],
+        )
+
+        corpus_mapping = dict(zip(corpus["_id"], corpus["text"]))
+        query_mapping = dict(zip(queries["_id"], queries["text"]))
+        qrels_mapping = {}
+        for sample in qrels:
+            corpus_ids = sample.get("corpus-id")
+            if sample["query-id"] not in qrels_mapping:
+                qrels_mapping[sample["query-id"]] = set()
+
+            if isinstance(corpus_ids, list):
+                qrels_mapping[sample["query-id"]].update(corpus_ids)
+            else:
+                qrels_mapping[sample["query-id"]].add(corpus_ids)
+        self._validate_retrieval_references(
+            dataset_name, split_name, query_mapping, corpus_mapping, qrels_mapping, bm25
+        )
+
+        def mapper(
+            sample,
+            corpus_mapping: dict[str, str],
+            query_mapping: dict[str, str],
+            qrels_mapping: dict[str, set[str]],
+            rerank_k: int,
+            retrieved_corpus_ids_column: str,
+        ):
+            query = query_mapping[sample["query-id"]]
+            positives = [corpus_mapping[positive_id] for positive_id in qrels_mapping[sample["query-id"]]]
+            documents = [corpus_mapping[document_id] for document_id in sample[retrieved_corpus_ids_column][:rerank_k]]
+            return {
+                "query": query,
+                "positive": positives,
+                "documents": documents,
+            }
+
+        relevance = bm25.map(
+            mapper,
+            fn_kwargs={
+                "corpus_mapping": corpus_mapping,
+                "query_mapping": query_mapping,
+                "qrels_mapping": qrels_mapping,
+                "rerank_k": self.rerank_k,
+                "retrieved_corpus_ids_column": self._get_retrieved_corpus_ids_column(),
+            },
+        )
+
+        human_readable_name = self._get_human_readable_name(dataset_name)
+        return self.reranking_evaluator_class(
+            samples=list(relevance),
+            name=human_readable_name,
+            **ir_evaluator_kwargs,
+        )
+
+    def _load_dataset_subset_split(self, subset: str, split: str, required_columns: list[str]):
+        if not is_datasets_available():
+            raise ValueError(
+                "datasets is not available. Please install it to use the CrossEncoderNanoBEIREvaluator via `pip install datasets`."
+            )
+        from datasets import load_dataset
+
+        try:
+            dataset = load_dataset(self.dataset_id, subset, split=split)
+        except Exception as e:
+            raise ValueError(
+                f"Could not load subset '{subset}' split '{split}' from dataset '{self.dataset_id}'."
+            ) from e
+
+        if missing_columns := set(required_columns) - set(dataset.column_names):
+            raise ValueError(
+                f"Subset '{subset}' split '{split}' from dataset '{self.dataset_id}' is missing required columns: {list(missing_columns)}."
+            )
+        return dataset
+
+    def _validate_dataset_names(self):
         if len(self.dataset_names) == 0:
             raise ValueError("dataset_names cannot be empty. Use None to evaluate on all datasets.")
-
         missing_datasets = [
             dataset_name
             for dataset_name in self.dataset_names
@@ -243,16 +437,61 @@ class CrossEncoderNanoBEIREvaluator(CrossEncoderNanoEvaluator):
                 f"Valid dataset names are: {list(DATASET_NAME_TO_HUMAN_READABLE.keys())}"
             )
 
-    def get_config_dict(self) -> dict[str, Any]:
-        config_dict: dict[str, Any] = {
+    def _get_default_dataset_names(self) -> list[str]:
+        # We exclude arguana and touche2020 because their Argument Retrieval meaningfully task differs from the others
+        return [key for key in DATASET_NAME_TO_HUMAN_READABLE if key not in ["arguana", "touche2020"]]
+
+    def _get_evaluator_name_root(self) -> str:
+        return "NanoBEIR"
+
+    def _get_evaluation_description(self) -> str:
+        return "NanoBEIR"
+
+    def _get_loading_description(self) -> str:
+        return "Loading NanoBEIR datasets"
+
+    def _get_split_name(self, dataset_name: DatasetNameType | str) -> str:
+        return f"Nano{DATASET_NAME_TO_HUMAN_READABLE[dataset_name.lower()]}"
+
+    def _get_corpus_subset_name(self) -> str:
+        return "corpus"
+
+    def _get_queries_subset_name(self) -> str:
+        return "queries"
+
+    def _get_qrels_subset_name(self) -> str:
+        return "qrels"
+
+    def _get_candidate_subset_name(self) -> str:
+        return "bm25"
+
+    def _get_retrieved_corpus_ids_column(self) -> str:
+        return "corpus-ids"
+
+    def _parse_evaluation_key(self, evaluator_name: str, full_key: str) -> tuple[str, str]:
+        del evaluator_name
+        _dataset, _rerank_k, metric = full_key.split("_", maxsplit=2)
+        return full_key, metric
+
+    def _validate_mapping_splits(self) -> None:
+        pass
+
+    def _validate_retrieval_references(
+        self,
+        dataset_name: DatasetNameType | str,
+        split_name: str,
+        query_mapping: dict[str, str],
+        corpus_mapping: dict[str, str],
+        qrels_mapping: dict[str, set[str]],
+        retrieved,
+    ) -> None:
+        pass
+
+    def get_config_dict(self):
+        return {
             "dataset_names": self.dataset_names,
             "dataset_id": self.dataset_id,
             "rerank_k": self.rerank_k,
             "at_k": self.at_k,
             "always_rerank_positives": self.always_rerank_positives,
-            "candidate_subset_name": self.candidate_subset_name,
-            "retrieved_corpus_ids_column": self.retrieved_corpus_ids_column,
         }
-        if self._bm25_subset_name_alias_input is not None:
-            config_dict["bm25_subset_name"] = self.candidate_subset_name
-        return config_dict

--- a/sentence_transformers/cross_encoder/evaluation/nano_beir.py
+++ b/sentence_transformers/cross_encoder/evaluation/nano_beir.py
@@ -331,11 +331,7 @@ class CrossEncoderNanoBEIREvaluator(SentenceEvaluator):
         corpus = self._load_dataset_subset_split("corpus", split=split_name, required_columns=["_id", "text"])
         queries = self._load_dataset_subset_split("queries", split=split_name, required_columns=["_id", "text"])
         qrels = self._load_dataset_subset_split("qrels", split=split_name, required_columns=["query-id", "corpus-id"])
-        bm25 = self._load_dataset_subset_split(
-            "bm25",
-            split=split_name,
-            required_columns=["query-id", "corpus-ids"],
-        )
+        bm25 = self._load_dataset_subset_split("bm25", split=split_name, required_columns=["query-id", "corpus-ids"])
 
         corpus_mapping = dict(zip(corpus["_id"], corpus["text"]))
         query_mapping = dict(zip(queries["_id"], queries["text"]))

--- a/sentence_transformers/cross_encoder/evaluation/nano_evaluator.py
+++ b/sentence_transformers/cross_encoder/evaluation/nano_evaluator.py
@@ -19,7 +19,43 @@ logger = logging.getLogger(__name__)
 
 
 class CrossEncoderNanoEvaluator(SentenceEvaluator):
-    """Generic cross-encoder evaluator for Nano-style IR datasets on Hugging Face."""
+    """
+    Generic cross-encoder evaluator for Nano-style IR datasets on Hugging Face.
+
+    This evaluator expects ``corpus``, ``queries``, ``qrels``, and a first-stage
+    candidate subset (``candidate_subset_name``, default ``bm25``). It reranks the
+    top ``rerank_k`` candidates per query and reports MAP / MRR@k / nDCG@k via
+    :class:`~sentence_transformers.cross_encoder.evaluation.CrossEncoderRerankingEvaluator`.
+
+    Dataset-name handling supports both mapping mode (short name -> split name)
+    and direct split mode, mirroring :class:`~sentence_transformers.evaluation.NanoEvaluator`.
+
+    The deprecated ``bm25_subset_name`` alias is still accepted for backward
+    compatibility and mapped to ``candidate_subset_name``.
+
+    Args:
+        dataset_names (list[str] | None): Dataset names or split names to evaluate.
+        dataset_id (str): Hugging Face dataset ID.
+        rerank_k (int): Number of candidates reranked per query.
+        at_k (int): Metric cutoff for MRR/nDCG.
+        always_rerank_positives (bool): Whether to enforce positives in rerank pool.
+        batch_size (int): Evaluation batch size.
+        show_progress_bar (bool): Whether to show progress bars.
+        write_csv (bool): Whether to write aggregated metrics CSV.
+        aggregate_fn (Callable[[list[float]], float]): Aggregation function across datasets.
+        aggregate_key (str): Aggregate metric key prefix.
+        dataset_name_to_human_readable (Mapping[str, str] | None): Optional short-name mapping.
+        split_prefix (str): Optional split prefix applied in mapping mode.
+        strict_dataset_name_validation (bool): Whether to validate names strictly against mapping.
+        auto_expand_splits_when_dataset_names_none (bool): Whether to infer dataset names from query splits.
+        corpus_subset_name (str): Subset name for corpus.
+        queries_subset_name (str): Subset name for queries.
+        qrels_subset_name (str): Subset name for qrels.
+        candidate_subset_name (str): First-stage candidate subset name.
+        bm25_subset_name (str | None): Deprecated alias of ``candidate_subset_name``.
+        retrieved_corpus_ids_column (str): Column name containing candidate corpus IDs.
+        name (str | None): Optional base name for aggregate metric prefixes.
+    """
 
     reranking_evaluator_class = CrossEncoderRerankingEvaluator
 

--- a/sentence_transformers/cross_encoder/evaluation/nano_evaluator.py
+++ b/sentence_transformers/cross_encoder/evaluation/nano_evaluator.py
@@ -174,7 +174,7 @@ class CrossEncoderNanoEvaluator(SentenceEvaluator):
             evaluation = evaluator(model, output_path, epoch, steps)
             evaluator_prefix = f"{evaluator.name}_"
             for full_key, metric_value in evaluation.items():
-                # Parse metrics by the concrete sub-evaluator prefix to avoid underscore-splitting bugs.
+                # Metric keys are prefixed with "{evaluator.name}_"; strip that prefix when present.
                 metric = full_key[len(evaluator_prefix) :] if full_key.startswith(evaluator_prefix) else full_key
                 per_metric_results.setdefault(metric, []).append(metric_value)
                 per_dataset_results[full_key] = metric_value
@@ -499,7 +499,7 @@ class CrossEncoderNanoEvaluator(SentenceEvaluator):
             )
 
     def get_config_dict(self) -> dict[str, Any]:
-        return {
+        config_dict: dict[str, Any] = {
             "dataset_names": self.dataset_names,
             "dataset_id": self.dataset_id,
             "rerank_k": self.rerank_k,

--- a/sentence_transformers/cross_encoder/evaluation/nano_evaluator.py
+++ b/sentence_transformers/cross_encoder/evaluation/nano_evaluator.py
@@ -1,0 +1,494 @@
+from __future__ import annotations
+
+import logging
+import os
+from collections.abc import Callable, Mapping
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+from tqdm import tqdm
+
+from sentence_transformers.cross_encoder.evaluation.reranking import CrossEncoderRerankingEvaluator
+from sentence_transformers.evaluation.SentenceEvaluator import SentenceEvaluator
+from sentence_transformers.util import is_datasets_available
+
+if TYPE_CHECKING:
+    from sentence_transformers.cross_encoder.CrossEncoder import CrossEncoder
+
+logger = logging.getLogger(__name__)
+
+
+class CrossEncoderNanoEvaluator(SentenceEvaluator):
+    """Generic cross-encoder evaluator for Nano-style IR datasets on Hugging Face."""
+
+    reranking_evaluator_class = CrossEncoderRerankingEvaluator
+
+    def __init__(
+        self,
+        dataset_names: list[str] | None = None,
+        dataset_id: str = "sentence-transformers/NanoBEIR-en",
+        rerank_k: int = 100,
+        at_k: int = 10,
+        always_rerank_positives: bool = True,
+        batch_size: int = 32,
+        show_progress_bar: bool = False,
+        write_csv: bool = True,
+        aggregate_fn: Callable[[list[float]], float] = np.mean,
+        aggregate_key: str = "mean",
+        dataset_name_to_human_readable: Mapping[str, str] | None = None,
+        split_prefix: str = "",
+        strict_dataset_name_validation: bool = False,
+        auto_expand_splits_when_dataset_names_none: bool = True,
+        corpus_subset_name: str = "corpus",
+        queries_subset_name: str = "queries",
+        qrels_subset_name: str = "qrels",
+        candidate_subset_name: str = "bm25",
+        bm25_subset_name: str | None = None,
+        retrieved_corpus_ids_column: str = "corpus-ids",
+        name: str | None = None,
+    ) -> None:
+        super().__init__()
+
+        self.dataset_id = dataset_id
+        self.dataset_repo_name = dataset_id.split("/")[-1]
+        self.dataset_name_to_human_readable = (
+            dict(dataset_name_to_human_readable) if dataset_name_to_human_readable else None
+        )
+        self.split_prefix = split_prefix
+        self.strict_dataset_name_validation = strict_dataset_name_validation
+        self.auto_expand_splits_when_dataset_names_none = auto_expand_splits_when_dataset_names_none
+
+        self.rerank_k = rerank_k
+        self.at_k = at_k
+        self.always_rerank_positives = always_rerank_positives
+        self.batch_size = batch_size
+        self.show_progress_bar = show_progress_bar
+        self.write_csv = write_csv
+        self.aggregate_fn = aggregate_fn
+        self.aggregate_key = aggregate_key
+
+        self.corpus_subset_name = corpus_subset_name
+        self.queries_subset_name = queries_subset_name
+        self.qrels_subset_name = qrels_subset_name
+        self._bm25_subset_name_alias_input = bm25_subset_name
+        if bm25_subset_name is not None:
+            if candidate_subset_name != "bm25" and bm25_subset_name != candidate_subset_name:
+                raise ValueError(
+                    "Received both candidate_subset_name and bm25_subset_name with different values. "
+                    "Please pass only candidate_subset_name."
+                )
+            logger.warning(
+                "The `bm25_subset_name` parameter is deprecated; please use "
+                f"`candidate_subset_name={bm25_subset_name!r}` instead."
+            )
+            candidate_subset_name = bm25_subset_name
+        self.candidate_subset_name = candidate_subset_name
+        self.retrieved_corpus_ids_column = retrieved_corpus_ids_column
+        self._subset_to_split_names_cache: dict[str, list[str]] = {}
+
+        if dataset_names is None:
+            if not self.auto_expand_splits_when_dataset_names_none:
+                raise ValueError("dataset_names cannot be None when auto split expansion is disabled.")
+            # Queries splits define the evaluation tasks. We expand from this subset by default.
+            dataset_names = self._get_available_splits(self.queries_subset_name)
+
+        self.dataset_names = dataset_names
+        self._validate_dataset_names()
+        self._validate_mapping_splits()
+
+        reranking_kwargs: dict[str, Any] = {
+            "at_k": self.at_k,
+            "always_rerank_positives": self.always_rerank_positives,
+            "show_progress_bar": self.show_progress_bar,
+            "batch_size": self.batch_size,
+            "write_csv": self.write_csv,
+        }
+        self.evaluators = [
+            self._load_dataset(dataset_name, **reranking_kwargs)
+            for dataset_name in tqdm(self.dataset_names, desc="Loading Nano datasets", leave=False)
+        ]
+
+        base_name = name if name is not None else self.dataset_repo_name
+        self.name = f"{base_name}_R{self.rerank_k}_{self.aggregate_key}"
+
+        self.csv_file: str = f"{base_name}_evaluation_{aggregate_key}_results.csv"
+        self.csv_headers = ["epoch", "steps", "MAP", f"MRR@{self.at_k}", f"NDCG@{self.at_k}"]
+        self.primary_metric = f"ndcg@{self.at_k}"
+
+    def __call__(
+        self,
+        model: CrossEncoder,
+        output_path: str | None = None,
+        epoch: int = -1,
+        steps: int = -1,
+        *args: Any,
+        **kwargs: Any,
+    ) -> dict[str, float]:
+        per_metric_results: dict[str, list[float]] = {}
+        per_dataset_results: dict[str, float] = {}
+
+        if epoch != -1:
+            out_txt = f" after epoch {epoch}" if steps == -1 else f" in epoch {epoch} after {steps} steps"
+        else:
+            out_txt = ""
+        logger.info(f"Nano Evaluation of the model on {self.dataset_names} dataset{out_txt}:")
+
+        for evaluator in tqdm(self.evaluators, desc="Evaluating datasets", disable=not self.show_progress_bar):
+            logger.info(f"Evaluating {evaluator.name}")
+            evaluation = evaluator(model, output_path, epoch, steps)
+            evaluator_prefix = f"{evaluator.name}_"
+            for full_key, metric_value in evaluation.items():
+                # Parse metrics by the concrete sub-evaluator prefix to avoid underscore-splitting bugs.
+                metric = full_key[len(evaluator_prefix) :] if full_key.startswith(evaluator_prefix) else full_key
+                per_metric_results.setdefault(metric, []).append(metric_value)
+                per_dataset_results[full_key] = metric_value
+            logger.info("")
+
+        agg_results = {metric: self.aggregate_fn(values) for metric, values in per_metric_results.items()}
+
+        if output_path is not None and self.write_csv:
+            os.makedirs(output_path, exist_ok=True)
+            csv_path = os.path.join(output_path, self.csv_file)
+            output_file_exists = os.path.isfile(csv_path)
+            with open(csv_path, mode="a" if output_file_exists else "w", encoding="utf-8") as file_out:
+                if not output_file_exists:
+                    file_out.write(",".join(self.csv_headers))
+                    file_out.write("\n")
+                output_data: list[int | float] = [
+                    epoch,
+                    steps,
+                    agg_results["map"],
+                    agg_results[f"mrr@{self.at_k}"],
+                    agg_results[f"ndcg@{self.at_k}"],
+                ]
+                file_out.write(",".join(map(str, output_data)))
+                file_out.write("\n")
+
+        logger.info(f"{self.__class__.__name__}: Aggregated Results:")
+        if all(f"base_{metric}" in agg_results for metric in ["map", f"mrr@{self.at_k}", f"ndcg@{self.at_k}"]):
+            logger.info(f"{' ' * len(str(self.at_k))}       Base  -> Reranked")
+            logger.info(
+                f"MAP:{' ' * len(str(self.at_k))}   {agg_results['base_map'] * 100:.2f} -> {agg_results['map'] * 100:.2f}"
+            )
+            logger.info(
+                f"MRR@{self.at_k}:  {agg_results[f'base_mrr@{self.at_k}'] * 100:.2f} -> {agg_results[f'mrr@{self.at_k}'] * 100:.2f}"
+            )
+            logger.info(
+                f"NDCG@{self.at_k}: {agg_results[f'base_ndcg@{self.at_k}'] * 100:.2f} -> {agg_results[f'ndcg@{self.at_k}'] * 100:.2f}"
+            )
+            model_card_metrics = {
+                "map": f"{agg_results['map']:.4f} ({agg_results['map'] - agg_results['base_map']:+.4f})",
+                f"mrr@{self.at_k}": (
+                    f"{agg_results[f'mrr@{self.at_k}']:.4f} "
+                    f"({agg_results[f'mrr@{self.at_k}'] - agg_results[f'base_mrr@{self.at_k}']:+.4f})"
+                ),
+                f"ndcg@{self.at_k}": (
+                    f"{agg_results[f'ndcg@{self.at_k}']:.4f} "
+                    f"({agg_results[f'ndcg@{self.at_k}'] - agg_results[f'base_ndcg@{self.at_k}']:+.4f})"
+                ),
+            }
+        else:
+            logger.info(f"MAP:{' ' * len(str(self.at_k))}   {agg_results['map'] * 100:.2f}")
+            logger.info(f"MRR@{self.at_k}:  {agg_results[f'mrr@{self.at_k}'] * 100:.2f}")
+            logger.info(f"NDCG@{self.at_k}: {agg_results[f'ndcg@{self.at_k}'] * 100:.2f}")
+            model_card_metrics = {
+                "map": agg_results["map"],
+                f"mrr@{self.at_k}": agg_results[f"mrr@{self.at_k}"],
+                f"ndcg@{self.at_k}": agg_results[f"ndcg@{self.at_k}"],
+            }
+
+        model_card_metrics = self.prefix_name_to_metrics(model_card_metrics, self.name)
+        self.store_metrics_in_model_card_data(model, model_card_metrics, epoch, steps)
+
+        agg_results = self.prefix_name_to_metrics(agg_results, self.name)
+        per_dataset_results.update(agg_results)
+        return per_dataset_results
+
+    def _get_dataset_mapping_value(self, dataset_name: str) -> str:
+        if self.dataset_name_to_human_readable is None:
+            raise ValueError("dataset_name_to_human_readable is not configured.")
+
+        if dataset_name in self.dataset_name_to_human_readable:
+            return self.dataset_name_to_human_readable[dataset_name]
+
+        lowered = dataset_name.lower()
+        if lowered in self.dataset_name_to_human_readable:
+            return self.dataset_name_to_human_readable[lowered]
+
+        raise ValueError(
+            f"Dataset '{dataset_name}' does not exist in dataset_name_to_human_readable mapping. "
+            f"Available dataset names are: {list(self.dataset_name_to_human_readable.keys())}"
+        )
+
+    def _get_split_name(self, dataset_name: str) -> str:
+        if self.dataset_name_to_human_readable is None:
+            return dataset_name
+        mapping_value = self._get_dataset_mapping_value(dataset_name)
+        return f"{self.split_prefix}{mapping_value}"
+
+    def _get_human_readable_name(self, dataset_name: str) -> str:
+        split_name = self._get_split_name(dataset_name)
+        if self.dataset_name_to_human_readable is None:
+            human_readable_name = f"{self.dataset_repo_name}_{split_name}"
+        else:
+            human_readable_name = split_name
+        return f"{human_readable_name}_R{self.rerank_k}"
+
+    def _load_dataset(self, dataset_name: str, **reranking_kwargs: Any) -> CrossEncoderRerankingEvaluator:
+        split_name = self._get_split_name(dataset_name)
+
+        corpus = self._load_dataset_subset_split(
+            self.corpus_subset_name,
+            split=split_name,
+            required_columns=["_id", "text"],
+        )
+        queries = self._load_dataset_subset_split(
+            self.queries_subset_name,
+            split=split_name,
+            required_columns=["_id", "text"],
+        )
+        qrels = self._load_dataset_subset_split(
+            self.qrels_subset_name,
+            split=split_name,
+            required_columns=["query-id", "corpus-id"],
+        )
+        retrieved = self._load_dataset_subset_split(
+            self.candidate_subset_name,
+            split=split_name,
+            required_columns=["query-id", self.retrieved_corpus_ids_column],
+        )
+
+        corpus_mapping: dict[str, str] = dict(zip(corpus["_id"], corpus["text"]))
+        query_mapping: dict[str, str] = dict(zip(queries["_id"], queries["text"]))
+        qrels_mapping: dict[str, set[str]] = {}
+        for sample in qrels:
+            corpus_ids = sample.get("corpus-id")
+            qrels_mapping.setdefault(sample["query-id"], set())
+            if isinstance(corpus_ids, list):
+                qrels_mapping[sample["query-id"]].update(corpus_ids)
+            else:
+                qrels_mapping[sample["query-id"]].add(corpus_ids)
+        self._validate_retrieval_references(
+            dataset_name=dataset_name,
+            split_name=split_name,
+            query_mapping=query_mapping,
+            corpus_mapping=corpus_mapping,
+            qrels_mapping=qrels_mapping,
+            retrieved=retrieved,
+        )
+
+        def mapper(
+            sample: dict[str, Any],
+            corpus_mapping: dict[str, str],
+            query_mapping: dict[str, str],
+            qrels_mapping: dict[str, set[str]],
+            rerank_k: int,
+            retrieved_corpus_ids_column: str,
+        ) -> dict[str, str | list[str]]:
+            query_id: str = sample["query-id"]
+            query = query_mapping[query_id]
+            positives = [corpus_mapping[positive_id] for positive_id in qrels_mapping[query_id]]
+            # Keep first-stage retrieval order and trim to top-k candidates for reranking.
+            retrieved_corpus_ids = sample[retrieved_corpus_ids_column]
+            documents = [corpus_mapping[document_id] for document_id in retrieved_corpus_ids[:rerank_k]]
+            return {
+                "query": query,
+                "positive": positives,
+                "documents": documents,
+            }
+
+        relevance = retrieved.map(
+            mapper,
+            fn_kwargs={
+                "corpus_mapping": corpus_mapping,
+                "query_mapping": query_mapping,
+                "qrels_mapping": qrels_mapping,
+                "rerank_k": self.rerank_k,
+                "retrieved_corpus_ids_column": self.retrieved_corpus_ids_column,
+            },
+        )
+
+        human_readable_name = self._get_human_readable_name(dataset_name)
+        return self.reranking_evaluator_class(
+            samples=list(relevance),
+            name=human_readable_name,
+            **reranking_kwargs,
+        )
+
+    def _validate_retrieval_references(
+        self,
+        dataset_name: str,
+        split_name: str,
+        query_mapping: dict[str, str],
+        corpus_mapping: dict[str, str],
+        qrels_mapping: dict[str, set[str]],
+        retrieved: Any,
+    ) -> None:
+        missing_query_ids_in_qrels = [query_id for query_id in qrels_mapping if query_id not in query_mapping]
+        missing_positive_ids = sorted(
+            {
+                corpus_id
+                for corpus_ids in qrels_mapping.values()
+                for corpus_id in corpus_ids
+                if corpus_id not in corpus_mapping
+            }
+        )
+
+        missing_query_ids_in_candidates: set[str] = set()
+        missing_qrels_for_candidates: set[str] = set()
+        missing_retrieved_ids: set[str] = set()
+        for sample in retrieved:
+            query_id = sample["query-id"]
+            if query_id not in query_mapping:
+                missing_query_ids_in_candidates.add(query_id)
+            if query_id not in qrels_mapping:
+                missing_qrels_for_candidates.add(query_id)
+            for document_id in sample[self.retrieved_corpus_ids_column]:
+                if document_id not in corpus_mapping:
+                    missing_retrieved_ids.add(document_id)
+
+        if any(
+            [
+                missing_query_ids_in_qrels,
+                missing_positive_ids,
+                missing_query_ids_in_candidates,
+                missing_qrels_for_candidates,
+                missing_retrieved_ids,
+            ]
+        ):
+            error_details: list[str] = []
+            if missing_query_ids_in_qrels:
+                error_details.append(f"qrels references unknown query IDs: {sorted(missing_query_ids_in_qrels)[:5]}")
+            if missing_positive_ids:
+                error_details.append(f"qrels references unknown corpus IDs: {missing_positive_ids[:5]}")
+            if missing_query_ids_in_candidates:
+                error_details.append(
+                    f"candidate subset references unknown query IDs: {sorted(missing_query_ids_in_candidates)[:5]}"
+                )
+            if missing_qrels_for_candidates:
+                error_details.append(
+                    f"candidate subset contains queries missing in qrels: {sorted(missing_qrels_for_candidates)[:5]}"
+                )
+            if missing_retrieved_ids:
+                error_details.append(
+                    f"candidate subset references unknown corpus IDs: {sorted(missing_retrieved_ids)[:5]}"
+                )
+            raise ValueError(
+                f"Inconsistent IDs found for dataset '{dataset_name}' split '{split_name}' in '{self.dataset_id}'. "
+                + " | ".join(error_details)
+            )
+
+    def _load_dataset_subset_split(self, subset: str, split: str, required_columns: list[str]) -> Any:
+        if not is_datasets_available():
+            raise ValueError(
+                "datasets is not available. Please install it to use the CrossEncoderNanoEvaluator via `pip install datasets`."
+            )
+        from datasets import load_dataset
+
+        try:
+            dataset = load_dataset(self.dataset_id, subset, split=split)
+        except Exception as exc:
+            raise ValueError(
+                f"Could not load subset '{subset}' split '{split}' from dataset '{self.dataset_id}'."
+            ) from exc
+
+        if missing_columns := set(required_columns) - set(dataset.column_names):
+            raise ValueError(
+                f"Subset '{subset}' split '{split}' from dataset '{self.dataset_id}' is missing required columns: {list(missing_columns)}."
+            )
+        return dataset
+
+    def _get_available_splits(self, subset: str) -> list[str]:
+        if subset in self._subset_to_split_names_cache:
+            return self._subset_to_split_names_cache[subset]
+
+        if not is_datasets_available():
+            raise ValueError(
+                "datasets is not available. Please install it to use the CrossEncoderNanoEvaluator via `pip install datasets`."
+            )
+        from datasets import get_dataset_split_names
+
+        try:
+            split_names = get_dataset_split_names(self.dataset_id, subset)
+        except Exception as exc:
+            raise ValueError(
+                f"Could not list split names for subset '{subset}' from dataset '{self.dataset_id}'."
+            ) from exc
+
+        if not split_names:
+            raise ValueError(f"No split names were found for subset '{subset}' in dataset '{self.dataset_id}'.")
+        self._subset_to_split_names_cache[subset] = list(split_names)
+        return self._subset_to_split_names_cache[subset]
+
+    def _validate_split_exists(self, dataset_name: str, subset: str, split_name: str) -> None:
+        available_splits = self._get_available_splits(subset)
+        if split_name not in available_splits:
+            raise ValueError(
+                f"Dataset '{dataset_name}' maps to split '{split_name}', but it does not exist in subset '{subset}' "
+                f"for dataset '{self.dataset_id}'. Available splits: {available_splits}"
+            )
+
+    def _validate_mapping_splits(self) -> None:
+        if self.dataset_name_to_human_readable is None:
+            return
+
+        for dataset_name in self.dataset_names:
+            split_name = self._get_split_name(dataset_name)
+            self._validate_split_exists(dataset_name, self.corpus_subset_name, split_name)
+            self._validate_split_exists(dataset_name, self.queries_subset_name, split_name)
+            self._validate_split_exists(dataset_name, self.qrels_subset_name, split_name)
+            self._validate_split_exists(dataset_name, self.candidate_subset_name, split_name)
+
+    def _validate_dataset_names(self) -> None:
+        if len(self.dataset_names) == 0:
+            raise ValueError("dataset_names cannot be empty. Use None to evaluate on all datasets.")
+
+        if self.dataset_name_to_human_readable is None:
+            return
+
+        if not self.strict_dataset_name_validation:
+            return
+
+        missing_datasets: list[str] = []
+        for dataset_name in self.dataset_names:
+            try:
+                self._get_dataset_mapping_value(dataset_name)
+            except ValueError:
+                missing_datasets.append(dataset_name)
+
+        if missing_datasets:
+            raise ValueError(
+                f"Dataset(s) {missing_datasets} do not exist in dataset_name_to_human_readable mapping. "
+                f"Available dataset names are: {list(self.dataset_name_to_human_readable.keys())}"
+            )
+
+    def get_config_dict(self) -> dict[str, Any]:
+        return {
+            "dataset_names": self.dataset_names,
+            "dataset_id": self.dataset_id,
+            "rerank_k": self.rerank_k,
+            "at_k": self.at_k,
+            "always_rerank_positives": self.always_rerank_positives,
+            "dataset_name_to_human_readable": self.dataset_name_to_human_readable,
+            "split_prefix": self.split_prefix,
+            "strict_dataset_name_validation": self.strict_dataset_name_validation,
+            "auto_expand_splits_when_dataset_names_none": self.auto_expand_splits_when_dataset_names_none,
+            "corpus_subset_name": self.corpus_subset_name,
+            "queries_subset_name": self.queries_subset_name,
+            "qrels_subset_name": self.qrels_subset_name,
+            "candidate_subset_name": self.candidate_subset_name,
+            "retrieved_corpus_ids_column": self.retrieved_corpus_ids_column,
+        }
+        if self._bm25_subset_name_alias_input is not None:
+            config_dict["bm25_subset_name"] = self.candidate_subset_name
+        return config_dict
+
+    def store_metrics_in_model_card_data(
+        self,
+        model: CrossEncoder,
+        metrics: dict[str, Any],
+        epoch: int = 0,
+        step: int = 0,
+    ) -> None:
+        if len(self.dataset_names) > 1:
+            super().store_metrics_in_model_card_data(model, metrics, epoch, step)

--- a/sentence_transformers/cross_encoder/evaluation/nano_evaluator.py
+++ b/sentence_transformers/cross_encoder/evaluation/nano_evaluator.py
@@ -35,8 +35,6 @@ class CrossEncoderNanoEvaluator(_GenericCrossEncoderNanoMixin, CrossEncoderNanoB
         split_prefix: str = "",
         strict_dataset_name_validation: bool = False,
         auto_expand_splits_when_dataset_names_none: bool = True,
-        candidate_subset_name: str = "bm25",
-        bm25_subset_name: str | None = None,
         name: str | None = None,
     ) -> None:
         self._initialize_generic_cross_encoder_state(
@@ -45,12 +43,14 @@ class CrossEncoderNanoEvaluator(_GenericCrossEncoderNanoMixin, CrossEncoderNanoB
             split_prefix=split_prefix,
             strict_dataset_name_validation=strict_dataset_name_validation,
             auto_expand_splits_when_dataset_names_none=auto_expand_splits_when_dataset_names_none,
-            candidate_subset_name=candidate_subset_name,
-            bm25_subset_name=bm25_subset_name,
             name=name,
         )
+        dataset_names = self._resolve_dataset_names(dataset_names)
+        self.dataset_names = dataset_names
+        self._validate_dataset_names()
+        self._validate_mapping_splits()
         super().__init__(
-            dataset_names=self._resolve_dataset_names(dataset_names),
+            dataset_names=dataset_names,
             dataset_id=dataset_id,
             rerank_k=rerank_k,
             at_k=at_k,
@@ -76,12 +76,6 @@ class CrossEncoderNanoEvaluator(_GenericCrossEncoderNanoMixin, CrossEncoderNanoB
         if self.dataset_name_to_human_readable is None:
             return f"{self.evaluator_name}_{split_name}_R{self.rerank_k}"
         return f"{split_name}_R{self.rerank_k}"
-
-    def _get_candidate_subset_name(self) -> str:
-        return self.candidate_subset_name
-
-    def _get_retrieved_corpus_ids_column(self) -> str:
-        return "corpus-ids"
 
     def _parse_evaluation_key(self, evaluator_name: str, full_key: str) -> tuple[str, str]:
         prefix = f"{evaluator_name}_"

--- a/sentence_transformers/cross_encoder/evaluation/nano_evaluator.py
+++ b/sentence_transformers/cross_encoder/evaluation/nano_evaluator.py
@@ -62,14 +62,9 @@ class CrossEncoderNanoEvaluator(_GenericCrossEncoderNanoMixin, CrossEncoderNanoB
             aggregate_key=aggregate_key,
         )
 
-    def _get_evaluator_name_root(self) -> str:
+    @property
+    def description(self) -> str:
         return self.evaluator_name
-
-    def _get_evaluation_description(self) -> str:
-        return "Nano"
-
-    def _get_loading_description(self) -> str:
-        return "Loading Nano datasets"
 
     def _get_human_readable_name(self, dataset_name: str) -> str:
         split_name = self._get_split_name(dataset_name)

--- a/sentence_transformers/cross_encoder/evaluation/nano_evaluator.py
+++ b/sentence_transformers/cross_encoder/evaluation/nano_evaluator.py
@@ -1,63 +1,23 @@
 from __future__ import annotations
 
-import logging
-import os
 from collections.abc import Callable, Mapping
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 import numpy as np
-from tqdm import tqdm
 
-from sentence_transformers.cross_encoder.evaluation.reranking import CrossEncoderRerankingEvaluator
-from sentence_transformers.evaluation.SentenceEvaluator import SentenceEvaluator
-from sentence_transformers.util import is_datasets_available
-
-if TYPE_CHECKING:
-    from sentence_transformers.cross_encoder.CrossEncoder import CrossEncoder
-
-logger = logging.getLogger(__name__)
+from sentence_transformers.cross_encoder.evaluation.nano_beir import CrossEncoderNanoBEIREvaluator
+from sentence_transformers.evaluation._nano_utils import _GenericCrossEncoderNanoMixin
 
 
-class CrossEncoderNanoEvaluator(SentenceEvaluator):
+class CrossEncoderNanoEvaluator(_GenericCrossEncoderNanoMixin, CrossEncoderNanoBEIREvaluator):
     """
-    Generic cross-encoder evaluator for Nano-style IR datasets on Hugging Face.
+    Generic cross-encoder evaluator for Nano-style reranking datasets on Hugging Face.
 
-    This evaluator expects ``corpus``, ``queries``, ``qrels``, and a first-stage
-    candidate subset (``candidate_subset_name``, default ``bm25``). It reranks the
-    top ``rerank_k`` candidates per query and reports MAP / MRR@k / nDCG@k via
-    :class:`~sentence_transformers.cross_encoder.evaluation.CrossEncoderRerankingEvaluator`.
-
-    Dataset-name handling supports both mapping mode (short name -> split name)
-    and direct split mode, mirroring :class:`~sentence_transformers.evaluation.NanoEvaluator`.
-
-    The deprecated ``bm25_subset_name`` alias is still accepted for backward
-    compatibility and mapped to ``candidate_subset_name``.
-
-    Args:
-        dataset_names (list[str] | None): Dataset names or split names to evaluate.
-        dataset_id (str): Hugging Face dataset ID.
-        rerank_k (int): Number of candidates reranked per query.
-        at_k (int): Metric cutoff for MRR/nDCG.
-        always_rerank_positives (bool): Whether to enforce positives in rerank pool.
-        batch_size (int): Evaluation batch size.
-        show_progress_bar (bool): Whether to show progress bars.
-        write_csv (bool): Whether to write aggregated metrics CSV.
-        aggregate_fn (Callable[[list[float]], float]): Aggregation function across datasets.
-        aggregate_key (str): Aggregate metric key prefix.
-        dataset_name_to_human_readable (Mapping[str, str] | None): Optional short-name mapping.
-        split_prefix (str): Optional split prefix applied in mapping mode.
-        strict_dataset_name_validation (bool): Whether to validate names strictly against mapping.
-        auto_expand_splits_when_dataset_names_none (bool): Whether to infer dataset names from query splits.
-        corpus_subset_name (str): Subset name for corpus.
-        queries_subset_name (str): Subset name for queries.
-        qrels_subset_name (str): Subset name for qrels.
-        candidate_subset_name (str): First-stage candidate subset name.
-        bm25_subset_name (str | None): Deprecated alias of ``candidate_subset_name``.
-        retrieved_corpus_ids_column (str): Column name containing candidate corpus IDs.
-        name (str | None): Optional base name for aggregate metric prefixes.
+    This evaluator reuses :class:`~sentence_transformers.cross_encoder.evaluation.CrossEncoderNanoBEIREvaluator`
+    and overrides only dataset/split resolution plus candidate subset handling.
     """
 
-    reranking_evaluator_class = CrossEncoderRerankingEvaluator
+    reranking_evaluator_class = CrossEncoderNanoBEIREvaluator.reranking_evaluator_class
 
     def __init__(
         self,
@@ -83,448 +43,32 @@ class CrossEncoderNanoEvaluator(SentenceEvaluator):
         retrieved_corpus_ids_column: str = "corpus-ids",
         name: str | None = None,
     ) -> None:
-        super().__init__()
-
-        self.dataset_id = dataset_id
-        self.dataset_repo_name = dataset_id.split("/")[-1]
-        self.dataset_name_to_human_readable = (
-            dict(dataset_name_to_human_readable) if dataset_name_to_human_readable else None
+        self._initialize_generic_cross_encoder_state(
+            dataset_id=dataset_id,
+            dataset_name_to_human_readable=dataset_name_to_human_readable,
+            split_prefix=split_prefix,
+            strict_dataset_name_validation=strict_dataset_name_validation,
+            auto_expand_splits_when_dataset_names_none=auto_expand_splits_when_dataset_names_none,
+            corpus_subset_name=corpus_subset_name,
+            queries_subset_name=queries_subset_name,
+            qrels_subset_name=qrels_subset_name,
+            candidate_subset_name=candidate_subset_name,
+            bm25_subset_name=bm25_subset_name,
+            retrieved_corpus_ids_column=retrieved_corpus_ids_column,
+            name=name,
         )
-        self.split_prefix = split_prefix
-        self.strict_dataset_name_validation = strict_dataset_name_validation
-        self.auto_expand_splits_when_dataset_names_none = auto_expand_splits_when_dataset_names_none
-
-        self.rerank_k = rerank_k
-        self.at_k = at_k
-        self.always_rerank_positives = always_rerank_positives
-        self.batch_size = batch_size
-        self.show_progress_bar = show_progress_bar
-        self.write_csv = write_csv
-        self.aggregate_fn = aggregate_fn
-        self.aggregate_key = aggregate_key
-
-        self.corpus_subset_name = corpus_subset_name
-        self.queries_subset_name = queries_subset_name
-        self.qrels_subset_name = qrels_subset_name
-        self._bm25_subset_name_alias_input = bm25_subset_name
-        if bm25_subset_name is not None:
-            if candidate_subset_name != "bm25" and bm25_subset_name != candidate_subset_name:
-                raise ValueError(
-                    "Received both candidate_subset_name and bm25_subset_name with different values. "
-                    "Please pass only candidate_subset_name."
-                )
-            logger.warning(
-                "The `bm25_subset_name` parameter is deprecated; please use "
-                f"`candidate_subset_name={bm25_subset_name!r}` instead."
-            )
-            candidate_subset_name = bm25_subset_name
-        self.candidate_subset_name = candidate_subset_name
-        self.retrieved_corpus_ids_column = retrieved_corpus_ids_column
-        self._subset_to_split_names_cache: dict[str, list[str]] = {}
-
-        if dataset_names is None:
-            if not self.auto_expand_splits_when_dataset_names_none:
-                raise ValueError("dataset_names cannot be None when auto split expansion is disabled.")
-            # Queries splits define the evaluation tasks. We expand from this subset by default.
-            dataset_names = self._get_available_splits(self.queries_subset_name)
-
-        self.dataset_names = dataset_names
-        self._validate_dataset_names()
-        self._validate_mapping_splits()
-
-        reranking_kwargs: dict[str, Any] = {
-            "at_k": self.at_k,
-            "always_rerank_positives": self.always_rerank_positives,
-            "show_progress_bar": self.show_progress_bar,
-            "batch_size": self.batch_size,
-            "write_csv": self.write_csv,
-        }
-        self.evaluators = [
-            self._load_dataset(dataset_name, **reranking_kwargs)
-            for dataset_name in tqdm(self.dataset_names, desc="Loading Nano datasets", leave=False)
-        ]
-
-        base_name = name if name is not None else self.dataset_repo_name
-        self.name = f"{base_name}_R{self.rerank_k}_{self.aggregate_key}"
-
-        self.csv_file: str = f"{base_name}_evaluation_{aggregate_key}_results.csv"
-        self.csv_headers = ["epoch", "steps", "MAP", f"MRR@{self.at_k}", f"NDCG@{self.at_k}"]
-        self.primary_metric = f"ndcg@{self.at_k}"
-
-    def __call__(
-        self,
-        model: CrossEncoder,
-        output_path: str | None = None,
-        epoch: int = -1,
-        steps: int = -1,
-        *args: Any,
-        **kwargs: Any,
-    ) -> dict[str, float]:
-        per_metric_results: dict[str, list[float]] = {}
-        per_dataset_results: dict[str, float] = {}
-
-        if epoch != -1:
-            out_txt = f" after epoch {epoch}" if steps == -1 else f" in epoch {epoch} after {steps} steps"
-        else:
-            out_txt = ""
-        logger.info(f"Nano Evaluation of the model on {self.dataset_names} dataset{out_txt}:")
-
-        for evaluator in tqdm(self.evaluators, desc="Evaluating datasets", disable=not self.show_progress_bar):
-            logger.info(f"Evaluating {evaluator.name}")
-            evaluation = evaluator(model, output_path, epoch, steps)
-            evaluator_prefix = f"{evaluator.name}_"
-            for full_key, metric_value in evaluation.items():
-                # Metric keys are prefixed with "{evaluator.name}_"; strip that prefix when present.
-                metric = full_key[len(evaluator_prefix) :] if full_key.startswith(evaluator_prefix) else full_key
-                per_metric_results.setdefault(metric, []).append(metric_value)
-                per_dataset_results[full_key] = metric_value
-            logger.info("")
-
-        agg_results = {metric: self.aggregate_fn(values) for metric, values in per_metric_results.items()}
-
-        if output_path is not None and self.write_csv:
-            os.makedirs(output_path, exist_ok=True)
-            csv_path = os.path.join(output_path, self.csv_file)
-            output_file_exists = os.path.isfile(csv_path)
-            with open(csv_path, mode="a" if output_file_exists else "w", encoding="utf-8") as file_out:
-                if not output_file_exists:
-                    file_out.write(",".join(self.csv_headers))
-                    file_out.write("\n")
-                output_data: list[int | float] = [
-                    epoch,
-                    steps,
-                    agg_results["map"],
-                    agg_results[f"mrr@{self.at_k}"],
-                    agg_results[f"ndcg@{self.at_k}"],
-                ]
-                file_out.write(",".join(map(str, output_data)))
-                file_out.write("\n")
-
-        logger.info(f"{self.__class__.__name__}: Aggregated Results:")
-        if all(f"base_{metric}" in agg_results for metric in ["map", f"mrr@{self.at_k}", f"ndcg@{self.at_k}"]):
-            logger.info(f"{' ' * len(str(self.at_k))}       Base  -> Reranked")
-            logger.info(
-                f"MAP:{' ' * len(str(self.at_k))}   {agg_results['base_map'] * 100:.2f} -> {agg_results['map'] * 100:.2f}"
-            )
-            logger.info(
-                f"MRR@{self.at_k}:  {agg_results[f'base_mrr@{self.at_k}'] * 100:.2f} -> {agg_results[f'mrr@{self.at_k}'] * 100:.2f}"
-            )
-            logger.info(
-                f"NDCG@{self.at_k}: {agg_results[f'base_ndcg@{self.at_k}'] * 100:.2f} -> {agg_results[f'ndcg@{self.at_k}'] * 100:.2f}"
-            )
-            model_card_metrics = {
-                "map": f"{agg_results['map']:.4f} ({agg_results['map'] - agg_results['base_map']:+.4f})",
-                f"mrr@{self.at_k}": (
-                    f"{agg_results[f'mrr@{self.at_k}']:.4f} "
-                    f"({agg_results[f'mrr@{self.at_k}'] - agg_results[f'base_mrr@{self.at_k}']:+.4f})"
-                ),
-                f"ndcg@{self.at_k}": (
-                    f"{agg_results[f'ndcg@{self.at_k}']:.4f} "
-                    f"({agg_results[f'ndcg@{self.at_k}'] - agg_results[f'base_ndcg@{self.at_k}']:+.4f})"
-                ),
-            }
-        else:
-            logger.info(f"MAP:{' ' * len(str(self.at_k))}   {agg_results['map'] * 100:.2f}")
-            logger.info(f"MRR@{self.at_k}:  {agg_results[f'mrr@{self.at_k}'] * 100:.2f}")
-            logger.info(f"NDCG@{self.at_k}: {agg_results[f'ndcg@{self.at_k}'] * 100:.2f}")
-            model_card_metrics = {
-                "map": agg_results["map"],
-                f"mrr@{self.at_k}": agg_results[f"mrr@{self.at_k}"],
-                f"ndcg@{self.at_k}": agg_results[f"ndcg@{self.at_k}"],
-            }
-
-        model_card_metrics = self.prefix_name_to_metrics(model_card_metrics, self.name)
-        self.store_metrics_in_model_card_data(model, model_card_metrics, epoch, steps)
-
-        agg_results = self.prefix_name_to_metrics(agg_results, self.name)
-        per_dataset_results.update(agg_results)
-        return per_dataset_results
-
-    def _get_dataset_mapping_value(self, dataset_name: str) -> str:
-        if self.dataset_name_to_human_readable is None:
-            raise ValueError("dataset_name_to_human_readable is not configured.")
-
-        if dataset_name in self.dataset_name_to_human_readable:
-            return self.dataset_name_to_human_readable[dataset_name]
-
-        lowered = dataset_name.lower()
-        if lowered in self.dataset_name_to_human_readable:
-            return self.dataset_name_to_human_readable[lowered]
-
-        raise ValueError(
-            f"Dataset '{dataset_name}' does not exist in dataset_name_to_human_readable mapping. "
-            f"Available dataset names are: {list(self.dataset_name_to_human_readable.keys())}"
+        super().__init__(
+            dataset_names=self._resolve_dataset_names(dataset_names),
+            dataset_id=dataset_id,
+            rerank_k=rerank_k,
+            at_k=at_k,
+            always_rerank_positives=always_rerank_positives,
+            batch_size=batch_size,
+            show_progress_bar=show_progress_bar,
+            write_csv=write_csv,
+            aggregate_fn=aggregate_fn,
+            aggregate_key=aggregate_key,
         )
-
-    def _get_split_name(self, dataset_name: str) -> str:
-        if self.dataset_name_to_human_readable is None:
-            return dataset_name
-        mapping_value = self._get_dataset_mapping_value(dataset_name)
-        return f"{self.split_prefix}{mapping_value}"
-
-    def _get_human_readable_name(self, dataset_name: str) -> str:
-        split_name = self._get_split_name(dataset_name)
-        if self.dataset_name_to_human_readable is None:
-            human_readable_name = f"{self.dataset_repo_name}_{split_name}"
-        else:
-            human_readable_name = split_name
-        return f"{human_readable_name}_R{self.rerank_k}"
-
-    def _load_dataset(self, dataset_name: str, **reranking_kwargs: Any) -> CrossEncoderRerankingEvaluator:
-        split_name = self._get_split_name(dataset_name)
-
-        corpus = self._load_dataset_subset_split(
-            self.corpus_subset_name,
-            split=split_name,
-            required_columns=["_id", "text"],
-        )
-        queries = self._load_dataset_subset_split(
-            self.queries_subset_name,
-            split=split_name,
-            required_columns=["_id", "text"],
-        )
-        qrels = self._load_dataset_subset_split(
-            self.qrels_subset_name,
-            split=split_name,
-            required_columns=["query-id", "corpus-id"],
-        )
-        retrieved = self._load_dataset_subset_split(
-            self.candidate_subset_name,
-            split=split_name,
-            required_columns=["query-id", self.retrieved_corpus_ids_column],
-        )
-
-        corpus_mapping: dict[str, str] = dict(zip(corpus["_id"], corpus["text"]))
-        query_mapping: dict[str, str] = dict(zip(queries["_id"], queries["text"]))
-        qrels_mapping: dict[str, set[str]] = {}
-        for sample in qrels:
-            corpus_ids = sample.get("corpus-id")
-            qrels_mapping.setdefault(sample["query-id"], set())
-            if isinstance(corpus_ids, list):
-                qrels_mapping[sample["query-id"]].update(corpus_ids)
-            else:
-                qrels_mapping[sample["query-id"]].add(corpus_ids)
-        self._validate_retrieval_references(
-            dataset_name=dataset_name,
-            split_name=split_name,
-            query_mapping=query_mapping,
-            corpus_mapping=corpus_mapping,
-            qrels_mapping=qrels_mapping,
-            retrieved=retrieved,
-        )
-
-        def mapper(
-            sample: dict[str, Any],
-            corpus_mapping: dict[str, str],
-            query_mapping: dict[str, str],
-            qrels_mapping: dict[str, set[str]],
-            rerank_k: int,
-            retrieved_corpus_ids_column: str,
-        ) -> dict[str, str | list[str]]:
-            query_id: str = sample["query-id"]
-            query = query_mapping[query_id]
-            positives = [corpus_mapping[positive_id] for positive_id in qrels_mapping[query_id]]
-            # Keep first-stage retrieval order and trim to top-k candidates for reranking.
-            retrieved_corpus_ids = sample[retrieved_corpus_ids_column]
-            documents = [corpus_mapping[document_id] for document_id in retrieved_corpus_ids[:rerank_k]]
-            return {
-                "query": query,
-                "positive": positives,
-                "documents": documents,
-            }
-
-        relevance = retrieved.map(
-            mapper,
-            fn_kwargs={
-                "corpus_mapping": corpus_mapping,
-                "query_mapping": query_mapping,
-                "qrels_mapping": qrels_mapping,
-                "rerank_k": self.rerank_k,
-                "retrieved_corpus_ids_column": self.retrieved_corpus_ids_column,
-            },
-        )
-
-        human_readable_name = self._get_human_readable_name(dataset_name)
-        return self.reranking_evaluator_class(
-            samples=list(relevance),
-            name=human_readable_name,
-            **reranking_kwargs,
-        )
-
-    def _validate_retrieval_references(
-        self,
-        dataset_name: str,
-        split_name: str,
-        query_mapping: dict[str, str],
-        corpus_mapping: dict[str, str],
-        qrels_mapping: dict[str, set[str]],
-        retrieved: Any,
-    ) -> None:
-        missing_query_ids_in_qrels = [query_id for query_id in qrels_mapping if query_id not in query_mapping]
-        missing_positive_ids = sorted(
-            {
-                corpus_id
-                for corpus_ids in qrels_mapping.values()
-                for corpus_id in corpus_ids
-                if corpus_id not in corpus_mapping
-            }
-        )
-
-        missing_query_ids_in_candidates: set[str] = set()
-        missing_qrels_for_candidates: set[str] = set()
-        missing_retrieved_ids: set[str] = set()
-        for sample in retrieved:
-            query_id = sample["query-id"]
-            if query_id not in query_mapping:
-                missing_query_ids_in_candidates.add(query_id)
-            if query_id not in qrels_mapping:
-                missing_qrels_for_candidates.add(query_id)
-            for document_id in sample[self.retrieved_corpus_ids_column]:
-                if document_id not in corpus_mapping:
-                    missing_retrieved_ids.add(document_id)
-
-        if any(
-            [
-                missing_query_ids_in_qrels,
-                missing_positive_ids,
-                missing_query_ids_in_candidates,
-                missing_qrels_for_candidates,
-                missing_retrieved_ids,
-            ]
-        ):
-            error_details: list[str] = []
-            if missing_query_ids_in_qrels:
-                error_details.append(f"qrels references unknown query IDs: {sorted(missing_query_ids_in_qrels)[:5]}")
-            if missing_positive_ids:
-                error_details.append(f"qrels references unknown corpus IDs: {missing_positive_ids[:5]}")
-            if missing_query_ids_in_candidates:
-                error_details.append(
-                    f"candidate subset references unknown query IDs: {sorted(missing_query_ids_in_candidates)[:5]}"
-                )
-            if missing_qrels_for_candidates:
-                error_details.append(
-                    f"candidate subset contains queries missing in qrels: {sorted(missing_qrels_for_candidates)[:5]}"
-                )
-            if missing_retrieved_ids:
-                error_details.append(
-                    f"candidate subset references unknown corpus IDs: {sorted(missing_retrieved_ids)[:5]}"
-                )
-            raise ValueError(
-                f"Inconsistent IDs found for dataset '{dataset_name}' split '{split_name}' in '{self.dataset_id}'. "
-                + " | ".join(error_details)
-            )
-
-    def _load_dataset_subset_split(self, subset: str, split: str, required_columns: list[str]) -> Any:
-        if not is_datasets_available():
-            raise ValueError(
-                "datasets is not available. Please install it to use the CrossEncoderNanoEvaluator via `pip install datasets`."
-            )
-        from datasets import load_dataset
-
-        try:
-            dataset = load_dataset(self.dataset_id, subset, split=split)
-        except Exception as exc:
-            raise ValueError(
-                f"Could not load subset '{subset}' split '{split}' from dataset '{self.dataset_id}'."
-            ) from exc
-
-        if missing_columns := set(required_columns) - set(dataset.column_names):
-            raise ValueError(
-                f"Subset '{subset}' split '{split}' from dataset '{self.dataset_id}' is missing required columns: {list(missing_columns)}."
-            )
-        return dataset
-
-    def _get_available_splits(self, subset: str) -> list[str]:
-        if subset in self._subset_to_split_names_cache:
-            return self._subset_to_split_names_cache[subset]
-
-        if not is_datasets_available():
-            raise ValueError(
-                "datasets is not available. Please install it to use the CrossEncoderNanoEvaluator via `pip install datasets`."
-            )
-        from datasets import get_dataset_split_names
-
-        try:
-            split_names = get_dataset_split_names(self.dataset_id, subset)
-        except Exception as exc:
-            raise ValueError(
-                f"Could not list split names for subset '{subset}' from dataset '{self.dataset_id}'."
-            ) from exc
-
-        if not split_names:
-            raise ValueError(f"No split names were found for subset '{subset}' in dataset '{self.dataset_id}'.")
-        self._subset_to_split_names_cache[subset] = list(split_names)
-        return self._subset_to_split_names_cache[subset]
-
-    def _validate_split_exists(self, dataset_name: str, subset: str, split_name: str) -> None:
-        available_splits = self._get_available_splits(subset)
-        if split_name not in available_splits:
-            raise ValueError(
-                f"Dataset '{dataset_name}' maps to split '{split_name}', but it does not exist in subset '{subset}' "
-                f"for dataset '{self.dataset_id}'. Available splits: {available_splits}"
-            )
-
-    def _validate_mapping_splits(self) -> None:
-        if self.dataset_name_to_human_readable is None:
-            return
-
-        for dataset_name in self.dataset_names:
-            split_name = self._get_split_name(dataset_name)
-            self._validate_split_exists(dataset_name, self.corpus_subset_name, split_name)
-            self._validate_split_exists(dataset_name, self.queries_subset_name, split_name)
-            self._validate_split_exists(dataset_name, self.qrels_subset_name, split_name)
-            self._validate_split_exists(dataset_name, self.candidate_subset_name, split_name)
-
-    def _validate_dataset_names(self) -> None:
-        if len(self.dataset_names) == 0:
-            raise ValueError("dataset_names cannot be empty. Use None to evaluate on all datasets.")
-
-        if self.dataset_name_to_human_readable is None:
-            return
-
-        if not self.strict_dataset_name_validation:
-            return
-
-        missing_datasets: list[str] = []
-        for dataset_name in self.dataset_names:
-            try:
-                self._get_dataset_mapping_value(dataset_name)
-            except ValueError:
-                missing_datasets.append(dataset_name)
-
-        if missing_datasets:
-            raise ValueError(
-                f"Dataset(s) {missing_datasets} do not exist in dataset_name_to_human_readable mapping. "
-                f"Available dataset names are: {list(self.dataset_name_to_human_readable.keys())}"
-            )
 
     def get_config_dict(self) -> dict[str, Any]:
-        config_dict: dict[str, Any] = {
-            "dataset_names": self.dataset_names,
-            "dataset_id": self.dataset_id,
-            "rerank_k": self.rerank_k,
-            "at_k": self.at_k,
-            "always_rerank_positives": self.always_rerank_positives,
-            "dataset_name_to_human_readable": self.dataset_name_to_human_readable,
-            "split_prefix": self.split_prefix,
-            "strict_dataset_name_validation": self.strict_dataset_name_validation,
-            "auto_expand_splits_when_dataset_names_none": self.auto_expand_splits_when_dataset_names_none,
-            "corpus_subset_name": self.corpus_subset_name,
-            "queries_subset_name": self.queries_subset_name,
-            "qrels_subset_name": self.qrels_subset_name,
-            "candidate_subset_name": self.candidate_subset_name,
-            "retrieved_corpus_ids_column": self.retrieved_corpus_ids_column,
-        }
-        if self._bm25_subset_name_alias_input is not None:
-            config_dict["bm25_subset_name"] = self.candidate_subset_name
-        return config_dict
-
-    def store_metrics_in_model_card_data(
-        self,
-        model: CrossEncoder,
-        metrics: dict[str, Any],
-        epoch: int = 0,
-        step: int = 0,
-    ) -> None:
-        if len(self.dataset_names) > 1:
-            super().store_metrics_in_model_card_data(model, metrics, epoch, step)
+        return self._get_generic_cross_encoder_config_dict()

--- a/sentence_transformers/cross_encoder/evaluation/nano_evaluator.py
+++ b/sentence_transformers/cross_encoder/evaluation/nano_evaluator.py
@@ -70,5 +70,34 @@ class CrossEncoderNanoEvaluator(_GenericCrossEncoderNanoMixin, CrossEncoderNanoB
             aggregate_key=aggregate_key,
         )
 
+    def _get_evaluator_name_root(self) -> str:
+        return self.evaluator_name
+
+    def _get_evaluation_description(self) -> str:
+        return "Nano"
+
+    def _get_loading_description(self) -> str:
+        return "Loading Nano datasets"
+
+    def _get_human_readable_name(self, dataset_name: str) -> str:
+        split_name = self._get_split_name(dataset_name)
+        if self.dataset_name_to_human_readable is None:
+            return f"{self.evaluator_name}_{split_name}_R{self.rerank_k}"
+        return f"{split_name}_R{self.rerank_k}"
+
+    def _get_candidate_subset_name(self) -> str:
+        return self.candidate_subset_name
+
+    def _get_retrieved_corpus_ids_column(self) -> str:
+        return self.retrieved_corpus_ids_column
+
+    def _parse_evaluation_key(self, evaluator_name: str, full_key: str) -> tuple[str, str]:
+        prefix = f"{evaluator_name}_"
+        if full_key.startswith(prefix):
+            metric = full_key.removeprefix(prefix)
+        else:
+            metric = full_key.split("_", maxsplit=self.name.count("_"))[-1]
+        return full_key, metric
+
     def get_config_dict(self) -> dict[str, Any]:
         return self._get_generic_cross_encoder_config_dict()

--- a/sentence_transformers/cross_encoder/evaluation/nano_evaluator.py
+++ b/sentence_transformers/cross_encoder/evaluation/nano_evaluator.py
@@ -35,12 +35,8 @@ class CrossEncoderNanoEvaluator(_GenericCrossEncoderNanoMixin, CrossEncoderNanoB
         split_prefix: str = "",
         strict_dataset_name_validation: bool = False,
         auto_expand_splits_when_dataset_names_none: bool = True,
-        corpus_subset_name: str = "corpus",
-        queries_subset_name: str = "queries",
-        qrels_subset_name: str = "qrels",
         candidate_subset_name: str = "bm25",
         bm25_subset_name: str | None = None,
-        retrieved_corpus_ids_column: str = "corpus-ids",
         name: str | None = None,
     ) -> None:
         self._initialize_generic_cross_encoder_state(
@@ -49,12 +45,8 @@ class CrossEncoderNanoEvaluator(_GenericCrossEncoderNanoMixin, CrossEncoderNanoB
             split_prefix=split_prefix,
             strict_dataset_name_validation=strict_dataset_name_validation,
             auto_expand_splits_when_dataset_names_none=auto_expand_splits_when_dataset_names_none,
-            corpus_subset_name=corpus_subset_name,
-            queries_subset_name=queries_subset_name,
-            qrels_subset_name=qrels_subset_name,
             candidate_subset_name=candidate_subset_name,
             bm25_subset_name=bm25_subset_name,
-            retrieved_corpus_ids_column=retrieved_corpus_ids_column,
             name=name,
         )
         super().__init__(
@@ -89,7 +81,7 @@ class CrossEncoderNanoEvaluator(_GenericCrossEncoderNanoMixin, CrossEncoderNanoB
         return self.candidate_subset_name
 
     def _get_retrieved_corpus_ids_column(self) -> str:
-        return self.retrieved_corpus_ids_column
+        return "corpus-ids"
 
     def _parse_evaluation_key(self, evaluator_name: str, full_key: str) -> tuple[str, str]:
         prefix = f"{evaluator_name}_"

--- a/sentence_transformers/evaluation/NanoBEIREvaluator.py
+++ b/sentence_transformers/evaluation/NanoBEIREvaluator.py
@@ -1,24 +1,13 @@
 from __future__ import annotations
 
-import logging
-import os
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Any, Literal
+from typing import Any, Literal
 
 import numpy as np
 from torch import Tensor
-from tqdm import tqdm
 
-from sentence_transformers import SentenceTransformer
-from sentence_transformers.evaluation.InformationRetrievalEvaluator import InformationRetrievalEvaluator
-from sentence_transformers.evaluation.SentenceEvaluator import SentenceEvaluator
+from sentence_transformers.evaluation.NanoEvaluator import NanoEvaluator
 from sentence_transformers.similarity_functions import SimilarityFunction
-from sentence_transformers.util import is_datasets_available
-
-if TYPE_CHECKING:
-    from sentence_transformers.SentenceTransformer import SentenceTransformer
-
-logger = logging.getLogger(__name__)
 
 DatasetNameType = Literal[
     "climatefever",
@@ -36,7 +25,7 @@ DatasetNameType = Literal[
     "touche2020",
 ]
 
-DATASET_NAME_TO_HUMAN_READABLE = {
+DATASET_NAME_TO_HUMAN_READABLE: dict[str, str] = {
     "climatefever": "ClimateFEVER",
     "dbpedia": "DBPedia",
     "fever": "FEVER",
@@ -53,162 +42,50 @@ DATASET_NAME_TO_HUMAN_READABLE = {
 }
 
 
-class NanoBEIREvaluator(SentenceEvaluator):
-    """
-    This class evaluates the performance of a SentenceTransformer Model on the NanoBEIR collection of Information Retrieval datasets.
+class NanoBEIREvaluator(NanoEvaluator):
+    """Evaluate a SentenceTransformer model on NanoBEIR datasets.
 
-    The NanoBEIR collection consists of downsized versions of several BEIR information-retrieval datasets, making it
-    suitable for quickly benchmarking a model's retrieval performance before running a full-scale BEIR evaluation.
-    The datasets are available on Hugging Face in the Sentence Transformers `NanoBEIR collection <https://huggingface.co/collections/sentence-transformers/nanobeir-datasets>`_,
-    which reformats the `original collection <https://huggingface.co/collections/zeta-alpha-ai/nanobeir>`_ from Zeta Alpha
-    into the default `NanoBEIR-en <https://huggingface.co/datasets/sentence-transformers/NanoBEIR-en>`_ dataset,
-    alongside many translated versions.
-    This evaluator reports the same metrics as the :class:`~sentence_transformers.evaluation.InformationRetrievalEvaluator`
-    (e.g., MRR, nDCG, Recall@k) for each dataset individually, as well as aggregated across all datasets.
+    The NanoBEIR collection consists of downsized BEIR retrieval datasets for
+    fast, practical benchmarking before running full-scale BEIR evaluations.
+    Datasets are available in the Sentence Transformers
+    `NanoBEIR collection <https://huggingface.co/collections/sentence-transformers/nanobeir-datasets>`_.
+
+    This class preserves the NanoBEIR short-name API (e.g., ``msmarco``, ``nq``),
+    while delegating shared loading and aggregation mechanics to
+    :class:`~sentence_transformers.evaluation.NanoEvaluator`.
+    It reports the same IR metrics as
+    :class:`~sentence_transformers.evaluation.InformationRetrievalEvaluator`
+    for each dataset and for the aggregated score.
 
     Args:
-        dataset_names (List[str]): The short names of the datasets to evaluate on (e.g., "climatefever", "msmarco").
-            If not specified, all predefined NanoBEIR datasets are used. The full list of available datasets is:
-            "climatefever", "dbpedia", "fever", "fiqa2018", "hotpotqa", "msmarco", "nfcorpus", "nq", "quoraretrieval",
-            "scidocs", "arguana", "scifact", and "touche2020".
-        dataset_id (str): The HuggingFace dataset ID to load the datasets from. Defaults to
-            "sentence-transformers/NanoBEIR-en". The dataset must contain "corpus", "queries", and "qrels"
-            subsets for each NanoBEIR dataset, stored under splits named ``Nano{DatasetName}`` (for example,
-            ``NanoMSMARCO`` or ``NanoNFCorpus``).
-        mrr_at_k (List[int]): A list of integers representing the values of k for MRR calculation. Defaults to [10].
-        ndcg_at_k (List[int]): A list of integers representing the values of k for NDCG calculation. Defaults to [10].
-        accuracy_at_k (List[int]): A list of integers representing the values of k for accuracy calculation. Defaults to [1, 3, 5, 10].
-        precision_recall_at_k (List[int]): A list of integers representing the values of k for precision and recall calculation. Defaults to [1, 3, 5, 10].
-        map_at_k (List[int]): A list of integers representing the values of k for MAP calculation. Defaults to [100].
-        show_progress_bar (bool): Whether to show a progress bar during evaluation. Defaults to False.
-        batch_size (int): The batch size for evaluation. Defaults to 32.
-        write_csv (bool): Whether to write the evaluation results to a CSV file. Defaults to True.
-        truncate_dim (int, optional): The dimension to truncate the embeddings to. Defaults to None.
-        score_functions (Dict[str, Callable[[Tensor, Tensor], Tensor]]): A dictionary mapping score function names to score functions. Defaults to {SimilarityFunction.COSINE.value: cos_sim, SimilarityFunction.DOT_PRODUCT.value: dot_score}.
-        main_score_function (Union[str, SimilarityFunction], optional): The main score function to use for evaluation. Defaults to None.
-        aggregate_fn (Callable[[list[float]], float]): The function to aggregate the scores. Defaults to np.mean.
-        aggregate_key (str): The key to use for the aggregated score. Defaults to "mean".
-        query_prompts (str | dict[str, str], optional): The prompts to add to the queries. If a string, will add the same prompt to all queries. If a dict, expects that all datasets in dataset_names are keys.
-        corpus_prompts (str | dict[str, str], optional): The prompts to add to the corpus. If a string, will add the same prompt to all corpus. If a dict, expects that all datasets in dataset_names are keys.
-        write_predictions (bool): Whether to write the predictions to a JSONL file. Defaults to False.
-            This can be useful for downstream evaluation as it can be used as input to the :class:`~sentence_transformers.sparse_encoder.evaluation.ReciprocalRankFusionEvaluator` that accept precomputed predictions.
+        dataset_names (List[str]): NanoBEIR short names to evaluate.
+            If not specified, all predefined NanoBEIR datasets are used.
+        dataset_id (str): Hugging Face dataset ID. Must contain ``corpus``,
+            ``queries``, and ``qrels`` subsets with ``Nano{DatasetName}`` splits.
+        mrr_at_k (List[int]): ``k`` values for MRR. Defaults to ``[10]``.
+        ndcg_at_k (List[int]): ``k`` values for nDCG. Defaults to ``[10]``.
+        accuracy_at_k (List[int]): ``k`` values for accuracy. Defaults to ``[1, 3, 5, 10]``.
+        precision_recall_at_k (List[int]): ``k`` values for precision/recall. Defaults to ``[1, 3, 5, 10]``.
+        map_at_k (List[int]): ``k`` values for MAP. Defaults to ``[100]``.
+        show_progress_bar (bool): Whether to show progress bars.
+        batch_size (int): Batch size for evaluation.
+        write_csv (bool): Whether to write CSV metrics.
+        truncate_dim (int, optional): Optional embedding truncation dimension.
+        score_functions (Dict[str, Callable[[Tensor, Tensor], Tensor]], optional):
+            Optional custom score functions.
+        main_score_function (str | SimilarityFunction, optional):
+            Optional main score function.
+        aggregate_fn (Callable[[list[float]], float]): Aggregation function across datasets.
+        aggregate_key (str): Aggregate metric key prefix.
+        query_prompts (str | dict[str, str], optional): Query prompt(s).
+        corpus_prompts (str | dict[str, str], optional): Corpus prompt(s).
+        write_predictions (bool): Whether to write per-query predictions.
 
     .. tip::
 
-        See this `NanoBEIR datasets collection on Hugging Face <https://huggingface.co/collections/sentence-transformers/nanobeir-datasets>`_
-        with valid NanoBEIR ``dataset_id`` options for different languages.
-
-    Example:
-        ::
-
-            from sentence_transformers import SentenceTransformer
-            from sentence_transformers.evaluation import NanoBEIREvaluator
-
-            model = SentenceTransformer('intfloat/multilingual-e5-large-instruct')
-
-            datasets = ["QuoraRetrieval", "MSMARCO"]
-            query_prompts = {
-                "QuoraRetrieval": "Instruct: Given a question, retrieve questions that are semantically equivalent to the given question\\nQuery: ",
-                "MSMARCO": "Instruct: Given a web search query, retrieve relevant passages that answer the query\\nQuery: "
-            }
-
-            evaluator = NanoBEIREvaluator(
-                dataset_names=datasets,
-                query_prompts=query_prompts,
-            )
-
-            results = evaluator(model)
-            '''
-            NanoBEIR Evaluation of the model on ['QuoraRetrieval', 'MSMARCO'] dataset:
-            Evaluating NanoQuoraRetrieval
-            Information Retrieval Evaluation of the model on the NanoQuoraRetrieval dataset:
-            Queries: 50
-            Corpus: 5046
-
-            Score-Function: cosine
-            Accuracy@1: 92.00%
-            Accuracy@3: 98.00%
-            Accuracy@5: 100.00%
-            Accuracy@10: 100.00%
-            Precision@1: 92.00%
-            Precision@3: 40.67%
-            Precision@5: 26.00%
-            Precision@10: 14.00%
-            Recall@1: 81.73%
-            Recall@3: 94.20%
-            Recall@5: 97.93%
-            Recall@10: 100.00%
-            MRR@10: 0.9540
-            NDCG@10: 0.9597
-            MAP@100: 0.9395
-
-            Evaluating NanoMSMARCO
-            Information Retrieval Evaluation of the model on the NanoMSMARCO dataset:
-            Queries: 50
-            Corpus: 5043
-
-            Score-Function: cosine
-            Accuracy@1: 40.00%
-            Accuracy@3: 74.00%
-            Accuracy@5: 78.00%
-            Accuracy@10: 88.00%
-            Precision@1: 40.00%
-            Precision@3: 24.67%
-            Precision@5: 15.60%
-            Precision@10: 8.80%
-            Recall@1: 40.00%
-            Recall@3: 74.00%
-            Recall@5: 78.00%
-            Recall@10: 88.00%
-            MRR@10: 0.5849
-            NDCG@10: 0.6572
-            MAP@100: 0.5892
-            Average Queries: 50.0
-            Average Corpus: 5044.5
-
-            Aggregated for Score Function: cosine
-            Accuracy@1: 66.00%
-            Accuracy@3: 86.00%
-            Accuracy@5: 89.00%
-            Accuracy@10: 94.00%
-            Precision@1: 66.00%
-            Recall@1: 60.87%
-            Precision@3: 32.67%
-            Recall@3: 84.10%
-            Precision@5: 20.80%
-            Recall@5: 87.97%
-            Precision@10: 11.40%
-            Recall@10: 94.00%
-            MRR@10: 0.7694
-            NDCG@10: 0.8085
-            '''
-            print(evaluator.primary_metric)
-            # => "NanoBEIR_mean_cosine_ndcg@10"
-            print(results[evaluator.primary_metric])
-            # => 0.8084508771660436
-
-        Evaluating on custom/translated datasets::
-
-            import logging
-            from pprint import pprint
-
-            from sentence_transformers import SentenceTransformer
-            from sentence_transformers.evaluation import NanoBEIREvaluator
-
-            logging.basicConfig(format="%(asctime)s - %(message)s", datefmt="%Y-%m-%d %H:%M:%S", level=logging.INFO)
-
-            model = SentenceTransformer("google/embeddinggemma-300m")
-            evaluator = NanoBEIREvaluator(
-                ["msmarco", "nq"],
-                dataset_id="lightonai/NanoBEIR-de",
-                batch_size=32,
-            )
-            results = evaluator(model)
-            print(results[evaluator.primary_metric])
-            pprint({key: value for key, value in results.items() if "ndcg@10" in key})
+        See the NanoBEIR collection for translated dataset IDs with the same
+        format and split conventions.
     """
-
-    information_retrieval_class = InformationRetrievalEvaluator
 
     def __init__(
         self,
@@ -230,263 +107,40 @@ class NanoBEIREvaluator(SentenceEvaluator):
         query_prompts: str | dict[str, str] | None = None,
         corpus_prompts: str | dict[str, str] | None = None,
         write_predictions: bool = False,
-    ):
-        super().__init__()
+    ) -> None:
         if dataset_names is None:
             dataset_names = list(DATASET_NAME_TO_HUMAN_READABLE.keys())
-        self.dataset_names = dataset_names
-        self.dataset_id = dataset_id
-        self.aggregate_fn = aggregate_fn
-        self.aggregate_key = aggregate_key
-        self.write_csv = write_csv
-        self.query_prompts = query_prompts
-        self.corpus_prompts = corpus_prompts
-        self.show_progress_bar = show_progress_bar
-        self.write_csv = write_csv
-        self.score_functions = score_functions
-        self.score_function_names = sorted(list(self.score_functions.keys())) if score_functions else []
-        self.main_score_function = main_score_function
-        self.truncate_dim = truncate_dim
-        self.name = f"NanoBEIR_{aggregate_key}"
-        if self.truncate_dim:
-            self.name += f"_{self.truncate_dim}"
 
-        self.mrr_at_k = mrr_at_k
-        self.ndcg_at_k = ndcg_at_k
-        self.accuracy_at_k = accuracy_at_k
-        self.precision_recall_at_k = precision_recall_at_k
-        self.map_at_k = map_at_k
-
-        self._validate_dataset_names()
-        self._validate_prompts()
-
-        ir_evaluator_kwargs = {
-            "mrr_at_k": mrr_at_k,
-            "ndcg_at_k": ndcg_at_k,
-            "accuracy_at_k": accuracy_at_k,
-            "precision_recall_at_k": precision_recall_at_k,
-            "map_at_k": map_at_k,
-            "show_progress_bar": show_progress_bar,
-            "batch_size": batch_size,
-            "write_csv": write_csv,
-            "truncate_dim": truncate_dim,
-            "score_functions": score_functions,
-            "main_score_function": main_score_function,
-            "write_predictions": write_predictions,
-        }
-        self.evaluators = [
-            self._load_dataset(name, **ir_evaluator_kwargs)
-            for name in tqdm(self.dataset_names, desc="Loading NanoBEIR datasets", leave=False)
-        ]
-
-        self.csv_file: str = f"NanoBEIR_evaluation_{aggregate_key}_results.csv"
-        self.csv_headers = ["epoch", "steps"]
-
-        self._append_csv_headers(self.score_function_names)
-
-    def _append_csv_headers(self, score_function_names):
-        for score_name in score_function_names:
-            for k in self.accuracy_at_k:
-                self.csv_headers.append(f"{score_name}-Accuracy@{k}")
-
-            for k in self.precision_recall_at_k:
-                self.csv_headers.append(f"{score_name}-Precision@{k}")
-                self.csv_headers.append(f"{score_name}-Recall@{k}")
-
-            for k in self.mrr_at_k:
-                self.csv_headers.append(f"{score_name}-MRR@{k}")
-
-            for k in self.ndcg_at_k:
-                self.csv_headers.append(f"{score_name}-NDCG@{k}")
-
-            for k in self.map_at_k:
-                self.csv_headers.append(f"{score_name}-MAP@{k}")
-
-    def __call__(
-        self,
-        model: SentenceTransformer,
-        output_path: str | None = None,
-        epoch: int = -1,
-        steps: int = -1,
-        *args,
-        **kwargs,
-    ) -> dict[str, float]:
-        per_metric_results = {}
-        per_dataset_results = {}
-        if epoch != -1:
-            if steps == -1:
-                out_txt = f" after epoch {epoch}"
-            else:
-                out_txt = f" in epoch {epoch} after {steps} steps"
-        else:
-            out_txt = ""
-        if self.truncate_dim is not None:
-            out_txt += f" (truncated to {self.truncate_dim})"
-        logger.info(f"NanoBEIR Evaluation of the model on {self.dataset_names} dataset{out_txt}:")
-
-        if self.score_functions is None:
-            self.score_functions = {model.similarity_fn_name: model.similarity}
-            self.score_function_names = [model.similarity_fn_name]
-            self._append_csv_headers(self.score_function_names)
-
-        num_underscores_in_name = self.name.count("_")
-        for evaluator in tqdm(self.evaluators, desc="Evaluating datasets", disable=not self.show_progress_bar):
-            logger.info(f"Evaluating {evaluator.name}")
-            evaluation = evaluator(model, output_path, epoch, steps)
-            for full_key, metric_value in evaluation.items():
-                splits = full_key.split("_", maxsplit=num_underscores_in_name)
-                metric = splits[-1]
-                if metric not in per_metric_results:
-                    per_metric_results[metric] = []
-                per_dataset_results[full_key] = metric_value
-                per_metric_results[metric].append(metric_value)
-
-        agg_results = {}
-        for metric in per_metric_results:
-            agg_results[metric] = self.aggregate_fn(per_metric_results[metric])
-
-        if output_path is not None and self.write_csv:
-            os.makedirs(output_path, exist_ok=True)
-            csv_path = os.path.join(output_path, self.csv_file)
-            if not os.path.isfile(csv_path):
-                fOut = open(csv_path, mode="w", encoding="utf-8")
-                fOut.write(",".join(self.csv_headers))
-                fOut.write("\n")
-
-            else:
-                fOut = open(csv_path, mode="a", encoding="utf-8")
-
-            output_data = [epoch, steps]
-            for name in self.score_function_names:
-                for k in self.accuracy_at_k:
-                    output_data.append(agg_results[f"{name}_accuracy@{k}"])
-
-                for k in self.precision_recall_at_k:
-                    output_data.append(agg_results[f"{name}_precision@{k}"])
-                    output_data.append(agg_results[f"{name}_recall@{k}"])
-
-                for k in self.mrr_at_k:
-                    output_data.append(agg_results[f"{name}_mrr@{k}"])
-
-                for k in self.ndcg_at_k:
-                    output_data.append(agg_results[f"{name}_ndcg@{k}"])
-
-                for k in self.map_at_k:
-                    output_data.append(agg_results[f"{name}_map@{k}"])
-
-            fOut.write(",".join(map(str, output_data)))
-            fOut.write("\n")
-            fOut.close()
-
-        if not self.primary_metric:
-            if self.main_score_function is None:
-                score_function = max(
-                    [(name, agg_results[f"{name}_ndcg@{max(self.ndcg_at_k)}"]) for name in self.score_function_names],
-                    key=lambda x: x[1],
-                )[0]
-                self.primary_metric = f"{score_function}_ndcg@{max(self.ndcg_at_k)}"
-            else:
-                self.primary_metric = f"{self.main_score_function.value}_ndcg@{max(self.ndcg_at_k)}"
-
-        avg_queries = np.mean([len(evaluator.queries) for evaluator in self.evaluators])
-        avg_corpus = np.mean([len(evaluator.corpus) for evaluator in self.evaluators])
-        logger.info(f"Average Queries: {avg_queries}")
-        logger.info(f"Average Corpus: {avg_corpus}\n")
-
-        for name in self.score_function_names:
-            logger.info(f"Aggregated for Score Function: {name}")
-            for k in self.accuracy_at_k:
-                logger.info("Accuracy@{}: {:.2f}%".format(k, agg_results[f"{name}_accuracy@{k}"] * 100))
-
-            for k in self.precision_recall_at_k:
-                logger.info("Precision@{}: {:.2f}%".format(k, agg_results[f"{name}_precision@{k}"] * 100))
-                logger.info("Recall@{}: {:.2f}%".format(k, agg_results[f"{name}_recall@{k}"] * 100))
-
-            for k in self.mrr_at_k:
-                logger.info("MRR@{}: {:.4f}".format(k, agg_results[f"{name}_mrr@{k}"]))
-
-            for k in self.ndcg_at_k:
-                logger.info("NDCG@{}: {:.4f}".format(k, agg_results[f"{name}_ndcg@{k}"]))
-
-            for k in self.map_at_k:
-                logger.info("MAP@{}: {:.4f}".format(k, agg_results[f"{name}_map@{k}"]))
-
-        agg_results = self.prefix_name_to_metrics(agg_results, self.name)
-        self.store_metrics_in_model_card_data(model, agg_results, epoch, steps)
-
-        per_dataset_results.update(agg_results)
-
-        return per_dataset_results
-
-    def _get_human_readable_name(self, dataset_name: DatasetNameType | str) -> str:
-        human_readable_name = f"Nano{DATASET_NAME_TO_HUMAN_READABLE[dataset_name.lower()]}"
-
-        if self.truncate_dim is not None:
-            human_readable_name += f"_{self.truncate_dim}"
-        return human_readable_name
-
-    def _load_dataset(
-        self, dataset_name: DatasetNameType | str, **ir_evaluator_kwargs
-    ) -> InformationRetrievalEvaluator:
-        if dataset_name.lower() not in DATASET_NAME_TO_HUMAN_READABLE:
-            raise ValueError(f"Dataset '{dataset_name}' is not a valid NanoBEIR dataset.")
-        human_readable = DATASET_NAME_TO_HUMAN_READABLE[dataset_name.lower()]
-        split_name = f"Nano{human_readable}"
-
-        corpus = self._load_dataset_subset_split("corpus", split=split_name, required_columns=["_id", "text"])
-        queries = self._load_dataset_subset_split("queries", split=split_name, required_columns=["_id", "text"])
-        qrels = self._load_dataset_subset_split("qrels", split=split_name, required_columns=["query-id", "corpus-id"])
-
-        corpus_dict = {sample["_id"]: sample["text"] for sample in corpus if len(sample["text"]) > 0}
-        queries_dict = {sample["_id"]: sample["text"] for sample in queries if len(sample["text"]) > 0}
-
-        qrels_dict = {}
-        for sample in qrels:
-            corpus_ids = sample.get("corpus-id")
-            if sample["query-id"] not in qrels_dict:
-                qrels_dict[sample["query-id"]] = set()
-
-            if isinstance(corpus_ids, list):
-                qrels_dict[sample["query-id"]].update(corpus_ids)
-            else:
-                qrels_dict[sample["query-id"]].add(corpus_ids)
-
-        if self.query_prompts is not None:
-            ir_evaluator_kwargs["query_prompt"] = self.query_prompts.get(dataset_name, None)
-        if self.corpus_prompts is not None:
-            ir_evaluator_kwargs["corpus_prompt"] = self.corpus_prompts.get(dataset_name, None)
-        human_readable_name = self._get_human_readable_name(dataset_name)
-        return self.information_retrieval_class(
-            queries=queries_dict,
-            corpus=corpus_dict,
-            relevant_docs=qrels_dict,
-            name=human_readable_name,
-            **ir_evaluator_kwargs,
+        super().__init__(
+            dataset_names=[str(name) for name in dataset_names],
+            dataset_id=dataset_id,
+            mrr_at_k=mrr_at_k,
+            ndcg_at_k=ndcg_at_k,
+            accuracy_at_k=accuracy_at_k,
+            precision_recall_at_k=precision_recall_at_k,
+            map_at_k=map_at_k,
+            show_progress_bar=show_progress_bar,
+            batch_size=batch_size,
+            write_csv=write_csv,
+            truncate_dim=truncate_dim,
+            score_functions=score_functions,
+            main_score_function=main_score_function,
+            aggregate_fn=aggregate_fn,
+            aggregate_key=aggregate_key,
+            query_prompts=query_prompts,
+            corpus_prompts=corpus_prompts,
+            write_predictions=write_predictions,
+            dataset_name_to_human_readable=DATASET_NAME_TO_HUMAN_READABLE,
+            split_prefix="Nano",
+            strict_dataset_name_validation=True,
+            auto_expand_splits_when_dataset_names_none=False,
+            name="NanoBEIR",
         )
 
-    def _load_dataset_subset_split(self, subset: str, split: str, required_columns: list[str]):
-        if not is_datasets_available():
-            raise ValueError(
-                "datasets is not available. Please install it to use the NanoBEIREvaluator via `pip install datasets`."
-            )
-        from datasets import load_dataset
-
-        try:
-            dataset = load_dataset(self.dataset_id, subset, split=split)
-        except Exception as e:
-            raise ValueError(
-                f"Could not load subset '{subset}' split '{split}' from dataset '{self.dataset_id}'."
-            ) from e
-
-        if missing_columns := set(required_columns) - set(dataset.column_names):
-            raise ValueError(
-                f"Subset '{subset}' split '{split}' from dataset '{self.dataset_id}' is missing required columns: {list(missing_columns)}."
-            )
-        return dataset
-
-    def _validate_dataset_names(self):
+    def _validate_dataset_names(self) -> None:
         if len(self.dataset_names) == 0:
             raise ValueError("dataset_names cannot be empty. Use None to evaluate on all datasets.")
+
         missing_datasets = [
             dataset_name
             for dataset_name in self.dataset_names
@@ -498,38 +152,14 @@ class NanoBEIREvaluator(SentenceEvaluator):
                 f"Valid dataset names are: {list(DATASET_NAME_TO_HUMAN_READABLE.keys())}"
             )
 
-    def _validate_prompts(self):
-        error_msg = ""
-        if self.query_prompts is not None:
-            if isinstance(self.query_prompts, str):
-                self.query_prompts = {dataset_name: self.query_prompts for dataset_name in self.dataset_names}
-            elif missing_query_prompts := [
-                dataset_name for dataset_name in self.dataset_names if dataset_name not in self.query_prompts
-            ]:
-                error_msg += f"The following datasets are missing query prompts: {missing_query_prompts}\n"
-
-        if self.corpus_prompts is not None:
-            if isinstance(self.corpus_prompts, str):
-                self.corpus_prompts = {dataset_name: self.corpus_prompts for dataset_name in self.dataset_names}
-            elif missing_corpus_prompts := [
-                dataset_name for dataset_name in self.dataset_names if dataset_name not in self.corpus_prompts
-            ]:
-                error_msg += f"The following datasets are missing corpus prompts: {missing_corpus_prompts}\n"
-
-        if error_msg:
-            raise ValueError(error_msg.strip())
-
-    def store_metrics_in_model_card_data(self, *args, **kwargs):
-        # Only store metrics in the model card data if there is more than one dataset.
-        # Otherwise the e.g. mean scores for NanoBEIR are the same as the scores for
-        # the single dataset, and we'd end up with duplicate entries.
-        if len(self.dataset_names) > 1:
-            super().store_metrics_in_model_card_data(*args, **kwargs)
-
     def get_config_dict(self) -> dict[str, Any]:
-        config_dict = {"dataset_names": self.dataset_names, "dataset_id": self.dataset_id}
+        config_dict: dict[str, Any] = {
+            "dataset_names": self.dataset_names,
+            "dataset_id": self.dataset_id,
+        }
         config_dict_candidate_keys = ["truncate_dim", "query_prompts", "corpus_prompts"]
         for key in config_dict_candidate_keys:
-            if getattr(self, key) is not None:
-                config_dict[key] = getattr(self, key)
+            value = getattr(self, key)
+            if value is not None:
+                config_dict[key] = value
         return config_dict

--- a/sentence_transformers/evaluation/NanoBEIREvaluator.py
+++ b/sentence_transformers/evaluation/NanoBEIREvaluator.py
@@ -233,7 +233,7 @@ class NanoBEIREvaluator(SentenceEvaluator):
     ):
         super().__init__()
         if dataset_names is None:
-            dataset_names = self._get_default_dataset_names()
+            dataset_names = list(DATASET_NAME_TO_HUMAN_READABLE.keys())
         self.dataset_names = dataset_names
         self.dataset_id = dataset_id
         self.aggregate_fn = aggregate_fn
@@ -247,7 +247,7 @@ class NanoBEIREvaluator(SentenceEvaluator):
         self.score_function_names = sorted(list(self.score_functions.keys())) if score_functions else []
         self.main_score_function = main_score_function
         self.truncate_dim = truncate_dim
-        self.name = f"{self._get_evaluator_name_root()}_{aggregate_key}"
+        self.name = f"{self.description}_{aggregate_key}"
         if self.truncate_dim:
             self.name += f"_{self.truncate_dim}"
 
@@ -276,10 +276,10 @@ class NanoBEIREvaluator(SentenceEvaluator):
         }
         self.evaluators = [
             self._load_dataset(name, **ir_evaluator_kwargs)
-            for name in tqdm(self.dataset_names, desc=self._get_loading_description(), leave=False)
+            for name in tqdm(self.dataset_names, desc=f"Loading {self.description} datasets", leave=False)
         ]
 
-        self.csv_file: str = f"{self._get_evaluator_name_root()}_evaluation_{aggregate_key}_results.csv"
+        self.csv_file: str = f"{self.description}_evaluation_{aggregate_key}_results.csv"
         self.csv_headers = ["epoch", "steps"]
 
         self._append_csv_headers(self.score_function_names)
@@ -322,9 +322,7 @@ class NanoBEIREvaluator(SentenceEvaluator):
             out_txt = ""
         if self.truncate_dim is not None:
             out_txt += f" (truncated to {self.truncate_dim})"
-        logger.info(
-            f"{self._get_evaluation_description()} Evaluation of the model on {self.dataset_names} dataset{out_txt}:"
-        )
+        logger.info(f"{self.description} Evaluation of the model on {self.dataset_names} dataset{out_txt}:")
 
         if self.score_functions is None:
             self.score_functions = {model.similarity_fn_name: model.similarity}
@@ -450,9 +448,9 @@ class NanoBEIREvaluator(SentenceEvaluator):
                 qrels_dict[sample["query-id"]].add(corpus_ids)
 
         if self.query_prompts is not None:
-            ir_evaluator_kwargs["query_prompt"] = self._get_prompt_for_dataset(self.query_prompts, dataset_name)
+            ir_evaluator_kwargs["query_prompt"] = self.query_prompts.get(dataset_name, None)
         if self.corpus_prompts is not None:
-            ir_evaluator_kwargs["corpus_prompt"] = self._get_prompt_for_dataset(self.corpus_prompts, dataset_name)
+            ir_evaluator_kwargs["corpus_prompt"] = self.corpus_prompts.get(dataset_name, None)
         human_readable_name = self._get_human_readable_name(dataset_name)
         return self.information_retrieval_class(
             queries=queries_dict,
@@ -461,6 +459,10 @@ class NanoBEIREvaluator(SentenceEvaluator):
             name=human_readable_name,
             **ir_evaluator_kwargs,
         )
+
+    @property
+    def description(self) -> str:
+        return "NanoBEIR"
 
     def _load_dataset_subset_split(self, subset: str, split: str, required_columns: list[str]):
         if not is_datasets_available():
@@ -502,9 +504,7 @@ class NanoBEIREvaluator(SentenceEvaluator):
             if isinstance(self.query_prompts, str):
                 self.query_prompts = {dataset_name: self.query_prompts for dataset_name in self.dataset_names}
             elif missing_query_prompts := [
-                dataset_name
-                for dataset_name in self.dataset_names
-                if self._get_prompt_for_dataset(self.query_prompts, dataset_name) is None
+                dataset_name for dataset_name in self.dataset_names if dataset_name not in self.query_prompts
             ]:
                 error_msg += f"The following datasets are missing query prompts: {missing_query_prompts}\n"
 
@@ -512,34 +512,15 @@ class NanoBEIREvaluator(SentenceEvaluator):
             if isinstance(self.corpus_prompts, str):
                 self.corpus_prompts = {dataset_name: self.corpus_prompts for dataset_name in self.dataset_names}
             elif missing_corpus_prompts := [
-                dataset_name
-                for dataset_name in self.dataset_names
-                if self._get_prompt_for_dataset(self.corpus_prompts, dataset_name) is None
+                dataset_name for dataset_name in self.dataset_names if dataset_name not in self.corpus_prompts
             ]:
                 error_msg += f"The following datasets are missing corpus prompts: {missing_corpus_prompts}\n"
 
         if error_msg:
             raise ValueError(error_msg.strip())
 
-    def _get_default_dataset_names(self) -> list[str]:
-        return list(DATASET_NAME_TO_HUMAN_READABLE.keys())
-
-    def _get_evaluator_name_root(self) -> str:
-        return "NanoBEIR"
-
-    def _get_evaluation_description(self) -> str:
-        return "NanoBEIR"
-
-    def _get_loading_description(self) -> str:
-        return "Loading NanoBEIR datasets"
-
     def _get_split_name(self, dataset_name: DatasetNameType | str) -> str:
         return f"Nano{DATASET_NAME_TO_HUMAN_READABLE[dataset_name.lower()]}"
-
-    def _get_prompt_for_dataset(
-        self, prompt_mapping: dict[str, str], dataset_name: DatasetNameType | str
-    ) -> str | None:
-        return prompt_mapping.get(dataset_name, None)
 
     def _get_metric_from_full_key(self, evaluator_name: str, full_key: str, num_underscores_in_name: int) -> str:
         del evaluator_name

--- a/sentence_transformers/evaluation/NanoBEIREvaluator.py
+++ b/sentence_transformers/evaluation/NanoBEIREvaluator.py
@@ -1,13 +1,24 @@
 from __future__ import annotations
 
+import logging
+import os
 from collections.abc import Callable
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 import numpy as np
 from torch import Tensor
+from tqdm import tqdm
 
-from sentence_transformers.evaluation.NanoEvaluator import NanoEvaluator
+from sentence_transformers import SentenceTransformer
+from sentence_transformers.evaluation.InformationRetrievalEvaluator import InformationRetrievalEvaluator
+from sentence_transformers.evaluation.SentenceEvaluator import SentenceEvaluator
 from sentence_transformers.similarity_functions import SimilarityFunction
+from sentence_transformers.util import is_datasets_available
+
+if TYPE_CHECKING:
+    from sentence_transformers.SentenceTransformer import SentenceTransformer
+
+logger = logging.getLogger(__name__)
 
 DatasetNameType = Literal[
     "climatefever",
@@ -25,7 +36,7 @@ DatasetNameType = Literal[
     "touche2020",
 ]
 
-DATASET_NAME_TO_HUMAN_READABLE: dict[str, str] = {
+DATASET_NAME_TO_HUMAN_READABLE = {
     "climatefever": "ClimateFEVER",
     "dbpedia": "DBPedia",
     "fever": "FEVER",
@@ -42,7 +53,7 @@ DATASET_NAME_TO_HUMAN_READABLE: dict[str, str] = {
 }
 
 
-class NanoBEIREvaluator(NanoEvaluator):
+class NanoBEIREvaluator(SentenceEvaluator):
     """
     This class evaluates the performance of a SentenceTransformer Model on the NanoBEIR collection of Information Retrieval datasets.
 
@@ -54,9 +65,6 @@ class NanoBEIREvaluator(NanoEvaluator):
     alongside many translated versions.
     This evaluator reports the same metrics as the :class:`~sentence_transformers.evaluation.InformationRetrievalEvaluator`
     (e.g., MRR, nDCG, Recall@k) for each dataset individually, as well as aggregated across all datasets.
-
-    This class preserves the NanoBEIR short-name API and delegates dataset-agnostic loading/aggregation mechanics to
-    :class:`~sentence_transformers.evaluation.NanoEvaluator`.
 
     Args:
         dataset_names (List[str]): The short names of the datasets to evaluate on (e.g., "climatefever", "msmarco").
@@ -200,6 +208,8 @@ class NanoBEIREvaluator(NanoEvaluator):
             pprint({key: value for key, value in results.items() if "ndcg@10" in key})
     """
 
+    information_retrieval_class = InformationRetrievalEvaluator
+
     def __init__(
         self,
         dataset_names: list[DatasetNameType | str] | None = None,
@@ -220,40 +230,274 @@ class NanoBEIREvaluator(NanoEvaluator):
         query_prompts: str | dict[str, str] | None = None,
         corpus_prompts: str | dict[str, str] | None = None,
         write_predictions: bool = False,
-    ) -> None:
+    ):
+        super().__init__()
         if dataset_names is None:
-            dataset_names = list(DATASET_NAME_TO_HUMAN_READABLE.keys())
+            dataset_names = self._get_default_dataset_names()
+        self.dataset_names = dataset_names
+        self.dataset_id = dataset_id
+        self.aggregate_fn = aggregate_fn
+        self.aggregate_key = aggregate_key
+        self.write_csv = write_csv
+        self.query_prompts = query_prompts
+        self.corpus_prompts = corpus_prompts
+        self.show_progress_bar = show_progress_bar
+        self.write_csv = write_csv
+        self.score_functions = score_functions
+        self.score_function_names = sorted(list(self.score_functions.keys())) if score_functions else []
+        self.main_score_function = main_score_function
+        self.truncate_dim = truncate_dim
+        self.name = f"{self._get_evaluator_name_root()}_{aggregate_key}"
+        if self.truncate_dim:
+            self.name += f"_{self.truncate_dim}"
 
-        super().__init__(
-            dataset_names=[str(name) for name in dataset_names],
-            dataset_id=dataset_id,
-            mrr_at_k=mrr_at_k,
-            ndcg_at_k=ndcg_at_k,
-            accuracy_at_k=accuracy_at_k,
-            precision_recall_at_k=precision_recall_at_k,
-            map_at_k=map_at_k,
-            show_progress_bar=show_progress_bar,
-            batch_size=batch_size,
-            write_csv=write_csv,
-            truncate_dim=truncate_dim,
-            score_functions=score_functions,
-            main_score_function=main_score_function,
-            aggregate_fn=aggregate_fn,
-            aggregate_key=aggregate_key,
-            query_prompts=query_prompts,
-            corpus_prompts=corpus_prompts,
-            write_predictions=write_predictions,
-            dataset_name_to_human_readable=DATASET_NAME_TO_HUMAN_READABLE,
-            split_prefix="Nano",
-            strict_dataset_name_validation=True,
-            auto_expand_splits_when_dataset_names_none=False,
-            name="NanoBEIR",
+        self.mrr_at_k = mrr_at_k
+        self.ndcg_at_k = ndcg_at_k
+        self.accuracy_at_k = accuracy_at_k
+        self.precision_recall_at_k = precision_recall_at_k
+        self.map_at_k = map_at_k
+
+        self._validate_dataset_names()
+        self._validate_prompts()
+        self._validate_mapping_splits()
+
+        ir_evaluator_kwargs = {
+            "mrr_at_k": mrr_at_k,
+            "ndcg_at_k": ndcg_at_k,
+            "accuracy_at_k": accuracy_at_k,
+            "precision_recall_at_k": precision_recall_at_k,
+            "map_at_k": map_at_k,
+            "show_progress_bar": show_progress_bar,
+            "batch_size": batch_size,
+            "write_csv": write_csv,
+            "truncate_dim": truncate_dim,
+            "score_functions": score_functions,
+            "main_score_function": main_score_function,
+            "write_predictions": write_predictions,
+        }
+        self.evaluators = [
+            self._load_dataset(name, **ir_evaluator_kwargs)
+            for name in tqdm(self.dataset_names, desc=self._get_loading_description(), leave=False)
+        ]
+
+        self.csv_file: str = f"{self._get_evaluator_name_root()}_evaluation_{aggregate_key}_results.csv"
+        self.csv_headers = ["epoch", "steps"]
+
+        self._append_csv_headers(self.score_function_names)
+
+    def _append_csv_headers(self, score_function_names):
+        for score_name in score_function_names:
+            for k in self.accuracy_at_k:
+                self.csv_headers.append(f"{score_name}-Accuracy@{k}")
+
+            for k in self.precision_recall_at_k:
+                self.csv_headers.append(f"{score_name}-Precision@{k}")
+                self.csv_headers.append(f"{score_name}-Recall@{k}")
+
+            for k in self.mrr_at_k:
+                self.csv_headers.append(f"{score_name}-MRR@{k}")
+
+            for k in self.ndcg_at_k:
+                self.csv_headers.append(f"{score_name}-NDCG@{k}")
+
+            for k in self.map_at_k:
+                self.csv_headers.append(f"{score_name}-MAP@{k}")
+
+    def __call__(
+        self,
+        model: SentenceTransformer,
+        output_path: str | None = None,
+        epoch: int = -1,
+        steps: int = -1,
+        *args,
+        **kwargs,
+    ) -> dict[str, float]:
+        per_metric_results = {}
+        per_dataset_results = {}
+        if epoch != -1:
+            if steps == -1:
+                out_txt = f" after epoch {epoch}"
+            else:
+                out_txt = f" in epoch {epoch} after {steps} steps"
+        else:
+            out_txt = ""
+        if self.truncate_dim is not None:
+            out_txt += f" (truncated to {self.truncate_dim})"
+        logger.info(
+            f"{self._get_evaluation_description()} Evaluation of the model on {self.dataset_names} dataset{out_txt}:"
         )
 
-    def _validate_dataset_names(self) -> None:
+        if self.score_functions is None:
+            self.score_functions = {model.similarity_fn_name: model.similarity}
+            self.score_function_names = [model.similarity_fn_name]
+            self._append_csv_headers(self.score_function_names)
+
+        num_underscores_in_name = self.name.count("_")
+        for evaluator in tqdm(self.evaluators, desc="Evaluating datasets", disable=not self.show_progress_bar):
+            logger.info(f"Evaluating {evaluator.name}")
+            evaluation = evaluator(model, output_path, epoch, steps)
+            for full_key, metric_value in evaluation.items():
+                metric = self._get_metric_from_full_key(evaluator.name, full_key, num_underscores_in_name)
+                if metric not in per_metric_results:
+                    per_metric_results[metric] = []
+                per_dataset_results[full_key] = metric_value
+                per_metric_results[metric].append(metric_value)
+
+        agg_results = {}
+        for metric in per_metric_results:
+            agg_results[metric] = self.aggregate_fn(per_metric_results[metric])
+
+        if output_path is not None and self.write_csv:
+            os.makedirs(output_path, exist_ok=True)
+            csv_path = os.path.join(output_path, self.csv_file)
+            if not os.path.isfile(csv_path):
+                fOut = open(csv_path, mode="w", encoding="utf-8")
+                fOut.write(",".join(self.csv_headers))
+                fOut.write("\n")
+
+            else:
+                fOut = open(csv_path, mode="a", encoding="utf-8")
+
+            output_data = [epoch, steps]
+            for name in self.score_function_names:
+                for k in self.accuracy_at_k:
+                    output_data.append(agg_results[f"{name}_accuracy@{k}"])
+
+                for k in self.precision_recall_at_k:
+                    output_data.append(agg_results[f"{name}_precision@{k}"])
+                    output_data.append(agg_results[f"{name}_recall@{k}"])
+
+                for k in self.mrr_at_k:
+                    output_data.append(agg_results[f"{name}_mrr@{k}"])
+
+                for k in self.ndcg_at_k:
+                    output_data.append(agg_results[f"{name}_ndcg@{k}"])
+
+                for k in self.map_at_k:
+                    output_data.append(agg_results[f"{name}_map@{k}"])
+
+            fOut.write(",".join(map(str, output_data)))
+            fOut.write("\n")
+            fOut.close()
+
+        if not self.primary_metric:
+            if self.main_score_function is None:
+                score_function = max(
+                    [(name, agg_results[f"{name}_ndcg@{max(self.ndcg_at_k)}"]) for name in self.score_function_names],
+                    key=lambda x: x[1],
+                )[0]
+                self.primary_metric = f"{score_function}_ndcg@{max(self.ndcg_at_k)}"
+            else:
+                self.primary_metric = f"{self.main_score_function.value}_ndcg@{max(self.ndcg_at_k)}"
+
+        avg_queries = np.mean([len(evaluator.queries) for evaluator in self.evaluators])
+        avg_corpus = np.mean([len(evaluator.corpus) for evaluator in self.evaluators])
+        logger.info(f"Average Queries: {avg_queries}")
+        logger.info(f"Average Corpus: {avg_corpus}\n")
+
+        for name in self.score_function_names:
+            logger.info(f"Aggregated for Score Function: {name}")
+            for k in self.accuracy_at_k:
+                logger.info("Accuracy@{}: {:.2f}%".format(k, agg_results[f"{name}_accuracy@{k}"] * 100))
+
+            for k in self.precision_recall_at_k:
+                logger.info("Precision@{}: {:.2f}%".format(k, agg_results[f"{name}_precision@{k}"] * 100))
+                logger.info("Recall@{}: {:.2f}%".format(k, agg_results[f"{name}_recall@{k}"] * 100))
+
+            for k in self.mrr_at_k:
+                logger.info("MRR@{}: {:.4f}".format(k, agg_results[f"{name}_mrr@{k}"]))
+
+            for k in self.ndcg_at_k:
+                logger.info("NDCG@{}: {:.4f}".format(k, agg_results[f"{name}_ndcg@{k}"]))
+
+            for k in self.map_at_k:
+                logger.info("MAP@{}: {:.4f}".format(k, agg_results[f"{name}_map@{k}"]))
+
+        agg_results = self.prefix_name_to_metrics(agg_results, self.name)
+        self.store_metrics_in_model_card_data(model, agg_results, epoch, steps)
+
+        per_dataset_results.update(agg_results)
+
+        return per_dataset_results
+
+    def _get_human_readable_name(self, dataset_name: DatasetNameType | str) -> str:
+        human_readable_name = self._get_split_name(dataset_name)
+
+        if self.truncate_dim is not None:
+            human_readable_name += f"_{self.truncate_dim}"
+        return human_readable_name
+
+    def _load_dataset(
+        self, dataset_name: DatasetNameType | str, **ir_evaluator_kwargs
+    ) -> InformationRetrievalEvaluator:
+        split_name = self._get_split_name(dataset_name)
+
+        corpus = self._load_dataset_subset_split(
+            self._get_corpus_subset_name(),
+            split=split_name,
+            required_columns=["_id", "text"],
+        )
+        queries = self._load_dataset_subset_split(
+            self._get_queries_subset_name(),
+            split=split_name,
+            required_columns=["_id", "text"],
+        )
+        qrels = self._load_dataset_subset_split(
+            self._get_qrels_subset_name(),
+            split=split_name,
+            required_columns=["query-id", "corpus-id"],
+        )
+
+        corpus_dict = {sample["_id"]: sample["text"] for sample in corpus if len(sample["text"]) > 0}
+        queries_dict = {sample["_id"]: sample["text"] for sample in queries if len(sample["text"]) > 0}
+
+        qrels_dict = {}
+        for sample in qrels:
+            corpus_ids = sample.get("corpus-id")
+            if sample["query-id"] not in qrels_dict:
+                qrels_dict[sample["query-id"]] = set()
+
+            if isinstance(corpus_ids, list):
+                qrels_dict[sample["query-id"]].update(corpus_ids)
+            else:
+                qrels_dict[sample["query-id"]].add(corpus_ids)
+
+        if self.query_prompts is not None:
+            ir_evaluator_kwargs["query_prompt"] = self._get_prompt_for_dataset(self.query_prompts, dataset_name)
+        if self.corpus_prompts is not None:
+            ir_evaluator_kwargs["corpus_prompt"] = self._get_prompt_for_dataset(self.corpus_prompts, dataset_name)
+        human_readable_name = self._get_human_readable_name(dataset_name)
+        return self.information_retrieval_class(
+            queries=queries_dict,
+            corpus=corpus_dict,
+            relevant_docs=qrels_dict,
+            name=human_readable_name,
+            **ir_evaluator_kwargs,
+        )
+
+    def _load_dataset_subset_split(self, subset: str, split: str, required_columns: list[str]):
+        if not is_datasets_available():
+            raise ValueError(
+                "datasets is not available. Please install it to use the NanoBEIREvaluator via `pip install datasets`."
+            )
+        from datasets import load_dataset
+
+        try:
+            dataset = load_dataset(self.dataset_id, subset, split=split)
+        except Exception as e:
+            raise ValueError(
+                f"Could not load subset '{subset}' split '{split}' from dataset '{self.dataset_id}'."
+            ) from e
+
+        if missing_columns := set(required_columns) - set(dataset.column_names):
+            raise ValueError(
+                f"Subset '{subset}' split '{split}' from dataset '{self.dataset_id}' is missing required columns: {list(missing_columns)}."
+            )
+        return dataset
+
+    def _validate_dataset_names(self):
         if len(self.dataset_names) == 0:
             raise ValueError("dataset_names cannot be empty. Use None to evaluate on all datasets.")
-
         missing_datasets = [
             dataset_name
             for dataset_name in self.dataset_names
@@ -265,14 +509,79 @@ class NanoBEIREvaluator(NanoEvaluator):
                 f"Valid dataset names are: {list(DATASET_NAME_TO_HUMAN_READABLE.keys())}"
             )
 
+    def _validate_prompts(self):
+        error_msg = ""
+        if self.query_prompts is not None:
+            if isinstance(self.query_prompts, str):
+                self.query_prompts = {dataset_name: self.query_prompts for dataset_name in self.dataset_names}
+            elif missing_query_prompts := [
+                dataset_name
+                for dataset_name in self.dataset_names
+                if self._get_prompt_for_dataset(self.query_prompts, dataset_name) is None
+            ]:
+                error_msg += f"The following datasets are missing query prompts: {missing_query_prompts}\n"
+
+        if self.corpus_prompts is not None:
+            if isinstance(self.corpus_prompts, str):
+                self.corpus_prompts = {dataset_name: self.corpus_prompts for dataset_name in self.dataset_names}
+            elif missing_corpus_prompts := [
+                dataset_name
+                for dataset_name in self.dataset_names
+                if self._get_prompt_for_dataset(self.corpus_prompts, dataset_name) is None
+            ]:
+                error_msg += f"The following datasets are missing corpus prompts: {missing_corpus_prompts}\n"
+
+        if error_msg:
+            raise ValueError(error_msg.strip())
+
+    def _get_default_dataset_names(self) -> list[str]:
+        return list(DATASET_NAME_TO_HUMAN_READABLE.keys())
+
+    def _get_evaluator_name_root(self) -> str:
+        return "NanoBEIR"
+
+    def _get_evaluation_description(self) -> str:
+        return "NanoBEIR"
+
+    def _get_loading_description(self) -> str:
+        return "Loading NanoBEIR datasets"
+
+    def _get_split_name(self, dataset_name: DatasetNameType | str) -> str:
+        return f"Nano{DATASET_NAME_TO_HUMAN_READABLE[dataset_name.lower()]}"
+
+    def _get_corpus_subset_name(self) -> str:
+        return "corpus"
+
+    def _get_queries_subset_name(self) -> str:
+        return "queries"
+
+    def _get_qrels_subset_name(self) -> str:
+        return "qrels"
+
+    def _get_prompt_for_dataset(
+        self, prompt_mapping: dict[str, str], dataset_name: DatasetNameType | str
+    ) -> str | None:
+        return prompt_mapping.get(dataset_name, None)
+
+    def _get_metric_from_full_key(self, evaluator_name: str, full_key: str, num_underscores_in_name: int) -> str:
+        del evaluator_name
+        splits = full_key.split("_", maxsplit=num_underscores_in_name)
+        return splits[-1]
+
+    def _validate_mapping_splits(self) -> None:
+        pass
+
+    def store_metrics_in_model_card_data(self, *args, **kwargs):
+        # Only store metrics in the model card data if there is more than one dataset.
+        # Otherwise the e.g. mean scores for NanoBEIR are the same as the scores for
+        # the single dataset, and we'd end up with duplicate entries.
+        if len(self.dataset_names) > 1:
+            super().store_metrics_in_model_card_data(*args, **kwargs)
+
     def get_config_dict(self) -> dict[str, Any]:
-        config_dict: dict[str, Any] = {
-            "dataset_names": self.dataset_names,
-            "dataset_id": self.dataset_id,
-        }
+        config_dict = {"dataset_names": self.dataset_names, "dataset_id": self.dataset_id}
         config_dict_candidate_keys = ["truncate_dim", "query_prompts", "corpus_prompts"]
         for key in config_dict_candidate_keys:
-            value = getattr(self, key)
-            if value is not None:
-                config_dict[key] = value
+            if getattr(self, key) is not None:
+                config_dict[key] = getattr(self, key)
         return config_dict

--- a/sentence_transformers/evaluation/NanoBEIREvaluator.py
+++ b/sentence_transformers/evaluation/NanoBEIREvaluator.py
@@ -522,8 +522,7 @@ class NanoBEIREvaluator(SentenceEvaluator):
     def _get_split_name(self, dataset_name: DatasetNameType | str) -> str:
         return f"Nano{DATASET_NAME_TO_HUMAN_READABLE[dataset_name.lower()]}"
 
-    def _get_metric_from_full_key(self, evaluator_name: str, full_key: str, num_underscores_in_name: int) -> str:
-        del evaluator_name
+    def _get_metric_from_full_key(self, _evaluator_name: str, full_key: str, num_underscores_in_name: int) -> str:
         splits = full_key.split("_", maxsplit=num_underscores_in_name)
         return splits[-1]
 

--- a/sentence_transformers/evaluation/NanoBEIREvaluator.py
+++ b/sentence_transformers/evaluation/NanoBEIREvaluator.py
@@ -259,7 +259,6 @@ class NanoBEIREvaluator(SentenceEvaluator):
 
         self._validate_dataset_names()
         self._validate_prompts()
-        self._validate_mapping_splits()
 
         ir_evaluator_kwargs = {
             "mrr_at_k": mrr_at_k,
@@ -432,21 +431,9 @@ class NanoBEIREvaluator(SentenceEvaluator):
     ) -> InformationRetrievalEvaluator:
         split_name = self._get_split_name(dataset_name)
 
-        corpus = self._load_dataset_subset_split(
-            self._get_corpus_subset_name(),
-            split=split_name,
-            required_columns=["_id", "text"],
-        )
-        queries = self._load_dataset_subset_split(
-            self._get_queries_subset_name(),
-            split=split_name,
-            required_columns=["_id", "text"],
-        )
-        qrels = self._load_dataset_subset_split(
-            self._get_qrels_subset_name(),
-            split=split_name,
-            required_columns=["query-id", "corpus-id"],
-        )
+        corpus = self._load_dataset_subset_split("corpus", split=split_name, required_columns=["_id", "text"])
+        queries = self._load_dataset_subset_split("queries", split=split_name, required_columns=["_id", "text"])
+        qrels = self._load_dataset_subset_split("qrels", split=split_name, required_columns=["query-id", "corpus-id"])
 
         corpus_dict = {sample["_id"]: sample["text"] for sample in corpus if len(sample["text"]) > 0}
         queries_dict = {sample["_id"]: sample["text"] for sample in queries if len(sample["text"]) > 0}
@@ -549,15 +536,6 @@ class NanoBEIREvaluator(SentenceEvaluator):
     def _get_split_name(self, dataset_name: DatasetNameType | str) -> str:
         return f"Nano{DATASET_NAME_TO_HUMAN_READABLE[dataset_name.lower()]}"
 
-    def _get_corpus_subset_name(self) -> str:
-        return "corpus"
-
-    def _get_queries_subset_name(self) -> str:
-        return "queries"
-
-    def _get_qrels_subset_name(self) -> str:
-        return "qrels"
-
     def _get_prompt_for_dataset(
         self, prompt_mapping: dict[str, str], dataset_name: DatasetNameType | str
     ) -> str | None:
@@ -567,9 +545,6 @@ class NanoBEIREvaluator(SentenceEvaluator):
         del evaluator_name
         splits = full_key.split("_", maxsplit=num_underscores_in_name)
         return splits[-1]
-
-    def _validate_mapping_splits(self) -> None:
-        pass
 
     def store_metrics_in_model_card_data(self, *args, **kwargs):
         # Only store metrics in the model card data if there is more than one dataset.

--- a/sentence_transformers/evaluation/NanoEvaluator.py
+++ b/sentence_transformers/evaluation/NanoEvaluator.py
@@ -227,7 +227,7 @@ class NanoEvaluator(SentenceEvaluator):
             evaluation = evaluator(model, output_path, epoch, steps)
             evaluator_prefix = f"{evaluator.name}_"
             for full_key, metric_value in evaluation.items():
-                # Parse metrics by concrete evaluator name to avoid underscore-splitting ambiguities.
+                # Metric keys are prefixed with "{evaluator.name}_"; strip that prefix when present.
                 metric = full_key[len(evaluator_prefix) :] if full_key.startswith(evaluator_prefix) else full_key
                 per_metric_results.setdefault(metric, []).append(metric_value)
                 per_dataset_results[full_key] = metric_value

--- a/sentence_transformers/evaluation/NanoEvaluator.py
+++ b/sentence_transformers/evaluation/NanoEvaluator.py
@@ -21,10 +21,13 @@ logger = logging.getLogger(__name__)
 
 
 class NanoEvaluator(SentenceEvaluator):
-    """Generic evaluator for Nano-style IR datasets on Hugging Face.
+    """
+    Generic evaluator for Nano-style Information Retrieval datasets on Hugging Face.
 
     This evaluator expects ``corpus``, ``queries``, and ``qrels`` subsets and computes
     IR metrics via :class:`~sentence_transformers.evaluation.InformationRetrievalEvaluator`.
+    It is dataset-agnostic and powers specialized evaluators such as
+    :class:`~sentence_transformers.evaluation.NanoBEIREvaluator`.
 
     Dataset-name handling supports two modes:
 
@@ -35,6 +38,40 @@ class NanoEvaluator(SentenceEvaluator):
        the split directly.
 
     If ``dataset_names`` is ``None``, split names are expanded from the ``queries`` subset.
+    Set ``auto_expand_splits_when_dataset_names_none=False`` to require explicit names.
+
+    Aggregate metrics are prefixed by ``{name}_{aggregate_key}``.
+    For example: ``NanoBEIR_mean_cosine_ndcg@10``.
+
+    Args:
+        dataset_names (list[str] | None): Dataset names or split names to evaluate.
+            ``None`` can be used with auto-expansion from available query splits.
+        dataset_id (str): Hugging Face dataset ID.
+        mrr_at_k (list[int]): ``k`` values for MRR.
+        ndcg_at_k (list[int]): ``k`` values for nDCG.
+        accuracy_at_k (list[int]): ``k`` values for accuracy.
+        precision_recall_at_k (list[int]): ``k`` values for precision/recall.
+        map_at_k (list[int]): ``k`` values for MAP.
+        show_progress_bar (bool): Whether to show progress bars.
+        batch_size (int): Evaluation batch size.
+        write_csv (bool): Whether to write aggregated metrics CSV.
+        truncate_dim (int | None): Optional embedding truncation dimension.
+        score_functions (dict[str, Callable[[Tensor, Tensor], Tensor]] | None):
+            Optional custom score functions.
+        main_score_function (str | SimilarityFunction | None): Optional main score function.
+        aggregate_fn (Callable[[list[float]], float]): Aggregation function across datasets.
+        aggregate_key (str): Aggregate metric key prefix.
+        query_prompts (str | dict[str, str] | None): Query prompt(s), global or per-dataset.
+        corpus_prompts (str | dict[str, str] | None): Corpus prompt(s), global or per-dataset.
+        write_predictions (bool): Whether to write per-query predictions JSONL.
+        dataset_name_to_human_readable (Mapping[str, str] | None): Optional short-name mapping.
+        split_prefix (str): Optional split prefix applied in mapping mode.
+        strict_dataset_name_validation (bool): Whether to validate names strictly against mapping.
+        auto_expand_splits_when_dataset_names_none (bool): Whether to infer dataset names from query splits.
+        corpus_subset_name (str): Subset name for corpus.
+        queries_subset_name (str): Subset name for queries.
+        qrels_subset_name (str): Subset name for qrels.
+        name (str | None): Optional base name for aggregate metric prefixes.
     """
 
     information_retrieval_class = InformationRetrievalEvaluator

--- a/sentence_transformers/evaluation/NanoEvaluator.py
+++ b/sentence_transformers/evaluation/NanoEvaluator.py
@@ -1,0 +1,502 @@
+from __future__ import annotations
+
+import logging
+import os
+from collections.abc import Callable, Mapping
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+from torch import Tensor
+from tqdm import tqdm
+
+from sentence_transformers.evaluation.InformationRetrievalEvaluator import InformationRetrievalEvaluator
+from sentence_transformers.evaluation.SentenceEvaluator import SentenceEvaluator
+from sentence_transformers.similarity_functions import SimilarityFunction
+from sentence_transformers.util import is_datasets_available
+
+if TYPE_CHECKING:
+    from sentence_transformers.SentenceTransformer import SentenceTransformer
+
+logger = logging.getLogger(__name__)
+
+
+class NanoEvaluator(SentenceEvaluator):
+    """Generic evaluator for Nano-style IR datasets on Hugging Face.
+
+    This evaluator expects ``corpus``, ``queries``, and ``qrels`` subsets and computes
+    IR metrics via :class:`~sentence_transformers.evaluation.InformationRetrievalEvaluator`.
+
+    Dataset-name handling supports two modes:
+
+    1. Mapping mode: pass ``dataset_name_to_human_readable`` and ``split_prefix``
+       to convert a logical dataset name (e.g. ``msmarco``) to a split
+       (e.g. ``NanoMSMARCO``).
+    2. Direct split mode: without mapping, each ``dataset_name`` is treated as
+       the split directly.
+
+    If ``dataset_names`` is ``None``, split names are expanded from the ``queries`` subset.
+    """
+
+    information_retrieval_class = InformationRetrievalEvaluator
+
+    def __init__(
+        self,
+        dataset_names: list[str] | None = None,
+        dataset_id: str = "sentence-transformers/NanoBEIR-en",
+        mrr_at_k: list[int] = [10],
+        ndcg_at_k: list[int] = [10],
+        accuracy_at_k: list[int] = [1, 3, 5, 10],
+        precision_recall_at_k: list[int] = [1, 3, 5, 10],
+        map_at_k: list[int] = [100],
+        show_progress_bar: bool = False,
+        batch_size: int = 32,
+        write_csv: bool = True,
+        truncate_dim: int | None = None,
+        score_functions: dict[str, Callable[[Tensor, Tensor], Tensor]] | None = None,
+        main_score_function: str | SimilarityFunction | None = None,
+        aggregate_fn: Callable[[list[float]], float] = np.mean,
+        aggregate_key: str = "mean",
+        query_prompts: str | dict[str, str] | None = None,
+        corpus_prompts: str | dict[str, str] | None = None,
+        write_predictions: bool = False,
+        dataset_name_to_human_readable: Mapping[str, str] | None = None,
+        split_prefix: str = "",
+        strict_dataset_name_validation: bool = False,
+        auto_expand_splits_when_dataset_names_none: bool = True,
+        corpus_subset_name: str = "corpus",
+        queries_subset_name: str = "queries",
+        qrels_subset_name: str = "qrels",
+        name: str | None = None,
+    ) -> None:
+        super().__init__()
+
+        self.dataset_id = dataset_id
+        self.dataset_repo_name = dataset_id.split("/")[-1]
+        self.dataset_name_to_human_readable = (
+            dict(dataset_name_to_human_readable) if dataset_name_to_human_readable else None
+        )
+        self.split_prefix = split_prefix
+        self.strict_dataset_name_validation = strict_dataset_name_validation
+        self.auto_expand_splits_when_dataset_names_none = auto_expand_splits_when_dataset_names_none
+
+        self.corpus_subset_name = corpus_subset_name
+        self.queries_subset_name = queries_subset_name
+        self.qrels_subset_name = qrels_subset_name
+        self._subset_to_split_names_cache: dict[str, list[str]] = {}
+
+        if dataset_names is None:
+            if not self.auto_expand_splits_when_dataset_names_none:
+                raise ValueError("dataset_names cannot be None when auto split expansion is disabled.")
+            # Queries splits define evaluation tasks, so we discover them from this subset.
+            dataset_names = self._get_available_splits(self.queries_subset_name)
+
+        self.dataset_names = dataset_names
+        self.aggregate_fn = aggregate_fn
+        self.aggregate_key = aggregate_key
+        self.write_csv = write_csv
+        self.query_prompts = query_prompts
+        self.corpus_prompts = corpus_prompts
+        self.show_progress_bar = show_progress_bar
+        self.score_functions = score_functions
+        self.score_function_names = sorted(list(self.score_functions.keys())) if score_functions else []
+        self.main_score_function = main_score_function
+        self.truncate_dim = truncate_dim
+
+        base_name = name if name is not None else self.dataset_repo_name
+        self.name = f"{base_name}_{aggregate_key}"
+        if self.truncate_dim:
+            self.name += f"_{self.truncate_dim}"
+
+        # Copy list-like inputs so instances don't share mutable defaults.
+        self.mrr_at_k = list(mrr_at_k)
+        self.ndcg_at_k = list(ndcg_at_k)
+        self.accuracy_at_k = list(accuracy_at_k)
+        self.precision_recall_at_k = list(precision_recall_at_k)
+        self.map_at_k = list(map_at_k)
+
+        self._validate_dataset_names()
+        self._normalize_prompts()
+        self._validate_prompts()
+        self._validate_mapping_splits()
+
+        ir_evaluator_kwargs: dict[str, Any] = {
+            "mrr_at_k": mrr_at_k,
+            "ndcg_at_k": ndcg_at_k,
+            "accuracy_at_k": accuracy_at_k,
+            "precision_recall_at_k": precision_recall_at_k,
+            "map_at_k": map_at_k,
+            "show_progress_bar": show_progress_bar,
+            "batch_size": batch_size,
+            "write_csv": write_csv,
+            "truncate_dim": truncate_dim,
+            "score_functions": score_functions,
+            "main_score_function": main_score_function,
+            "write_predictions": write_predictions,
+        }
+        self.evaluators = [
+            self._load_dataset(dataset_name, **ir_evaluator_kwargs)
+            for dataset_name in tqdm(self.dataset_names, desc="Loading Nano datasets", leave=False)
+        ]
+
+        self.csv_file: str = f"{base_name}_evaluation_{aggregate_key}_results.csv"
+        self.csv_headers = ["epoch", "steps"]
+        self._append_csv_headers(self.score_function_names)
+
+    def _append_csv_headers(self, score_function_names: list[str]) -> None:
+        for score_name in score_function_names:
+            for k_value in self.accuracy_at_k:
+                self.csv_headers.append(f"{score_name}-Accuracy@{k_value}")
+
+            for k_value in self.precision_recall_at_k:
+                self.csv_headers.append(f"{score_name}-Precision@{k_value}")
+                self.csv_headers.append(f"{score_name}-Recall@{k_value}")
+
+            for k_value in self.mrr_at_k:
+                self.csv_headers.append(f"{score_name}-MRR@{k_value}")
+
+            for k_value in self.ndcg_at_k:
+                self.csv_headers.append(f"{score_name}-NDCG@{k_value}")
+
+            for k_value in self.map_at_k:
+                self.csv_headers.append(f"{score_name}-MAP@{k_value}")
+
+    def __call__(
+        self,
+        model: SentenceTransformer,
+        output_path: str | None = None,
+        epoch: int = -1,
+        steps: int = -1,
+        *args: Any,
+        **kwargs: Any,
+    ) -> dict[str, float]:
+        per_metric_results: dict[str, list[float]] = {}
+        per_dataset_results: dict[str, float] = {}
+
+        if epoch != -1:
+            out_txt = f" after epoch {epoch}" if steps == -1 else f" in epoch {epoch} after {steps} steps"
+        else:
+            out_txt = ""
+        if self.truncate_dim is not None:
+            out_txt += f" (truncated to {self.truncate_dim})"
+        logger.info(f"Nano Evaluation of the model on {self.dataset_names} dataset{out_txt}:")
+
+        if self.score_functions is None:
+            self.score_functions = {model.similarity_fn_name: model.similarity}
+            self.score_function_names = [model.similarity_fn_name]
+            self._append_csv_headers(self.score_function_names)
+
+        for evaluator in tqdm(self.evaluators, desc="Evaluating datasets", disable=not self.show_progress_bar):
+            logger.info(f"Evaluating {evaluator.name}")
+            evaluation = evaluator(model, output_path, epoch, steps)
+            evaluator_prefix = f"{evaluator.name}_"
+            for full_key, metric_value in evaluation.items():
+                # Parse metrics by concrete evaluator name to avoid underscore-splitting ambiguities.
+                metric = full_key[len(evaluator_prefix) :] if full_key.startswith(evaluator_prefix) else full_key
+                per_metric_results.setdefault(metric, []).append(metric_value)
+                per_dataset_results[full_key] = metric_value
+
+        agg_results = {metric: self.aggregate_fn(values) for metric, values in per_metric_results.items()}
+
+        if output_path is not None and self.write_csv:
+            os.makedirs(output_path, exist_ok=True)
+            csv_path = os.path.join(output_path, self.csv_file)
+            output_file_exists = os.path.isfile(csv_path)
+            with open(csv_path, mode="a" if output_file_exists else "w", encoding="utf-8") as file_out:
+                if not output_file_exists:
+                    file_out.write(",".join(self.csv_headers))
+                    file_out.write("\n")
+                output_data: list[float | int] = [epoch, steps]
+                for score_name in self.score_function_names:
+                    for k_value in self.accuracy_at_k:
+                        output_data.append(agg_results[f"{score_name}_accuracy@{k_value}"])
+
+                    for k_value in self.precision_recall_at_k:
+                        output_data.append(agg_results[f"{score_name}_precision@{k_value}"])
+                        output_data.append(agg_results[f"{score_name}_recall@{k_value}"])
+
+                    for k_value in self.mrr_at_k:
+                        output_data.append(agg_results[f"{score_name}_mrr@{k_value}"])
+
+                    for k_value in self.ndcg_at_k:
+                        output_data.append(agg_results[f"{score_name}_ndcg@{k_value}"])
+
+                    for k_value in self.map_at_k:
+                        output_data.append(agg_results[f"{score_name}_map@{k_value}"])
+
+                file_out.write(",".join(map(str, output_data)))
+                file_out.write("\n")
+
+        if not self.primary_metric:
+            if self.main_score_function is None:
+                score_function = max(
+                    [(name, agg_results[f"{name}_ndcg@{max(self.ndcg_at_k)}"]) for name in self.score_function_names],
+                    key=lambda item: item[1],
+                )[0]
+                self.primary_metric = f"{score_function}_ndcg@{max(self.ndcg_at_k)}"
+            else:
+                main_score_function_name = (
+                    self.main_score_function.value
+                    if isinstance(self.main_score_function, SimilarityFunction)
+                    else self.main_score_function
+                )
+                self.primary_metric = f"{main_score_function_name}_ndcg@{max(self.ndcg_at_k)}"
+
+        avg_queries = np.mean([len(evaluator.queries) for evaluator in self.evaluators])
+        avg_corpus = np.mean([len(evaluator.corpus) for evaluator in self.evaluators])
+        logger.info(f"Average Queries: {avg_queries}")
+        logger.info(f"Average Corpus: {avg_corpus}\n")
+
+        for score_name in self.score_function_names:
+            logger.info(f"Aggregated for Score Function: {score_name}")
+            for k_value in self.accuracy_at_k:
+                logger.info(
+                    "Accuracy@{}: {:.2f}%".format(k_value, agg_results[f"{score_name}_accuracy@{k_value}"] * 100)
+                )
+
+            for k_value in self.precision_recall_at_k:
+                logger.info(
+                    "Precision@{}: {:.2f}%".format(k_value, agg_results[f"{score_name}_precision@{k_value}"] * 100)
+                )
+                logger.info("Recall@{}: {:.2f}%".format(k_value, agg_results[f"{score_name}_recall@{k_value}"] * 100))
+
+            for k_value in self.mrr_at_k:
+                logger.info("MRR@{}: {:.4f}".format(k_value, agg_results[f"{score_name}_mrr@{k_value}"]))
+
+            for k_value in self.ndcg_at_k:
+                logger.info("NDCG@{}: {:.4f}".format(k_value, agg_results[f"{score_name}_ndcg@{k_value}"]))
+
+            for k_value in self.map_at_k:
+                logger.info("MAP@{}: {:.4f}".format(k_value, agg_results[f"{score_name}_map@{k_value}"]))
+
+        agg_results = self.prefix_name_to_metrics(agg_results, self.name)
+        self.store_metrics_in_model_card_data(model, agg_results, epoch, steps)
+        per_dataset_results.update(agg_results)
+        return per_dataset_results
+
+    def _get_dataset_mapping_value(self, dataset_name: str) -> str:
+        if self.dataset_name_to_human_readable is None:
+            raise ValueError("dataset_name_to_human_readable is not configured.")
+
+        if dataset_name in self.dataset_name_to_human_readable:
+            return self.dataset_name_to_human_readable[dataset_name]
+
+        lowered = dataset_name.lower()
+        if lowered in self.dataset_name_to_human_readable:
+            return self.dataset_name_to_human_readable[lowered]
+
+        raise ValueError(
+            f"Dataset '{dataset_name}' does not exist in dataset_name_to_human_readable mapping. "
+            f"Available dataset names are: {list(self.dataset_name_to_human_readable.keys())}"
+        )
+
+    def _get_split_name(self, dataset_name: str) -> str:
+        if self.dataset_name_to_human_readable is None:
+            return dataset_name
+        mapping_value = self._get_dataset_mapping_value(dataset_name)
+        return f"{self.split_prefix}{mapping_value}"
+
+    def _get_human_readable_name(self, dataset_name: str) -> str:
+        split_name = self._get_split_name(dataset_name)
+        if self.dataset_name_to_human_readable is None:
+            human_readable_name = f"{self.dataset_repo_name}_{split_name}"
+        else:
+            human_readable_name = split_name
+
+        if self.truncate_dim is not None:
+            human_readable_name += f"_{self.truncate_dim}"
+        return human_readable_name
+
+    def _load_dataset(self, dataset_name: str, **ir_evaluator_kwargs: Any) -> InformationRetrievalEvaluator:
+        split_name = self._get_split_name(dataset_name)
+
+        corpus = self._load_dataset_subset_split(
+            self.corpus_subset_name,
+            split=split_name,
+            required_columns=["_id", "text"],
+        )
+        queries = self._load_dataset_subset_split(
+            self.queries_subset_name,
+            split=split_name,
+            required_columns=["_id", "text"],
+        )
+        qrels = self._load_dataset_subset_split(
+            self.qrels_subset_name,
+            split=split_name,
+            required_columns=["query-id", "corpus-id"],
+        )
+
+        corpus_dict = {sample["_id"]: sample["text"] for sample in corpus if len(sample["text"]) > 0}
+        queries_dict = {sample["_id"]: sample["text"] for sample in queries if len(sample["text"]) > 0}
+
+        qrels_dict: dict[str, set[str]] = {}
+        for sample in qrels:
+            corpus_ids = sample.get("corpus-id")
+            qrels_dict.setdefault(sample["query-id"], set())
+            if isinstance(corpus_ids, list):
+                qrels_dict[sample["query-id"]].update(corpus_ids)
+            else:
+                qrels_dict[sample["query-id"]].add(corpus_ids)
+
+        if self.query_prompts is not None:
+            ir_evaluator_kwargs["query_prompt"] = self._get_prompt_for_dataset(self.query_prompts, dataset_name)
+        if self.corpus_prompts is not None:
+            ir_evaluator_kwargs["corpus_prompt"] = self._get_prompt_for_dataset(self.corpus_prompts, dataset_name)
+
+        human_readable_name = self._get_human_readable_name(dataset_name)
+        return self.information_retrieval_class(
+            queries=queries_dict,
+            corpus=corpus_dict,
+            relevant_docs=qrels_dict,
+            name=human_readable_name,
+            **ir_evaluator_kwargs,
+        )
+
+    def _load_dataset_subset_split(self, subset: str, split: str, required_columns: list[str]) -> Any:
+        if not is_datasets_available():
+            raise ValueError(
+                "datasets is not available. Please install it to use the NanoEvaluator via `pip install datasets`."
+            )
+        from datasets import load_dataset
+
+        try:
+            dataset = load_dataset(self.dataset_id, subset, split=split)
+        except Exception as exc:
+            raise ValueError(
+                f"Could not load subset '{subset}' split '{split}' from dataset '{self.dataset_id}'."
+            ) from exc
+
+        if missing_columns := set(required_columns) - set(dataset.column_names):
+            raise ValueError(
+                f"Subset '{subset}' split '{split}' from dataset '{self.dataset_id}' is missing required columns: {list(missing_columns)}."
+            )
+        return dataset
+
+    def _get_available_splits(self, subset: str) -> list[str]:
+        if subset in self._subset_to_split_names_cache:
+            return self._subset_to_split_names_cache[subset]
+
+        if not is_datasets_available():
+            raise ValueError(
+                "datasets is not available. Please install it to use the NanoEvaluator via `pip install datasets`."
+            )
+        from datasets import get_dataset_split_names
+
+        try:
+            split_names = get_dataset_split_names(self.dataset_id, subset)
+        except Exception as exc:
+            raise ValueError(
+                f"Could not list split names for subset '{subset}' from dataset '{self.dataset_id}'."
+            ) from exc
+
+        if not split_names:
+            raise ValueError(f"No split names were found for subset '{subset}' in dataset '{self.dataset_id}'.")
+        self._subset_to_split_names_cache[subset] = list(split_names)
+        return self._subset_to_split_names_cache[subset]
+
+    def _validate_split_exists(self, dataset_name: str, subset: str, split_name: str) -> None:
+        available_splits = self._get_available_splits(subset)
+        if split_name not in available_splits:
+            raise ValueError(
+                f"Dataset '{dataset_name}' maps to split '{split_name}', but it does not exist in subset '{subset}' "
+                f"for dataset '{self.dataset_id}'. Available splits: {available_splits}"
+            )
+
+    def _validate_mapping_splits(self) -> None:
+        if self.dataset_name_to_human_readable is None:
+            return
+
+        # Mapping mode should fail fast on typos/mismatches between mapping and dataset splits.
+        for dataset_name in self.dataset_names:
+            split_name = self._get_split_name(dataset_name)
+            self._validate_split_exists(dataset_name, self.corpus_subset_name, split_name)
+            self._validate_split_exists(dataset_name, self.queries_subset_name, split_name)
+            self._validate_split_exists(dataset_name, self.qrels_subset_name, split_name)
+
+    def _validate_dataset_names(self) -> None:
+        if len(self.dataset_names) == 0:
+            raise ValueError("dataset_names cannot be empty. Use None to evaluate on all datasets.")
+
+        if self.dataset_name_to_human_readable is None:
+            return
+
+        if not self.strict_dataset_name_validation:
+            return
+
+        missing_datasets: list[str] = []
+        for dataset_name in self.dataset_names:
+            try:
+                self._get_dataset_mapping_value(dataset_name)
+            except ValueError:
+                missing_datasets.append(dataset_name)
+
+        if missing_datasets:
+            raise ValueError(
+                f"Dataset(s) {missing_datasets} do not exist in dataset_name_to_human_readable mapping. "
+                f"Available dataset names are: {list(self.dataset_name_to_human_readable.keys())}"
+            )
+
+    def _normalize_prompts(self) -> None:
+        if isinstance(self.query_prompts, str):
+            self.query_prompts = {dataset_name: self.query_prompts for dataset_name in self.dataset_names}
+        if isinstance(self.corpus_prompts, str):
+            self.corpus_prompts = {dataset_name: self.corpus_prompts for dataset_name in self.dataset_names}
+
+    def _get_prompt_for_dataset(self, prompt_mapping: dict[str, str], dataset_name: str) -> str | None:
+        if dataset_name in prompt_mapping:
+            return prompt_mapping[dataset_name]
+        lower_to_prompt = {key.lower(): value for key, value in prompt_mapping.items()}
+        return lower_to_prompt.get(dataset_name.lower())
+
+    def _validate_prompts(self) -> None:
+        error_msg = ""
+        if self.query_prompts is not None:
+            missing_query_prompts = [
+                dataset_name
+                for dataset_name in self.dataset_names
+                if self._get_prompt_for_dataset(self.query_prompts, dataset_name) is None
+            ]
+            if missing_query_prompts:
+                error_msg += f"The following datasets are missing query prompts: {missing_query_prompts}\n"
+
+        if self.corpus_prompts is not None:
+            missing_corpus_prompts = [
+                dataset_name
+                for dataset_name in self.dataset_names
+                if self._get_prompt_for_dataset(self.corpus_prompts, dataset_name) is None
+            ]
+            if missing_corpus_prompts:
+                error_msg += f"The following datasets are missing corpus prompts: {missing_corpus_prompts}\n"
+
+        if error_msg:
+            raise ValueError(error_msg.strip())
+
+    def get_config_dict(self) -> dict[str, Any]:
+        config_dict: dict[str, Any] = {
+            "dataset_names": self.dataset_names,
+            "dataset_id": self.dataset_id,
+            "dataset_name_to_human_readable": self.dataset_name_to_human_readable,
+            "split_prefix": self.split_prefix,
+            "strict_dataset_name_validation": self.strict_dataset_name_validation,
+            "auto_expand_splits_when_dataset_names_none": self.auto_expand_splits_when_dataset_names_none,
+            "corpus_subset_name": self.corpus_subset_name,
+            "queries_subset_name": self.queries_subset_name,
+            "qrels_subset_name": self.qrels_subset_name,
+        }
+        config_dict_candidate_keys = ["truncate_dim", "query_prompts", "corpus_prompts"]
+        for key in config_dict_candidate_keys:
+            value = getattr(self, key)
+            if value is not None:
+                config_dict[key] = value
+        return config_dict
+
+    def store_metrics_in_model_card_data(
+        self,
+        model: SentenceTransformer,
+        metrics: dict[str, Any],
+        epoch: int = 0,
+        step: int = 0,
+    ) -> None:
+        # Avoid duplicate entries when evaluating a single dataset split, where
+        # aggregate metrics equal the per-dataset metrics.
+        if len(self.dataset_names) > 1:
+            super().store_metrics_in_model_card_data(model, metrics, epoch, step)

--- a/sentence_transformers/evaluation/NanoEvaluator.py
+++ b/sentence_transformers/evaluation/NanoEvaluator.py
@@ -1,80 +1,23 @@
 from __future__ import annotations
 
-import logging
-import os
 from collections.abc import Callable, Mapping
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 import numpy as np
 from torch import Tensor
-from tqdm import tqdm
 
-from sentence_transformers.evaluation.InformationRetrievalEvaluator import InformationRetrievalEvaluator
-from sentence_transformers.evaluation.SentenceEvaluator import SentenceEvaluator
+from sentence_transformers.evaluation._nano_utils import _GenericNanoDatasetMixin
+from sentence_transformers.evaluation.NanoBEIREvaluator import NanoBEIREvaluator
 from sentence_transformers.similarity_functions import SimilarityFunction
-from sentence_transformers.util import is_datasets_available
-
-if TYPE_CHECKING:
-    from sentence_transformers.SentenceTransformer import SentenceTransformer
-
-logger = logging.getLogger(__name__)
 
 
-class NanoEvaluator(SentenceEvaluator):
+class NanoEvaluator(_GenericNanoDatasetMixin, NanoBEIREvaluator):
     """
     Generic evaluator for Nano-style Information Retrieval datasets on Hugging Face.
 
-    This evaluator expects ``corpus``, ``queries``, and ``qrels`` subsets and computes
-    IR metrics via :class:`~sentence_transformers.evaluation.InformationRetrievalEvaluator`.
-    It is dataset-agnostic and powers specialized evaluators such as
-    :class:`~sentence_transformers.evaluation.NanoBEIREvaluator`.
-
-    Dataset-name handling supports two modes:
-
-    1. Mapping mode: pass ``dataset_name_to_human_readable`` and ``split_prefix``
-       to convert a logical dataset name (e.g. ``msmarco``) to a split
-       (e.g. ``NanoMSMARCO``).
-    2. Direct split mode: without mapping, each ``dataset_name`` is treated as
-       the split directly.
-
-    If ``dataset_names`` is ``None``, split names are expanded from the ``queries`` subset.
-    Set ``auto_expand_splits_when_dataset_names_none=False`` to require explicit names.
-
-    Aggregate metrics are prefixed by ``{name}_{aggregate_key}``.
-    For example: ``NanoBEIR_mean_cosine_ndcg@10``.
-
-    Args:
-        dataset_names (list[str] | None): Dataset names or split names to evaluate.
-            ``None`` can be used with auto-expansion from available query splits.
-        dataset_id (str): Hugging Face dataset ID.
-        mrr_at_k (list[int]): ``k`` values for MRR.
-        ndcg_at_k (list[int]): ``k`` values for nDCG.
-        accuracy_at_k (list[int]): ``k`` values for accuracy.
-        precision_recall_at_k (list[int]): ``k`` values for precision/recall.
-        map_at_k (list[int]): ``k`` values for MAP.
-        show_progress_bar (bool): Whether to show progress bars.
-        batch_size (int): Evaluation batch size.
-        write_csv (bool): Whether to write aggregated metrics CSV.
-        truncate_dim (int | None): Optional embedding truncation dimension.
-        score_functions (dict[str, Callable[[Tensor, Tensor], Tensor]] | None):
-            Optional custom score functions.
-        main_score_function (str | SimilarityFunction | None): Optional main score function.
-        aggregate_fn (Callable[[list[float]], float]): Aggregation function across datasets.
-        aggregate_key (str): Aggregate metric key prefix.
-        query_prompts (str | dict[str, str] | None): Query prompt(s), global or per-dataset.
-        corpus_prompts (str | dict[str, str] | None): Corpus prompt(s), global or per-dataset.
-        write_predictions (bool): Whether to write per-query predictions JSONL.
-        dataset_name_to_human_readable (Mapping[str, str] | None): Optional short-name mapping.
-        split_prefix (str): Optional split prefix applied in mapping mode.
-        strict_dataset_name_validation (bool): Whether to validate names strictly against mapping.
-        auto_expand_splits_when_dataset_names_none (bool): Whether to infer dataset names from query splits.
-        corpus_subset_name (str): Subset name for corpus.
-        queries_subset_name (str): Subset name for queries.
-        qrels_subset_name (str): Subset name for qrels.
-        name (str | None): Optional base name for aggregate metric prefixes.
+    This evaluator supports direct split names as well as short dataset names that are
+    expanded through ``dataset_name_to_human_readable`` and ``split_prefix``.
     """
-
-    information_retrieval_class = InformationRetrievalEvaluator
 
     def __init__(
         self,
@@ -105,435 +48,37 @@ class NanoEvaluator(SentenceEvaluator):
         qrels_subset_name: str = "qrels",
         name: str | None = None,
     ) -> None:
-        super().__init__()
-
-        self.dataset_id = dataset_id
-        self.dataset_repo_name = dataset_id.split("/")[-1]
-        self.dataset_name_to_human_readable = (
-            dict(dataset_name_to_human_readable) if dataset_name_to_human_readable else None
+        self._initialize_generic_nano_state(
+            dataset_id=dataset_id,
+            dataset_name_to_human_readable=dataset_name_to_human_readable,
+            split_prefix=split_prefix,
+            strict_dataset_name_validation=strict_dataset_name_validation,
+            auto_expand_splits_when_dataset_names_none=auto_expand_splits_when_dataset_names_none,
+            corpus_subset_name=corpus_subset_name,
+            queries_subset_name=queries_subset_name,
+            qrels_subset_name=qrels_subset_name,
+            name=name,
         )
-        self.split_prefix = split_prefix
-        self.strict_dataset_name_validation = strict_dataset_name_validation
-        self.auto_expand_splits_when_dataset_names_none = auto_expand_splits_when_dataset_names_none
-
-        self.corpus_subset_name = corpus_subset_name
-        self.queries_subset_name = queries_subset_name
-        self.qrels_subset_name = qrels_subset_name
-        self._subset_to_split_names_cache: dict[str, list[str]] = {}
-
-        if dataset_names is None:
-            if not self.auto_expand_splits_when_dataset_names_none:
-                raise ValueError("dataset_names cannot be None when auto split expansion is disabled.")
-            # Queries splits define evaluation tasks, so we discover them from this subset.
-            dataset_names = self._get_available_splits(self.queries_subset_name)
-
-        self.dataset_names = dataset_names
-        self.aggregate_fn = aggregate_fn
-        self.aggregate_key = aggregate_key
-        self.write_csv = write_csv
-        self.query_prompts = query_prompts
-        self.corpus_prompts = corpus_prompts
-        self.show_progress_bar = show_progress_bar
-        self.score_functions = score_functions
-        self.score_function_names = sorted(list(self.score_functions.keys())) if score_functions else []
-        self.main_score_function = main_score_function
-        self.truncate_dim = truncate_dim
-
-        base_name = name if name is not None else self.dataset_repo_name
-        self.name = f"{base_name}_{aggregate_key}"
-        if self.truncate_dim:
-            self.name += f"_{self.truncate_dim}"
-
-        # Copy list-like inputs so instances don't share mutable defaults.
-        self.mrr_at_k = list(mrr_at_k)
-        self.ndcg_at_k = list(ndcg_at_k)
-        self.accuracy_at_k = list(accuracy_at_k)
-        self.precision_recall_at_k = list(precision_recall_at_k)
-        self.map_at_k = list(map_at_k)
-
-        self._validate_dataset_names()
-        self._normalize_prompts()
-        self._validate_prompts()
-        self._validate_mapping_splits()
-
-        ir_evaluator_kwargs: dict[str, Any] = {
-            "mrr_at_k": mrr_at_k,
-            "ndcg_at_k": ndcg_at_k,
-            "accuracy_at_k": accuracy_at_k,
-            "precision_recall_at_k": precision_recall_at_k,
-            "map_at_k": map_at_k,
-            "show_progress_bar": show_progress_bar,
-            "batch_size": batch_size,
-            "write_csv": write_csv,
-            "truncate_dim": truncate_dim,
-            "score_functions": score_functions,
-            "main_score_function": main_score_function,
-            "write_predictions": write_predictions,
-        }
-        self.evaluators = [
-            self._load_dataset(dataset_name, **ir_evaluator_kwargs)
-            for dataset_name in tqdm(self.dataset_names, desc="Loading Nano datasets", leave=False)
-        ]
-
-        self.csv_file: str = f"{base_name}_evaluation_{aggregate_key}_results.csv"
-        self.csv_headers = ["epoch", "steps"]
-        self._append_csv_headers(self.score_function_names)
-
-    def _append_csv_headers(self, score_function_names: list[str]) -> None:
-        for score_name in score_function_names:
-            for k_value in self.accuracy_at_k:
-                self.csv_headers.append(f"{score_name}-Accuracy@{k_value}")
-
-            for k_value in self.precision_recall_at_k:
-                self.csv_headers.append(f"{score_name}-Precision@{k_value}")
-                self.csv_headers.append(f"{score_name}-Recall@{k_value}")
-
-            for k_value in self.mrr_at_k:
-                self.csv_headers.append(f"{score_name}-MRR@{k_value}")
-
-            for k_value in self.ndcg_at_k:
-                self.csv_headers.append(f"{score_name}-NDCG@{k_value}")
-
-            for k_value in self.map_at_k:
-                self.csv_headers.append(f"{score_name}-MAP@{k_value}")
-
-    def __call__(
-        self,
-        model: SentenceTransformer,
-        output_path: str | None = None,
-        epoch: int = -1,
-        steps: int = -1,
-        *args: Any,
-        **kwargs: Any,
-    ) -> dict[str, float]:
-        per_metric_results: dict[str, list[float]] = {}
-        per_dataset_results: dict[str, float] = {}
-
-        if epoch != -1:
-            out_txt = f" after epoch {epoch}" if steps == -1 else f" in epoch {epoch} after {steps} steps"
-        else:
-            out_txt = ""
-        if self.truncate_dim is not None:
-            out_txt += f" (truncated to {self.truncate_dim})"
-        logger.info(f"Nano Evaluation of the model on {self.dataset_names} dataset{out_txt}:")
-
-        if self.score_functions is None:
-            self.score_functions = {model.similarity_fn_name: model.similarity}
-            self.score_function_names = [model.similarity_fn_name]
-            self._append_csv_headers(self.score_function_names)
-
-        for evaluator in tqdm(self.evaluators, desc="Evaluating datasets", disable=not self.show_progress_bar):
-            logger.info(f"Evaluating {evaluator.name}")
-            evaluation = evaluator(model, output_path, epoch, steps)
-            evaluator_prefix = f"{evaluator.name}_"
-            for full_key, metric_value in evaluation.items():
-                # Metric keys are prefixed with "{evaluator.name}_"; strip that prefix when present.
-                metric = full_key[len(evaluator_prefix) :] if full_key.startswith(evaluator_prefix) else full_key
-                per_metric_results.setdefault(metric, []).append(metric_value)
-                per_dataset_results[full_key] = metric_value
-
-        agg_results = {metric: self.aggregate_fn(values) for metric, values in per_metric_results.items()}
-
-        if output_path is not None and self.write_csv:
-            os.makedirs(output_path, exist_ok=True)
-            csv_path = os.path.join(output_path, self.csv_file)
-            output_file_exists = os.path.isfile(csv_path)
-            with open(csv_path, mode="a" if output_file_exists else "w", encoding="utf-8") as file_out:
-                if not output_file_exists:
-                    file_out.write(",".join(self.csv_headers))
-                    file_out.write("\n")
-                output_data: list[float | int] = [epoch, steps]
-                for score_name in self.score_function_names:
-                    for k_value in self.accuracy_at_k:
-                        output_data.append(agg_results[f"{score_name}_accuracy@{k_value}"])
-
-                    for k_value in self.precision_recall_at_k:
-                        output_data.append(agg_results[f"{score_name}_precision@{k_value}"])
-                        output_data.append(agg_results[f"{score_name}_recall@{k_value}"])
-
-                    for k_value in self.mrr_at_k:
-                        output_data.append(agg_results[f"{score_name}_mrr@{k_value}"])
-
-                    for k_value in self.ndcg_at_k:
-                        output_data.append(agg_results[f"{score_name}_ndcg@{k_value}"])
-
-                    for k_value in self.map_at_k:
-                        output_data.append(agg_results[f"{score_name}_map@{k_value}"])
-
-                file_out.write(",".join(map(str, output_data)))
-                file_out.write("\n")
-
-        if not self.primary_metric:
-            if self.main_score_function is None:
-                score_function = max(
-                    [(name, agg_results[f"{name}_ndcg@{max(self.ndcg_at_k)}"]) for name in self.score_function_names],
-                    key=lambda item: item[1],
-                )[0]
-                self.primary_metric = f"{score_function}_ndcg@{max(self.ndcg_at_k)}"
-            else:
-                main_score_function_name = (
-                    self.main_score_function.value
-                    if isinstance(self.main_score_function, SimilarityFunction)
-                    else self.main_score_function
-                )
-                self.primary_metric = f"{main_score_function_name}_ndcg@{max(self.ndcg_at_k)}"
-
-        avg_queries = np.mean([len(evaluator.queries) for evaluator in self.evaluators])
-        avg_corpus = np.mean([len(evaluator.corpus) for evaluator in self.evaluators])
-        logger.info(f"Average Queries: {avg_queries}")
-        logger.info(f"Average Corpus: {avg_corpus}\n")
-
-        for score_name in self.score_function_names:
-            logger.info(f"Aggregated for Score Function: {score_name}")
-            for k_value in self.accuracy_at_k:
-                logger.info(
-                    "Accuracy@{}: {:.2f}%".format(k_value, agg_results[f"{score_name}_accuracy@{k_value}"] * 100)
-                )
-
-            for k_value in self.precision_recall_at_k:
-                logger.info(
-                    "Precision@{}: {:.2f}%".format(k_value, agg_results[f"{score_name}_precision@{k_value}"] * 100)
-                )
-                logger.info("Recall@{}: {:.2f}%".format(k_value, agg_results[f"{score_name}_recall@{k_value}"] * 100))
-
-            for k_value in self.mrr_at_k:
-                logger.info("MRR@{}: {:.4f}".format(k_value, agg_results[f"{score_name}_mrr@{k_value}"]))
-
-            for k_value in self.ndcg_at_k:
-                logger.info("NDCG@{}: {:.4f}".format(k_value, agg_results[f"{score_name}_ndcg@{k_value}"]))
-
-            for k_value in self.map_at_k:
-                logger.info("MAP@{}: {:.4f}".format(k_value, agg_results[f"{score_name}_map@{k_value}"]))
-
-        agg_results = self.prefix_name_to_metrics(agg_results, self.name)
-        self.store_metrics_in_model_card_data(model, agg_results, epoch, steps)
-        per_dataset_results.update(agg_results)
-        return per_dataset_results
-
-    def _get_dataset_mapping_value(self, dataset_name: str) -> str:
-        if self.dataset_name_to_human_readable is None:
-            raise ValueError("dataset_name_to_human_readable is not configured.")
-
-        if dataset_name in self.dataset_name_to_human_readable:
-            return self.dataset_name_to_human_readable[dataset_name]
-
-        lowered = dataset_name.lower()
-        if lowered in self.dataset_name_to_human_readable:
-            return self.dataset_name_to_human_readable[lowered]
-
-        raise ValueError(
-            f"Dataset '{dataset_name}' does not exist in dataset_name_to_human_readable mapping. "
-            f"Available dataset names are: {list(self.dataset_name_to_human_readable.keys())}"
+        super().__init__(
+            dataset_names=self._resolve_dataset_names(dataset_names),
+            dataset_id=dataset_id,
+            mrr_at_k=mrr_at_k,
+            ndcg_at_k=ndcg_at_k,
+            accuracy_at_k=accuracy_at_k,
+            precision_recall_at_k=precision_recall_at_k,
+            map_at_k=map_at_k,
+            show_progress_bar=show_progress_bar,
+            batch_size=batch_size,
+            write_csv=write_csv,
+            truncate_dim=truncate_dim,
+            score_functions=score_functions,
+            main_score_function=main_score_function,
+            aggregate_fn=aggregate_fn,
+            aggregate_key=aggregate_key,
+            query_prompts=query_prompts,
+            corpus_prompts=corpus_prompts,
+            write_predictions=write_predictions,
         )
-
-    def _get_split_name(self, dataset_name: str) -> str:
-        if self.dataset_name_to_human_readable is None:
-            return dataset_name
-        mapping_value = self._get_dataset_mapping_value(dataset_name)
-        return f"{self.split_prefix}{mapping_value}"
-
-    def _get_human_readable_name(self, dataset_name: str) -> str:
-        split_name = self._get_split_name(dataset_name)
-        if self.dataset_name_to_human_readable is None:
-            human_readable_name = f"{self.dataset_repo_name}_{split_name}"
-        else:
-            human_readable_name = split_name
-
-        if self.truncate_dim is not None:
-            human_readable_name += f"_{self.truncate_dim}"
-        return human_readable_name
-
-    def _load_dataset(self, dataset_name: str, **ir_evaluator_kwargs: Any) -> InformationRetrievalEvaluator:
-        split_name = self._get_split_name(dataset_name)
-
-        corpus = self._load_dataset_subset_split(
-            self.corpus_subset_name,
-            split=split_name,
-            required_columns=["_id", "text"],
-        )
-        queries = self._load_dataset_subset_split(
-            self.queries_subset_name,
-            split=split_name,
-            required_columns=["_id", "text"],
-        )
-        qrels = self._load_dataset_subset_split(
-            self.qrels_subset_name,
-            split=split_name,
-            required_columns=["query-id", "corpus-id"],
-        )
-
-        corpus_dict = {sample["_id"]: sample["text"] for sample in corpus if len(sample["text"]) > 0}
-        queries_dict = {sample["_id"]: sample["text"] for sample in queries if len(sample["text"]) > 0}
-
-        qrels_dict: dict[str, set[str]] = {}
-        for sample in qrels:
-            corpus_ids = sample.get("corpus-id")
-            qrels_dict.setdefault(sample["query-id"], set())
-            if isinstance(corpus_ids, list):
-                qrels_dict[sample["query-id"]].update(corpus_ids)
-            else:
-                qrels_dict[sample["query-id"]].add(corpus_ids)
-
-        if self.query_prompts is not None:
-            ir_evaluator_kwargs["query_prompt"] = self._get_prompt_for_dataset(self.query_prompts, dataset_name)
-        if self.corpus_prompts is not None:
-            ir_evaluator_kwargs["corpus_prompt"] = self._get_prompt_for_dataset(self.corpus_prompts, dataset_name)
-
-        human_readable_name = self._get_human_readable_name(dataset_name)
-        return self.information_retrieval_class(
-            queries=queries_dict,
-            corpus=corpus_dict,
-            relevant_docs=qrels_dict,
-            name=human_readable_name,
-            **ir_evaluator_kwargs,
-        )
-
-    def _load_dataset_subset_split(self, subset: str, split: str, required_columns: list[str]) -> Any:
-        if not is_datasets_available():
-            raise ValueError(
-                "datasets is not available. Please install it to use the NanoEvaluator via `pip install datasets`."
-            )
-        from datasets import load_dataset
-
-        try:
-            dataset = load_dataset(self.dataset_id, subset, split=split)
-        except Exception as exc:
-            raise ValueError(
-                f"Could not load subset '{subset}' split '{split}' from dataset '{self.dataset_id}'."
-            ) from exc
-
-        if missing_columns := set(required_columns) - set(dataset.column_names):
-            raise ValueError(
-                f"Subset '{subset}' split '{split}' from dataset '{self.dataset_id}' is missing required columns: {list(missing_columns)}."
-            )
-        return dataset
-
-    def _get_available_splits(self, subset: str) -> list[str]:
-        if subset in self._subset_to_split_names_cache:
-            return self._subset_to_split_names_cache[subset]
-
-        if not is_datasets_available():
-            raise ValueError(
-                "datasets is not available. Please install it to use the NanoEvaluator via `pip install datasets`."
-            )
-        from datasets import get_dataset_split_names
-
-        try:
-            split_names = get_dataset_split_names(self.dataset_id, subset)
-        except Exception as exc:
-            raise ValueError(
-                f"Could not list split names for subset '{subset}' from dataset '{self.dataset_id}'."
-            ) from exc
-
-        if not split_names:
-            raise ValueError(f"No split names were found for subset '{subset}' in dataset '{self.dataset_id}'.")
-        self._subset_to_split_names_cache[subset] = list(split_names)
-        return self._subset_to_split_names_cache[subset]
-
-    def _validate_split_exists(self, dataset_name: str, subset: str, split_name: str) -> None:
-        available_splits = self._get_available_splits(subset)
-        if split_name not in available_splits:
-            raise ValueError(
-                f"Dataset '{dataset_name}' maps to split '{split_name}', but it does not exist in subset '{subset}' "
-                f"for dataset '{self.dataset_id}'. Available splits: {available_splits}"
-            )
-
-    def _validate_mapping_splits(self) -> None:
-        if self.dataset_name_to_human_readable is None:
-            return
-
-        # Mapping mode should fail fast on typos/mismatches between mapping and dataset splits.
-        for dataset_name in self.dataset_names:
-            split_name = self._get_split_name(dataset_name)
-            self._validate_split_exists(dataset_name, self.corpus_subset_name, split_name)
-            self._validate_split_exists(dataset_name, self.queries_subset_name, split_name)
-            self._validate_split_exists(dataset_name, self.qrels_subset_name, split_name)
-
-    def _validate_dataset_names(self) -> None:
-        if len(self.dataset_names) == 0:
-            raise ValueError("dataset_names cannot be empty. Use None to evaluate on all datasets.")
-
-        if self.dataset_name_to_human_readable is None:
-            return
-
-        if not self.strict_dataset_name_validation:
-            return
-
-        missing_datasets: list[str] = []
-        for dataset_name in self.dataset_names:
-            try:
-                self._get_dataset_mapping_value(dataset_name)
-            except ValueError:
-                missing_datasets.append(dataset_name)
-
-        if missing_datasets:
-            raise ValueError(
-                f"Dataset(s) {missing_datasets} do not exist in dataset_name_to_human_readable mapping. "
-                f"Available dataset names are: {list(self.dataset_name_to_human_readable.keys())}"
-            )
-
-    def _normalize_prompts(self) -> None:
-        if isinstance(self.query_prompts, str):
-            self.query_prompts = {dataset_name: self.query_prompts for dataset_name in self.dataset_names}
-        if isinstance(self.corpus_prompts, str):
-            self.corpus_prompts = {dataset_name: self.corpus_prompts for dataset_name in self.dataset_names}
-
-    def _get_prompt_for_dataset(self, prompt_mapping: dict[str, str], dataset_name: str) -> str | None:
-        if dataset_name in prompt_mapping:
-            return prompt_mapping[dataset_name]
-        lower_to_prompt = {key.lower(): value for key, value in prompt_mapping.items()}
-        return lower_to_prompt.get(dataset_name.lower())
-
-    def _validate_prompts(self) -> None:
-        error_msg = ""
-        if self.query_prompts is not None:
-            missing_query_prompts = [
-                dataset_name
-                for dataset_name in self.dataset_names
-                if self._get_prompt_for_dataset(self.query_prompts, dataset_name) is None
-            ]
-            if missing_query_prompts:
-                error_msg += f"The following datasets are missing query prompts: {missing_query_prompts}\n"
-
-        if self.corpus_prompts is not None:
-            missing_corpus_prompts = [
-                dataset_name
-                for dataset_name in self.dataset_names
-                if self._get_prompt_for_dataset(self.corpus_prompts, dataset_name) is None
-            ]
-            if missing_corpus_prompts:
-                error_msg += f"The following datasets are missing corpus prompts: {missing_corpus_prompts}\n"
-
-        if error_msg:
-            raise ValueError(error_msg.strip())
 
     def get_config_dict(self) -> dict[str, Any]:
-        config_dict: dict[str, Any] = {
-            "dataset_names": self.dataset_names,
-            "dataset_id": self.dataset_id,
-            "dataset_name_to_human_readable": self.dataset_name_to_human_readable,
-            "split_prefix": self.split_prefix,
-            "strict_dataset_name_validation": self.strict_dataset_name_validation,
-            "auto_expand_splits_when_dataset_names_none": self.auto_expand_splits_when_dataset_names_none,
-            "corpus_subset_name": self.corpus_subset_name,
-            "queries_subset_name": self.queries_subset_name,
-            "qrels_subset_name": self.qrels_subset_name,
-        }
-        config_dict_candidate_keys = ["truncate_dim", "query_prompts", "corpus_prompts"]
-        for key in config_dict_candidate_keys:
-            value = getattr(self, key)
-            if value is not None:
-                config_dict[key] = value
-        return config_dict
-
-    def store_metrics_in_model_card_data(
-        self,
-        model: SentenceTransformer,
-        metrics: dict[str, Any],
-        epoch: int = 0,
-        step: int = 0,
-    ) -> None:
-        # Avoid duplicate entries when evaluating a single dataset split, where
-        # aggregate metrics equal the per-dataset metrics.
-        if len(self.dataset_names) > 1:
-            super().store_metrics_in_model_card_data(model, metrics, epoch, step)
+        return self._get_generic_config_dict()

--- a/sentence_transformers/evaluation/NanoEvaluator.py
+++ b/sentence_transformers/evaluation/NanoEvaluator.py
@@ -57,6 +57,8 @@ class NanoEvaluator(_GenericNanoDatasetMixin, NanoBEIREvaluator):
         self.dataset_names = dataset_names
         self._validate_dataset_names()
         self._validate_mapping_splits()
+        query_prompts = self._normalize_prompt_mapping(query_prompts, dataset_names)
+        corpus_prompts = self._normalize_prompt_mapping(corpus_prompts, dataset_names)
         super().__init__(
             dataset_names=dataset_names,
             dataset_id=dataset_id,
@@ -78,14 +80,9 @@ class NanoEvaluator(_GenericNanoDatasetMixin, NanoBEIREvaluator):
             write_predictions=write_predictions,
         )
 
-    def _get_evaluator_name_root(self) -> str:
+    @property
+    def description(self) -> str:
         return self.evaluator_name
-
-    def _get_evaluation_description(self) -> str:
-        return "Nano"
-
-    def _get_loading_description(self) -> str:
-        return "Loading Nano datasets"
 
     def _get_human_readable_name(self, dataset_name: str) -> str:
         split_name = self._get_split_name(dataset_name)
@@ -96,12 +93,6 @@ class NanoEvaluator(_GenericNanoDatasetMixin, NanoBEIREvaluator):
         if self.truncate_dim is not None:
             human_readable_name += f"_{self.truncate_dim}"
         return human_readable_name
-
-    def _get_prompt_for_dataset(self, prompt_mapping: dict[str, str], dataset_name: str) -> str | None:
-        if dataset_name in prompt_mapping:
-            return prompt_mapping[dataset_name]
-        lower_to_prompt = {key.lower(): value for key, value in prompt_mapping.items()}
-        return lower_to_prompt.get(dataset_name.lower())
 
     def _get_metric_from_full_key(self, evaluator_name: str, full_key: str, num_underscores_in_name: int) -> str:
         prefix = f"{evaluator_name}_"

--- a/sentence_transformers/evaluation/NanoEvaluator.py
+++ b/sentence_transformers/evaluation/NanoEvaluator.py
@@ -43,9 +43,6 @@ class NanoEvaluator(_GenericNanoDatasetMixin, NanoBEIREvaluator):
         split_prefix: str = "",
         strict_dataset_name_validation: bool = False,
         auto_expand_splits_when_dataset_names_none: bool = True,
-        corpus_subset_name: str = "corpus",
-        queries_subset_name: str = "queries",
-        qrels_subset_name: str = "qrels",
         name: str | None = None,
     ) -> None:
         self._initialize_generic_nano_state(
@@ -54,13 +51,14 @@ class NanoEvaluator(_GenericNanoDatasetMixin, NanoBEIREvaluator):
             split_prefix=split_prefix,
             strict_dataset_name_validation=strict_dataset_name_validation,
             auto_expand_splits_when_dataset_names_none=auto_expand_splits_when_dataset_names_none,
-            corpus_subset_name=corpus_subset_name,
-            queries_subset_name=queries_subset_name,
-            qrels_subset_name=qrels_subset_name,
             name=name,
         )
+        dataset_names = self._resolve_dataset_names(dataset_names)
+        self.dataset_names = dataset_names
+        self._validate_dataset_names()
+        self._validate_mapping_splits()
         super().__init__(
-            dataset_names=self._resolve_dataset_names(dataset_names),
+            dataset_names=dataset_names,
             dataset_id=dataset_id,
             mrr_at_k=mrr_at_k,
             ndcg_at_k=ndcg_at_k,
@@ -98,15 +96,6 @@ class NanoEvaluator(_GenericNanoDatasetMixin, NanoBEIREvaluator):
         if self.truncate_dim is not None:
             human_readable_name += f"_{self.truncate_dim}"
         return human_readable_name
-
-    def _get_corpus_subset_name(self) -> str:
-        return self.corpus_subset_name
-
-    def _get_queries_subset_name(self) -> str:
-        return self.queries_subset_name
-
-    def _get_qrels_subset_name(self) -> str:
-        return self.qrels_subset_name
 
     def _get_prompt_for_dataset(self, prompt_mapping: dict[str, str], dataset_name: str) -> str | None:
         if dataset_name in prompt_mapping:

--- a/sentence_transformers/evaluation/NanoEvaluator.py
+++ b/sentence_transformers/evaluation/NanoEvaluator.py
@@ -80,5 +80,45 @@ class NanoEvaluator(_GenericNanoDatasetMixin, NanoBEIREvaluator):
             write_predictions=write_predictions,
         )
 
+    def _get_evaluator_name_root(self) -> str:
+        return self.evaluator_name
+
+    def _get_evaluation_description(self) -> str:
+        return "Nano"
+
+    def _get_loading_description(self) -> str:
+        return "Loading Nano datasets"
+
+    def _get_human_readable_name(self, dataset_name: str) -> str:
+        split_name = self._get_split_name(dataset_name)
+        if self.dataset_name_to_human_readable is None:
+            human_readable_name = f"{self.evaluator_name}_{split_name}"
+        else:
+            human_readable_name = split_name
+        if self.truncate_dim is not None:
+            human_readable_name += f"_{self.truncate_dim}"
+        return human_readable_name
+
+    def _get_corpus_subset_name(self) -> str:
+        return self.corpus_subset_name
+
+    def _get_queries_subset_name(self) -> str:
+        return self.queries_subset_name
+
+    def _get_qrels_subset_name(self) -> str:
+        return self.qrels_subset_name
+
+    def _get_prompt_for_dataset(self, prompt_mapping: dict[str, str], dataset_name: str) -> str | None:
+        if dataset_name in prompt_mapping:
+            return prompt_mapping[dataset_name]
+        lower_to_prompt = {key.lower(): value for key, value in prompt_mapping.items()}
+        return lower_to_prompt.get(dataset_name.lower())
+
+    def _get_metric_from_full_key(self, evaluator_name: str, full_key: str, num_underscores_in_name: int) -> str:
+        prefix = f"{evaluator_name}_"
+        if full_key.startswith(prefix):
+            return full_key.removeprefix(prefix)
+        return full_key.split("_", maxsplit=num_underscores_in_name)[-1]
+
     def get_config_dict(self) -> dict[str, Any]:
         return self._get_generic_config_dict()

--- a/sentence_transformers/evaluation/__init__.py
+++ b/sentence_transformers/evaluation/__init__.py
@@ -7,6 +7,7 @@ from .LabelAccuracyEvaluator import LabelAccuracyEvaluator
 from .MSEEvaluator import MSEEvaluator
 from .MSEEvaluatorFromDataFrame import MSEEvaluatorFromDataFrame
 from .NanoBEIREvaluator import NanoBEIREvaluator
+from .NanoEvaluator import NanoEvaluator
 from .ParaphraseMiningEvaluator import ParaphraseMiningEvaluator
 from .RerankingEvaluator import RerankingEvaluator
 from .SentenceEvaluator import SentenceEvaluator
@@ -24,6 +25,7 @@ __all__ = [
     "LabelAccuracyEvaluator",
     "MSEEvaluator",
     "MSEEvaluatorFromDataFrame",
+    "NanoEvaluator",
     "ParaphraseMiningEvaluator",
     "SequentialEvaluator",
     "TranslationEvaluator",

--- a/sentence_transformers/evaluation/_nano_utils.py
+++ b/sentence_transformers/evaluation/_nano_utils.py
@@ -35,6 +35,24 @@ class _GenericNanoDatasetMixin:
             raise ValueError("dataset_names cannot be None when auto split expansion is disabled.")
         return self._get_available_splits("queries")
 
+    def _normalize_prompt_mapping(
+        self,
+        prompt_mapping: str | dict[str, str] | None,
+        dataset_names: list[str],
+    ) -> str | dict[str, str] | None:
+        if prompt_mapping is None or isinstance(prompt_mapping, str):
+            return prompt_mapping
+
+        lower_to_prompt = {key.lower(): value for key, value in prompt_mapping.items()}
+        normalized_prompt_mapping = {}
+        for dataset_name in dataset_names:
+            prompt = prompt_mapping.get(dataset_name)
+            if prompt is None:
+                prompt = lower_to_prompt.get(dataset_name.lower())
+            if prompt is not None:
+                normalized_prompt_mapping[dataset_name] = prompt
+        return normalized_prompt_mapping
+
     def _is_known_split_name(self, dataset_name: str) -> bool:
         return dataset_name in self._get_available_splits("queries")
 

--- a/sentence_transformers/evaluation/_nano_utils.py
+++ b/sentence_transformers/evaluation/_nano_utils.py
@@ -57,6 +57,8 @@ class _GenericNanoDatasetMixin:
         lowered = dataset_name.lower()
         if lowered in self.dataset_name_to_human_readable:
             return f"{self.split_prefix}{self.dataset_name_to_human_readable[lowered]}"
+        if not self.strict_dataset_name_validation:
+            return dataset_name
         raise ValueError(
             f"Dataset '{dataset_name}' does not exist in dataset_name_to_human_readable mapping. "
             f"Available dataset names are: {list(self.dataset_name_to_human_readable.keys())}"

--- a/sentence_transformers/evaluation/_nano_utils.py
+++ b/sentence_transformers/evaluation/_nano_utils.py
@@ -1,0 +1,308 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from sentence_transformers.util import is_datasets_available
+
+
+class _GenericNanoDatasetMixin:
+    def _initialize_generic_nano_state(
+        self,
+        *,
+        dataset_id: str,
+        dataset_name_to_human_readable: Mapping[str, str] | None,
+        split_prefix: str,
+        strict_dataset_name_validation: bool,
+        auto_expand_splits_when_dataset_names_none: bool,
+        corpus_subset_name: str,
+        queries_subset_name: str,
+        qrels_subset_name: str,
+        name: str | None,
+    ) -> None:
+        self.dataset_id = dataset_id
+        self.dataset_name_to_human_readable = (
+            dict(dataset_name_to_human_readable) if dataset_name_to_human_readable else None
+        )
+        self.split_prefix = split_prefix
+        self.strict_dataset_name_validation = strict_dataset_name_validation
+        self.auto_expand_splits_when_dataset_names_none = auto_expand_splits_when_dataset_names_none
+        self.corpus_subset_name = corpus_subset_name
+        self.queries_subset_name = queries_subset_name
+        self.qrels_subset_name = qrels_subset_name
+        self.evaluator_name = name or dataset_id.split("/")[-1]
+        self._subset_to_split_names_cache: dict[str, list[str]] = {}
+
+    def _resolve_dataset_names(self, dataset_names: list[str] | None) -> list[str]:
+        if dataset_names is not None:
+            return dataset_names
+        if not self.auto_expand_splits_when_dataset_names_none:
+            raise ValueError("dataset_names cannot be None when auto split expansion is disabled.")
+        return self._get_available_splits(self.queries_subset_name)
+
+    def _get_evaluator_name_root(self) -> str:
+        return self.evaluator_name
+
+    def _get_evaluation_description(self) -> str:
+        return "Nano"
+
+    def _get_loading_description(self) -> str:
+        return "Loading Nano datasets"
+
+    def _get_split_name(self, dataset_name: str) -> str:
+        if self.dataset_name_to_human_readable is None:
+            return dataset_name
+        if dataset_name in self.dataset_name_to_human_readable:
+            return f"{self.split_prefix}{self.dataset_name_to_human_readable[dataset_name]}"
+        lowered = dataset_name.lower()
+        if lowered in self.dataset_name_to_human_readable:
+            return f"{self.split_prefix}{self.dataset_name_to_human_readable[lowered]}"
+        raise ValueError(
+            f"Dataset '{dataset_name}' does not exist in dataset_name_to_human_readable mapping. "
+            f"Available dataset names are: {list(self.dataset_name_to_human_readable.keys())}"
+        )
+
+    def _get_human_readable_name(self, dataset_name: str) -> str:
+        split_name = self._get_split_name(dataset_name)
+        if self.dataset_name_to_human_readable is None:
+            human_readable_name = f"{self.evaluator_name}_{split_name}"
+        else:
+            human_readable_name = split_name
+        truncate_dim = getattr(self, "truncate_dim", None)
+        if truncate_dim is not None:
+            human_readable_name += f"_{truncate_dim}"
+        return human_readable_name
+
+    def _get_corpus_subset_name(self) -> str:
+        return self.corpus_subset_name
+
+    def _get_queries_subset_name(self) -> str:
+        return self.queries_subset_name
+
+    def _get_qrels_subset_name(self) -> str:
+        return self.qrels_subset_name
+
+    def _get_prompt_for_dataset(self, prompt_mapping: dict[str, str], dataset_name: str) -> str | None:
+        if dataset_name in prompt_mapping:
+            return prompt_mapping[dataset_name]
+        lower_to_prompt = {key.lower(): value for key, value in prompt_mapping.items()}
+        return lower_to_prompt.get(dataset_name.lower())
+
+    def _validate_dataset_names(self) -> None:
+        if len(self.dataset_names) == 0:
+            raise ValueError("dataset_names cannot be empty. Use None to evaluate on all datasets.")
+        if self.dataset_name_to_human_readable is None or not self.strict_dataset_name_validation:
+            return
+
+        missing_datasets = []
+        for dataset_name in self.dataset_names:
+            try:
+                self._get_split_name(dataset_name)
+            except ValueError:
+                missing_datasets.append(dataset_name)
+        if missing_datasets:
+            raise ValueError(
+                f"Dataset(s) {missing_datasets} do not exist in dataset_name_to_human_readable mapping. "
+                f"Available dataset names are: {list(self.dataset_name_to_human_readable.keys())}"
+            )
+
+    def _get_required_subset_names_for_split_validation(self) -> list[str]:
+        return [self.corpus_subset_name, self.queries_subset_name, self.qrels_subset_name]
+
+    def _validate_mapping_splits(self) -> None:
+        if self.dataset_name_to_human_readable is None:
+            return
+        for dataset_name in self.dataset_names:
+            split_name = self._get_split_name(dataset_name)
+            for subset_name in self._get_required_subset_names_for_split_validation():
+                self._validate_split_exists(dataset_name, subset_name, split_name)
+
+    def _get_available_splits(self, subset: str) -> list[str]:
+        if subset in self._subset_to_split_names_cache:
+            return self._subset_to_split_names_cache[subset]
+        if not is_datasets_available():
+            raise ValueError(f"datasets is not available. Please install it to use the {type(self).__name__}.")
+        from datasets import get_dataset_split_names
+
+        try:
+            split_names = get_dataset_split_names(self.dataset_id, subset)
+        except Exception as exc:
+            raise ValueError(
+                f"Could not list split names for subset '{subset}' from dataset '{self.dataset_id}'."
+            ) from exc
+
+        if not split_names:
+            raise ValueError(f"No split names were found for subset '{subset}' in dataset '{self.dataset_id}'.")
+        self._subset_to_split_names_cache[subset] = list(split_names)
+        return self._subset_to_split_names_cache[subset]
+
+    def _validate_split_exists(self, dataset_name: str, subset: str, split_name: str) -> None:
+        available_splits = self._get_available_splits(subset)
+        if split_name not in available_splits:
+            raise ValueError(
+                f"Dataset '{dataset_name}' maps to split '{split_name}', but it does not exist in subset '{subset}' "
+                f"for dataset '{self.dataset_id}'. Available splits: {available_splits}"
+            )
+
+    def _get_metric_from_full_key(self, evaluator_name: str, full_key: str, num_underscores_in_name: int) -> str:
+        prefix = f"{evaluator_name}_"
+        if full_key.startswith(prefix):
+            return full_key.removeprefix(prefix)
+        return full_key.split("_", maxsplit=num_underscores_in_name)[-1]
+
+    def _get_generic_config_dict(self) -> dict[str, Any]:
+        config_dict: dict[str, Any] = {
+            "dataset_names": self.dataset_names,
+            "dataset_id": self.dataset_id,
+            "dataset_name_to_human_readable": self.dataset_name_to_human_readable,
+            "split_prefix": self.split_prefix,
+            "strict_dataset_name_validation": self.strict_dataset_name_validation,
+            "auto_expand_splits_when_dataset_names_none": self.auto_expand_splits_when_dataset_names_none,
+            "corpus_subset_name": self.corpus_subset_name,
+            "queries_subset_name": self.queries_subset_name,
+            "qrels_subset_name": self.qrels_subset_name,
+        }
+        for key in ["truncate_dim", "query_prompts", "corpus_prompts"]:
+            value = getattr(self, key, None)
+            if value is not None:
+                config_dict[key] = value
+        return config_dict
+
+
+class _GenericCrossEncoderNanoMixin(_GenericNanoDatasetMixin):
+    def _initialize_generic_cross_encoder_state(
+        self,
+        *,
+        dataset_id: str,
+        dataset_name_to_human_readable: Mapping[str, str] | None,
+        split_prefix: str,
+        strict_dataset_name_validation: bool,
+        auto_expand_splits_when_dataset_names_none: bool,
+        corpus_subset_name: str,
+        queries_subset_name: str,
+        qrels_subset_name: str,
+        candidate_subset_name: str,
+        bm25_subset_name: str | None,
+        retrieved_corpus_ids_column: str,
+        name: str | None,
+    ) -> None:
+        self._initialize_generic_nano_state(
+            dataset_id=dataset_id,
+            dataset_name_to_human_readable=dataset_name_to_human_readable,
+            split_prefix=split_prefix,
+            strict_dataset_name_validation=strict_dataset_name_validation,
+            auto_expand_splits_when_dataset_names_none=auto_expand_splits_when_dataset_names_none,
+            corpus_subset_name=corpus_subset_name,
+            queries_subset_name=queries_subset_name,
+            qrels_subset_name=qrels_subset_name,
+            name=name,
+        )
+        if bm25_subset_name is not None:
+            if candidate_subset_name != "bm25" and bm25_subset_name != candidate_subset_name:
+                raise ValueError(
+                    "Received both candidate_subset_name and bm25_subset_name with different values. "
+                    "Please pass only candidate_subset_name."
+                )
+            candidate_subset_name = bm25_subset_name
+        self.candidate_subset_name = candidate_subset_name
+        self.bm25_subset_name = bm25_subset_name
+        self.retrieved_corpus_ids_column = retrieved_corpus_ids_column
+
+    def _get_human_readable_name(self, dataset_name: str) -> str:
+        return f"{super()._get_human_readable_name(dataset_name)}_R{self.rerank_k}"
+
+    def _get_candidate_subset_name(self) -> str:
+        return self.candidate_subset_name
+
+    def _get_retrieved_corpus_ids_column(self) -> str:
+        return self.retrieved_corpus_ids_column
+
+    def _get_required_subset_names_for_split_validation(self) -> list[str]:
+        return [*super()._get_required_subset_names_for_split_validation(), self.candidate_subset_name]
+
+    def _parse_evaluation_key(self, evaluator_name: str, full_key: str) -> tuple[str, str]:
+        return full_key, self._get_metric_from_full_key(evaluator_name, full_key, self.name.count("_"))
+
+    def _validate_retrieval_references(
+        self,
+        dataset_name: str,
+        split_name: str,
+        query_mapping: dict[str, str],
+        corpus_mapping: dict[str, str],
+        qrels_mapping: dict[str, set[str]],
+        retrieved: Any,
+    ) -> None:
+        missing_query_ids_in_qrels = [query_id for query_id in qrels_mapping if query_id not in query_mapping]
+        missing_positive_ids = sorted(
+            {
+                corpus_id
+                for corpus_ids in qrels_mapping.values()
+                for corpus_id in corpus_ids
+                if corpus_id not in corpus_mapping
+            }
+        )
+
+        missing_query_ids_in_candidates: set[str] = set()
+        missing_qrels_for_candidates: set[str] = set()
+        missing_retrieved_ids: set[str] = set()
+        for sample in retrieved:
+            query_id = sample["query-id"]
+            if query_id not in query_mapping:
+                missing_query_ids_in_candidates.add(query_id)
+            if query_id not in qrels_mapping:
+                missing_qrels_for_candidates.add(query_id)
+            for document_id in sample[self.retrieved_corpus_ids_column]:
+                if document_id not in corpus_mapping:
+                    missing_retrieved_ids.add(document_id)
+
+        if any(
+            [
+                missing_query_ids_in_qrels,
+                missing_positive_ids,
+                missing_query_ids_in_candidates,
+                missing_qrels_for_candidates,
+                missing_retrieved_ids,
+            ]
+        ):
+            error_details: list[str] = []
+            if missing_query_ids_in_qrels:
+                error_details.append(f"qrels references unknown query IDs: {sorted(missing_query_ids_in_qrels)[:5]}")
+            if missing_positive_ids:
+                error_details.append(f"qrels references unknown corpus IDs: {missing_positive_ids[:5]}")
+            if missing_query_ids_in_candidates:
+                error_details.append(
+                    f"candidate subset references unknown query IDs: {sorted(missing_query_ids_in_candidates)[:5]}"
+                )
+            if missing_qrels_for_candidates:
+                error_details.append(
+                    f"candidate subset contains queries missing in qrels: {sorted(missing_qrels_for_candidates)[:5]}"
+                )
+            if missing_retrieved_ids:
+                error_details.append(
+                    f"candidate subset references unknown corpus IDs: {sorted(missing_retrieved_ids)[:5]}"
+                )
+            raise ValueError(
+                f"Inconsistent IDs found for dataset '{dataset_name}' split '{split_name}' in '{self.dataset_id}'. "
+                + " | ".join(error_details)
+            )
+
+    def _get_generic_cross_encoder_config_dict(self) -> dict[str, Any]:
+        config_dict: dict[str, Any] = {
+            "dataset_names": self.dataset_names,
+            "dataset_id": self.dataset_id,
+            "rerank_k": self.rerank_k,
+            "at_k": self.at_k,
+            "always_rerank_positives": self.always_rerank_positives,
+            "dataset_name_to_human_readable": self.dataset_name_to_human_readable,
+            "split_prefix": self.split_prefix,
+            "strict_dataset_name_validation": self.strict_dataset_name_validation,
+            "auto_expand_splits_when_dataset_names_none": self.auto_expand_splits_when_dataset_names_none,
+            "corpus_subset_name": self.corpus_subset_name,
+            "queries_subset_name": self.queries_subset_name,
+            "qrels_subset_name": self.qrels_subset_name,
+            "candidate_subset_name": self.candidate_subset_name,
+            "retrieved_corpus_ids_column": self.retrieved_corpus_ids_column,
+        }
+        if self.bm25_subset_name is not None:
+            config_dict["bm25_subset_name"] = self.candidate_subset_name
+        return config_dict

--- a/sentence_transformers/evaluation/_nano_utils.py
+++ b/sentence_transformers/evaluation/_nano_utils.py
@@ -15,9 +15,6 @@ class _GenericNanoDatasetMixin:
         split_prefix: str,
         strict_dataset_name_validation: bool,
         auto_expand_splits_when_dataset_names_none: bool,
-        corpus_subset_name: str,
-        queries_subset_name: str,
-        qrels_subset_name: str,
         name: str | None,
     ) -> None:
         self.dataset_id = dataset_id
@@ -27,9 +24,7 @@ class _GenericNanoDatasetMixin:
         self.split_prefix = split_prefix
         self.strict_dataset_name_validation = strict_dataset_name_validation
         self.auto_expand_splits_when_dataset_names_none = auto_expand_splits_when_dataset_names_none
-        self.corpus_subset_name = corpus_subset_name
-        self.queries_subset_name = queries_subset_name
-        self.qrels_subset_name = qrels_subset_name
+        self._configured_name = name
         self.evaluator_name = name or dataset_id.split("/")[-1]
         self._subset_to_split_names_cache: dict[str, list[str]] = {}
 
@@ -38,7 +33,10 @@ class _GenericNanoDatasetMixin:
             return dataset_names
         if not self.auto_expand_splits_when_dataset_names_none:
             raise ValueError("dataset_names cannot be None when auto split expansion is disabled.")
-        return self._get_available_splits(self.queries_subset_name)
+        return self._get_available_splits("queries")
+
+    def _is_known_split_name(self, dataset_name: str) -> bool:
+        return dataset_name in self._get_available_splits("queries")
 
     def _get_split_name(self, dataset_name: str) -> str:
         if self.dataset_name_to_human_readable is None:
@@ -49,6 +47,8 @@ class _GenericNanoDatasetMixin:
         if lowered in self.dataset_name_to_human_readable:
             return f"{self.split_prefix}{self.dataset_name_to_human_readable[lowered]}"
         if not self.strict_dataset_name_validation:
+            return dataset_name
+        if self._is_known_split_name(dataset_name):
             return dataset_name
         raise ValueError(
             f"Dataset '{dataset_name}' does not exist in dataset_name_to_human_readable mapping. "
@@ -63,10 +63,13 @@ class _GenericNanoDatasetMixin:
 
         missing_datasets = []
         for dataset_name in self.dataset_names:
-            try:
-                self._get_split_name(dataset_name)
-            except ValueError:
-                missing_datasets.append(dataset_name)
+            if dataset_name in self.dataset_name_to_human_readable:
+                continue
+            if dataset_name.lower() in self.dataset_name_to_human_readable:
+                continue
+            if self._is_known_split_name(dataset_name):
+                continue
+            missing_datasets.append(dataset_name)
         if missing_datasets:
             raise ValueError(
                 f"Dataset(s) {missing_datasets} do not exist in dataset_name_to_human_readable mapping. "
@@ -74,7 +77,7 @@ class _GenericNanoDatasetMixin:
             )
 
     def _get_required_subset_names_for_split_validation(self) -> list[str]:
-        return [self.corpus_subset_name, self.queries_subset_name, self.qrels_subset_name]
+        return ["corpus", "queries", "qrels"]
 
     def _validate_mapping_splits(self) -> None:
         if self.dataset_name_to_human_readable is None:
@@ -119,10 +122,9 @@ class _GenericNanoDatasetMixin:
             "split_prefix": self.split_prefix,
             "strict_dataset_name_validation": self.strict_dataset_name_validation,
             "auto_expand_splits_when_dataset_names_none": self.auto_expand_splits_when_dataset_names_none,
-            "corpus_subset_name": self.corpus_subset_name,
-            "queries_subset_name": self.queries_subset_name,
-            "qrels_subset_name": self.qrels_subset_name,
         }
+        if self._configured_name is not None:
+            config_dict["name"] = self._configured_name
         for key in ["truncate_dim", "query_prompts", "corpus_prompts"]:
             value = getattr(self, key, None)
             if value is not None:
@@ -139,8 +141,6 @@ class _GenericCrossEncoderNanoMixin(_GenericNanoDatasetMixin):
         split_prefix: str,
         strict_dataset_name_validation: bool,
         auto_expand_splits_when_dataset_names_none: bool,
-        candidate_subset_name: str,
-        bm25_subset_name: str | None,
         name: str | None,
     ) -> None:
         self._initialize_generic_nano_state(
@@ -149,23 +149,11 @@ class _GenericCrossEncoderNanoMixin(_GenericNanoDatasetMixin):
             split_prefix=split_prefix,
             strict_dataset_name_validation=strict_dataset_name_validation,
             auto_expand_splits_when_dataset_names_none=auto_expand_splits_when_dataset_names_none,
-            corpus_subset_name="corpus",
-            queries_subset_name="queries",
-            qrels_subset_name="qrels",
             name=name,
         )
-        if bm25_subset_name is not None:
-            if candidate_subset_name != "bm25" and bm25_subset_name != candidate_subset_name:
-                raise ValueError(
-                    "Received both candidate_subset_name and bm25_subset_name with different values. "
-                    "Please pass only candidate_subset_name."
-                )
-            candidate_subset_name = bm25_subset_name
-        self.candidate_subset_name = candidate_subset_name
-        self.bm25_subset_name = bm25_subset_name
 
     def _get_required_subset_names_for_split_validation(self) -> list[str]:
-        return [*super()._get_required_subset_names_for_split_validation(), self.candidate_subset_name]
+        return [*super()._get_required_subset_names_for_split_validation(), "bm25"]
 
     def _validate_retrieval_references(
         self,
@@ -241,8 +229,7 @@ class _GenericCrossEncoderNanoMixin(_GenericNanoDatasetMixin):
             "split_prefix": self.split_prefix,
             "strict_dataset_name_validation": self.strict_dataset_name_validation,
             "auto_expand_splits_when_dataset_names_none": self.auto_expand_splits_when_dataset_names_none,
-            "candidate_subset_name": self.candidate_subset_name,
         }
-        if self.bm25_subset_name is not None:
-            config_dict["bm25_subset_name"] = self.candidate_subset_name
+        if self._configured_name is not None:
+            config_dict["name"] = self._configured_name
         return config_dict

--- a/sentence_transformers/evaluation/_nano_utils.py
+++ b/sentence_transformers/evaluation/_nano_utils.py
@@ -40,15 +40,6 @@ class _GenericNanoDatasetMixin:
             raise ValueError("dataset_names cannot be None when auto split expansion is disabled.")
         return self._get_available_splits(self.queries_subset_name)
 
-    def _get_evaluator_name_root(self) -> str:
-        return self.evaluator_name
-
-    def _get_evaluation_description(self) -> str:
-        return "Nano"
-
-    def _get_loading_description(self) -> str:
-        return "Loading Nano datasets"
-
     def _get_split_name(self, dataset_name: str) -> str:
         if self.dataset_name_to_human_readable is None:
             return dataset_name
@@ -63,32 +54,6 @@ class _GenericNanoDatasetMixin:
             f"Dataset '{dataset_name}' does not exist in dataset_name_to_human_readable mapping. "
             f"Available dataset names are: {list(self.dataset_name_to_human_readable.keys())}"
         )
-
-    def _get_human_readable_name(self, dataset_name: str) -> str:
-        split_name = self._get_split_name(dataset_name)
-        if self.dataset_name_to_human_readable is None:
-            human_readable_name = f"{self.evaluator_name}_{split_name}"
-        else:
-            human_readable_name = split_name
-        truncate_dim = getattr(self, "truncate_dim", None)
-        if truncate_dim is not None:
-            human_readable_name += f"_{truncate_dim}"
-        return human_readable_name
-
-    def _get_corpus_subset_name(self) -> str:
-        return self.corpus_subset_name
-
-    def _get_queries_subset_name(self) -> str:
-        return self.queries_subset_name
-
-    def _get_qrels_subset_name(self) -> str:
-        return self.qrels_subset_name
-
-    def _get_prompt_for_dataset(self, prompt_mapping: dict[str, str], dataset_name: str) -> str | None:
-        if dataset_name in prompt_mapping:
-            return prompt_mapping[dataset_name]
-        lower_to_prompt = {key.lower(): value for key, value in prompt_mapping.items()}
-        return lower_to_prompt.get(dataset_name.lower())
 
     def _validate_dataset_names(self) -> None:
         if len(self.dataset_names) == 0:
@@ -145,12 +110,6 @@ class _GenericNanoDatasetMixin:
                 f"Dataset '{dataset_name}' maps to split '{split_name}', but it does not exist in subset '{subset}' "
                 f"for dataset '{self.dataset_id}'. Available splits: {available_splits}"
             )
-
-    def _get_metric_from_full_key(self, evaluator_name: str, full_key: str, num_underscores_in_name: int) -> str:
-        prefix = f"{evaluator_name}_"
-        if full_key.startswith(prefix):
-            return full_key.removeprefix(prefix)
-        return full_key.split("_", maxsplit=num_underscores_in_name)[-1]
 
     def _get_generic_config_dict(self) -> dict[str, Any]:
         config_dict: dict[str, Any] = {
@@ -210,20 +169,8 @@ class _GenericCrossEncoderNanoMixin(_GenericNanoDatasetMixin):
         self.bm25_subset_name = bm25_subset_name
         self.retrieved_corpus_ids_column = retrieved_corpus_ids_column
 
-    def _get_human_readable_name(self, dataset_name: str) -> str:
-        return f"{super()._get_human_readable_name(dataset_name)}_R{self.rerank_k}"
-
-    def _get_candidate_subset_name(self) -> str:
-        return self.candidate_subset_name
-
-    def _get_retrieved_corpus_ids_column(self) -> str:
-        return self.retrieved_corpus_ids_column
-
     def _get_required_subset_names_for_split_validation(self) -> list[str]:
         return [*super()._get_required_subset_names_for_split_validation(), self.candidate_subset_name]
-
-    def _parse_evaluation_key(self, evaluator_name: str, full_key: str) -> tuple[str, str]:
-        return full_key, self._get_metric_from_full_key(evaluator_name, full_key, self.name.count("_"))
 
     def _validate_retrieval_references(
         self,

--- a/sentence_transformers/evaluation/_nano_utils.py
+++ b/sentence_transformers/evaluation/_nano_utils.py
@@ -139,12 +139,8 @@ class _GenericCrossEncoderNanoMixin(_GenericNanoDatasetMixin):
         split_prefix: str,
         strict_dataset_name_validation: bool,
         auto_expand_splits_when_dataset_names_none: bool,
-        corpus_subset_name: str,
-        queries_subset_name: str,
-        qrels_subset_name: str,
         candidate_subset_name: str,
         bm25_subset_name: str | None,
-        retrieved_corpus_ids_column: str,
         name: str | None,
     ) -> None:
         self._initialize_generic_nano_state(
@@ -153,9 +149,9 @@ class _GenericCrossEncoderNanoMixin(_GenericNanoDatasetMixin):
             split_prefix=split_prefix,
             strict_dataset_name_validation=strict_dataset_name_validation,
             auto_expand_splits_when_dataset_names_none=auto_expand_splits_when_dataset_names_none,
-            corpus_subset_name=corpus_subset_name,
-            queries_subset_name=queries_subset_name,
-            qrels_subset_name=qrels_subset_name,
+            corpus_subset_name="corpus",
+            queries_subset_name="queries",
+            qrels_subset_name="qrels",
             name=name,
         )
         if bm25_subset_name is not None:
@@ -167,7 +163,6 @@ class _GenericCrossEncoderNanoMixin(_GenericNanoDatasetMixin):
             candidate_subset_name = bm25_subset_name
         self.candidate_subset_name = candidate_subset_name
         self.bm25_subset_name = bm25_subset_name
-        self.retrieved_corpus_ids_column = retrieved_corpus_ids_column
 
     def _get_required_subset_names_for_split_validation(self) -> list[str]:
         return [*super()._get_required_subset_names_for_split_validation(), self.candidate_subset_name]
@@ -200,7 +195,7 @@ class _GenericCrossEncoderNanoMixin(_GenericNanoDatasetMixin):
                 missing_query_ids_in_candidates.add(query_id)
             if query_id not in qrels_mapping:
                 missing_qrels_for_candidates.add(query_id)
-            for document_id in sample[self.retrieved_corpus_ids_column]:
+            for document_id in sample["corpus-ids"]:
                 if document_id not in corpus_mapping:
                     missing_retrieved_ids.add(document_id)
 
@@ -246,11 +241,7 @@ class _GenericCrossEncoderNanoMixin(_GenericNanoDatasetMixin):
             "split_prefix": self.split_prefix,
             "strict_dataset_name_validation": self.strict_dataset_name_validation,
             "auto_expand_splits_when_dataset_names_none": self.auto_expand_splits_when_dataset_names_none,
-            "corpus_subset_name": self.corpus_subset_name,
-            "queries_subset_name": self.queries_subset_name,
-            "qrels_subset_name": self.qrels_subset_name,
             "candidate_subset_name": self.candidate_subset_name,
-            "retrieved_corpus_ids_column": self.retrieved_corpus_ids_column,
         }
         if self.bm25_subset_name is not None:
             config_dict["bm25_subset_name"] = self.candidate_subset_name

--- a/sentence_transformers/sparse_encoder/evaluation/SparseNanoBEIREvaluator.py
+++ b/sentence_transformers/sparse_encoder/evaluation/SparseNanoBEIREvaluator.py
@@ -11,64 +11,174 @@ from sentence_transformers.sparse_encoder.evaluation.SparseNanoEvaluator import 
 
 
 class SparseNanoBEIREvaluator(SparseNanoEvaluator):
-    """Evaluate sparse encoders on NanoBEIR datasets.
+    """
+    This class evaluates the performance of a SparseEncoder Model on the NanoBEIR collection of Information Retrieval datasets.
 
-    This evaluator is the sparse counterpart of
-    :class:`~sentence_transformers.evaluation.NanoBEIREvaluator`, and reports
-    sparse retrieval metrics via
-    :class:`~sentence_transformers.sparse_encoder.evaluation.SparseInformationRetrievalEvaluator`.
+    The NanoBEIR collection consists of downsized versions of several BEIR information-retrieval datasets, making it
+    suitable for quickly benchmarking a model's retrieval performance before running a full-scale BEIR evaluation.
+    The datasets are available on Hugging Face in the Sentence Transformers `NanoBEIR collection <https://huggingface.co/collections/sentence-transformers/nanobeir-datasets>`_,
+    which reformats the `original collection <https://huggingface.co/collections/zeta-alpha-ai/nanobeir>`_ from Zeta Alpha
+    into the default `NanoBEIR-en <https://huggingface.co/datasets/sentence-transformers/NanoBEIR-en>`_ dataset,
+    alongside many translated versions.
+    This evaluator will return the same metrics as the :class:`~sentence_transformers.sparse_encoder.evaluation.SparseInformationRetrievalEvaluator`
+    (i.e., MRR, nDCG, Recall@k, Sparsity, FLOPS), for each dataset and on average.
 
-    This class preserves the NanoBEIR short-name API
-    (for example ``msmarco``, ``nq``) while delegating generic
-    loading and aggregation mechanics to
+    This class preserves the NanoBEIR short-name API and delegates dataset-agnostic sparse logic to
     :class:`~sentence_transformers.sparse_encoder.evaluation.SparseNanoEvaluator`.
 
-    It uses the NanoBEIR mapping and split convention:
-    short dataset name -> ``Nano{HumanReadableName}`` split.
+    Args:
+        dataset_names (List[str]): The short names of the datasets to evaluate on (e.g., "climatefever", "msmarco").
+            If not specified, all predefined NanoBEIR datasets are used. The full list of available datasets is:
+            "climatefever", "dbpedia", "fever", "fiqa2018", "hotpotqa", "msmarco", "nfcorpus", "nq", "quoraretrieval",
+            "scidocs", "arguana", "scifact", and "touche2020".
+        dataset_id (str): The HuggingFace dataset ID to load the datasets from. Defaults to
+            "sentence-transformers/NanoBEIR-en". The dataset must contain "corpus", "queries", and "qrels"
+            subsets for each NanoBEIR dataset, stored under splits named ``Nano{DatasetName}`` (for example,
+            ``NanoMSMARCO`` or ``NanoNFCorpus``).
+        mrr_at_k (List[int]): A list of integers representing the values of k for MRR calculation. Defaults to [10].
+        ndcg_at_k (List[int]): A list of integers representing the values of k for NDCG calculation. Defaults to [10].
+        accuracy_at_k (List[int]): A list of integers representing the values of k for accuracy calculation. Defaults to [1, 3, 5, 10].
+        precision_recall_at_k (List[int]): A list of integers representing the values of k for precision and recall calculation. Defaults to [1, 3, 5, 10].
+        map_at_k (List[int]): A list of integers representing the values of k for MAP calculation. Defaults to [100].
+        show_progress_bar (bool): Whether to show a progress bar during evaluation. Defaults to False.
+        batch_size (int): The batch size for evaluation. Defaults to 32.
+        write_csv (bool): Whether to write the evaluation results to a CSV file. Defaults to True.
+        max_active_dims (Optional[int], optional): The maximum number of active dimensions to use.
+            `None` uses the model's current `max_active_dims`. Defaults to None.
+        score_functions (Dict[str, Callable[[Tensor, Tensor], Tensor]]): A dictionary mapping score function names to score functions. Defaults to {SimilarityFunction.COSINE.value: cos_sim, SimilarityFunction.DOT_PRODUCT.value: dot_score}.
+        main_score_function (Union[str, SimilarityFunction], optional): The main score function to use for evaluation. Defaults to None.
+        aggregate_fn (Callable[[list[float]], float]): The function to aggregate the scores. Defaults to np.mean.
+        aggregate_key (str): The key to use for the aggregated score. Defaults to "mean".
+        query_prompts (str | dict[str, str], optional): The prompts to add to the queries. If a string, will add the same prompt to all queries. If a dict, expects that all datasets in dataset_names are keys.
+        corpus_prompts (str | dict[str, str], optional): The prompts to add to the corpus. If a string, will add the same prompt to all corpus. If a dict, expects that all datasets in dataset_names are keys.
+        write_predictions (bool): Whether to write the predictions to a JSONL file. Defaults to False.
+            This can be useful for downstream evaluation as it can be used as input to the :class:`~sentence_transformers.sparse_encoder.evaluation.ReciprocalRankFusionEvaluator` that accept precomputed predictions.
 
-    Tip:
-        Use :class:`~sentence_transformers.sparse_encoder.evaluation.SparseNanoEvaluator`
-        directly for non-NanoBEIR datasets with compatible
-        ``corpus``/``queries``/``qrels`` subsets.
+    .. tip::
 
-    Reference:
-        NanoBEIR dataset card:
-        https://huggingface.co/datasets/sentence-transformers/NanoBEIR-en
+        See this `NanoBEIR datasets collection on Hugging Face <https://huggingface.co/collections/sentence-transformers/nanobeir-datasets>`_
+        with valid NanoBEIR ``dataset_id`` options for different languages.
 
     Example:
         ::
 
+            import logging
+
             from sentence_transformers import SparseEncoder
             from sentence_transformers.sparse_encoder.evaluation import SparseNanoBEIREvaluator
 
-            model = SparseEncoder("sparse-encoder/example-inference-splade-cocondenser-ensembledistil")
+            logging.basicConfig(format="%(message)s", level=logging.INFO)
+
+            # Load a model
+            model = SparseEncoder("naver/splade-cocondenser-ensembledistil")
+
+            datasets = ["QuoraRetrieval", "MSMARCO"]
+
+            evaluator = SparseNanoBEIREvaluator(
+                dataset_names=datasets,
+                show_progress_bar=True,
+                batch_size=32,
+            )
+
+            # Run evaluation
+            results = evaluator(model)
+            '''
+            Evaluating NanoQuoraRetrieval
+            Information Retrieval Evaluation of the model on the NanoQuoraRetrieval dataset:
+            Queries: 50
+            Corpus: 5046
+
+            Score-Function: dot
+            Accuracy@1: 92.00%
+            Accuracy@3: 96.00%
+            Accuracy@5: 98.00%
+            Accuracy@10: 100.00%
+            Precision@1: 92.00%
+            Precision@3: 40.00%
+            Precision@5: 24.80%
+            Precision@10: 13.20%
+            Recall@1: 79.73%
+            Recall@3: 92.53%
+            Recall@5: 94.93%
+            Recall@10: 98.27%
+            MRR@10: 0.9439
+            NDCG@10: 0.9339
+            MAP@100: 0.9070
+            Model Query Sparsity: Active Dimensions: 59.4, Sparsity Ratio: 0.9981
+            Model Corpus Sparsity: Active Dimensions: 61.9, Sparsity Ratio: 0.9980
+            Average FLOPS: 4.10
+
+            Information Retrieval Evaluation of the model on the NanoMSMARCO dataset:
+            Queries: 50
+            Corpus: 5043
+
+            Score-Function: dot
+            Accuracy@1: 48.00%
+            Accuracy@3: 74.00%
+            Accuracy@5: 76.00%
+            Accuracy@10: 86.00%
+            Precision@1: 48.00%
+            Precision@3: 24.67%
+            Precision@5: 15.20%
+            Precision@10: 8.60%
+            Recall@1: 48.00%
+            Recall@3: 74.00%
+            Recall@5: 76.00%
+            Recall@10: 86.00%
+            MRR@10: 0.6191
+            NDCG@10: 0.6780
+            MAP@100: 0.6277
+            Model Query Sparsity: Active Dimensions: 45.4, Sparsity Ratio: 0.9985
+            Model Corpus Sparsity: Active Dimensions: 122.6, Sparsity Ratio: 0.9960
+            Average FLOPS: 2.41
+
+            Average Queries: 50.0
+            Average Corpus: 5044.5
+            Aggregated for Score Function: dot
+            Accuracy@1: 70.00%
+            Accuracy@3: 85.00%
+            Accuracy@5: 87.00%
+            Accuracy@10: 93.00%
+            Precision@1: 70.00%
+            Recall@1: 63.87%
+            Precision@3: 32.33%
+            Recall@3: 83.27%
+            Precision@5: 20.00%
+            Recall@5: 85.47%
+            Precision@10: 10.90%
+            Recall@10: 92.13%
+            MRR@10: 0.7815
+            NDCG@10: 0.8060
+            MAP@100: 0.7674
+            Model Query Sparsity: Active Dimensions: 52.4, Sparsity Ratio: 0.9983
+            Model Corpus Sparsity: Active Dimensions: 92.2, Sparsity Ratio: 0.9970
+            Average FLOPS: 2.59
+            '''
+            # Print the results
+            print(f"Primary metric: {evaluator.primary_metric}")
+            # => Primary metric: NanoBEIR_mean_dot_ndcg@10
+            print(f"Primary metric value: {results[evaluator.primary_metric]:.4f}")
+            # => Primary metric value: 0.8060
+
+        Evaluating on custom/translated datasets::
+
+            import logging
+            from pprint import pprint
+
+            from sentence_transformers import SparseEncoder
+            from sentence_transformers.sparse_encoder.evaluation import SparseNanoBEIREvaluator
+
+            logging.basicConfig(format="%(asctime)s - %(message)s", datefmt="%Y-%m-%d %H:%M:%S", level=logging.INFO)
+
+            model = SparseEncoder("opensearch-project/opensearch-neural-sparse-encoding-multilingual-v1")
             evaluator = SparseNanoBEIREvaluator(
                 dataset_names=["msmarco", "nq"],
+                dataset_id="lightonai/NanoBEIR-de",
                 batch_size=32,
-                show_progress_bar=True,
             )
             results = evaluator(model)
-            print(results["NanoBEIR_mean_dot_ndcg@10"])
-
-    Args:
-        dataset_names: NanoBEIR short names (e.g., ``msmarco``, ``nq``). If ``None``, all NanoBEIR subsets.
-        dataset_id: Hugging Face dataset ID with NanoBEIR-style subsets/splits.
-        mrr_at_k: ``k`` values for MRR.
-        ndcg_at_k: ``k`` values for nDCG.
-        accuracy_at_k: ``k`` values for accuracy.
-        precision_recall_at_k: ``k`` values for precision/recall.
-        map_at_k: ``k`` values for MAP.
-        show_progress_bar: Whether to show progress bars.
-        batch_size: Batch size for sparse retrieval evaluation.
-        write_csv: Whether to write CSV metrics to the output path.
-        max_active_dims: Optional maximum active dimensions for sparse vectors.
-        score_functions: Optional custom score functions.
-        main_score_function: Optional main score function name/value.
-        aggregate_fn: Aggregation function across subsets.
-        aggregate_key: Aggregate metric key prefix.
-        query_prompts: Optional per-subset or global query prompts.
-        corpus_prompts: Optional per-subset or global corpus prompts.
-        write_predictions: Whether to write per-query predictions.
+            print(results[evaluator.primary_metric])
+            pprint({key: value for key, value in results.items() if "ndcg@10" in key})
     """
 
     def __init__(

--- a/sentence_transformers/sparse_encoder/evaluation/SparseNanoBEIREvaluator.py
+++ b/sentence_transformers/sparse_encoder/evaluation/SparseNanoBEIREvaluator.py
@@ -1,201 +1,75 @@
 from __future__ import annotations
 
-import logging
-import os
-from collections import defaultdict
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Any
 
 import numpy as np
-import torch
+from torch import Tensor
 
-from sentence_transformers.evaluation.NanoBEIREvaluator import NanoBEIREvaluator
-from sentence_transformers.sparse_encoder.evaluation.SparseInformationRetrievalEvaluator import (
-    SparseInformationRetrievalEvaluator,
-)
-from sentence_transformers.util import append_to_last_row
-
-if TYPE_CHECKING:
-    from torch import Tensor
-
-    from sentence_transformers.evaluation import SimilarityFunction
-    from sentence_transformers.evaluation.NanoBEIREvaluator import DatasetNameType
-    from sentence_transformers.sparse_encoder import SparseEncoder
-
-logger = logging.getLogger(__name__)
+from sentence_transformers.evaluation.NanoBEIREvaluator import DATASET_NAME_TO_HUMAN_READABLE, DatasetNameType
+from sentence_transformers.similarity_functions import SimilarityFunction
+from sentence_transformers.sparse_encoder.evaluation.SparseNanoEvaluator import SparseNanoEvaluator
 
 
-class SparseNanoBEIREvaluator(NanoBEIREvaluator):
-    """
-    This evaluator extends :class:`~sentence_transformers.evaluation.NanoBEIREvaluator` but is specifically designed for sparse encoder models.
+class SparseNanoBEIREvaluator(SparseNanoEvaluator):
+    """Evaluate sparse encoders on NanoBEIR datasets.
 
-    This class evaluates the performance of a SparseEncoder Model on the NanoBEIR collection of Information Retrieval datasets.
+    This evaluator is the sparse counterpart of
+    :class:`~sentence_transformers.evaluation.NanoBEIREvaluator`, and reports
+    sparse retrieval metrics via
+    :class:`~sentence_transformers.sparse_encoder.evaluation.SparseInformationRetrievalEvaluator`.
 
-    The NanoBEIR collection consists of downsized versions of several BEIR information-retrieval datasets, making it
-    suitable for quickly benchmarking a model's retrieval performance before running a full-scale BEIR evaluation.
-    The datasets are available on Hugging Face in the Sentence Transformers `NanoBEIR collection <https://huggingface.co/collections/sentence-transformers/nanobeir-datasets>`_,
-    which reformats the `original collection <https://huggingface.co/collections/zeta-alpha-ai/nanobeir>`_ from Zeta Alpha
-    into the default `NanoBEIR-en <https://huggingface.co/datasets/sentence-transformers/NanoBEIR-en>`_ dataset,
-    alongside many translated versions.
-    This evaluator will return the same metrics as the :class:`~sentence_transformers.sparse_encoder.evaluation.SparseInformationRetrievalEvaluator`
-    (i.e., MRR, nDCG, Recall@k, Sparsity, FLOPS), for each dataset and on average.
+    This class preserves the NanoBEIR short-name API
+    (for example ``msmarco``, ``nq``) while delegating generic
+    loading and aggregation mechanics to
+    :class:`~sentence_transformers.sparse_encoder.evaluation.SparseNanoEvaluator`.
 
-    Args:
-        dataset_names (List[str]): The short names of the datasets to evaluate on (e.g., "climatefever", "msmarco").
-            If not specified, all predefined NanoBEIR datasets are used. The full list of available datasets is:
-            "climatefever", "dbpedia", "fever", "fiqa2018", "hotpotqa", "msmarco", "nfcorpus", "nq", "quoraretrieval",
-            "scidocs", "arguana", "scifact", and "touche2020".
-        dataset_id (str): The HuggingFace dataset ID to load the datasets from. Defaults to
-            "sentence-transformers/NanoBEIR-en". The dataset must contain "corpus", "queries", and "qrels"
-            subsets for each NanoBEIR dataset, stored under splits named ``Nano{DatasetName}`` (for example,
-            ``NanoMSMARCO`` or ``NanoNFCorpus``).
-        mrr_at_k (List[int]): A list of integers representing the values of k for MRR calculation. Defaults to [10].
-        ndcg_at_k (List[int]): A list of integers representing the values of k for NDCG calculation. Defaults to [10].
-        accuracy_at_k (List[int]): A list of integers representing the values of k for accuracy calculation. Defaults to [1, 3, 5, 10].
-        precision_recall_at_k (List[int]): A list of integers representing the values of k for precision and recall calculation. Defaults to [1, 3, 5, 10].
-        map_at_k (List[int]): A list of integers representing the values of k for MAP calculation. Defaults to [100].
-        show_progress_bar (bool): Whether to show a progress bar during evaluation. Defaults to False.
-        batch_size (int): The batch size for evaluation. Defaults to 32.
-        write_csv (bool): Whether to write the evaluation results to a CSV file. Defaults to True.
-        max_active_dims (Optional[int], optional): The maximum number of active dimensions to use.
-            `None` uses the model's current `max_active_dims`. Defaults to None.
-        score_functions (Dict[str, Callable[[Tensor, Tensor], Tensor]]): A dictionary mapping score function names to score functions. Defaults to {SimilarityFunction.COSINE.value: cos_sim, SimilarityFunction.DOT_PRODUCT.value: dot_score}.
-        main_score_function (Union[str, SimilarityFunction], optional): The main score function to use for evaluation. Defaults to None.
-        aggregate_fn (Callable[[list[float]], float]): The function to aggregate the scores. Defaults to np.mean.
-        aggregate_key (str): The key to use for the aggregated score. Defaults to "mean".
-        query_prompts (str | dict[str, str], optional): The prompts to add to the queries. If a string, will add the same prompt to all queries. If a dict, expects that all datasets in dataset_names are keys.
-        corpus_prompts (str | dict[str, str], optional): The prompts to add to the corpus. If a string, will add the same prompt to all corpus. If a dict, expects that all datasets in dataset_names are keys.
-        write_predictions (bool): Whether to write the predictions to a JSONL file. Defaults to False.
-            This can be useful for downstream evaluation as it can be used as input to the :class:`~sentence_transformers.sparse_encoder.evaluation.ReciprocalRankFusionEvaluator` that accept precomputed predictions.
+    It uses the NanoBEIR mapping and split convention:
+    short dataset name -> ``Nano{HumanReadableName}`` split.
 
-    .. tip::
+    Tip:
+        Use :class:`~sentence_transformers.sparse_encoder.evaluation.SparseNanoEvaluator`
+        directly for non-NanoBEIR datasets with compatible
+        ``corpus``/``queries``/``qrels`` subsets.
 
-        See this `NanoBEIR datasets collection on Hugging Face <https://huggingface.co/collections/sentence-transformers/nanobeir-datasets>`_
-        with valid NanoBEIR ``dataset_id`` options for different languages.
+    Reference:
+        NanoBEIR dataset card:
+        https://huggingface.co/datasets/sentence-transformers/NanoBEIR-en
 
     Example:
         ::
 
-            import logging
-
             from sentence_transformers import SparseEncoder
             from sentence_transformers.sparse_encoder.evaluation import SparseNanoBEIREvaluator
 
-            logging.basicConfig(format="%(message)s", level=logging.INFO)
-
-            # Load a model
-            model = SparseEncoder("naver/splade-cocondenser-ensembledistil")
-
-            datasets = ["QuoraRetrieval", "MSMARCO"]
-
-            evaluator = SparseNanoBEIREvaluator(
-                dataset_names=datasets,
-                show_progress_bar=True,
-                batch_size=32,
-            )
-
-            # Run evaluation
-            results = evaluator(model)
-            '''
-            Evaluating NanoQuoraRetrieval
-            Information Retrieval Evaluation of the model on the NanoQuoraRetrieval dataset:
-            Queries: 50
-            Corpus: 5046
-
-            Score-Function: dot
-            Accuracy@1: 92.00%
-            Accuracy@3: 96.00%
-            Accuracy@5: 98.00%
-            Accuracy@10: 100.00%
-            Precision@1: 92.00%
-            Precision@3: 40.00%
-            Precision@5: 24.80%
-            Precision@10: 13.20%
-            Recall@1: 79.73%
-            Recall@3: 92.53%
-            Recall@5: 94.93%
-            Recall@10: 98.27%
-            MRR@10: 0.9439
-            NDCG@10: 0.9339
-            MAP@100: 0.9070
-            Model Query Sparsity: Active Dimensions: 59.4, Sparsity Ratio: 0.9981
-            Model Corpus Sparsity: Active Dimensions: 61.9, Sparsity Ratio: 0.9980
-            Average FLOPS: 4.10
-
-            Information Retrieval Evaluation of the model on the NanoMSMARCO dataset:
-            Queries: 50
-            Corpus: 5043
-
-            Score-Function: dot
-            Accuracy@1: 48.00%
-            Accuracy@3: 74.00%
-            Accuracy@5: 76.00%
-            Accuracy@10: 86.00%
-            Precision@1: 48.00%
-            Precision@3: 24.67%
-            Precision@5: 15.20%
-            Precision@10: 8.60%
-            Recall@1: 48.00%
-            Recall@3: 74.00%
-            Recall@5: 76.00%
-            Recall@10: 86.00%
-            MRR@10: 0.6191
-            NDCG@10: 0.6780
-            MAP@100: 0.6277
-            Model Query Sparsity: Active Dimensions: 45.4, Sparsity Ratio: 0.9985
-            Model Corpus Sparsity: Active Dimensions: 122.6, Sparsity Ratio: 0.9960
-            Average FLOPS: 2.41
-
-            Average Queries: 50.0
-            Average Corpus: 5044.5
-            Aggregated for Score Function: dot
-            Accuracy@1: 70.00%
-            Accuracy@3: 85.00%
-            Accuracy@5: 87.00%
-            Accuracy@10: 93.00%
-            Precision@1: 70.00%
-            Recall@1: 63.87%
-            Precision@3: 32.33%
-            Recall@3: 83.27%
-            Precision@5: 20.00%
-            Recall@5: 85.47%
-            Precision@10: 10.90%
-            Recall@10: 92.13%
-            MRR@10: 0.7815
-            NDCG@10: 0.8060
-            MAP@100: 0.7674
-            Model Query Sparsity: Active Dimensions: 52.4, Sparsity Ratio: 0.9983
-            Model Corpus Sparsity: Active Dimensions: 92.2, Sparsity Ratio: 0.9970
-            Average FLOPS: 2.59
-            '''
-            # Print the results
-            print(f"Primary metric: {evaluator.primary_metric}")
-            # => Primary metric: NanoBEIR_mean_dot_ndcg@10
-            print(f"Primary metric value: {results[evaluator.primary_metric]:.4f}")
-            # => Primary metric value: 0.8060
-
-        Evaluating on custom/translated datasets::
-
-            import logging
-            from pprint import pprint
-
-            from sentence_transformers import SparseEncoder
-            from sentence_transformers.sparse_encoder.evaluation import SparseNanoBEIREvaluator
-
-            logging.basicConfig(format="%(asctime)s - %(message)s", datefmt="%Y-%m-%d %H:%M:%S", level=logging.INFO)
-
-            model = SparseEncoder("opensearch-project/opensearch-neural-sparse-encoding-multilingual-v1")
+            model = SparseEncoder("sparse-encoder/example-inference-splade-cocondenser-ensembledistil")
             evaluator = SparseNanoBEIREvaluator(
                 dataset_names=["msmarco", "nq"],
-                dataset_id="lightonai/NanoBEIR-de",
                 batch_size=32,
+                show_progress_bar=True,
             )
             results = evaluator(model)
-            print(results[evaluator.primary_metric])
-            pprint({key: value for key, value in results.items() if "ndcg@10" in key})
-    """
+            print(results["NanoBEIR_mean_dot_ndcg@10"])
 
-    information_retrieval_class = SparseInformationRetrievalEvaluator
+    Args:
+        dataset_names: NanoBEIR short names (e.g., ``msmarco``, ``nq``). If ``None``, all NanoBEIR subsets.
+        dataset_id: Hugging Face dataset ID with NanoBEIR-style subsets/splits.
+        mrr_at_k: ``k`` values for MRR.
+        ndcg_at_k: ``k`` values for nDCG.
+        accuracy_at_k: ``k`` values for accuracy.
+        precision_recall_at_k: ``k`` values for precision/recall.
+        map_at_k: ``k`` values for MAP.
+        show_progress_bar: Whether to show progress bars.
+        batch_size: Batch size for sparse retrieval evaluation.
+        write_csv: Whether to write CSV metrics to the output path.
+        max_active_dims: Optional maximum active dimensions for sparse vectors.
+        score_functions: Optional custom score functions.
+        main_score_function: Optional main score function name/value.
+        aggregate_fn: Aggregation function across subsets.
+        aggregate_key: Aggregate metric key prefix.
+        query_prompts: Optional per-subset or global query prompts.
+        corpus_prompts: Optional per-subset or global corpus prompts.
+        write_predictions: Whether to write per-query predictions.
+    """
 
     def __init__(
         self,
@@ -217,11 +91,12 @@ class SparseNanoBEIREvaluator(NanoBEIREvaluator):
         query_prompts: str | dict[str, str] | None = None,
         corpus_prompts: str | dict[str, str] | None = None,
         write_predictions: bool = False,
-    ):
-        self.max_active_dims = max_active_dims
-        self.sparsity_stats = defaultdict(list)
+    ) -> None:
+        if dataset_names is None:
+            dataset_names = list(DATASET_NAME_TO_HUMAN_READABLE.keys())
+
         super().__init__(
-            dataset_names=dataset_names,
+            dataset_names=[str(name) for name in dataset_names],
             dataset_id=dataset_id,
             mrr_at_k=mrr_at_k,
             ndcg_at_k=ndcg_at_k,
@@ -231,6 +106,7 @@ class SparseNanoBEIREvaluator(NanoBEIREvaluator):
             show_progress_bar=show_progress_bar,
             batch_size=batch_size,
             write_csv=write_csv,
+            max_active_dims=max_active_dims,
             score_functions=score_functions,
             main_score_function=main_score_function,
             aggregate_fn=aggregate_fn,
@@ -238,95 +114,9 @@ class SparseNanoBEIREvaluator(NanoBEIREvaluator):
             query_prompts=query_prompts,
             corpus_prompts=corpus_prompts,
             write_predictions=write_predictions,
+            dataset_name_to_human_readable=DATASET_NAME_TO_HUMAN_READABLE,
+            split_prefix="Nano",
+            strict_dataset_name_validation=True,
+            auto_expand_splits_when_dataset_names_none=False,
+            name="NanoBEIR",
         )
-        if self.max_active_dims is not None:
-            self.name += f"_{self.max_active_dims}"
-
-    def _get_human_readable_name(self, dataset_name: DatasetNameType) -> str:
-        human_readable_name = super()._get_human_readable_name(dataset_name)
-        if self.max_active_dims is not None:
-            human_readable_name += f"_{self.max_active_dims}"
-        return human_readable_name
-
-    def _append_csv_headers(self, score_function_names):
-        super()._append_csv_headers(score_function_names)
-        # To avoid adding the sparse-specific headers multiple times, we only add them if the superclass will
-        # add metric columns for the specified score functions
-        if score_function_names:
-            self.csv_headers.extend(
-                [
-                    "query_active_dims",
-                    "query_sparsity_ratio",
-                    "corpus_active_dims",
-                    "corpus_sparsity_ratio",
-                    "avg_flops",
-                ]
-            )
-
-    def __call__(
-        self, model: SparseEncoder, output_path: str | None = None, epoch: int = -1, steps: int = -1, *args, **kwargs
-    ) -> dict[str, float]:
-        self.sparsity_stats = defaultdict(list)
-        self.lengths = defaultdict(list)
-        per_dataset_results = super().__call__(
-            model, output_path=output_path, epoch=epoch, steps=steps, *args, **kwargs
-        )
-        total_query_count, total_corpus_count = None, None
-        for evaluator in self.evaluators:
-            self.lengths["query"].append(len(evaluator.queries))
-            self.lengths["corpus"].append(len(evaluator.corpus))
-            for key, value in evaluator.sparsity_stats.items():
-                self.sparsity_stats[key].append(value)
-
-            if total_query_count is None:
-                total_query_count = evaluator.count_vectors["query"]
-                total_corpus_count = evaluator.count_vectors["corpus"]
-            else:
-                total_query_count += evaluator.count_vectors["query"]
-                total_corpus_count += evaluator.count_vectors["corpus"]
-
-        # Compute the weighted mean for each of the sparsity stats, except avg_flops as a weighted mean would
-        # not be accurate
-        for key, values in self.sparsity_stats.items():
-            if key == "avg_flops":
-                continue
-
-            lengths = self.lengths[key.split("_")[0]]
-            self.sparsity_stats[key] = sum(val * length for val, length in zip(values, lengths)) / sum(lengths)
-
-        avg_query_count = total_query_count / sum(self.lengths["query"])
-        avg_corpus_count = total_corpus_count / sum(self.lengths["corpus"])
-        self.sparsity_stats["avg_flops"] = float(torch.dot(avg_query_count, avg_corpus_count).cpu())
-
-        per_dataset_results.update(self.prefix_name_to_metrics(self.sparsity_stats, self.name))
-        aggregated_results = {
-            key: value for key, value in per_dataset_results.items() if key.startswith(self.name) and key != self.name
-        }
-        self.store_metrics_in_model_card_data(model, aggregated_results, epoch, steps)
-        logger.info(
-            f"Model Query Sparsity: Active Dimensions: {self.sparsity_stats['query_active_dims']:.1f}, Sparsity Ratio: {self.sparsity_stats['query_sparsity_ratio']:.4f}"
-        )
-        logger.info(
-            f"Model Corpus Sparsity: Active Dimensions: {self.sparsity_stats['corpus_active_dims']:.1f}, Sparsity Ratio: {self.sparsity_stats['corpus_sparsity_ratio']:.4f}"
-        )
-        logger.info(f"Average FLOPS: {self.sparsity_stats['avg_flops']:.2f}")
-        if output_path is not None and self.write_csv:
-            append_to_last_row(
-                os.path.join(output_path, self.csv_file),
-                self.sparsity_stats.values(),
-            )
-
-        return per_dataset_results
-
-    def _load_dataset(
-        self, dataset_name: DatasetNameType | str, **ir_evaluator_kwargs
-    ) -> SparseInformationRetrievalEvaluator:
-        ir_evaluator_kwargs["max_active_dims"] = self.max_active_dims
-        ir_evaluator_kwargs.pop("truncate_dim", None)
-        return super()._load_dataset(dataset_name, **ir_evaluator_kwargs)
-
-    def get_config_dict(self) -> dict[str, Any]:
-        config_dict = super().get_config_dict()
-        if self.max_active_dims is not None:
-            config_dict["max_active_dims"] = self.max_active_dims
-        return config_dict

--- a/sentence_transformers/sparse_encoder/evaluation/SparseNanoBEIREvaluator.py
+++ b/sentence_transformers/sparse_encoder/evaluation/SparseNanoBEIREvaluator.py
@@ -1,17 +1,34 @@
 from __future__ import annotations
 
+import logging
+import os
+from collections import defaultdict
 from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
-from torch import Tensor
+import torch
 
-from sentence_transformers.evaluation.NanoBEIREvaluator import DATASET_NAME_TO_HUMAN_READABLE, DatasetNameType
-from sentence_transformers.similarity_functions import SimilarityFunction
-from sentence_transformers.sparse_encoder.evaluation.SparseNanoEvaluator import SparseNanoEvaluator
+from sentence_transformers.evaluation.NanoBEIREvaluator import NanoBEIREvaluator
+from sentence_transformers.sparse_encoder.evaluation.SparseInformationRetrievalEvaluator import (
+    SparseInformationRetrievalEvaluator,
+)
+from sentence_transformers.util import append_to_last_row
+
+if TYPE_CHECKING:
+    from torch import Tensor
+
+    from sentence_transformers.evaluation import SimilarityFunction
+    from sentence_transformers.evaluation.NanoBEIREvaluator import DatasetNameType
+    from sentence_transformers.sparse_encoder import SparseEncoder
+
+logger = logging.getLogger(__name__)
 
 
-class SparseNanoBEIREvaluator(SparseNanoEvaluator):
+class SparseNanoBEIREvaluator(NanoBEIREvaluator):
     """
+    This evaluator extends :class:`~sentence_transformers.evaluation.NanoBEIREvaluator` but is specifically designed for sparse encoder models.
+
     This class evaluates the performance of a SparseEncoder Model on the NanoBEIR collection of Information Retrieval datasets.
 
     The NanoBEIR collection consists of downsized versions of several BEIR information-retrieval datasets, making it
@@ -22,9 +39,6 @@ class SparseNanoBEIREvaluator(SparseNanoEvaluator):
     alongside many translated versions.
     This evaluator will return the same metrics as the :class:`~sentence_transformers.sparse_encoder.evaluation.SparseInformationRetrievalEvaluator`
     (i.e., MRR, nDCG, Recall@k, Sparsity, FLOPS), for each dataset and on average.
-
-    This class preserves the NanoBEIR short-name API and delegates dataset-agnostic sparse logic to
-    :class:`~sentence_transformers.sparse_encoder.evaluation.SparseNanoEvaluator`.
 
     Args:
         dataset_names (List[str]): The short names of the datasets to evaluate on (e.g., "climatefever", "msmarco").
@@ -181,6 +195,8 @@ class SparseNanoBEIREvaluator(SparseNanoEvaluator):
             pprint({key: value for key, value in results.items() if "ndcg@10" in key})
     """
 
+    information_retrieval_class = SparseInformationRetrievalEvaluator
+
     def __init__(
         self,
         dataset_names: list[DatasetNameType | str] | None = None,
@@ -201,12 +217,11 @@ class SparseNanoBEIREvaluator(SparseNanoEvaluator):
         query_prompts: str | dict[str, str] | None = None,
         corpus_prompts: str | dict[str, str] | None = None,
         write_predictions: bool = False,
-    ) -> None:
-        if dataset_names is None:
-            dataset_names = list(DATASET_NAME_TO_HUMAN_READABLE.keys())
-
+    ):
+        self.max_active_dims = max_active_dims
+        self.sparsity_stats = defaultdict(list)
         super().__init__(
-            dataset_names=[str(name) for name in dataset_names],
+            dataset_names=dataset_names,
             dataset_id=dataset_id,
             mrr_at_k=mrr_at_k,
             ndcg_at_k=ndcg_at_k,
@@ -216,7 +231,6 @@ class SparseNanoBEIREvaluator(SparseNanoEvaluator):
             show_progress_bar=show_progress_bar,
             batch_size=batch_size,
             write_csv=write_csv,
-            max_active_dims=max_active_dims,
             score_functions=score_functions,
             main_score_function=main_score_function,
             aggregate_fn=aggregate_fn,
@@ -224,9 +238,95 @@ class SparseNanoBEIREvaluator(SparseNanoEvaluator):
             query_prompts=query_prompts,
             corpus_prompts=corpus_prompts,
             write_predictions=write_predictions,
-            dataset_name_to_human_readable=DATASET_NAME_TO_HUMAN_READABLE,
-            split_prefix="Nano",
-            strict_dataset_name_validation=True,
-            auto_expand_splits_when_dataset_names_none=False,
-            name="NanoBEIR",
         )
+        if self.max_active_dims is not None:
+            self.name += f"_{self.max_active_dims}"
+
+    def _get_human_readable_name(self, dataset_name: DatasetNameType) -> str:
+        human_readable_name = super()._get_human_readable_name(dataset_name)
+        if self.max_active_dims is not None:
+            human_readable_name += f"_{self.max_active_dims}"
+        return human_readable_name
+
+    def _append_csv_headers(self, score_function_names):
+        super()._append_csv_headers(score_function_names)
+        # To avoid adding the sparse-specific headers multiple times, we only add them if the superclass will
+        # add metric columns for the specified score functions
+        if score_function_names:
+            self.csv_headers.extend(
+                [
+                    "query_active_dims",
+                    "query_sparsity_ratio",
+                    "corpus_active_dims",
+                    "corpus_sparsity_ratio",
+                    "avg_flops",
+                ]
+            )
+
+    def __call__(
+        self, model: SparseEncoder, output_path: str | None = None, epoch: int = -1, steps: int = -1, *args, **kwargs
+    ) -> dict[str, float]:
+        self.sparsity_stats = defaultdict(list)
+        self.lengths = defaultdict(list)
+        per_dataset_results = super().__call__(
+            model, output_path=output_path, epoch=epoch, steps=steps, *args, **kwargs
+        )
+        total_query_count, total_corpus_count = None, None
+        for evaluator in self.evaluators:
+            self.lengths["query"].append(len(evaluator.queries))
+            self.lengths["corpus"].append(len(evaluator.corpus))
+            for key, value in evaluator.sparsity_stats.items():
+                self.sparsity_stats[key].append(value)
+
+            if total_query_count is None:
+                total_query_count = evaluator.count_vectors["query"]
+                total_corpus_count = evaluator.count_vectors["corpus"]
+            else:
+                total_query_count += evaluator.count_vectors["query"]
+                total_corpus_count += evaluator.count_vectors["corpus"]
+
+        # Compute the weighted mean for each of the sparsity stats, except avg_flops as a weighted mean would
+        # not be accurate
+        for key, values in self.sparsity_stats.items():
+            if key == "avg_flops":
+                continue
+
+            lengths = self.lengths[key.split("_")[0]]
+            self.sparsity_stats[key] = sum(val * length for val, length in zip(values, lengths)) / sum(lengths)
+
+        avg_query_count = total_query_count / sum(self.lengths["query"])
+        avg_corpus_count = total_corpus_count / sum(self.lengths["corpus"])
+        self.sparsity_stats["avg_flops"] = float(torch.dot(avg_query_count, avg_corpus_count).cpu())
+
+        per_dataset_results.update(self.prefix_name_to_metrics(self.sparsity_stats, self.name))
+        aggregated_results = {
+            key: value for key, value in per_dataset_results.items() if key.startswith(self.name) and key != self.name
+        }
+        self.store_metrics_in_model_card_data(model, aggregated_results, epoch, steps)
+        logger.info(
+            f"Model Query Sparsity: Active Dimensions: {self.sparsity_stats['query_active_dims']:.1f}, Sparsity Ratio: {self.sparsity_stats['query_sparsity_ratio']:.4f}"
+        )
+        logger.info(
+            f"Model Corpus Sparsity: Active Dimensions: {self.sparsity_stats['corpus_active_dims']:.1f}, Sparsity Ratio: {self.sparsity_stats['corpus_sparsity_ratio']:.4f}"
+        )
+        logger.info(f"Average FLOPS: {self.sparsity_stats['avg_flops']:.2f}")
+        if output_path is not None and self.write_csv:
+            append_to_last_row(
+                os.path.join(output_path, self.csv_file),
+                self.sparsity_stats.values(),
+            )
+
+        return per_dataset_results
+
+    def _load_dataset(
+        self, dataset_name: DatasetNameType | str, **ir_evaluator_kwargs
+    ) -> SparseInformationRetrievalEvaluator:
+        ir_evaluator_kwargs["max_active_dims"] = self.max_active_dims
+        ir_evaluator_kwargs.pop("truncate_dim", None)
+        return super()._load_dataset(dataset_name, **ir_evaluator_kwargs)
+
+    def get_config_dict(self) -> dict[str, Any]:
+        config_dict = super().get_config_dict()
+        if self.max_active_dims is not None:
+            config_dict["max_active_dims"] = self.max_active_dims
+        return config_dict

--- a/sentence_transformers/sparse_encoder/evaluation/SparseNanoEvaluator.py
+++ b/sentence_transformers/sparse_encoder/evaluation/SparseNanoEvaluator.py
@@ -24,11 +24,44 @@ logger = logging.getLogger(__name__)
 
 
 class SparseNanoEvaluator(NanoEvaluator):
-    """Generic Nano-style evaluator for sparse encoders.
+    """
+    Generic Nano-style evaluator for sparse encoders.
 
     This class extends :class:`~sentence_transformers.evaluation.NanoEvaluator`
-    and adds sparse-specific aggregation metrics (active dims, sparsity ratio, FLOPS)
-    on top of the standard IR metrics.
+    and adds sparse-specific aggregation metrics (active dimensions, sparsity
+    ratio, FLOPS) on top of standard IR metrics.
+
+    Sparse metrics are aggregated across evaluated subsets and emitted with the
+    same aggregate prefix as IR metrics (for example ``NanoBEIR_mean_avg_flops``).
+
+    Args:
+        dataset_names (list[str] | None): Dataset names or split names to evaluate.
+        dataset_id (str): Hugging Face dataset ID.
+        mrr_at_k (list[int]): ``k`` values for MRR.
+        ndcg_at_k (list[int]): ``k`` values for nDCG.
+        accuracy_at_k (list[int]): ``k`` values for accuracy.
+        precision_recall_at_k (list[int]): ``k`` values for precision/recall.
+        map_at_k (list[int]): ``k`` values for MAP.
+        show_progress_bar (bool): Whether to show progress bars.
+        batch_size (int): Evaluation batch size.
+        write_csv (bool): Whether to write aggregated metrics CSV.
+        max_active_dims (int | None): Optional cap for active sparse dimensions.
+        score_functions (dict[str, Callable[[Tensor, Tensor], Tensor]] | None):
+            Optional custom score functions.
+        main_score_function (str | SimilarityFunction | None): Optional main score function.
+        aggregate_fn (Callable[[list[float]], float]): Aggregation function across datasets.
+        aggregate_key (str): Aggregate metric key prefix.
+        query_prompts (str | dict[str, str] | None): Query prompt(s), global or per-dataset.
+        corpus_prompts (str | dict[str, str] | None): Corpus prompt(s), global or per-dataset.
+        write_predictions (bool): Whether to write per-query predictions JSONL.
+        dataset_name_to_human_readable (Mapping[str, str] | None): Optional short-name mapping.
+        split_prefix (str): Optional split prefix applied in mapping mode.
+        strict_dataset_name_validation (bool): Whether to validate names strictly against mapping.
+        auto_expand_splits_when_dataset_names_none (bool): Whether to infer dataset names from query splits.
+        corpus_subset_name (str): Subset name for corpus.
+        queries_subset_name (str): Subset name for queries.
+        qrels_subset_name (str): Subset name for qrels.
+        name (str | None): Optional base name for aggregate metric prefixes.
     """
 
     information_retrieval_class = SparseInformationRetrievalEvaluator

--- a/sentence_transformers/sparse_encoder/evaluation/SparseNanoEvaluator.py
+++ b/sentence_transformers/sparse_encoder/evaluation/SparseNanoEvaluator.py
@@ -1,0 +1,228 @@
+from __future__ import annotations
+
+import logging
+import os
+from collections import defaultdict
+from collections.abc import Callable, Mapping
+from typing import TYPE_CHECKING, Any, cast
+
+import numpy as np
+import torch
+from torch import Tensor
+
+from sentence_transformers.evaluation.NanoEvaluator import NanoEvaluator
+from sentence_transformers.similarity_functions import SimilarityFunction
+from sentence_transformers.sparse_encoder.evaluation.SparseInformationRetrievalEvaluator import (
+    SparseInformationRetrievalEvaluator,
+)
+from sentence_transformers.util import append_to_last_row
+
+if TYPE_CHECKING:
+    from sentence_transformers.SentenceTransformer import SentenceTransformer
+
+logger = logging.getLogger(__name__)
+
+
+class SparseNanoEvaluator(NanoEvaluator):
+    """Generic Nano-style evaluator for sparse encoders.
+
+    This class extends :class:`~sentence_transformers.evaluation.NanoEvaluator`
+    and adds sparse-specific aggregation metrics (active dims, sparsity ratio, FLOPS)
+    on top of the standard IR metrics.
+    """
+
+    information_retrieval_class = SparseInformationRetrievalEvaluator
+
+    def __init__(
+        self,
+        dataset_names: list[str] | None = None,
+        dataset_id: str = "sentence-transformers/NanoBEIR-en",
+        mrr_at_k: list[int] = [10],
+        ndcg_at_k: list[int] = [10],
+        accuracy_at_k: list[int] = [1, 3, 5, 10],
+        precision_recall_at_k: list[int] = [1, 3, 5, 10],
+        map_at_k: list[int] = [100],
+        show_progress_bar: bool = False,
+        batch_size: int = 32,
+        write_csv: bool = True,
+        max_active_dims: int | None = None,
+        score_functions: dict[str, Callable[[Tensor, Tensor], Tensor]] | None = None,
+        main_score_function: str | SimilarityFunction | None = None,
+        aggregate_fn: Callable[[list[float]], float] = np.mean,
+        aggregate_key: str = "mean",
+        query_prompts: str | dict[str, str] | None = None,
+        corpus_prompts: str | dict[str, str] | None = None,
+        write_predictions: bool = False,
+        dataset_name_to_human_readable: Mapping[str, str] | None = None,
+        split_prefix: str = "",
+        strict_dataset_name_validation: bool = False,
+        auto_expand_splits_when_dataset_names_none: bool = True,
+        corpus_subset_name: str = "corpus",
+        queries_subset_name: str = "queries",
+        qrels_subset_name: str = "qrels",
+        name: str | None = None,
+    ) -> None:
+        self.max_active_dims = max_active_dims
+        super().__init__(
+            dataset_names=dataset_names,
+            dataset_id=dataset_id,
+            mrr_at_k=mrr_at_k,
+            ndcg_at_k=ndcg_at_k,
+            accuracy_at_k=accuracy_at_k,
+            precision_recall_at_k=precision_recall_at_k,
+            map_at_k=map_at_k,
+            show_progress_bar=show_progress_bar,
+            batch_size=batch_size,
+            write_csv=write_csv,
+            truncate_dim=None,
+            score_functions=score_functions,
+            main_score_function=main_score_function,
+            aggregate_fn=aggregate_fn,
+            aggregate_key=aggregate_key,
+            query_prompts=query_prompts,
+            corpus_prompts=corpus_prompts,
+            write_predictions=write_predictions,
+            dataset_name_to_human_readable=dataset_name_to_human_readable,
+            split_prefix=split_prefix,
+            strict_dataset_name_validation=strict_dataset_name_validation,
+            auto_expand_splits_when_dataset_names_none=auto_expand_splits_when_dataset_names_none,
+            corpus_subset_name=corpus_subset_name,
+            queries_subset_name=queries_subset_name,
+            qrels_subset_name=qrels_subset_name,
+            name=name,
+        )
+        if self.max_active_dims is not None:
+            self.name += f"_{self.max_active_dims}"
+
+    def _get_human_readable_name(self, dataset_name: str) -> str:
+        human_readable_name = super()._get_human_readable_name(dataset_name)
+        if self.max_active_dims is not None:
+            human_readable_name += f"_{self.max_active_dims}"
+        return human_readable_name
+
+    def _append_csv_headers(self, score_function_names: list[str]) -> None:
+        super()._append_csv_headers(score_function_names)
+        # Avoid duplicate sparse headers when no score function metrics are emitted.
+        if score_function_names:
+            self.csv_headers.extend(
+                [
+                    "query_active_dims",
+                    "query_sparsity_ratio",
+                    "corpus_active_dims",
+                    "corpus_sparsity_ratio",
+                    "avg_flops",
+                ]
+            )
+
+    def __call__(
+        self,
+        model: SentenceTransformer,
+        output_path: str | None = None,
+        epoch: int = -1,
+        steps: int = -1,
+        *args: Any,
+        **kwargs: Any,
+    ) -> dict[str, float]:
+        per_dataset_results = super().__call__(model, output_path, epoch, steps, *args, **kwargs)
+
+        sparsity_stats_by_key: defaultdict[str, list[float]] = defaultdict(list)
+        lengths_by_prefix: defaultdict[str, list[int]] = defaultdict(list)
+        total_query_count: torch.Tensor | None = None
+        total_corpus_count: torch.Tensor | None = None
+        for evaluator in self.evaluators:
+            sparse_evaluator = cast(SparseInformationRetrievalEvaluator, evaluator)
+            lengths_by_prefix["query"].append(len(sparse_evaluator.queries))
+            lengths_by_prefix["corpus"].append(len(sparse_evaluator.corpus))
+            for key, value in sparse_evaluator.sparsity_stats.items():
+                if not isinstance(value, (int, float)):
+                    continue
+                sparsity_stats_by_key[key].append(float(value))
+
+            if total_query_count is None:
+                total_query_count = sparse_evaluator.count_vectors["query"]
+                total_corpus_count = sparse_evaluator.count_vectors["corpus"]
+            else:
+                if total_query_count.shape != sparse_evaluator.count_vectors["query"].shape:
+                    raise ValueError(
+                        "Sparse evaluator query count vector shapes are inconsistent across splits: "
+                        f"{total_query_count.shape} vs {sparse_evaluator.count_vectors['query'].shape}"
+                    )
+                if total_corpus_count is None:
+                    raise ValueError(
+                        "Internal error: total_corpus_count should not be None when total_query_count is set."
+                    )
+                if total_corpus_count.shape != sparse_evaluator.count_vectors["corpus"].shape:
+                    raise ValueError(
+                        "Sparse evaluator corpus count vector shapes are inconsistent across splits: "
+                        f"{total_corpus_count.shape} vs {sparse_evaluator.count_vectors['corpus'].shape}"
+                    )
+                total_query_count += sparse_evaluator.count_vectors["query"]
+                total_corpus_count += sparse_evaluator.count_vectors["corpus"]
+
+        aggregated_sparsity_stats: dict[str, float] = {}
+        for key, values in sparsity_stats_by_key.items():
+            if key == "avg_flops":
+                continue
+            prefix = key.split("_")[0]
+            lengths = lengths_by_prefix[prefix]
+            if not lengths:
+                continue
+            aggregated_sparsity_stats[key] = sum(value * length for value, length in zip(values, lengths)) / sum(
+                lengths
+            )
+
+        if total_query_count is None or total_corpus_count is None:
+            aggregated_sparsity_stats["avg_flops"] = 0.0
+        else:
+            avg_query_count = total_query_count / sum(lengths_by_prefix["query"])
+            avg_corpus_count = total_corpus_count / sum(lengths_by_prefix["corpus"])
+            aggregated_sparsity_stats["avg_flops"] = float(torch.dot(avg_query_count, avg_corpus_count).cpu())
+
+        prefixed_sparsity_metrics = self.prefix_name_to_metrics(aggregated_sparsity_stats, self.name)
+        per_dataset_results.update(prefixed_sparsity_metrics)
+        # Store only sparse-specific metrics here to avoid duplicating IR aggregate keys
+        # already written by NanoEvaluator.__call__.
+        self.store_metrics_in_model_card_data(model, prefixed_sparsity_metrics, epoch, steps)
+
+        query_active_dims = aggregated_sparsity_stats.get("query_active_dims", float("nan"))
+        query_sparsity_ratio = aggregated_sparsity_stats.get("query_sparsity_ratio", float("nan"))
+        corpus_active_dims = aggregated_sparsity_stats.get("corpus_active_dims", float("nan"))
+        corpus_sparsity_ratio = aggregated_sparsity_stats.get("corpus_sparsity_ratio", float("nan"))
+        avg_flops = aggregated_sparsity_stats.get("avg_flops", float("nan"))
+
+        logger.info(
+            "Model Query Sparsity: Active Dimensions: %.1f, Sparsity Ratio: %.4f",
+            query_active_dims,
+            query_sparsity_ratio,
+        )
+        logger.info(
+            "Model Corpus Sparsity: Active Dimensions: %.1f, Sparsity Ratio: %.4f",
+            corpus_active_dims,
+            corpus_sparsity_ratio,
+        )
+        logger.info("Average FLOPS: %.2f", avg_flops)
+
+        if output_path is not None and self.write_csv:
+            os.makedirs(output_path, exist_ok=True)
+            append_to_last_row(
+                os.path.join(output_path, self.csv_file),
+                [
+                    query_active_dims,
+                    query_sparsity_ratio,
+                    corpus_active_dims,
+                    corpus_sparsity_ratio,
+                    avg_flops,
+                ],
+            )
+        return per_dataset_results
+
+    def _load_dataset(self, dataset_name: str, **ir_evaluator_kwargs: Any) -> SparseInformationRetrievalEvaluator:
+        ir_evaluator_kwargs["max_active_dims"] = self.max_active_dims
+        ir_evaluator_kwargs.pop("truncate_dim", None)
+        return cast(SparseInformationRetrievalEvaluator, super()._load_dataset(dataset_name, **ir_evaluator_kwargs))
+
+    def get_config_dict(self) -> dict[str, Any]:
+        config_dict = super().get_config_dict()
+        if self.max_active_dims is not None:
+            config_dict["max_active_dims"] = self.max_active_dims
+        return config_dict

--- a/sentence_transformers/sparse_encoder/evaluation/SparseNanoEvaluator.py
+++ b/sentence_transformers/sparse_encoder/evaluation/SparseNanoEvaluator.py
@@ -95,6 +95,7 @@ class SparseNanoEvaluator(NanoEvaluator):
         qrels_subset_name: str = "qrels",
         name: str | None = None,
     ) -> None:
+        # Parent initialization builds sub-evaluators via _load_dataset, which reads max_active_dims.
         self.max_active_dims = max_active_dims
         super().__init__(
             dataset_names=dataset_names,

--- a/sentence_transformers/sparse_encoder/evaluation/SparseNanoEvaluator.py
+++ b/sentence_transformers/sparse_encoder/evaluation/SparseNanoEvaluator.py
@@ -7,7 +7,6 @@ import numpy as np
 from torch import Tensor
 
 from sentence_transformers.evaluation._nano_utils import _GenericNanoDatasetMixin
-from sentence_transformers.evaluation.NanoEvaluator import NanoEvaluator
 from sentence_transformers.similarity_functions import SimilarityFunction
 from sentence_transformers.sparse_encoder.evaluation.SparseNanoBEIREvaluator import SparseNanoBEIREvaluator
 
@@ -82,13 +81,24 @@ class SparseNanoEvaluator(_GenericNanoDatasetMixin, SparseNanoBEIREvaluator):
         )
 
     def _get_human_readable_name(self, dataset_name: str) -> str:
-        human_readable_name = NanoEvaluator._get_human_readable_name(self, dataset_name)
+        split_name = self._get_split_name(dataset_name)
+        if self.dataset_name_to_human_readable is None:
+            human_readable_name = f"{self.evaluator_name}_{split_name}"
+        else:
+            human_readable_name = split_name
         if self.max_active_dims is not None:
             human_readable_name += f"_{self.max_active_dims}"
         return human_readable_name
 
-    description = NanoEvaluator.description
-    _get_metric_from_full_key = NanoEvaluator._get_metric_from_full_key
+    @property
+    def description(self) -> str:
+        return self.evaluator_name
+
+    def _get_metric_from_full_key(self, evaluator_name: str, full_key: str, num_underscores_in_name: int) -> str:
+        prefix = f"{evaluator_name}_"
+        if full_key.startswith(prefix):
+            return full_key.removeprefix(prefix)
+        return full_key.split("_", maxsplit=num_underscores_in_name)[-1]
 
     def get_config_dict(self) -> dict[str, Any]:
         config_dict = self._get_generic_config_dict()

--- a/sentence_transformers/sparse_encoder/evaluation/SparseNanoEvaluator.py
+++ b/sentence_transformers/sparse_encoder/evaluation/SparseNanoEvaluator.py
@@ -44,9 +44,6 @@ class SparseNanoEvaluator(_GenericNanoDatasetMixin, SparseNanoBEIREvaluator):
         split_prefix: str = "",
         strict_dataset_name_validation: bool = False,
         auto_expand_splits_when_dataset_names_none: bool = True,
-        corpus_subset_name: str = "corpus",
-        queries_subset_name: str = "queries",
-        qrels_subset_name: str = "qrels",
         name: str | None = None,
     ) -> None:
         self._initialize_generic_nano_state(
@@ -55,13 +52,14 @@ class SparseNanoEvaluator(_GenericNanoDatasetMixin, SparseNanoBEIREvaluator):
             split_prefix=split_prefix,
             strict_dataset_name_validation=strict_dataset_name_validation,
             auto_expand_splits_when_dataset_names_none=auto_expand_splits_when_dataset_names_none,
-            corpus_subset_name=corpus_subset_name,
-            queries_subset_name=queries_subset_name,
-            qrels_subset_name=qrels_subset_name,
             name=name,
         )
+        dataset_names = self._resolve_dataset_names(dataset_names)
+        self.dataset_names = dataset_names
+        self._validate_dataset_names()
+        self._validate_mapping_splits()
         super().__init__(
-            dataset_names=self._resolve_dataset_names(dataset_names),
+            dataset_names=dataset_names,
             dataset_id=dataset_id,
             mrr_at_k=mrr_at_k,
             ndcg_at_k=ndcg_at_k,
@@ -90,9 +88,6 @@ class SparseNanoEvaluator(_GenericNanoDatasetMixin, SparseNanoBEIREvaluator):
     _get_evaluator_name_root = NanoEvaluator._get_evaluator_name_root
     _get_evaluation_description = NanoEvaluator._get_evaluation_description
     _get_loading_description = NanoEvaluator._get_loading_description
-    _get_corpus_subset_name = NanoEvaluator._get_corpus_subset_name
-    _get_queries_subset_name = NanoEvaluator._get_queries_subset_name
-    _get_qrels_subset_name = NanoEvaluator._get_qrels_subset_name
     _get_prompt_for_dataset = NanoEvaluator._get_prompt_for_dataset
     _get_metric_from_full_key = NanoEvaluator._get_metric_from_full_key
 

--- a/sentence_transformers/sparse_encoder/evaluation/SparseNanoEvaluator.py
+++ b/sentence_transformers/sparse_encoder/evaluation/SparseNanoEvaluator.py
@@ -58,6 +58,8 @@ class SparseNanoEvaluator(_GenericNanoDatasetMixin, SparseNanoBEIREvaluator):
         self.dataset_names = dataset_names
         self._validate_dataset_names()
         self._validate_mapping_splits()
+        query_prompts = self._normalize_prompt_mapping(query_prompts, dataset_names)
+        corpus_prompts = self._normalize_prompt_mapping(corpus_prompts, dataset_names)
         super().__init__(
             dataset_names=dataset_names,
             dataset_id=dataset_id,
@@ -85,10 +87,7 @@ class SparseNanoEvaluator(_GenericNanoDatasetMixin, SparseNanoBEIREvaluator):
             human_readable_name += f"_{self.max_active_dims}"
         return human_readable_name
 
-    _get_evaluator_name_root = NanoEvaluator._get_evaluator_name_root
-    _get_evaluation_description = NanoEvaluator._get_evaluation_description
-    _get_loading_description = NanoEvaluator._get_loading_description
-    _get_prompt_for_dataset = NanoEvaluator._get_prompt_for_dataset
+    description = NanoEvaluator.description
     _get_metric_from_full_key = NanoEvaluator._get_metric_from_full_key
 
     def get_config_dict(self) -> dict[str, Any]:

--- a/sentence_transformers/sparse_encoder/evaluation/SparseNanoEvaluator.py
+++ b/sentence_transformers/sparse_encoder/evaluation/SparseNanoEvaluator.py
@@ -1,70 +1,23 @@
 from __future__ import annotations
 
-import logging
-import os
-from collections import defaultdict
 from collections.abc import Callable, Mapping
-from typing import TYPE_CHECKING, Any, cast
+from typing import Any
 
 import numpy as np
-import torch
 from torch import Tensor
 
-from sentence_transformers.evaluation.NanoEvaluator import NanoEvaluator
+from sentence_transformers.evaluation._nano_utils import _GenericNanoDatasetMixin
 from sentence_transformers.similarity_functions import SimilarityFunction
-from sentence_transformers.sparse_encoder.evaluation.SparseInformationRetrievalEvaluator import (
-    SparseInformationRetrievalEvaluator,
-)
-from sentence_transformers.util import append_to_last_row
-
-if TYPE_CHECKING:
-    from sentence_transformers.SentenceTransformer import SentenceTransformer
-
-logger = logging.getLogger(__name__)
+from sentence_transformers.sparse_encoder.evaluation.SparseNanoBEIREvaluator import SparseNanoBEIREvaluator
 
 
-class SparseNanoEvaluator(NanoEvaluator):
+class SparseNanoEvaluator(_GenericNanoDatasetMixin, SparseNanoBEIREvaluator):
     """
     Generic Nano-style evaluator for sparse encoders.
 
-    This class extends :class:`~sentence_transformers.evaluation.NanoEvaluator`
-    and adds sparse-specific aggregation metrics (active dimensions, sparsity
-    ratio, FLOPS) on top of standard IR metrics.
-
-    Sparse metrics are aggregated across evaluated subsets and emitted with the
-    same aggregate prefix as IR metrics (for example ``NanoBEIR_mean_avg_flops``).
-
-    Args:
-        dataset_names (list[str] | None): Dataset names or split names to evaluate.
-        dataset_id (str): Hugging Face dataset ID.
-        mrr_at_k (list[int]): ``k`` values for MRR.
-        ndcg_at_k (list[int]): ``k`` values for nDCG.
-        accuracy_at_k (list[int]): ``k`` values for accuracy.
-        precision_recall_at_k (list[int]): ``k`` values for precision/recall.
-        map_at_k (list[int]): ``k`` values for MAP.
-        show_progress_bar (bool): Whether to show progress bars.
-        batch_size (int): Evaluation batch size.
-        write_csv (bool): Whether to write aggregated metrics CSV.
-        max_active_dims (int | None): Optional cap for active sparse dimensions.
-        score_functions (dict[str, Callable[[Tensor, Tensor], Tensor]] | None):
-            Optional custom score functions.
-        main_score_function (str | SimilarityFunction | None): Optional main score function.
-        aggregate_fn (Callable[[list[float]], float]): Aggregation function across datasets.
-        aggregate_key (str): Aggregate metric key prefix.
-        query_prompts (str | dict[str, str] | None): Query prompt(s), global or per-dataset.
-        corpus_prompts (str | dict[str, str] | None): Corpus prompt(s), global or per-dataset.
-        write_predictions (bool): Whether to write per-query predictions JSONL.
-        dataset_name_to_human_readable (Mapping[str, str] | None): Optional short-name mapping.
-        split_prefix (str): Optional split prefix applied in mapping mode.
-        strict_dataset_name_validation (bool): Whether to validate names strictly against mapping.
-        auto_expand_splits_when_dataset_names_none (bool): Whether to infer dataset names from query splits.
-        corpus_subset_name (str): Subset name for corpus.
-        queries_subset_name (str): Subset name for queries.
-        qrels_subset_name (str): Subset name for qrels.
-        name (str | None): Optional base name for aggregate metric prefixes.
+    This evaluator reuses :class:`~sentence_transformers.sparse_encoder.evaluation.SparseNanoBEIREvaluator`
+    and overrides only dataset/split resolution so the sparse aggregation logic stays identical.
     """
-
-    information_retrieval_class = SparseInformationRetrievalEvaluator
 
     def __init__(
         self,
@@ -95,27 +48,8 @@ class SparseNanoEvaluator(NanoEvaluator):
         qrels_subset_name: str = "qrels",
         name: str | None = None,
     ) -> None:
-        # Parent initialization builds sub-evaluators via _load_dataset, which reads max_active_dims.
-        self.max_active_dims = max_active_dims
-        super().__init__(
-            dataset_names=dataset_names,
+        self._initialize_generic_nano_state(
             dataset_id=dataset_id,
-            mrr_at_k=mrr_at_k,
-            ndcg_at_k=ndcg_at_k,
-            accuracy_at_k=accuracy_at_k,
-            precision_recall_at_k=precision_recall_at_k,
-            map_at_k=map_at_k,
-            show_progress_bar=show_progress_bar,
-            batch_size=batch_size,
-            write_csv=write_csv,
-            truncate_dim=None,
-            score_functions=score_functions,
-            main_score_function=main_score_function,
-            aggregate_fn=aggregate_fn,
-            aggregate_key=aggregate_key,
-            query_prompts=query_prompts,
-            corpus_prompts=corpus_prompts,
-            write_predictions=write_predictions,
             dataset_name_to_human_readable=dataset_name_to_human_readable,
             split_prefix=split_prefix,
             strict_dataset_name_validation=strict_dataset_name_validation,
@@ -125,8 +59,26 @@ class SparseNanoEvaluator(NanoEvaluator):
             qrels_subset_name=qrels_subset_name,
             name=name,
         )
-        if self.max_active_dims is not None:
-            self.name += f"_{self.max_active_dims}"
+        super().__init__(
+            dataset_names=self._resolve_dataset_names(dataset_names),
+            dataset_id=dataset_id,
+            mrr_at_k=mrr_at_k,
+            ndcg_at_k=ndcg_at_k,
+            accuracy_at_k=accuracy_at_k,
+            precision_recall_at_k=precision_recall_at_k,
+            map_at_k=map_at_k,
+            show_progress_bar=show_progress_bar,
+            batch_size=batch_size,
+            write_csv=write_csv,
+            max_active_dims=max_active_dims,
+            score_functions=score_functions,
+            main_score_function=main_score_function,
+            aggregate_fn=aggregate_fn,
+            aggregate_key=aggregate_key,
+            query_prompts=query_prompts,
+            corpus_prompts=corpus_prompts,
+            write_predictions=write_predictions,
+        )
 
     def _get_human_readable_name(self, dataset_name: str) -> str:
         human_readable_name = super()._get_human_readable_name(dataset_name)
@@ -134,129 +86,8 @@ class SparseNanoEvaluator(NanoEvaluator):
             human_readable_name += f"_{self.max_active_dims}"
         return human_readable_name
 
-    def _append_csv_headers(self, score_function_names: list[str]) -> None:
-        super()._append_csv_headers(score_function_names)
-        # Avoid duplicate sparse headers when no score function metrics are emitted.
-        if score_function_names:
-            self.csv_headers.extend(
-                [
-                    "query_active_dims",
-                    "query_sparsity_ratio",
-                    "corpus_active_dims",
-                    "corpus_sparsity_ratio",
-                    "avg_flops",
-                ]
-            )
-
-    def __call__(
-        self,
-        model: SentenceTransformer,
-        output_path: str | None = None,
-        epoch: int = -1,
-        steps: int = -1,
-        *args: Any,
-        **kwargs: Any,
-    ) -> dict[str, float]:
-        per_dataset_results = super().__call__(model, output_path, epoch, steps, *args, **kwargs)
-
-        sparsity_stats_by_key: defaultdict[str, list[float]] = defaultdict(list)
-        lengths_by_prefix: defaultdict[str, list[int]] = defaultdict(list)
-        total_query_count: torch.Tensor | None = None
-        total_corpus_count: torch.Tensor | None = None
-        for evaluator in self.evaluators:
-            sparse_evaluator = cast(SparseInformationRetrievalEvaluator, evaluator)
-            lengths_by_prefix["query"].append(len(sparse_evaluator.queries))
-            lengths_by_prefix["corpus"].append(len(sparse_evaluator.corpus))
-            for key, value in sparse_evaluator.sparsity_stats.items():
-                if not isinstance(value, (int, float)):
-                    continue
-                sparsity_stats_by_key[key].append(float(value))
-
-            if total_query_count is None:
-                total_query_count = sparse_evaluator.count_vectors["query"]
-                total_corpus_count = sparse_evaluator.count_vectors["corpus"]
-            else:
-                if total_query_count.shape != sparse_evaluator.count_vectors["query"].shape:
-                    raise ValueError(
-                        "Sparse evaluator query count vector shapes are inconsistent across splits: "
-                        f"{total_query_count.shape} vs {sparse_evaluator.count_vectors['query'].shape}"
-                    )
-                if total_corpus_count is None:
-                    raise ValueError(
-                        "Internal error: total_corpus_count should not be None when total_query_count is set."
-                    )
-                if total_corpus_count.shape != sparse_evaluator.count_vectors["corpus"].shape:
-                    raise ValueError(
-                        "Sparse evaluator corpus count vector shapes are inconsistent across splits: "
-                        f"{total_corpus_count.shape} vs {sparse_evaluator.count_vectors['corpus'].shape}"
-                    )
-                total_query_count += sparse_evaluator.count_vectors["query"]
-                total_corpus_count += sparse_evaluator.count_vectors["corpus"]
-
-        aggregated_sparsity_stats: dict[str, float] = {}
-        for key, values in sparsity_stats_by_key.items():
-            if key == "avg_flops":
-                continue
-            prefix = key.split("_")[0]
-            lengths = lengths_by_prefix[prefix]
-            if not lengths:
-                continue
-            aggregated_sparsity_stats[key] = sum(value * length for value, length in zip(values, lengths)) / sum(
-                lengths
-            )
-
-        if total_query_count is None or total_corpus_count is None:
-            aggregated_sparsity_stats["avg_flops"] = 0.0
-        else:
-            avg_query_count = total_query_count / sum(lengths_by_prefix["query"])
-            avg_corpus_count = total_corpus_count / sum(lengths_by_prefix["corpus"])
-            aggregated_sparsity_stats["avg_flops"] = float(torch.dot(avg_query_count, avg_corpus_count).cpu())
-
-        prefixed_sparsity_metrics = self.prefix_name_to_metrics(aggregated_sparsity_stats, self.name)
-        per_dataset_results.update(prefixed_sparsity_metrics)
-        # Store only sparse-specific metrics here to avoid duplicating IR aggregate keys
-        # already written by NanoEvaluator.__call__.
-        self.store_metrics_in_model_card_data(model, prefixed_sparsity_metrics, epoch, steps)
-
-        query_active_dims = aggregated_sparsity_stats.get("query_active_dims", float("nan"))
-        query_sparsity_ratio = aggregated_sparsity_stats.get("query_sparsity_ratio", float("nan"))
-        corpus_active_dims = aggregated_sparsity_stats.get("corpus_active_dims", float("nan"))
-        corpus_sparsity_ratio = aggregated_sparsity_stats.get("corpus_sparsity_ratio", float("nan"))
-        avg_flops = aggregated_sparsity_stats.get("avg_flops", float("nan"))
-
-        logger.info(
-            "Model Query Sparsity: Active Dimensions: %.1f, Sparsity Ratio: %.4f",
-            query_active_dims,
-            query_sparsity_ratio,
-        )
-        logger.info(
-            "Model Corpus Sparsity: Active Dimensions: %.1f, Sparsity Ratio: %.4f",
-            corpus_active_dims,
-            corpus_sparsity_ratio,
-        )
-        logger.info("Average FLOPS: %.2f", avg_flops)
-
-        if output_path is not None and self.write_csv:
-            os.makedirs(output_path, exist_ok=True)
-            append_to_last_row(
-                os.path.join(output_path, self.csv_file),
-                [
-                    query_active_dims,
-                    query_sparsity_ratio,
-                    corpus_active_dims,
-                    corpus_sparsity_ratio,
-                    avg_flops,
-                ],
-            )
-        return per_dataset_results
-
-    def _load_dataset(self, dataset_name: str, **ir_evaluator_kwargs: Any) -> SparseInformationRetrievalEvaluator:
-        ir_evaluator_kwargs["max_active_dims"] = self.max_active_dims
-        ir_evaluator_kwargs.pop("truncate_dim", None)
-        return cast(SparseInformationRetrievalEvaluator, super()._load_dataset(dataset_name, **ir_evaluator_kwargs))
-
     def get_config_dict(self) -> dict[str, Any]:
-        config_dict = super().get_config_dict()
+        config_dict = self._get_generic_config_dict()
         if self.max_active_dims is not None:
             config_dict["max_active_dims"] = self.max_active_dims
         return config_dict

--- a/sentence_transformers/sparse_encoder/evaluation/SparseNanoEvaluator.py
+++ b/sentence_transformers/sparse_encoder/evaluation/SparseNanoEvaluator.py
@@ -7,6 +7,7 @@ import numpy as np
 from torch import Tensor
 
 from sentence_transformers.evaluation._nano_utils import _GenericNanoDatasetMixin
+from sentence_transformers.evaluation.NanoEvaluator import NanoEvaluator
 from sentence_transformers.similarity_functions import SimilarityFunction
 from sentence_transformers.sparse_encoder.evaluation.SparseNanoBEIREvaluator import SparseNanoBEIREvaluator
 
@@ -81,10 +82,19 @@ class SparseNanoEvaluator(_GenericNanoDatasetMixin, SparseNanoBEIREvaluator):
         )
 
     def _get_human_readable_name(self, dataset_name: str) -> str:
-        human_readable_name = super()._get_human_readable_name(dataset_name)
+        human_readable_name = NanoEvaluator._get_human_readable_name(self, dataset_name)
         if self.max_active_dims is not None:
             human_readable_name += f"_{self.max_active_dims}"
         return human_readable_name
+
+    _get_evaluator_name_root = NanoEvaluator._get_evaluator_name_root
+    _get_evaluation_description = NanoEvaluator._get_evaluation_description
+    _get_loading_description = NanoEvaluator._get_loading_description
+    _get_corpus_subset_name = NanoEvaluator._get_corpus_subset_name
+    _get_queries_subset_name = NanoEvaluator._get_queries_subset_name
+    _get_qrels_subset_name = NanoEvaluator._get_qrels_subset_name
+    _get_prompt_for_dataset = NanoEvaluator._get_prompt_for_dataset
+    _get_metric_from_full_key = NanoEvaluator._get_metric_from_full_key
 
     def get_config_dict(self) -> dict[str, Any]:
         config_dict = self._get_generic_config_dict()

--- a/sentence_transformers/sparse_encoder/evaluation/__init__.py
+++ b/sentence_transformers/sparse_encoder/evaluation/__init__.py
@@ -18,6 +18,9 @@ from sentence_transformers.sparse_encoder.evaluation.SparseMSEEvaluator import (
 from sentence_transformers.sparse_encoder.evaluation.SparseNanoBEIREvaluator import (
     SparseNanoBEIREvaluator,
 )
+from sentence_transformers.sparse_encoder.evaluation.SparseNanoEvaluator import (
+    SparseNanoEvaluator,
+)
 from sentence_transformers.sparse_encoder.evaluation.SparseRerankingEvaluator import (
     SparseRerankingEvaluator,
 )
@@ -34,6 +37,7 @@ __all__ = [
     "SparseBinaryClassificationEvaluator",
     "SparseMSEEvaluator",
     "SparseNanoBEIREvaluator",
+    "SparseNanoEvaluator",
     "SparseTripletEvaluator",
     "SparseTranslationEvaluator",
     "SparseRerankingEvaluator",

--- a/tests/cross_encoder/test_nano_evaluator.py
+++ b/tests/cross_encoder/test_nano_evaluator.py
@@ -91,18 +91,18 @@ def fake_datasets_module() -> Any:
         add_split("sentence-transformers/NanoBEIR-en", split)
 
     for split in ["python", "java"]:
-        add_split("hotchpotch/NanoCodeSearchNet", split)
+        add_split("example/NanoFooBar", split)
 
     split_names: dict[tuple[str, str], list[str]] = {
         ("sentence-transformers/NanoBEIR-en", "corpus"): ["NanoMSMARCO", "NanoNQ"],
         ("sentence-transformers/NanoBEIR-en", "queries"): ["NanoMSMARCO", "NanoNQ"],
         ("sentence-transformers/NanoBEIR-en", "qrels"): ["NanoMSMARCO", "NanoNQ"],
         ("sentence-transformers/NanoBEIR-en", "bm25"): ["NanoMSMARCO", "NanoNQ"],
-        ("hotchpotch/NanoCodeSearchNet", "corpus"): ["python", "java"],
-        ("hotchpotch/NanoCodeSearchNet", "queries"): ["python", "java"],
-        ("hotchpotch/NanoCodeSearchNet", "qrels"): ["python", "java"],
-        ("hotchpotch/NanoCodeSearchNet", "dense"): ["python", "java"],
-        ("hotchpotch/NanoCodeSearchNet", "bm25"): ["python", "java"],
+        ("example/NanoFooBar", "corpus"): ["python", "java"],
+        ("example/NanoFooBar", "queries"): ["python", "java"],
+        ("example/NanoFooBar", "qrels"): ["python", "java"],
+        ("example/NanoFooBar", "dense"): ["python", "java"],
+        ("example/NanoFooBar", "bm25"): ["python", "java"],
     }
 
     def load_dataset(dataset_id: str, subset: str, split: str) -> FakeDataset:
@@ -133,7 +133,7 @@ def test_cross_encoder_nano_evaluator_auto_expand_with_custom_candidate_subset(
 ) -> None:
     evaluator = CrossEncoderNanoEvaluator(
         dataset_names=None,
-        dataset_id="hotchpotch/NanoCodeSearchNet",
+        dataset_id="example/NanoFooBar",
         write_csv=False,
         candidate_subset_name="dense",
         retrieved_corpus_ids_column="retrieved-ids",
@@ -141,12 +141,12 @@ def test_cross_encoder_nano_evaluator_auto_expand_with_custom_candidate_subset(
 
     assert evaluator.dataset_names == ["python", "java"]
     assert [sub_evaluator.name for sub_evaluator in evaluator.evaluators] == [
-        "NanoCodeSearchNet_python_R100",
-        "NanoCodeSearchNet_java_R100",
+        "NanoFooBar_python_R100",
+        "NanoFooBar_java_R100",
     ]
 
     metrics = evaluator(dummy_cross_encoder)
-    assert "NanoCodeSearchNet_R100_mean_ndcg@10" in metrics
+    assert "NanoFooBar_R100_mean_ndcg@10" in metrics
 
 
 def test_cross_encoder_nano_evaluator_bm25_alias_keeps_backward_compatibility(
@@ -155,14 +155,14 @@ def test_cross_encoder_nano_evaluator_bm25_alias_keeps_backward_compatibility(
 ) -> None:
     evaluator = CrossEncoderNanoEvaluator(
         dataset_names=["python"],
-        dataset_id="hotchpotch/NanoCodeSearchNet",
+        dataset_id="example/NanoFooBar",
         write_csv=False,
         bm25_subset_name="dense",
         retrieved_corpus_ids_column="retrieved-ids",
     )
     assert evaluator.candidate_subset_name == "dense"
     metrics = evaluator(dummy_cross_encoder)
-    assert "NanoCodeSearchNet_python_R100_ndcg@10" in metrics
+    assert "NanoFooBar_python_R100_ndcg@10" in metrics
 
 
 def test_cross_encoder_nano_evaluator_mapping_validates_split_exists(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/cross_encoder/test_nano_evaluator.py
+++ b/tests/cross_encoder/test_nano_evaluator.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+import sys
+from collections.abc import Iterator
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from sentence_transformers.cross_encoder.evaluation import CrossEncoderNanoBEIREvaluator, CrossEncoderNanoEvaluator
+
+
+class FakeDataset:
+    def __init__(self, rows: list[dict[str, Any]]) -> None:
+        self.rows = rows
+        self.column_names = list(rows[0].keys()) if rows else []
+
+    def __iter__(self) -> Iterator[dict[str, Any]]:
+        return iter(self.rows)
+
+    def __len__(self) -> int:
+        return len(self.rows)
+
+    def __getitem__(self, key: str | int) -> Any:
+        if isinstance(key, str):
+            return [row[key] for row in self.rows]
+        return self.rows[key]
+
+    def map(self, fn: Any, fn_kwargs: dict[str, Any] | None = None) -> FakeDataset:
+        kwargs = fn_kwargs or {}
+        return FakeDataset([fn(row, **kwargs) for row in self.rows])
+
+
+class FakeCrossEncoderRerankingEvaluator:
+    def __init__(
+        self,
+        samples: list[dict[str, str | list[str]]],
+        name: str,
+        at_k: int = 10,
+        **kwargs: Any,
+    ) -> None:
+        del kwargs
+        self.samples = samples
+        self.name = name
+        self.at_k = at_k
+
+    def __call__(
+        self,
+        model: Any,
+        output_path: str | None = None,
+        epoch: int = -1,
+        steps: int = -1,
+        *args: Any,
+        **kwargs: Any,
+    ) -> dict[str, float]:
+        del model, output_path, epoch, steps, args, kwargs
+        return {
+            f"{self.name}_base_map": 0.10,
+            f"{self.name}_map": 0.20,
+            f"{self.name}_base_mrr@{self.at_k}": 0.30,
+            f"{self.name}_mrr@{self.at_k}": 0.40,
+            f"{self.name}_base_ndcg@{self.at_k}": 0.50,
+            f"{self.name}_ndcg@{self.at_k}": 0.60,
+        }
+
+
+@pytest.fixture
+def dummy_cross_encoder() -> Any:
+    return SimpleNamespace(model_card_data=SimpleNamespace(set_evaluation_metrics=lambda *args, **kwargs: None))
+
+
+@pytest.fixture
+def fake_datasets_module() -> Any:
+    data: dict[tuple[str, str, str], list[dict[str, Any]]] = {}
+
+    def add_split(dataset_id: str, split_name: str) -> None:
+        data[(dataset_id, "corpus", split_name)] = [
+            {"_id": f"{split_name}-d1", "text": "Document 1"},
+            {"_id": f"{split_name}-d2", "text": "Document 2"},
+        ]
+        data[(dataset_id, "queries", split_name)] = [{"_id": f"{split_name}-q1", "text": "Query 1"}]
+        data[(dataset_id, "qrels", split_name)] = [{"query-id": f"{split_name}-q1", "corpus-id": f"{split_name}-d1"}]
+        data[(dataset_id, "dense", split_name)] = [
+            {"query-id": f"{split_name}-q1", "retrieved-ids": [f"{split_name}-d2", f"{split_name}-d1"]}
+        ]
+        data[(dataset_id, "bm25", split_name)] = [
+            {"query-id": f"{split_name}-q1", "corpus-ids": [f"{split_name}-d2", f"{split_name}-d1"]}
+        ]
+
+    for split in ["NanoMSMARCO", "NanoNQ"]:
+        add_split("sentence-transformers/NanoBEIR-en", split)
+
+    for split in ["python", "java"]:
+        add_split("hotchpotch/NanoCodeSearchNet", split)
+
+    split_names: dict[tuple[str, str], list[str]] = {
+        ("sentence-transformers/NanoBEIR-en", "corpus"): ["NanoMSMARCO", "NanoNQ"],
+        ("sentence-transformers/NanoBEIR-en", "queries"): ["NanoMSMARCO", "NanoNQ"],
+        ("sentence-transformers/NanoBEIR-en", "qrels"): ["NanoMSMARCO", "NanoNQ"],
+        ("sentence-transformers/NanoBEIR-en", "bm25"): ["NanoMSMARCO", "NanoNQ"],
+        ("hotchpotch/NanoCodeSearchNet", "corpus"): ["python", "java"],
+        ("hotchpotch/NanoCodeSearchNet", "queries"): ["python", "java"],
+        ("hotchpotch/NanoCodeSearchNet", "qrels"): ["python", "java"],
+        ("hotchpotch/NanoCodeSearchNet", "dense"): ["python", "java"],
+        ("hotchpotch/NanoCodeSearchNet", "bm25"): ["python", "java"],
+    }
+
+    def load_dataset(dataset_id: str, subset: str, split: str) -> FakeDataset:
+        return FakeDataset(data[(dataset_id, subset, split)])
+
+    def get_dataset_split_names(dataset_id: str, subset: str) -> list[str]:
+        return split_names[(dataset_id, subset)]
+
+    return SimpleNamespace(load_dataset=load_dataset, get_dataset_split_names=get_dataset_split_names)
+
+
+@pytest.fixture
+def patch_cross_nano_eval(monkeypatch: pytest.MonkeyPatch, fake_datasets_module: Any) -> None:
+    import sentence_transformers.cross_encoder.evaluation.nano_evaluator as cross_nano_module
+
+    monkeypatch.setattr(cross_nano_module, "is_datasets_available", lambda: True)
+    monkeypatch.setitem(sys.modules, "datasets", fake_datasets_module)
+    monkeypatch.setattr(
+        CrossEncoderNanoEvaluator,
+        "reranking_evaluator_class",
+        FakeCrossEncoderRerankingEvaluator,
+    )
+
+
+def test_cross_encoder_nano_evaluator_auto_expand_with_custom_candidate_subset(
+    patch_cross_nano_eval: None,
+    dummy_cross_encoder: Any,
+) -> None:
+    evaluator = CrossEncoderNanoEvaluator(
+        dataset_names=None,
+        dataset_id="hotchpotch/NanoCodeSearchNet",
+        write_csv=False,
+        candidate_subset_name="dense",
+        retrieved_corpus_ids_column="retrieved-ids",
+    )
+
+    assert evaluator.dataset_names == ["python", "java"]
+    assert [sub_evaluator.name for sub_evaluator in evaluator.evaluators] == [
+        "NanoCodeSearchNet_python_R100",
+        "NanoCodeSearchNet_java_R100",
+    ]
+
+    metrics = evaluator(dummy_cross_encoder)
+    assert "NanoCodeSearchNet_R100_mean_ndcg@10" in metrics
+
+
+def test_cross_encoder_nano_evaluator_bm25_alias_keeps_backward_compatibility(
+    patch_cross_nano_eval: None,
+    dummy_cross_encoder: Any,
+) -> None:
+    evaluator = CrossEncoderNanoEvaluator(
+        dataset_names=["python"],
+        dataset_id="hotchpotch/NanoCodeSearchNet",
+        write_csv=False,
+        bm25_subset_name="dense",
+        retrieved_corpus_ids_column="retrieved-ids",
+    )
+    assert evaluator.candidate_subset_name == "dense"
+    metrics = evaluator(dummy_cross_encoder)
+    assert "NanoCodeSearchNet_python_R100_ndcg@10" in metrics
+
+
+def test_cross_encoder_nano_evaluator_mapping_validates_split_exists(monkeypatch: pytest.MonkeyPatch) -> None:
+    import sentence_transformers.cross_encoder.evaluation.nano_evaluator as cross_nano_module
+
+    def get_dataset_split_names(dataset_id: str, subset: str) -> list[str]:
+        del dataset_id, subset
+        return ["NanoNQ"]
+
+    monkeypatch.setattr(cross_nano_module, "is_datasets_available", lambda: True)
+    monkeypatch.setitem(
+        sys.modules,
+        "datasets",
+        SimpleNamespace(load_dataset=lambda *args, **kwargs: None, get_dataset_split_names=get_dataset_split_names),
+    )
+
+    with pytest.raises(ValueError, match="maps to split 'NanoMSMARCO'.*does not exist"):
+        CrossEncoderNanoEvaluator(
+            dataset_names=["msmarco"],
+            dataset_id="sentence-transformers/NanoBEIR-en",
+            dataset_name_to_human_readable={"msmarco": "MSMARCO"},
+            split_prefix="Nano",
+            write_csv=False,
+        )
+
+
+def test_cross_encoder_nanobeir_invalid_dataset_name() -> None:
+    with pytest.raises(ValueError, match="are not valid NanoBEIR datasets"):
+        CrossEncoderNanoBEIREvaluator(dataset_names=["invalidDataset"])
+
+
+def test_cross_encoder_nanobeir_primary_metric_key(
+    patch_cross_nano_eval: None,
+    dummy_cross_encoder: Any,
+) -> None:
+    evaluator = CrossEncoderNanoBEIREvaluator(
+        dataset_names=["msmarco"],
+        write_csv=False,
+    )
+
+    metrics = evaluator(dummy_cross_encoder)
+    assert "NanoBEIR_R100_mean_ndcg@10" in metrics

--- a/tests/cross_encoder/test_nano_evaluator.py
+++ b/tests/cross_encoder/test_nano_evaluator.py
@@ -53,7 +53,7 @@ def fake_datasets_module() -> Any:
     return build_fake_datasets_module(
         {
             "sentence-transformers/NanoBEIR-en": ["NanoMSMARCO", "NanoNQ"],
-            "example/FooBar": ["python", "java"],
+            "example/FooBar": ["ds_foo", "ds_bar"],
         },
         candidate_subsets={"bm25": "corpus-ids"},
     )
@@ -94,10 +94,10 @@ def test_cross_encoder_nano_evaluator_auto_expand_splits_and_auto_names(
         write_csv=False,
     )
 
-    assert evaluator.dataset_names == ["python", "java"]
+    assert evaluator.dataset_names == ["ds_foo", "ds_bar"]
     assert [sub_evaluator.name for sub_evaluator in evaluator.evaluators] == [
-        "FooBar_python_R100",
-        "FooBar_java_R100",
+        "FooBar_ds_foo_R100",
+        "FooBar_ds_bar_R100",
     ]
 
     metrics = evaluator(dummy_cross_encoder)
@@ -117,7 +117,7 @@ def test_cross_encoder_nano_evaluator_auto_expand_splits_with_mapping_in_strict_
         write_csv=False,
     )
 
-    assert evaluator.dataset_names == ["python", "java"]
+    assert evaluator.dataset_names == ["ds_foo", "ds_bar"]
     metrics = evaluator(dummy_cross_encoder)
     assert "FooBar_R100_mean_ndcg@10" in metrics
 
@@ -151,14 +151,14 @@ def test_cross_encoder_nano_evaluator_accepts_direct_split_names_with_mapping(
     dummy_cross_encoder: Any,
 ) -> None:
     evaluator = CrossEncoderNanoEvaluator(
-        dataset_names=["python"],
+        dataset_names=["ds_foo"],
         dataset_id="example/FooBar",
         dataset_name_to_human_readable={"msmarco": "MSMARCO"},
         split_prefix="Nano",
         write_csv=False,
     )
 
-    assert [sub_evaluator.name for sub_evaluator in evaluator.evaluators] == ["python_R100"]
+    assert [sub_evaluator.name for sub_evaluator in evaluator.evaluators] == ["ds_foo_R100"]
     metrics = evaluator(dummy_cross_encoder)
     assert "FooBar_R100_mean_ndcg@10" in metrics
 
@@ -168,14 +168,14 @@ def test_cross_encoder_nano_evaluator_custom_name_metric_root(
     dummy_cross_encoder: Any,
 ) -> None:
     evaluator = CrossEncoderNanoEvaluator(
-        dataset_names=["python"],
+        dataset_names=["ds_foo"],
         dataset_id="example/FooBar",
         write_csv=False,
         name="CustomCrossNano",
     )
 
     assert evaluator.name == "CustomCrossNano_R100_mean"
-    assert [sub_evaluator.name for sub_evaluator in evaluator.evaluators] == ["CustomCrossNano_python_R100"]
+    assert [sub_evaluator.name for sub_evaluator in evaluator.evaluators] == ["CustomCrossNano_ds_foo_R100"]
     metrics = evaluator(dummy_cross_encoder)
     assert "CustomCrossNano_R100_mean_ndcg@10" in metrics
 
@@ -184,7 +184,7 @@ def test_cross_encoder_nano_evaluator_config_keeps_custom_name(
     patch_cross_nano_eval: None,
 ) -> None:
     evaluator = CrossEncoderNanoEvaluator(
-        dataset_names=["python"],
+        dataset_names=["ds_foo"],
         dataset_id="example/FooBar",
         write_csv=False,
         name="CustomCrossNano",

--- a/tests/cross_encoder/test_nano_evaluator.py
+++ b/tests/cross_encoder/test_nano_evaluator.py
@@ -116,13 +116,25 @@ def fake_datasets_module() -> Any:
 
 @pytest.fixture
 def patch_cross_nano_eval(monkeypatch: pytest.MonkeyPatch, fake_datasets_module: Any) -> None:
-    import sentence_transformers.cross_encoder.evaluation.nano_evaluator as cross_nano_module
+    import sentence_transformers.cross_encoder.evaluation.nano_beir as cross_nanobeir_module
+    import sentence_transformers.evaluation._nano_utils as nano_utils_module
 
-    monkeypatch.setattr(cross_nano_module, "is_datasets_available", lambda: True)
+    monkeypatch.setattr(nano_utils_module, "is_datasets_available", lambda: True)
+    monkeypatch.setattr(cross_nanobeir_module, "is_datasets_available", lambda: True)
     monkeypatch.setitem(sys.modules, "datasets", fake_datasets_module)
     monkeypatch.setattr(
         CrossEncoderNanoEvaluator,
         "reranking_evaluator_class",
+        FakeCrossEncoderRerankingEvaluator,
+    )
+    monkeypatch.setattr(
+        CrossEncoderNanoBEIREvaluator,
+        "reranking_evaluator_class",
+        FakeCrossEncoderRerankingEvaluator,
+    )
+    monkeypatch.setattr(
+        cross_nanobeir_module,
+        "CrossEncoderRerankingEvaluator",
         FakeCrossEncoderRerankingEvaluator,
     )
 
@@ -166,13 +178,13 @@ def test_cross_encoder_nano_evaluator_bm25_alias_keeps_backward_compatibility(
 
 
 def test_cross_encoder_nano_evaluator_mapping_validates_split_exists(monkeypatch: pytest.MonkeyPatch) -> None:
-    import sentence_transformers.cross_encoder.evaluation.nano_evaluator as cross_nano_module
+    import sentence_transformers.evaluation._nano_utils as nano_utils_module
 
     def get_dataset_split_names(dataset_id: str, subset: str) -> list[str]:
         del dataset_id, subset
         return ["NanoNQ"]
 
-    monkeypatch.setattr(cross_nano_module, "is_datasets_available", lambda: True)
+    monkeypatch.setattr(nano_utils_module, "is_datasets_available", lambda: True)
     monkeypatch.setitem(
         sys.modules,
         "datasets",

--- a/tests/cross_encoder/test_nano_evaluator.py
+++ b/tests/cross_encoder/test_nano_evaluator.py
@@ -55,7 +55,7 @@ def fake_datasets_module() -> Any:
             "sentence-transformers/NanoBEIR-en": ["NanoMSMARCO", "NanoNQ"],
             "example/NanoFooBar": ["python", "java"],
         },
-        candidate_subsets={"dense": "corpus-ids", "bm25": "corpus-ids"},
+        candidate_subsets={"bm25": "corpus-ids"},
     )
 
 
@@ -84,7 +84,7 @@ def patch_cross_nano_eval(monkeypatch: pytest.MonkeyPatch, fake_datasets_module:
     )
 
 
-def test_cross_encoder_nano_evaluator_auto_expand_with_custom_candidate_subset(
+def test_cross_encoder_nano_evaluator_auto_expand_splits_and_auto_names(
     patch_cross_nano_eval: None,
     dummy_cross_encoder: Any,
 ) -> None:
@@ -92,7 +92,6 @@ def test_cross_encoder_nano_evaluator_auto_expand_with_custom_candidate_subset(
         dataset_names=None,
         dataset_id="example/NanoFooBar",
         write_csv=False,
-        candidate_subset_name="dense",
     )
 
     assert evaluator.dataset_names == ["python", "java"]
@@ -105,19 +104,22 @@ def test_cross_encoder_nano_evaluator_auto_expand_with_custom_candidate_subset(
     assert "NanoFooBar_R100_mean_ndcg@10" in metrics
 
 
-def test_cross_encoder_nano_evaluator_bm25_alias_keeps_backward_compatibility(
+def test_cross_encoder_nano_evaluator_auto_expand_splits_with_mapping_in_strict_mode(
     patch_cross_nano_eval: None,
     dummy_cross_encoder: Any,
 ) -> None:
     evaluator = CrossEncoderNanoEvaluator(
-        dataset_names=["python"],
+        dataset_names=None,
         dataset_id="example/NanoFooBar",
+        dataset_name_to_human_readable={"msmarco": "MSMARCO"},
+        split_prefix="Nano",
+        strict_dataset_name_validation=True,
         write_csv=False,
-        bm25_subset_name="dense",
     )
-    assert evaluator.candidate_subset_name == "dense"
+
+    assert evaluator.dataset_names == ["python", "java"]
     metrics = evaluator(dummy_cross_encoder)
-    assert "NanoFooBar_python_R100_ndcg@10" in metrics
+    assert "NanoFooBar_R100_mean_ndcg@10" in metrics
 
 
 def test_cross_encoder_nano_evaluator_mapping_validates_split_exists(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -154,7 +156,6 @@ def test_cross_encoder_nano_evaluator_accepts_direct_split_names_with_mapping(
         dataset_name_to_human_readable={"msmarco": "MSMARCO"},
         split_prefix="Nano",
         write_csv=False,
-        candidate_subset_name="dense",
     )
 
     assert [sub_evaluator.name for sub_evaluator in evaluator.evaluators] == ["python_R100"]
@@ -170,7 +171,6 @@ def test_cross_encoder_nano_evaluator_custom_name_metric_root(
         dataset_names=["python"],
         dataset_id="example/NanoFooBar",
         write_csv=False,
-        candidate_subset_name="dense",
         name="CustomCrossNano",
     )
 
@@ -180,23 +180,20 @@ def test_cross_encoder_nano_evaluator_custom_name_metric_root(
     assert "CustomCrossNano_R100_mean_ndcg@10" in metrics
 
 
-def test_cross_encoder_nano_evaluator_config_exposes_only_candidate_subset(
+def test_cross_encoder_nano_evaluator_config_keeps_custom_name(
     patch_cross_nano_eval: None,
 ) -> None:
     evaluator = CrossEncoderNanoEvaluator(
         dataset_names=["python"],
         dataset_id="example/NanoFooBar",
         write_csv=False,
-        candidate_subset_name="dense",
+        name="CustomCrossNano",
     )
 
     config = evaluator.get_config_dict()
 
-    assert config["candidate_subset_name"] == "dense"
-    assert "corpus_subset_name" not in config
-    assert "queries_subset_name" not in config
-    assert "qrels_subset_name" not in config
-    assert "retrieved_corpus_ids_column" not in config
+    assert config["name"] == "CustomCrossNano"
+    assert "candidate_subset_name" not in config
 
 
 def test_cross_encoder_nanobeir_invalid_dataset_name() -> None:

--- a/tests/cross_encoder/test_nano_evaluator.py
+++ b/tests/cross_encoder/test_nano_evaluator.py
@@ -144,6 +144,24 @@ def test_cross_encoder_nano_evaluator_mapping_validates_split_exists(monkeypatch
         )
 
 
+def test_cross_encoder_nano_evaluator_accepts_direct_split_names_with_mapping(
+    patch_cross_nano_eval: None,
+    dummy_cross_encoder: Any,
+) -> None:
+    evaluator = CrossEncoderNanoEvaluator(
+        dataset_names=["python"],
+        dataset_id="example/NanoFooBar",
+        dataset_name_to_human_readable={"msmarco": "MSMARCO"},
+        split_prefix="Nano",
+        write_csv=False,
+        candidate_subset_name="dense",
+    )
+
+    assert [sub_evaluator.name for sub_evaluator in evaluator.evaluators] == ["python_R100"]
+    metrics = evaluator(dummy_cross_encoder)
+    assert "NanoFooBar_R100_mean_ndcg@10" in metrics
+
+
 def test_cross_encoder_nanobeir_invalid_dataset_name() -> None:
     with pytest.raises(ValueError, match="are not valid NanoBEIR datasets"):
         CrossEncoderNanoBEIREvaluator(dataset_names=["invalidDataset"])

--- a/tests/cross_encoder/test_nano_evaluator.py
+++ b/tests/cross_encoder/test_nano_evaluator.py
@@ -1,34 +1,13 @@
 from __future__ import annotations
 
 import sys
-from collections.abc import Iterator
 from types import SimpleNamespace
 from typing import Any
 
 import pytest
 
 from sentence_transformers.cross_encoder.evaluation import CrossEncoderNanoBEIREvaluator, CrossEncoderNanoEvaluator
-
-
-class FakeDataset:
-    def __init__(self, rows: list[dict[str, Any]]) -> None:
-        self.rows = rows
-        self.column_names = list(rows[0].keys()) if rows else []
-
-    def __iter__(self) -> Iterator[dict[str, Any]]:
-        return iter(self.rows)
-
-    def __len__(self) -> int:
-        return len(self.rows)
-
-    def __getitem__(self, key: str | int) -> Any:
-        if isinstance(key, str):
-            return [row[key] for row in self.rows]
-        return self.rows[key]
-
-    def map(self, fn: Any, fn_kwargs: dict[str, Any] | None = None) -> FakeDataset:
-        kwargs = fn_kwargs or {}
-        return FakeDataset([fn(row, **kwargs) for row in self.rows])
+from tests.nano_evaluator_test_utils import build_fake_datasets_module
 
 
 class FakeCrossEncoderRerankingEvaluator:
@@ -71,47 +50,13 @@ def dummy_cross_encoder() -> Any:
 
 @pytest.fixture
 def fake_datasets_module() -> Any:
-    data: dict[tuple[str, str, str], list[dict[str, Any]]] = {}
-
-    def add_split(dataset_id: str, split_name: str) -> None:
-        data[(dataset_id, "corpus", split_name)] = [
-            {"_id": f"{split_name}-d1", "text": "Document 1"},
-            {"_id": f"{split_name}-d2", "text": "Document 2"},
-        ]
-        data[(dataset_id, "queries", split_name)] = [{"_id": f"{split_name}-q1", "text": "Query 1"}]
-        data[(dataset_id, "qrels", split_name)] = [{"query-id": f"{split_name}-q1", "corpus-id": f"{split_name}-d1"}]
-        data[(dataset_id, "dense", split_name)] = [
-            {"query-id": f"{split_name}-q1", "retrieved-ids": [f"{split_name}-d2", f"{split_name}-d1"]}
-        ]
-        data[(dataset_id, "bm25", split_name)] = [
-            {"query-id": f"{split_name}-q1", "corpus-ids": [f"{split_name}-d2", f"{split_name}-d1"]}
-        ]
-
-    for split in ["NanoMSMARCO", "NanoNQ"]:
-        add_split("sentence-transformers/NanoBEIR-en", split)
-
-    for split in ["python", "java"]:
-        add_split("example/NanoFooBar", split)
-
-    split_names: dict[tuple[str, str], list[str]] = {
-        ("sentence-transformers/NanoBEIR-en", "corpus"): ["NanoMSMARCO", "NanoNQ"],
-        ("sentence-transformers/NanoBEIR-en", "queries"): ["NanoMSMARCO", "NanoNQ"],
-        ("sentence-transformers/NanoBEIR-en", "qrels"): ["NanoMSMARCO", "NanoNQ"],
-        ("sentence-transformers/NanoBEIR-en", "bm25"): ["NanoMSMARCO", "NanoNQ"],
-        ("example/NanoFooBar", "corpus"): ["python", "java"],
-        ("example/NanoFooBar", "queries"): ["python", "java"],
-        ("example/NanoFooBar", "qrels"): ["python", "java"],
-        ("example/NanoFooBar", "dense"): ["python", "java"],
-        ("example/NanoFooBar", "bm25"): ["python", "java"],
-    }
-
-    def load_dataset(dataset_id: str, subset: str, split: str) -> FakeDataset:
-        return FakeDataset(data[(dataset_id, subset, split)])
-
-    def get_dataset_split_names(dataset_id: str, subset: str) -> list[str]:
-        return split_names[(dataset_id, subset)]
-
-    return SimpleNamespace(load_dataset=load_dataset, get_dataset_split_names=get_dataset_split_names)
+    return build_fake_datasets_module(
+        {
+            "sentence-transformers/NanoBEIR-en": ["NanoMSMARCO", "NanoNQ"],
+            "example/NanoFooBar": ["python", "java"],
+        },
+        candidate_subsets={"dense": "corpus-ids", "bm25": "corpus-ids"},
+    )
 
 
 @pytest.fixture
@@ -148,7 +93,6 @@ def test_cross_encoder_nano_evaluator_auto_expand_with_custom_candidate_subset(
         dataset_id="example/NanoFooBar",
         write_csv=False,
         candidate_subset_name="dense",
-        retrieved_corpus_ids_column="retrieved-ids",
     )
 
     assert evaluator.dataset_names == ["python", "java"]
@@ -170,7 +114,6 @@ def test_cross_encoder_nano_evaluator_bm25_alias_keeps_backward_compatibility(
         dataset_id="example/NanoFooBar",
         write_csv=False,
         bm25_subset_name="dense",
-        retrieved_corpus_ids_column="retrieved-ids",
     )
     assert evaluator.candidate_subset_name == "dense"
     metrics = evaluator(dummy_cross_encoder)

--- a/tests/cross_encoder/test_nano_evaluator.py
+++ b/tests/cross_encoder/test_nano_evaluator.py
@@ -53,7 +53,7 @@ def fake_datasets_module() -> Any:
     return build_fake_datasets_module(
         {
             "sentence-transformers/NanoBEIR-en": ["NanoMSMARCO", "NanoNQ"],
-            "example/NanoFooBar": ["python", "java"],
+            "example/FooBar": ["python", "java"],
         },
         candidate_subsets={"bm25": "corpus-ids"},
     )
@@ -90,18 +90,18 @@ def test_cross_encoder_nano_evaluator_auto_expand_splits_and_auto_names(
 ) -> None:
     evaluator = CrossEncoderNanoEvaluator(
         dataset_names=None,
-        dataset_id="example/NanoFooBar",
+        dataset_id="example/FooBar",
         write_csv=False,
     )
 
     assert evaluator.dataset_names == ["python", "java"]
     assert [sub_evaluator.name for sub_evaluator in evaluator.evaluators] == [
-        "NanoFooBar_python_R100",
-        "NanoFooBar_java_R100",
+        "FooBar_python_R100",
+        "FooBar_java_R100",
     ]
 
     metrics = evaluator(dummy_cross_encoder)
-    assert "NanoFooBar_R100_mean_ndcg@10" in metrics
+    assert "FooBar_R100_mean_ndcg@10" in metrics
 
 
 def test_cross_encoder_nano_evaluator_auto_expand_splits_with_mapping_in_strict_mode(
@@ -110,7 +110,7 @@ def test_cross_encoder_nano_evaluator_auto_expand_splits_with_mapping_in_strict_
 ) -> None:
     evaluator = CrossEncoderNanoEvaluator(
         dataset_names=None,
-        dataset_id="example/NanoFooBar",
+        dataset_id="example/FooBar",
         dataset_name_to_human_readable={"msmarco": "MSMARCO"},
         split_prefix="Nano",
         strict_dataset_name_validation=True,
@@ -119,7 +119,7 @@ def test_cross_encoder_nano_evaluator_auto_expand_splits_with_mapping_in_strict_
 
     assert evaluator.dataset_names == ["python", "java"]
     metrics = evaluator(dummy_cross_encoder)
-    assert "NanoFooBar_R100_mean_ndcg@10" in metrics
+    assert "FooBar_R100_mean_ndcg@10" in metrics
 
 
 def test_cross_encoder_nano_evaluator_mapping_validates_split_exists(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -152,7 +152,7 @@ def test_cross_encoder_nano_evaluator_accepts_direct_split_names_with_mapping(
 ) -> None:
     evaluator = CrossEncoderNanoEvaluator(
         dataset_names=["python"],
-        dataset_id="example/NanoFooBar",
+        dataset_id="example/FooBar",
         dataset_name_to_human_readable={"msmarco": "MSMARCO"},
         split_prefix="Nano",
         write_csv=False,
@@ -160,7 +160,7 @@ def test_cross_encoder_nano_evaluator_accepts_direct_split_names_with_mapping(
 
     assert [sub_evaluator.name for sub_evaluator in evaluator.evaluators] == ["python_R100"]
     metrics = evaluator(dummy_cross_encoder)
-    assert "NanoFooBar_R100_mean_ndcg@10" in metrics
+    assert "FooBar_R100_mean_ndcg@10" in metrics
 
 
 def test_cross_encoder_nano_evaluator_custom_name_metric_root(
@@ -169,7 +169,7 @@ def test_cross_encoder_nano_evaluator_custom_name_metric_root(
 ) -> None:
     evaluator = CrossEncoderNanoEvaluator(
         dataset_names=["python"],
-        dataset_id="example/NanoFooBar",
+        dataset_id="example/FooBar",
         write_csv=False,
         name="CustomCrossNano",
     )
@@ -185,7 +185,7 @@ def test_cross_encoder_nano_evaluator_config_keeps_custom_name(
 ) -> None:
     evaluator = CrossEncoderNanoEvaluator(
         dataset_names=["python"],
-        dataset_id="example/NanoFooBar",
+        dataset_id="example/FooBar",
         write_csv=False,
         name="CustomCrossNano",
     )

--- a/tests/cross_encoder/test_nano_evaluator.py
+++ b/tests/cross_encoder/test_nano_evaluator.py
@@ -180,6 +180,25 @@ def test_cross_encoder_nano_evaluator_custom_name_metric_root(
     assert "CustomCrossNano_R100_mean_ndcg@10" in metrics
 
 
+def test_cross_encoder_nano_evaluator_config_exposes_only_candidate_subset(
+    patch_cross_nano_eval: None,
+) -> None:
+    evaluator = CrossEncoderNanoEvaluator(
+        dataset_names=["python"],
+        dataset_id="example/NanoFooBar",
+        write_csv=False,
+        candidate_subset_name="dense",
+    )
+
+    config = evaluator.get_config_dict()
+
+    assert config["candidate_subset_name"] == "dense"
+    assert "corpus_subset_name" not in config
+    assert "queries_subset_name" not in config
+    assert "qrels_subset_name" not in config
+    assert "retrieved_corpus_ids_column" not in config
+
+
 def test_cross_encoder_nanobeir_invalid_dataset_name() -> None:
     with pytest.raises(ValueError, match="are not valid NanoBEIR datasets"):
         CrossEncoderNanoBEIREvaluator(dataset_names=["invalidDataset"])

--- a/tests/cross_encoder/test_nano_evaluator.py
+++ b/tests/cross_encoder/test_nano_evaluator.py
@@ -162,6 +162,24 @@ def test_cross_encoder_nano_evaluator_accepts_direct_split_names_with_mapping(
     assert "NanoFooBar_R100_mean_ndcg@10" in metrics
 
 
+def test_cross_encoder_nano_evaluator_custom_name_metric_root(
+    patch_cross_nano_eval: None,
+    dummy_cross_encoder: Any,
+) -> None:
+    evaluator = CrossEncoderNanoEvaluator(
+        dataset_names=["python"],
+        dataset_id="example/NanoFooBar",
+        write_csv=False,
+        candidate_subset_name="dense",
+        name="CustomCrossNano",
+    )
+
+    assert evaluator.name == "CustomCrossNano_R100_mean"
+    assert [sub_evaluator.name for sub_evaluator in evaluator.evaluators] == ["CustomCrossNano_python_R100"]
+    metrics = evaluator(dummy_cross_encoder)
+    assert "CustomCrossNano_R100_mean_ndcg@10" in metrics
+
+
 def test_cross_encoder_nanobeir_invalid_dataset_name() -> None:
     with pytest.raises(ValueError, match="are not valid NanoBEIR datasets"):
         CrossEncoderNanoBEIREvaluator(dataset_names=["invalidDataset"])

--- a/tests/evaluation/test_nano_evaluator.py
+++ b/tests/evaluation/test_nano_evaluator.py
@@ -111,15 +111,15 @@ def fake_datasets_module() -> Any:
         add_split("sentence-transformers/NanoBEIR-en", split)
 
     for split in ["python", "java"]:
-        add_split("hotchpotch/NanoCodeSearchNet", split)
+        add_split("example/NanoFooBar", split)
 
     split_names: dict[tuple[str, str], list[str]] = {
         ("sentence-transformers/NanoBEIR-en", "corpus"): ["NanoMSMARCO", "NanoNQ"],
         ("sentence-transformers/NanoBEIR-en", "queries"): ["NanoMSMARCO", "NanoNQ"],
         ("sentence-transformers/NanoBEIR-en", "qrels"): ["NanoMSMARCO", "NanoNQ"],
-        ("hotchpotch/NanoCodeSearchNet", "corpus"): ["python", "java"],
-        ("hotchpotch/NanoCodeSearchNet", "queries"): ["python", "java"],
-        ("hotchpotch/NanoCodeSearchNet", "qrels"): ["python", "java"],
+        ("example/NanoFooBar", "corpus"): ["python", "java"],
+        ("example/NanoFooBar", "queries"): ["python", "java"],
+        ("example/NanoFooBar", "qrels"): ["python", "java"],
     }
 
     def load_dataset(dataset_id: str, subset: str, split: str) -> FakeDataset:
@@ -143,7 +143,7 @@ def patch_nano_eval(monkeypatch: pytest.MonkeyPatch, fake_datasets_module: Any) 
 def test_nano_evaluator_auto_expand_splits_and_auto_names(patch_nano_eval: None, dummy_model: Any) -> None:
     evaluator = NanoEvaluator(
         dataset_names=None,
-        dataset_id="hotchpotch/NanoCodeSearchNet",
+        dataset_id="example/NanoFooBar",
         mrr_at_k=[10],
         ndcg_at_k=[10],
         accuracy_at_k=[1],
@@ -155,13 +155,13 @@ def test_nano_evaluator_auto_expand_splits_and_auto_names(patch_nano_eval: None,
 
     assert evaluator.dataset_names == ["python", "java"]
     assert [sub_evaluator.name for sub_evaluator in evaluator.evaluators] == [
-        "NanoCodeSearchNet_python",
-        "NanoCodeSearchNet_java",
+        "NanoFooBar_python",
+        "NanoFooBar_java",
     ]
 
     metrics = evaluator(dummy_model)
-    assert evaluator.primary_metric == "NanoCodeSearchNet_mean_cosine_ndcg@10"
-    assert "NanoCodeSearchNet_mean_cosine_ndcg@10" in metrics
+    assert evaluator.primary_metric == "NanoFooBar_mean_cosine_ndcg@10"
+    assert "NanoFooBar_mean_cosine_ndcg@10" in metrics
 
 
 def test_nano_evaluator_mapping_validates_split_exists(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -210,7 +210,7 @@ def test_sequential_evaluator_with_nanobeir_and_nanocodesearchnet(
     )
     nanocodesearchnet_evaluator = NanoEvaluator(
         dataset_names=["python"],
-        dataset_id="hotchpotch/NanoCodeSearchNet",
+        dataset_id="example/NanoFooBar",
         mrr_at_k=[10],
         ndcg_at_k=[10],
         accuracy_at_k=[1],
@@ -228,5 +228,5 @@ def test_sequential_evaluator_with_nanobeir_and_nanocodesearchnet(
 
     assert "sequential_score" in metrics
     assert any(key.startswith("NanoBEIR_mean_") for key in metrics)
-    assert any(key.startswith("NanoCodeSearchNet_mean_") for key in metrics)
+    assert any(key.startswith("NanoFooBar_mean_") for key in metrics)
     assert "NanoBEIR_mean_cosine_ndcg@10" in metrics

--- a/tests/evaluation/test_nano_evaluator.py
+++ b/tests/evaluation/test_nano_evaluator.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+import importlib
+import sys
+from collections.abc import Iterator
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from sentence_transformers.evaluation import NanoBEIREvaluator, NanoEvaluator, SequentialEvaluator
+
+
+class FakeDataset:
+    def __init__(self, rows: list[dict[str, Any]]) -> None:
+        self.rows = rows
+        self.column_names = list(rows[0].keys()) if rows else []
+
+    def __iter__(self) -> Iterator[dict[str, Any]]:
+        return iter(self.rows)
+
+    def __len__(self) -> int:
+        return len(self.rows)
+
+    def __getitem__(self, key: str | int) -> Any:
+        if isinstance(key, str):
+            return [row[key] for row in self.rows]
+        return self.rows[key]
+
+    def map(self, fn: Any, fn_kwargs: dict[str, Any] | None = None) -> FakeDataset:
+        kwargs = fn_kwargs or {}
+        return FakeDataset([fn(row, **kwargs) for row in self.rows])
+
+
+class FakeInformationRetrievalEvaluator:
+    def __init__(
+        self,
+        queries: dict[str, str],
+        corpus: dict[str, str],
+        relevant_docs: dict[str, set[str]],
+        name: str,
+        mrr_at_k: list[int],
+        ndcg_at_k: list[int],
+        accuracy_at_k: list[int],
+        precision_recall_at_k: list[int],
+        map_at_k: list[int],
+        score_functions: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        self.queries = queries
+        self.corpus = corpus
+        self.relevant_docs = relevant_docs
+        self.name = name
+        self.mrr_at_k = mrr_at_k
+        self.ndcg_at_k = ndcg_at_k
+        self.accuracy_at_k = accuracy_at_k
+        self.precision_recall_at_k = precision_recall_at_k
+        self.map_at_k = map_at_k
+        self.score_names = sorted(score_functions.keys()) if score_functions else ["cosine"]
+
+    def __call__(
+        self,
+        model: Any,
+        output_path: str | None = None,
+        epoch: int = -1,
+        steps: int = -1,
+        *args: Any,
+        **kwargs: Any,
+    ) -> dict[str, float]:
+        del model, output_path, epoch, steps, args, kwargs
+
+        base_value = 0.05 + (len(self.name) % 10) * 0.01
+        metrics: dict[str, float] = {}
+        for score_name in self.score_names:
+            for k in self.accuracy_at_k:
+                metrics[f"{self.name}_{score_name}_accuracy@{k}"] = base_value
+            for k in self.precision_recall_at_k:
+                metrics[f"{self.name}_{score_name}_precision@{k}"] = base_value
+                metrics[f"{self.name}_{score_name}_recall@{k}"] = base_value
+            for k in self.mrr_at_k:
+                metrics[f"{self.name}_{score_name}_mrr@{k}"] = base_value
+            for k in self.ndcg_at_k:
+                metrics[f"{self.name}_{score_name}_ndcg@{k}"] = base_value
+            for k in self.map_at_k:
+                metrics[f"{self.name}_{score_name}_map@{k}"] = base_value
+        return metrics
+
+
+@pytest.fixture
+def dummy_model() -> Any:
+    return SimpleNamespace(
+        similarity_fn_name="cosine",
+        similarity=lambda a, b: a,
+        model_card_data=SimpleNamespace(set_evaluation_metrics=lambda *args, **kwargs: None),
+    )
+
+
+@pytest.fixture
+def fake_datasets_module() -> Any:
+    data: dict[tuple[str, str, str], list[dict[str, Any]]] = {}
+
+    def add_split(dataset_id: str, split_name: str) -> None:
+        data[(dataset_id, "corpus", split_name)] = [
+            {"_id": f"{split_name}-d1", "text": "Document 1"},
+            {"_id": f"{split_name}-d2", "text": "Document 2"},
+        ]
+        data[(dataset_id, "queries", split_name)] = [{"_id": f"{split_name}-q1", "text": "Query 1"}]
+        data[(dataset_id, "qrels", split_name)] = [{"query-id": f"{split_name}-q1", "corpus-id": f"{split_name}-d1"}]
+
+    for split in ["NanoMSMARCO", "NanoNQ"]:
+        add_split("sentence-transformers/NanoBEIR-en", split)
+
+    for split in ["python", "java"]:
+        add_split("hotchpotch/NanoCodeSearchNet", split)
+
+    split_names: dict[tuple[str, str], list[str]] = {
+        ("sentence-transformers/NanoBEIR-en", "corpus"): ["NanoMSMARCO", "NanoNQ"],
+        ("sentence-transformers/NanoBEIR-en", "queries"): ["NanoMSMARCO", "NanoNQ"],
+        ("sentence-transformers/NanoBEIR-en", "qrels"): ["NanoMSMARCO", "NanoNQ"],
+        ("hotchpotch/NanoCodeSearchNet", "corpus"): ["python", "java"],
+        ("hotchpotch/NanoCodeSearchNet", "queries"): ["python", "java"],
+        ("hotchpotch/NanoCodeSearchNet", "qrels"): ["python", "java"],
+    }
+
+    def load_dataset(dataset_id: str, subset: str, split: str) -> FakeDataset:
+        return FakeDataset(data[(dataset_id, subset, split)])
+
+    def get_dataset_split_names(dataset_id: str, subset: str) -> list[str]:
+        return split_names[(dataset_id, subset)]
+
+    return SimpleNamespace(load_dataset=load_dataset, get_dataset_split_names=get_dataset_split_names)
+
+
+@pytest.fixture
+def patch_nano_eval(monkeypatch: pytest.MonkeyPatch, fake_datasets_module: Any) -> None:
+    nano_module = importlib.import_module("sentence_transformers.evaluation.NanoEvaluator")
+
+    monkeypatch.setattr(nano_module, "is_datasets_available", lambda: True)
+    monkeypatch.setitem(sys.modules, "datasets", fake_datasets_module)
+    monkeypatch.setattr(NanoEvaluator, "information_retrieval_class", FakeInformationRetrievalEvaluator)
+
+
+def test_nano_evaluator_auto_expand_splits_and_auto_names(patch_nano_eval: None, dummy_model: Any) -> None:
+    evaluator = NanoEvaluator(
+        dataset_names=None,
+        dataset_id="hotchpotch/NanoCodeSearchNet",
+        mrr_at_k=[10],
+        ndcg_at_k=[10],
+        accuracy_at_k=[1],
+        precision_recall_at_k=[1],
+        map_at_k=[100],
+        score_functions={"cosine": lambda a, b: a},
+        write_csv=False,
+    )
+
+    assert evaluator.dataset_names == ["python", "java"]
+    assert [sub_evaluator.name for sub_evaluator in evaluator.evaluators] == [
+        "NanoCodeSearchNet_python",
+        "NanoCodeSearchNet_java",
+    ]
+
+    metrics = evaluator(dummy_model)
+    assert evaluator.primary_metric == "NanoCodeSearchNet_mean_cosine_ndcg@10"
+    assert "NanoCodeSearchNet_mean_cosine_ndcg@10" in metrics
+
+
+def test_nano_evaluator_mapping_validates_split_exists(monkeypatch: pytest.MonkeyPatch) -> None:
+    nano_module = importlib.import_module("sentence_transformers.evaluation.NanoEvaluator")
+
+    def get_dataset_split_names(dataset_id: str, subset: str) -> list[str]:
+        del dataset_id, subset
+        return ["NanoNQ"]
+
+    monkeypatch.setattr(nano_module, "is_datasets_available", lambda: True)
+    monkeypatch.setitem(
+        sys.modules,
+        "datasets",
+        SimpleNamespace(load_dataset=lambda *args, **kwargs: None, get_dataset_split_names=get_dataset_split_names),
+    )
+
+    with pytest.raises(ValueError, match="maps to split 'NanoMSMARCO'.*does not exist"):
+        NanoEvaluator(
+            dataset_names=["msmarco"],
+            dataset_id="sentence-transformers/NanoBEIR-en",
+            dataset_name_to_human_readable={"msmarco": "MSMARCO"},
+            split_prefix="Nano",
+            mrr_at_k=[10],
+            ndcg_at_k=[10],
+            accuracy_at_k=[1],
+            precision_recall_at_k=[1],
+            map_at_k=[100],
+            score_functions={"cosine": lambda a, b: a},
+            write_csv=False,
+        )
+
+
+def test_sequential_evaluator_with_nanobeir_and_nanocodesearchnet(
+    patch_nano_eval: None,
+    dummy_model: Any,
+) -> None:
+    nanobeir_evaluator = NanoBEIREvaluator(
+        dataset_names=["msmarco"],
+        mrr_at_k=[10],
+        ndcg_at_k=[10],
+        accuracy_at_k=[1],
+        precision_recall_at_k=[1],
+        map_at_k=[100],
+        score_functions={"cosine": lambda a, b: a},
+        write_csv=False,
+    )
+    nanocodesearchnet_evaluator = NanoEvaluator(
+        dataset_names=["python"],
+        dataset_id="hotchpotch/NanoCodeSearchNet",
+        mrr_at_k=[10],
+        ndcg_at_k=[10],
+        accuracy_at_k=[1],
+        precision_recall_at_k=[1],
+        map_at_k=[100],
+        score_functions={"cosine": lambda a, b: a},
+        write_csv=False,
+    )
+    seq_evaluator = SequentialEvaluator(
+        [nanobeir_evaluator, nanocodesearchnet_evaluator],
+        main_score_function=lambda scores: float(sum(scores) / len(scores)),
+    )
+
+    metrics = seq_evaluator(dummy_model)
+
+    assert "sequential_score" in metrics
+    assert any(key.startswith("NanoBEIR_mean_") for key in metrics)
+    assert any(key.startswith("NanoCodeSearchNet_mean_") for key in metrics)
+    assert "NanoBEIR_mean_cosine_ndcg@10" in metrics

--- a/tests/evaluation/test_nano_evaluator.py
+++ b/tests/evaluation/test_nano_evaluator.py
@@ -102,12 +102,6 @@ def test_nano_evaluator_auto_expand_splits_and_auto_names(patch_nano_eval: None,
     evaluator = NanoEvaluator(
         dataset_names=None,
         dataset_id="example/NanoFooBar",
-        mrr_at_k=[10],
-        ndcg_at_k=[10],
-        accuracy_at_k=[1],
-        precision_recall_at_k=[1],
-        map_at_k=[100],
-        score_functions={"cosine": lambda a, b: a},
         write_csv=False,
     )
 
@@ -132,12 +126,6 @@ def test_nano_evaluator_auto_expand_splits_with_mapping_in_strict_mode(
         dataset_name_to_human_readable={"msmarco": "MSMARCO"},
         split_prefix="Nano",
         strict_dataset_name_validation=True,
-        mrr_at_k=[10],
-        ndcg_at_k=[10],
-        accuracy_at_k=[1],
-        precision_recall_at_k=[1],
-        map_at_k=[100],
-        score_functions={"cosine": lambda a, b: a},
         write_csv=False,
     )
 
@@ -166,12 +154,6 @@ def test_nano_evaluator_mapping_validates_split_exists(monkeypatch: pytest.Monke
             dataset_id="sentence-transformers/NanoBEIR-en",
             dataset_name_to_human_readable={"msmarco": "MSMARCO"},
             split_prefix="Nano",
-            mrr_at_k=[10],
-            ndcg_at_k=[10],
-            accuracy_at_k=[1],
-            precision_recall_at_k=[1],
-            map_at_k=[100],
-            score_functions={"cosine": lambda a, b: a},
             write_csv=False,
         )
 
@@ -185,12 +167,6 @@ def test_nano_evaluator_accepts_direct_split_names_with_mapping(
         dataset_id="example/NanoFooBar",
         dataset_name_to_human_readable={"msmarco": "MSMARCO"},
         split_prefix="Nano",
-        mrr_at_k=[10],
-        ndcg_at_k=[10],
-        accuracy_at_k=[1],
-        precision_recall_at_k=[1],
-        map_at_k=[100],
-        score_functions={"cosine": lambda a, b: a},
         write_csv=False,
     )
 
@@ -209,12 +185,6 @@ def test_nano_evaluator_custom_name_and_case_insensitive_prompts(
         query_prompts={"PYTHON": "query: "},
         corpus_prompts={"PYTHON": "passage: "},
         name="CustomNano",
-        mrr_at_k=[10],
-        ndcg_at_k=[10],
-        accuracy_at_k=[1],
-        precision_recall_at_k=[1],
-        map_at_k=[100],
-        score_functions={"cosine": lambda a, b: a},
         write_csv=False,
     )
 
@@ -231,12 +201,6 @@ def test_nano_evaluator_config_keeps_custom_name(patch_nano_eval: None) -> None:
         dataset_names=["python"],
         dataset_id="example/NanoFooBar",
         name="CustomNano",
-        mrr_at_k=[10],
-        ndcg_at_k=[10],
-        accuracy_at_k=[1],
-        precision_recall_at_k=[1],
-        map_at_k=[100],
-        score_functions={"cosine": lambda a, b: a},
         write_csv=False,
     )
 
@@ -251,23 +215,11 @@ def test_sequential_evaluator_with_nanobeir_and_nanocodesearchnet(
 ) -> None:
     nanobeir_evaluator = NanoBEIREvaluator(
         dataset_names=["msmarco"],
-        mrr_at_k=[10],
-        ndcg_at_k=[10],
-        accuracy_at_k=[1],
-        precision_recall_at_k=[1],
-        map_at_k=[100],
-        score_functions={"cosine": lambda a, b: a},
         write_csv=False,
     )
     nanocodesearchnet_evaluator = NanoEvaluator(
         dataset_names=["python"],
         dataset_id="example/NanoFooBar",
-        mrr_at_k=[10],
-        ndcg_at_k=[10],
-        accuracy_at_k=[1],
-        precision_recall_at_k=[1],
-        map_at_k=[100],
-        score_functions={"cosine": lambda a, b: a},
         write_csv=False,
     )
     seq_evaluator = SequentialEvaluator(

--- a/tests/evaluation/test_nano_evaluator.py
+++ b/tests/evaluation/test_nano_evaluator.py
@@ -81,7 +81,7 @@ def fake_datasets_module() -> Any:
     return build_fake_datasets_module(
         {
             "sentence-transformers/NanoBEIR-en": ["NanoMSMARCO", "NanoNQ"],
-            "example/FooBar": ["python", "java"],
+            "example/FooBar": ["ds_foo", "ds_bar"],
         }
     )
 
@@ -105,10 +105,10 @@ def test_nano_evaluator_auto_expand_splits_and_auto_names(patch_nano_eval: None,
         write_csv=False,
     )
 
-    assert evaluator.dataset_names == ["python", "java"]
+    assert evaluator.dataset_names == ["ds_foo", "ds_bar"]
     assert [sub_evaluator.name for sub_evaluator in evaluator.evaluators] == [
-        "FooBar_python",
-        "FooBar_java",
+        "FooBar_ds_foo",
+        "FooBar_ds_bar",
     ]
 
     metrics = evaluator(dummy_model)
@@ -129,7 +129,7 @@ def test_nano_evaluator_auto_expand_splits_with_mapping_in_strict_mode(
         write_csv=False,
     )
 
-    assert evaluator.dataset_names == ["python", "java"]
+    assert evaluator.dataset_names == ["ds_foo", "ds_bar"]
     metrics = evaluator(dummy_model)
     assert "FooBar_mean_cosine_ndcg@10" in metrics
 
@@ -163,14 +163,14 @@ def test_nano_evaluator_accepts_direct_split_names_with_mapping(
     dummy_model: Any,
 ) -> None:
     evaluator = NanoEvaluator(
-        dataset_names=["python"],
+        dataset_names=["ds_foo"],
         dataset_id="example/FooBar",
         dataset_name_to_human_readable={"msmarco": "MSMARCO"},
         split_prefix="Nano",
         write_csv=False,
     )
 
-    assert [sub_evaluator.name for sub_evaluator in evaluator.evaluators] == ["python"]
+    assert [sub_evaluator.name for sub_evaluator in evaluator.evaluators] == ["ds_foo"]
     metrics = evaluator(dummy_model)
     assert "FooBar_mean_cosine_ndcg@10" in metrics
 
@@ -180,16 +180,16 @@ def test_nano_evaluator_custom_name_and_case_insensitive_prompts(
     dummy_model: Any,
 ) -> None:
     evaluator = NanoEvaluator(
-        dataset_names=["python"],
+        dataset_names=["ds_foo"],
         dataset_id="example/FooBar",
-        query_prompts={"PYTHON": "query: "},
-        corpus_prompts={"PYTHON": "passage: "},
+        query_prompts={"DS_FOO": "query: "},
+        corpus_prompts={"DS_FOO": "passage: "},
         name="CustomNano",
         write_csv=False,
     )
 
     assert evaluator.name == "CustomNano_mean"
-    assert [sub_evaluator.name for sub_evaluator in evaluator.evaluators] == ["CustomNano_python"]
+    assert [sub_evaluator.name for sub_evaluator in evaluator.evaluators] == ["CustomNano_ds_foo"]
     assert evaluator.evaluators[0].query_prompt == "query: "
     assert evaluator.evaluators[0].corpus_prompt == "passage: "
     metrics = evaluator(dummy_model)
@@ -198,7 +198,7 @@ def test_nano_evaluator_custom_name_and_case_insensitive_prompts(
 
 def test_nano_evaluator_config_keeps_custom_name(patch_nano_eval: None) -> None:
     evaluator = NanoEvaluator(
-        dataset_names=["python"],
+        dataset_names=["ds_foo"],
         dataset_id="example/FooBar",
         name="CustomNano",
         write_csv=False,
@@ -218,7 +218,7 @@ def test_sequential_evaluator_with_nanobeir_and_generic_nano_dataset(
         write_csv=False,
     )
     generic_nano_evaluator = NanoEvaluator(
-        dataset_names=["python"],
+        dataset_names=["ds_foo"],
         dataset_id="example/FooBar",
         write_csv=False,
     )

--- a/tests/evaluation/test_nano_evaluator.py
+++ b/tests/evaluation/test_nano_evaluator.py
@@ -122,6 +122,30 @@ def test_nano_evaluator_auto_expand_splits_and_auto_names(patch_nano_eval: None,
     assert "NanoFooBar_mean_cosine_ndcg@10" in metrics
 
 
+def test_nano_evaluator_auto_expand_splits_with_mapping_in_strict_mode(
+    patch_nano_eval: None,
+    dummy_model: Any,
+) -> None:
+    evaluator = NanoEvaluator(
+        dataset_names=None,
+        dataset_id="example/NanoFooBar",
+        dataset_name_to_human_readable={"msmarco": "MSMARCO"},
+        split_prefix="Nano",
+        strict_dataset_name_validation=True,
+        mrr_at_k=[10],
+        ndcg_at_k=[10],
+        accuracy_at_k=[1],
+        precision_recall_at_k=[1],
+        map_at_k=[100],
+        score_functions={"cosine": lambda a, b: a},
+        write_csv=False,
+    )
+
+    assert evaluator.dataset_names == ["python", "java"]
+    metrics = evaluator(dummy_model)
+    assert "NanoFooBar_mean_cosine_ndcg@10" in metrics
+
+
 def test_nano_evaluator_mapping_validates_split_exists(monkeypatch: pytest.MonkeyPatch) -> None:
     nano_utils_module = importlib.import_module("sentence_transformers.evaluation._nano_utils")
 
@@ -200,6 +224,25 @@ def test_nano_evaluator_custom_name_and_case_insensitive_prompts(
     assert evaluator.evaluators[0].corpus_prompt == "passage: "
     metrics = evaluator(dummy_model)
     assert "CustomNano_mean_cosine_ndcg@10" in metrics
+
+
+def test_nano_evaluator_config_keeps_custom_name(patch_nano_eval: None) -> None:
+    evaluator = NanoEvaluator(
+        dataset_names=["python"],
+        dataset_id="example/NanoFooBar",
+        name="CustomNano",
+        mrr_at_k=[10],
+        ndcg_at_k=[10],
+        accuracy_at_k=[1],
+        precision_recall_at_k=[1],
+        map_at_k=[100],
+        score_functions={"cosine": lambda a, b: a},
+        write_csv=False,
+    )
+
+    config = evaluator.get_config_dict()
+
+    assert config["name"] == "CustomNano"
 
 
 def test_sequential_evaluator_with_nanobeir_and_nanocodesearchnet(

--- a/tests/evaluation/test_nano_evaluator.py
+++ b/tests/evaluation/test_nano_evaluator.py
@@ -133,11 +133,14 @@ def fake_datasets_module() -> Any:
 
 @pytest.fixture
 def patch_nano_eval(monkeypatch: pytest.MonkeyPatch, fake_datasets_module: Any) -> None:
-    nano_module = importlib.import_module("sentence_transformers.evaluation.NanoEvaluator")
+    nanobeir_module = importlib.import_module("sentence_transformers.evaluation.NanoBEIREvaluator")
+    nano_utils_module = importlib.import_module("sentence_transformers.evaluation._nano_utils")
 
-    monkeypatch.setattr(nano_module, "is_datasets_available", lambda: True)
+    monkeypatch.setattr(nanobeir_module, "is_datasets_available", lambda: True)
+    monkeypatch.setattr(nano_utils_module, "is_datasets_available", lambda: True)
     monkeypatch.setitem(sys.modules, "datasets", fake_datasets_module)
     monkeypatch.setattr(NanoEvaluator, "information_retrieval_class", FakeInformationRetrievalEvaluator)
+    monkeypatch.setattr(NanoBEIREvaluator, "information_retrieval_class", FakeInformationRetrievalEvaluator)
 
 
 def test_nano_evaluator_auto_expand_splits_and_auto_names(patch_nano_eval: None, dummy_model: Any) -> None:
@@ -165,13 +168,13 @@ def test_nano_evaluator_auto_expand_splits_and_auto_names(patch_nano_eval: None,
 
 
 def test_nano_evaluator_mapping_validates_split_exists(monkeypatch: pytest.MonkeyPatch) -> None:
-    nano_module = importlib.import_module("sentence_transformers.evaluation.NanoEvaluator")
+    nano_utils_module = importlib.import_module("sentence_transformers.evaluation._nano_utils")
 
     def get_dataset_split_names(dataset_id: str, subset: str) -> list[str]:
         del dataset_id, subset
         return ["NanoNQ"]
 
-    monkeypatch.setattr(nano_module, "is_datasets_available", lambda: True)
+    monkeypatch.setattr(nano_utils_module, "is_datasets_available", lambda: True)
     monkeypatch.setitem(
         sys.modules,
         "datasets",

--- a/tests/evaluation/test_nano_evaluator.py
+++ b/tests/evaluation/test_nano_evaluator.py
@@ -150,6 +150,29 @@ def test_nano_evaluator_mapping_validates_split_exists(monkeypatch: pytest.Monke
         )
 
 
+def test_nano_evaluator_accepts_direct_split_names_with_mapping(
+    patch_nano_eval: None,
+    dummy_model: Any,
+) -> None:
+    evaluator = NanoEvaluator(
+        dataset_names=["python"],
+        dataset_id="example/NanoFooBar",
+        dataset_name_to_human_readable={"msmarco": "MSMARCO"},
+        split_prefix="Nano",
+        mrr_at_k=[10],
+        ndcg_at_k=[10],
+        accuracy_at_k=[1],
+        precision_recall_at_k=[1],
+        map_at_k=[100],
+        score_functions={"cosine": lambda a, b: a},
+        write_csv=False,
+    )
+
+    assert [sub_evaluator.name for sub_evaluator in evaluator.evaluators] == ["python"]
+    metrics = evaluator(dummy_model)
+    assert "NanoFooBar_mean_cosine_ndcg@10" in metrics
+
+
 def test_sequential_evaluator_with_nanobeir_and_nanocodesearchnet(
     patch_nano_eval: None,
     dummy_model: Any,

--- a/tests/evaluation/test_nano_evaluator.py
+++ b/tests/evaluation/test_nano_evaluator.py
@@ -81,7 +81,7 @@ def fake_datasets_module() -> Any:
     return build_fake_datasets_module(
         {
             "sentence-transformers/NanoBEIR-en": ["NanoMSMARCO", "NanoNQ"],
-            "example/NanoFooBar": ["python", "java"],
+            "example/FooBar": ["python", "java"],
         }
     )
 
@@ -101,19 +101,19 @@ def patch_nano_eval(monkeypatch: pytest.MonkeyPatch, fake_datasets_module: Any) 
 def test_nano_evaluator_auto_expand_splits_and_auto_names(patch_nano_eval: None, dummy_model: Any) -> None:
     evaluator = NanoEvaluator(
         dataset_names=None,
-        dataset_id="example/NanoFooBar",
+        dataset_id="example/FooBar",
         write_csv=False,
     )
 
     assert evaluator.dataset_names == ["python", "java"]
     assert [sub_evaluator.name for sub_evaluator in evaluator.evaluators] == [
-        "NanoFooBar_python",
-        "NanoFooBar_java",
+        "FooBar_python",
+        "FooBar_java",
     ]
 
     metrics = evaluator(dummy_model)
-    assert evaluator.primary_metric == "NanoFooBar_mean_cosine_ndcg@10"
-    assert "NanoFooBar_mean_cosine_ndcg@10" in metrics
+    assert evaluator.primary_metric == "FooBar_mean_cosine_ndcg@10"
+    assert "FooBar_mean_cosine_ndcg@10" in metrics
 
 
 def test_nano_evaluator_auto_expand_splits_with_mapping_in_strict_mode(
@@ -122,7 +122,7 @@ def test_nano_evaluator_auto_expand_splits_with_mapping_in_strict_mode(
 ) -> None:
     evaluator = NanoEvaluator(
         dataset_names=None,
-        dataset_id="example/NanoFooBar",
+        dataset_id="example/FooBar",
         dataset_name_to_human_readable={"msmarco": "MSMARCO"},
         split_prefix="Nano",
         strict_dataset_name_validation=True,
@@ -131,7 +131,7 @@ def test_nano_evaluator_auto_expand_splits_with_mapping_in_strict_mode(
 
     assert evaluator.dataset_names == ["python", "java"]
     metrics = evaluator(dummy_model)
-    assert "NanoFooBar_mean_cosine_ndcg@10" in metrics
+    assert "FooBar_mean_cosine_ndcg@10" in metrics
 
 
 def test_nano_evaluator_mapping_validates_split_exists(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -164,7 +164,7 @@ def test_nano_evaluator_accepts_direct_split_names_with_mapping(
 ) -> None:
     evaluator = NanoEvaluator(
         dataset_names=["python"],
-        dataset_id="example/NanoFooBar",
+        dataset_id="example/FooBar",
         dataset_name_to_human_readable={"msmarco": "MSMARCO"},
         split_prefix="Nano",
         write_csv=False,
@@ -172,7 +172,7 @@ def test_nano_evaluator_accepts_direct_split_names_with_mapping(
 
     assert [sub_evaluator.name for sub_evaluator in evaluator.evaluators] == ["python"]
     metrics = evaluator(dummy_model)
-    assert "NanoFooBar_mean_cosine_ndcg@10" in metrics
+    assert "FooBar_mean_cosine_ndcg@10" in metrics
 
 
 def test_nano_evaluator_custom_name_and_case_insensitive_prompts(
@@ -181,7 +181,7 @@ def test_nano_evaluator_custom_name_and_case_insensitive_prompts(
 ) -> None:
     evaluator = NanoEvaluator(
         dataset_names=["python"],
-        dataset_id="example/NanoFooBar",
+        dataset_id="example/FooBar",
         query_prompts={"PYTHON": "query: "},
         corpus_prompts={"PYTHON": "passage: "},
         name="CustomNano",
@@ -199,7 +199,7 @@ def test_nano_evaluator_custom_name_and_case_insensitive_prompts(
 def test_nano_evaluator_config_keeps_custom_name(patch_nano_eval: None) -> None:
     evaluator = NanoEvaluator(
         dataset_names=["python"],
-        dataset_id="example/NanoFooBar",
+        dataset_id="example/FooBar",
         name="CustomNano",
         write_csv=False,
     )
@@ -209,7 +209,7 @@ def test_nano_evaluator_config_keeps_custom_name(patch_nano_eval: None) -> None:
     assert config["name"] == "CustomNano"
 
 
-def test_sequential_evaluator_with_nanobeir_and_nanocodesearchnet(
+def test_sequential_evaluator_with_nanobeir_and_generic_nano_dataset(
     patch_nano_eval: None,
     dummy_model: Any,
 ) -> None:
@@ -217,13 +217,13 @@ def test_sequential_evaluator_with_nanobeir_and_nanocodesearchnet(
         dataset_names=["msmarco"],
         write_csv=False,
     )
-    nanocodesearchnet_evaluator = NanoEvaluator(
+    generic_nano_evaluator = NanoEvaluator(
         dataset_names=["python"],
-        dataset_id="example/NanoFooBar",
+        dataset_id="example/FooBar",
         write_csv=False,
     )
     seq_evaluator = SequentialEvaluator(
-        [nanobeir_evaluator, nanocodesearchnet_evaluator],
+        [nanobeir_evaluator, generic_nano_evaluator],
         main_score_function=lambda scores: float(sum(scores) / len(scores)),
     )
 
@@ -231,5 +231,5 @@ def test_sequential_evaluator_with_nanobeir_and_nanocodesearchnet(
 
     assert "sequential_score" in metrics
     assert any(key.startswith("NanoBEIR_mean_") for key in metrics)
-    assert any(key.startswith("NanoFooBar_mean_") for key in metrics)
+    assert any(key.startswith("FooBar_mean_") for key in metrics)
     assert "NanoBEIR_mean_cosine_ndcg@10" in metrics

--- a/tests/evaluation/test_nano_evaluator.py
+++ b/tests/evaluation/test_nano_evaluator.py
@@ -2,34 +2,13 @@ from __future__ import annotations
 
 import importlib
 import sys
-from collections.abc import Iterator
 from types import SimpleNamespace
 from typing import Any
 
 import pytest
 
 from sentence_transformers.evaluation import NanoBEIREvaluator, NanoEvaluator, SequentialEvaluator
-
-
-class FakeDataset:
-    def __init__(self, rows: list[dict[str, Any]]) -> None:
-        self.rows = rows
-        self.column_names = list(rows[0].keys()) if rows else []
-
-    def __iter__(self) -> Iterator[dict[str, Any]]:
-        return iter(self.rows)
-
-    def __len__(self) -> int:
-        return len(self.rows)
-
-    def __getitem__(self, key: str | int) -> Any:
-        if isinstance(key, str):
-            return [row[key] for row in self.rows]
-        return self.rows[key]
-
-    def map(self, fn: Any, fn_kwargs: dict[str, Any] | None = None) -> FakeDataset:
-        kwargs = fn_kwargs or {}
-        return FakeDataset([fn(row, **kwargs) for row in self.rows])
+from tests.nano_evaluator_test_utils import build_fake_datasets_module
 
 
 class FakeInformationRetrievalEvaluator:
@@ -97,38 +76,12 @@ def dummy_model() -> Any:
 
 @pytest.fixture
 def fake_datasets_module() -> Any:
-    data: dict[tuple[str, str, str], list[dict[str, Any]]] = {}
-
-    def add_split(dataset_id: str, split_name: str) -> None:
-        data[(dataset_id, "corpus", split_name)] = [
-            {"_id": f"{split_name}-d1", "text": "Document 1"},
-            {"_id": f"{split_name}-d2", "text": "Document 2"},
-        ]
-        data[(dataset_id, "queries", split_name)] = [{"_id": f"{split_name}-q1", "text": "Query 1"}]
-        data[(dataset_id, "qrels", split_name)] = [{"query-id": f"{split_name}-q1", "corpus-id": f"{split_name}-d1"}]
-
-    for split in ["NanoMSMARCO", "NanoNQ"]:
-        add_split("sentence-transformers/NanoBEIR-en", split)
-
-    for split in ["python", "java"]:
-        add_split("example/NanoFooBar", split)
-
-    split_names: dict[tuple[str, str], list[str]] = {
-        ("sentence-transformers/NanoBEIR-en", "corpus"): ["NanoMSMARCO", "NanoNQ"],
-        ("sentence-transformers/NanoBEIR-en", "queries"): ["NanoMSMARCO", "NanoNQ"],
-        ("sentence-transformers/NanoBEIR-en", "qrels"): ["NanoMSMARCO", "NanoNQ"],
-        ("example/NanoFooBar", "corpus"): ["python", "java"],
-        ("example/NanoFooBar", "queries"): ["python", "java"],
-        ("example/NanoFooBar", "qrels"): ["python", "java"],
-    }
-
-    def load_dataset(dataset_id: str, subset: str, split: str) -> FakeDataset:
-        return FakeDataset(data[(dataset_id, subset, split)])
-
-    def get_dataset_split_names(dataset_id: str, subset: str) -> list[str]:
-        return split_names[(dataset_id, subset)]
-
-    return SimpleNamespace(load_dataset=load_dataset, get_dataset_split_names=get_dataset_split_names)
+    return build_fake_datasets_module(
+        {
+            "sentence-transformers/NanoBEIR-en": ["NanoMSMARCO", "NanoNQ"],
+            "example/NanoFooBar": ["python", "java"],
+        }
+    )
 
 
 @pytest.fixture

--- a/tests/evaluation/test_nano_evaluator.py
+++ b/tests/evaluation/test_nano_evaluator.py
@@ -30,6 +30,8 @@ class FakeInformationRetrievalEvaluator:
         self.corpus = corpus
         self.relevant_docs = relevant_docs
         self.name = name
+        self.query_prompt = kwargs.get("query_prompt")
+        self.corpus_prompt = kwargs.get("corpus_prompt")
         self.mrr_at_k = mrr_at_k
         self.ndcg_at_k = ndcg_at_k
         self.accuracy_at_k = accuracy_at_k
@@ -171,6 +173,33 @@ def test_nano_evaluator_accepts_direct_split_names_with_mapping(
     assert [sub_evaluator.name for sub_evaluator in evaluator.evaluators] == ["python"]
     metrics = evaluator(dummy_model)
     assert "NanoFooBar_mean_cosine_ndcg@10" in metrics
+
+
+def test_nano_evaluator_custom_name_and_case_insensitive_prompts(
+    patch_nano_eval: None,
+    dummy_model: Any,
+) -> None:
+    evaluator = NanoEvaluator(
+        dataset_names=["python"],
+        dataset_id="example/NanoFooBar",
+        query_prompts={"PYTHON": "query: "},
+        corpus_prompts={"PYTHON": "passage: "},
+        name="CustomNano",
+        mrr_at_k=[10],
+        ndcg_at_k=[10],
+        accuracy_at_k=[1],
+        precision_recall_at_k=[1],
+        map_at_k=[100],
+        score_functions={"cosine": lambda a, b: a},
+        write_csv=False,
+    )
+
+    assert evaluator.name == "CustomNano_mean"
+    assert [sub_evaluator.name for sub_evaluator in evaluator.evaluators] == ["CustomNano_python"]
+    assert evaluator.evaluators[0].query_prompt == "query: "
+    assert evaluator.evaluators[0].corpus_prompt == "passage: "
+    metrics = evaluator(dummy_model)
+    assert "CustomNano_mean_cosine_ndcg@10" in metrics
 
 
 def test_sequential_evaluator_with_nanobeir_and_nanocodesearchnet(

--- a/tests/evaluation/test_nanobeir_evaluator_unit.py
+++ b/tests/evaluation/test_nanobeir_evaluator_unit.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from sentence_transformers.evaluation import NanoBEIREvaluator
+
+
+class FakeInformationRetrievalEvaluator:
+    def __init__(
+        self,
+        queries: dict[str, str],
+        corpus: dict[str, str],
+        relevant_docs: dict[str, set[str]],
+        name: str,
+        mrr_at_k: list[int],
+        ndcg_at_k: list[int],
+        accuracy_at_k: list[int],
+        precision_recall_at_k: list[int],
+        map_at_k: list[int],
+        score_functions: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        del relevant_docs, kwargs
+        self.queries = queries
+        self.corpus = corpus
+        self.name = name
+        self.mrr_at_k = mrr_at_k
+        self.ndcg_at_k = ndcg_at_k
+        self.accuracy_at_k = accuracy_at_k
+        self.precision_recall_at_k = precision_recall_at_k
+        self.map_at_k = map_at_k
+        self.score_names = sorted(score_functions.keys()) if score_functions else ["cosine"]
+
+    def __call__(
+        self,
+        model: Any,
+        output_path: str | None = None,
+        epoch: int = -1,
+        steps: int = -1,
+        *args: Any,
+        **kwargs: Any,
+    ) -> dict[str, float]:
+        del model, output_path, epoch, steps, args, kwargs
+        metrics: dict[str, float] = {}
+        base_value = 0.42
+        for score_name in self.score_names:
+            for k in self.accuracy_at_k:
+                metrics[f"{self.name}_{score_name}_accuracy@{k}"] = base_value
+            for k in self.precision_recall_at_k:
+                metrics[f"{self.name}_{score_name}_precision@{k}"] = base_value
+                metrics[f"{self.name}_{score_name}_recall@{k}"] = base_value
+            for k in self.mrr_at_k:
+                metrics[f"{self.name}_{score_name}_mrr@{k}"] = base_value
+            for k in self.ndcg_at_k:
+                metrics[f"{self.name}_{score_name}_ndcg@{k}"] = base_value
+            for k in self.map_at_k:
+                metrics[f"{self.name}_{score_name}_map@{k}"] = base_value
+        return metrics
+
+
+@pytest.fixture
+def dummy_model() -> Any:
+    return SimpleNamespace(
+        similarity_fn_name="cosine",
+        similarity=lambda a, b: a,
+        model_card_data=SimpleNamespace(set_evaluation_metrics=lambda *args, **kwargs: None),
+    )
+
+
+@pytest.fixture
+def patch_nanobeir_loader(monkeypatch: pytest.MonkeyPatch) -> None:
+    if hasattr(NanoBEIREvaluator, "_validate_mapping_splits"):
+        monkeypatch.setattr(NanoBEIREvaluator, "_validate_mapping_splits", lambda self: None)
+
+    def fake_load_dataset(self: NanoBEIREvaluator, dataset_name: str, **ir_evaluator_kwargs: Any) -> Any:
+        return FakeInformationRetrievalEvaluator(
+            queries={"q1": "query 1"},
+            corpus={"d1": "doc 1"},
+            relevant_docs={"q1": {"d1"}},
+            name=self._get_human_readable_name(dataset_name),
+            **ir_evaluator_kwargs,
+        )
+
+    monkeypatch.setattr(NanoBEIREvaluator, "_load_dataset", fake_load_dataset)
+
+
+def test_nanobeir_primary_metric_key_default(patch_nanobeir_loader: None, dummy_model: Any) -> None:
+    evaluator = NanoBEIREvaluator(
+        dataset_names=["msmarco"],
+        mrr_at_k=[10],
+        ndcg_at_k=[10],
+        accuracy_at_k=[1],
+        precision_recall_at_k=[1],
+        map_at_k=[100],
+        score_functions={"cosine": lambda a, b: a},
+        write_csv=False,
+    )
+
+    results = evaluator(dummy_model)
+
+    assert evaluator.primary_metric == "NanoBEIR_mean_cosine_ndcg@10"
+    assert evaluator.primary_metric in results
+
+
+def test_nanobeir_primary_metric_key_with_truncate_dim(patch_nanobeir_loader: None, dummy_model: Any) -> None:
+    evaluator = NanoBEIREvaluator(
+        dataset_names=["msmarco"],
+        mrr_at_k=[10],
+        ndcg_at_k=[10],
+        accuracy_at_k=[1],
+        precision_recall_at_k=[1],
+        map_at_k=[100],
+        score_functions={"cosine": lambda a, b: a},
+        truncate_dim=64,
+        write_csv=False,
+    )
+
+    results = evaluator(dummy_model)
+
+    assert evaluator.primary_metric == "NanoBEIR_mean_64_cosine_ndcg@10"
+    assert evaluator.primary_metric in results
+    assert "NanoMSMARCO_64_cosine_ndcg@10" in results

--- a/tests/evaluation/test_nanobeir_evaluator_unit.py
+++ b/tests/evaluation/test_nanobeir_evaluator_unit.py
@@ -73,9 +73,6 @@ def dummy_model() -> Any:
 
 @pytest.fixture
 def patch_nanobeir_loader(monkeypatch: pytest.MonkeyPatch) -> None:
-    if hasattr(NanoBEIREvaluator, "_validate_mapping_splits"):
-        monkeypatch.setattr(NanoBEIREvaluator, "_validate_mapping_splits", lambda self: None)
-
     def fake_load_dataset(self: NanoBEIREvaluator, dataset_name: str, **ir_evaluator_kwargs: Any) -> Any:
         return FakeInformationRetrievalEvaluator(
             queries={"q1": "query 1"},
@@ -91,12 +88,6 @@ def patch_nanobeir_loader(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_nanobeir_primary_metric_key_default(patch_nanobeir_loader: None, dummy_model: Any) -> None:
     evaluator = NanoBEIREvaluator(
         dataset_names=["msmarco"],
-        mrr_at_k=[10],
-        ndcg_at_k=[10],
-        accuracy_at_k=[1],
-        precision_recall_at_k=[1],
-        map_at_k=[100],
-        score_functions={"cosine": lambda a, b: a},
         write_csv=False,
     )
 
@@ -109,12 +100,6 @@ def test_nanobeir_primary_metric_key_default(patch_nanobeir_loader: None, dummy_
 def test_nanobeir_primary_metric_key_with_truncate_dim(patch_nanobeir_loader: None, dummy_model: Any) -> None:
     evaluator = NanoBEIREvaluator(
         dataset_names=["msmarco"],
-        mrr_at_k=[10],
-        ndcg_at_k=[10],
-        accuracy_at_k=[1],
-        precision_recall_at_k=[1],
-        map_at_k=[100],
-        score_functions={"cosine": lambda a, b: a},
         truncate_dim=64,
         write_csv=False,
     )
@@ -133,12 +118,6 @@ def test_nanobeir_writes_csv_metrics(
 ) -> None:
     evaluator = NanoBEIREvaluator(
         dataset_names=["msmarco", "nq"],
-        mrr_at_k=[10],
-        ndcg_at_k=[10],
-        accuracy_at_k=[1],
-        precision_recall_at_k=[1],
-        map_at_k=[100],
-        score_functions={"cosine": lambda a, b: a},
         write_csv=True,
     )
 

--- a/tests/nano_evaluator_test_utils.py
+++ b/tests/nano_evaluator_test_utils.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from collections.abc import Iterator, Mapping
+from types import SimpleNamespace
+from typing import Any
+
+
+class FakeDataset:
+    def __init__(self, rows: list[dict[str, Any]]) -> None:
+        self.rows = rows
+        self.column_names = list(rows[0].keys()) if rows else []
+
+    def __iter__(self) -> Iterator[dict[str, Any]]:
+        return iter(self.rows)
+
+    def __len__(self) -> int:
+        return len(self.rows)
+
+    def __getitem__(self, key: str | int) -> Any:
+        if isinstance(key, str):
+            return [row[key] for row in self.rows]
+        return self.rows[key]
+
+    def map(self, fn: Any, fn_kwargs: dict[str, Any] | None = None) -> FakeDataset:
+        kwargs = fn_kwargs or {}
+        return FakeDataset([fn(row, **kwargs) for row in self.rows])
+
+
+def build_fake_datasets_module(
+    dataset_splits: Mapping[str, list[str]],
+    candidate_subsets: Mapping[str, str] | None = None,
+) -> Any:
+    data: dict[tuple[str, str, str], list[dict[str, Any]]] = {}
+    split_names: dict[tuple[str, str], list[str]] = {}
+    candidate_subsets = candidate_subsets or {}
+
+    def add_split(dataset_id: str, split_name: str) -> None:
+        data[(dataset_id, "corpus", split_name)] = [
+            {"_id": f"{split_name}-d1", "text": "Document 1"},
+            {"_id": f"{split_name}-d2", "text": "Document 2"},
+        ]
+        data[(dataset_id, "queries", split_name)] = [{"_id": f"{split_name}-q1", "text": "Query 1"}]
+        data[(dataset_id, "qrels", split_name)] = [{"query-id": f"{split_name}-q1", "corpus-id": f"{split_name}-d1"}]
+        for subset_name, column_name in candidate_subsets.items():
+            data[(dataset_id, subset_name, split_name)] = [
+                {"query-id": f"{split_name}-q1", column_name: [f"{split_name}-d2", f"{split_name}-d1"]}
+            ]
+
+    for dataset_id, splits in dataset_splits.items():
+        for split_name in splits:
+            add_split(dataset_id, split_name)
+        for subset_name in ["corpus", "queries", "qrels", *candidate_subsets]:
+            split_names[(dataset_id, subset_name)] = list(splits)
+
+    def load_dataset(dataset_id: str, subset: str, split: str) -> FakeDataset:
+        return FakeDataset(data[(dataset_id, subset, split)])
+
+    def get_dataset_split_names(dataset_id: str, subset: str) -> list[str]:
+        return split_names[(dataset_id, subset)]
+
+    return SimpleNamespace(load_dataset=load_dataset, get_dataset_split_names=get_dataset_split_names)

--- a/tests/sparse_encoder/test_nano_evaluator.py
+++ b/tests/sparse_encoder/test_nano_evaluator.py
@@ -126,15 +126,15 @@ def fake_datasets_module() -> Any:
         add_split("sentence-transformers/NanoBEIR-en", split)
 
     for split in ["python", "java"]:
-        add_split("hotchpotch/NanoCodeSearchNet", split)
+        add_split("example/NanoFooBar", split)
 
     split_names: dict[tuple[str, str], list[str]] = {
         ("sentence-transformers/NanoBEIR-en", "corpus"): ["NanoMSMARCO", "NanoNQ"],
         ("sentence-transformers/NanoBEIR-en", "queries"): ["NanoMSMARCO", "NanoNQ"],
         ("sentence-transformers/NanoBEIR-en", "qrels"): ["NanoMSMARCO", "NanoNQ"],
-        ("hotchpotch/NanoCodeSearchNet", "corpus"): ["python", "java"],
-        ("hotchpotch/NanoCodeSearchNet", "queries"): ["python", "java"],
-        ("hotchpotch/NanoCodeSearchNet", "qrels"): ["python", "java"],
+        ("example/NanoFooBar", "corpus"): ["python", "java"],
+        ("example/NanoFooBar", "queries"): ["python", "java"],
+        ("example/NanoFooBar", "qrels"): ["python", "java"],
     }
 
     def load_dataset(dataset_id: str, subset: str, split: str) -> FakeDataset:
@@ -160,7 +160,7 @@ def test_sparse_nano_evaluator_auto_expand_splits_and_auto_names(
 ) -> None:
     evaluator = SparseNanoEvaluator(
         dataset_names=None,
-        dataset_id="hotchpotch/NanoCodeSearchNet",
+        dataset_id="example/NanoFooBar",
         mrr_at_k=[10],
         ndcg_at_k=[10],
         accuracy_at_k=[1],
@@ -172,15 +172,15 @@ def test_sparse_nano_evaluator_auto_expand_splits_and_auto_names(
 
     assert evaluator.dataset_names == ["python", "java"]
     assert [sub_evaluator.name for sub_evaluator in evaluator.evaluators] == [
-        "NanoCodeSearchNet_python",
-        "NanoCodeSearchNet_java",
+        "NanoFooBar_python",
+        "NanoFooBar_java",
     ]
 
     metrics = evaluator(dummy_sparse_model)
-    assert evaluator.primary_metric == "NanoCodeSearchNet_mean_dot_ndcg@10"
-    assert "NanoCodeSearchNet_mean_dot_ndcg@10" in metrics
-    assert "NanoCodeSearchNet_mean_query_active_dims" in metrics
-    assert "NanoCodeSearchNet_mean_avg_flops" in metrics
+    assert evaluator.primary_metric == "NanoFooBar_mean_dot_ndcg@10"
+    assert "NanoFooBar_mean_dot_ndcg@10" in metrics
+    assert "NanoFooBar_mean_query_active_dims" in metrics
+    assert "NanoFooBar_mean_avg_flops" in metrics
 
 
 def test_sparse_nano_evaluator_single_split_path(
@@ -189,7 +189,7 @@ def test_sparse_nano_evaluator_single_split_path(
 ) -> None:
     evaluator = SparseNanoEvaluator(
         dataset_names=["python"],
-        dataset_id="hotchpotch/NanoCodeSearchNet",
+        dataset_id="example/NanoFooBar",
         mrr_at_k=[10],
         ndcg_at_k=[10],
         accuracy_at_k=[1],
@@ -200,9 +200,9 @@ def test_sparse_nano_evaluator_single_split_path(
     )
 
     metrics = evaluator(dummy_sparse_model)
-    assert evaluator.primary_metric == "NanoCodeSearchNet_mean_dot_ndcg@10"
-    assert "NanoCodeSearchNet_python_dot_ndcg@10" in metrics
-    assert "NanoCodeSearchNet_mean_avg_flops" in metrics
+    assert evaluator.primary_metric == "NanoFooBar_mean_dot_ndcg@10"
+    assert "NanoFooBar_python_dot_ndcg@10" in metrics
+    assert "NanoFooBar_mean_avg_flops" in metrics
 
 
 def test_sparse_nano_evaluator_mapping_validates_split_exists(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -251,7 +251,7 @@ def test_sequential_evaluator_with_sparse_nanobeir_and_nanocodesearchnet(
     )
     nanocodesearchnet_evaluator = SparseNanoEvaluator(
         dataset_names=["python"],
-        dataset_id="hotchpotch/NanoCodeSearchNet",
+        dataset_id="example/NanoFooBar",
         mrr_at_k=[10],
         ndcg_at_k=[10],
         accuracy_at_k=[1],
@@ -269,5 +269,5 @@ def test_sequential_evaluator_with_sparse_nanobeir_and_nanocodesearchnet(
 
     assert "sequential_score" in metrics
     assert any(key.startswith("NanoBEIR_mean_") for key in metrics)
-    assert any(key.startswith("NanoCodeSearchNet_mean_") for key in metrics)
+    assert any(key.startswith("NanoFooBar_mean_") for key in metrics)
     assert "NanoBEIR_mean_dot_ndcg@10" in metrics

--- a/tests/sparse_encoder/test_nano_evaluator.py
+++ b/tests/sparse_encoder/test_nano_evaluator.py
@@ -1,0 +1,273 @@
+from __future__ import annotations
+
+import importlib
+import sys
+from collections.abc import Iterator
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+import torch
+
+from sentence_transformers.evaluation import SequentialEvaluator
+from sentence_transformers.sparse_encoder.evaluation import SparseNanoBEIREvaluator, SparseNanoEvaluator
+
+
+class FakeDataset:
+    def __init__(self, rows: list[dict[str, Any]]) -> None:
+        self.rows = rows
+        self.column_names = list(rows[0].keys()) if rows else []
+
+    def __iter__(self) -> Iterator[dict[str, Any]]:
+        return iter(self.rows)
+
+    def __len__(self) -> int:
+        return len(self.rows)
+
+    def __getitem__(self, key: str | int) -> Any:
+        if isinstance(key, str):
+            return [row[key] for row in self.rows]
+        return self.rows[key]
+
+    def map(self, fn: Any, fn_kwargs: dict[str, Any] | None = None) -> FakeDataset:
+        kwargs = fn_kwargs or {}
+        return FakeDataset([fn(row, **kwargs) for row in self.rows])
+
+
+class FakeSparseInformationRetrievalEvaluator:
+    def __init__(
+        self,
+        queries: dict[str, str],
+        corpus: dict[str, str],
+        relevant_docs: dict[str, set[str]],
+        name: str,
+        mrr_at_k: list[int],
+        ndcg_at_k: list[int],
+        accuracy_at_k: list[int],
+        precision_recall_at_k: list[int],
+        map_at_k: list[int],
+        score_functions: dict[str, Any] | None = None,
+        max_active_dims: int | None = None,
+        **kwargs: Any,
+    ) -> None:
+        del relevant_docs, max_active_dims, kwargs
+        self.queries = queries
+        self.corpus = corpus
+        self.name = name
+        self.mrr_at_k = mrr_at_k
+        self.ndcg_at_k = ndcg_at_k
+        self.accuracy_at_k = accuracy_at_k
+        self.precision_recall_at_k = precision_recall_at_k
+        self.map_at_k = map_at_k
+        self.score_names = sorted(score_functions.keys()) if score_functions else ["dot"]
+        base = float(10 + len(name) % 4)
+        self.sparsity_stats: dict[str, float] = {
+            "query_active_dims": base,
+            "query_sparsity_ratio": 0.99,
+            "corpus_active_dims": base + 2.0,
+            "corpus_sparsity_ratio": 0.98,
+            "avg_flops": 0.0,
+        }
+        self.count_vectors = {
+            "query": torch.tensor([1.0, 2.0, 3.0]),
+            "corpus": torch.tensor([3.0, 2.0, 1.0]),
+        }
+
+    def __call__(
+        self,
+        model: Any,
+        output_path: str | None = None,
+        epoch: int = -1,
+        steps: int = -1,
+        *args: Any,
+        **kwargs: Any,
+    ) -> dict[str, float]:
+        del model, output_path, epoch, steps, args, kwargs
+
+        base_value = 0.05 + (len(self.name) % 10) * 0.01
+        metrics: dict[str, float] = {}
+        for score_name in self.score_names:
+            for k in self.accuracy_at_k:
+                metrics[f"{self.name}_{score_name}_accuracy@{k}"] = base_value
+            for k in self.precision_recall_at_k:
+                metrics[f"{self.name}_{score_name}_precision@{k}"] = base_value
+                metrics[f"{self.name}_{score_name}_recall@{k}"] = base_value
+            for k in self.mrr_at_k:
+                metrics[f"{self.name}_{score_name}_mrr@{k}"] = base_value
+            for k in self.ndcg_at_k:
+                metrics[f"{self.name}_{score_name}_ndcg@{k}"] = base_value
+            for k in self.map_at_k:
+                metrics[f"{self.name}_{score_name}_map@{k}"] = base_value
+        return metrics
+
+
+@pytest.fixture
+def dummy_sparse_model() -> Any:
+    return SimpleNamespace(
+        similarity_fn_name="dot",
+        similarity=lambda a, b: a,
+        model_card_data=SimpleNamespace(set_evaluation_metrics=lambda *args, **kwargs: None),
+    )
+
+
+@pytest.fixture
+def fake_datasets_module() -> Any:
+    data: dict[tuple[str, str, str], list[dict[str, Any]]] = {}
+
+    def add_split(dataset_id: str, split_name: str) -> None:
+        data[(dataset_id, "corpus", split_name)] = [
+            {"_id": f"{split_name}-d1", "text": "Document 1"},
+            {"_id": f"{split_name}-d2", "text": "Document 2"},
+        ]
+        data[(dataset_id, "queries", split_name)] = [{"_id": f"{split_name}-q1", "text": "Query 1"}]
+        data[(dataset_id, "qrels", split_name)] = [{"query-id": f"{split_name}-q1", "corpus-id": f"{split_name}-d1"}]
+
+    for split in ["NanoMSMARCO", "NanoNQ"]:
+        add_split("sentence-transformers/NanoBEIR-en", split)
+
+    for split in ["python", "java"]:
+        add_split("hotchpotch/NanoCodeSearchNet", split)
+
+    split_names: dict[tuple[str, str], list[str]] = {
+        ("sentence-transformers/NanoBEIR-en", "corpus"): ["NanoMSMARCO", "NanoNQ"],
+        ("sentence-transformers/NanoBEIR-en", "queries"): ["NanoMSMARCO", "NanoNQ"],
+        ("sentence-transformers/NanoBEIR-en", "qrels"): ["NanoMSMARCO", "NanoNQ"],
+        ("hotchpotch/NanoCodeSearchNet", "corpus"): ["python", "java"],
+        ("hotchpotch/NanoCodeSearchNet", "queries"): ["python", "java"],
+        ("hotchpotch/NanoCodeSearchNet", "qrels"): ["python", "java"],
+    }
+
+    def load_dataset(dataset_id: str, subset: str, split: str) -> FakeDataset:
+        return FakeDataset(data[(dataset_id, subset, split)])
+
+    def get_dataset_split_names(dataset_id: str, subset: str) -> list[str]:
+        return split_names[(dataset_id, subset)]
+
+    return SimpleNamespace(load_dataset=load_dataset, get_dataset_split_names=get_dataset_split_names)
+
+
+@pytest.fixture
+def patch_sparse_nano_eval(monkeypatch: pytest.MonkeyPatch, fake_datasets_module: Any) -> None:
+    nano_module = importlib.import_module("sentence_transformers.evaluation.NanoEvaluator")
+    monkeypatch.setattr(nano_module, "is_datasets_available", lambda: True)
+    monkeypatch.setitem(sys.modules, "datasets", fake_datasets_module)
+    monkeypatch.setattr(SparseNanoEvaluator, "information_retrieval_class", FakeSparseInformationRetrievalEvaluator)
+
+
+def test_sparse_nano_evaluator_auto_expand_splits_and_auto_names(
+    patch_sparse_nano_eval: None,
+    dummy_sparse_model: Any,
+) -> None:
+    evaluator = SparseNanoEvaluator(
+        dataset_names=None,
+        dataset_id="hotchpotch/NanoCodeSearchNet",
+        mrr_at_k=[10],
+        ndcg_at_k=[10],
+        accuracy_at_k=[1],
+        precision_recall_at_k=[1],
+        map_at_k=[100],
+        score_functions={"dot": lambda a, b: a},
+        write_csv=False,
+    )
+
+    assert evaluator.dataset_names == ["python", "java"]
+    assert [sub_evaluator.name for sub_evaluator in evaluator.evaluators] == [
+        "NanoCodeSearchNet_python",
+        "NanoCodeSearchNet_java",
+    ]
+
+    metrics = evaluator(dummy_sparse_model)
+    assert evaluator.primary_metric == "NanoCodeSearchNet_mean_dot_ndcg@10"
+    assert "NanoCodeSearchNet_mean_dot_ndcg@10" in metrics
+    assert "NanoCodeSearchNet_mean_query_active_dims" in metrics
+    assert "NanoCodeSearchNet_mean_avg_flops" in metrics
+
+
+def test_sparse_nano_evaluator_single_split_path(
+    patch_sparse_nano_eval: None,
+    dummy_sparse_model: Any,
+) -> None:
+    evaluator = SparseNanoEvaluator(
+        dataset_names=["python"],
+        dataset_id="hotchpotch/NanoCodeSearchNet",
+        mrr_at_k=[10],
+        ndcg_at_k=[10],
+        accuracy_at_k=[1],
+        precision_recall_at_k=[1],
+        map_at_k=[100],
+        score_functions={"dot": lambda a, b: a},
+        write_csv=False,
+    )
+
+    metrics = evaluator(dummy_sparse_model)
+    assert evaluator.primary_metric == "NanoCodeSearchNet_mean_dot_ndcg@10"
+    assert "NanoCodeSearchNet_python_dot_ndcg@10" in metrics
+    assert "NanoCodeSearchNet_mean_avg_flops" in metrics
+
+
+def test_sparse_nano_evaluator_mapping_validates_split_exists(monkeypatch: pytest.MonkeyPatch) -> None:
+    nano_module = importlib.import_module("sentence_transformers.evaluation.NanoEvaluator")
+
+    def get_dataset_split_names(dataset_id: str, subset: str) -> list[str]:
+        del dataset_id, subset
+        return ["NanoNQ"]
+
+    monkeypatch.setattr(nano_module, "is_datasets_available", lambda: True)
+    monkeypatch.setitem(
+        sys.modules,
+        "datasets",
+        SimpleNamespace(load_dataset=lambda *args, **kwargs: None, get_dataset_split_names=get_dataset_split_names),
+    )
+
+    with pytest.raises(ValueError, match="maps to split 'NanoMSMARCO'.*does not exist"):
+        SparseNanoEvaluator(
+            dataset_names=["msmarco"],
+            dataset_id="sentence-transformers/NanoBEIR-en",
+            dataset_name_to_human_readable={"msmarco": "MSMARCO"},
+            split_prefix="Nano",
+            mrr_at_k=[10],
+            ndcg_at_k=[10],
+            accuracy_at_k=[1],
+            precision_recall_at_k=[1],
+            map_at_k=[100],
+            score_functions={"dot": lambda a, b: a},
+            write_csv=False,
+        )
+
+
+def test_sequential_evaluator_with_sparse_nanobeir_and_nanocodesearchnet(
+    patch_sparse_nano_eval: None,
+    dummy_sparse_model: Any,
+) -> None:
+    nanobeir_evaluator = SparseNanoBEIREvaluator(
+        dataset_names=["msmarco"],
+        mrr_at_k=[10],
+        ndcg_at_k=[10],
+        accuracy_at_k=[1],
+        precision_recall_at_k=[1],
+        map_at_k=[100],
+        score_functions={"dot": lambda a, b: a},
+        write_csv=False,
+    )
+    nanocodesearchnet_evaluator = SparseNanoEvaluator(
+        dataset_names=["python"],
+        dataset_id="hotchpotch/NanoCodeSearchNet",
+        mrr_at_k=[10],
+        ndcg_at_k=[10],
+        accuracy_at_k=[1],
+        precision_recall_at_k=[1],
+        map_at_k=[100],
+        score_functions={"dot": lambda a, b: a},
+        write_csv=False,
+    )
+    seq_evaluator = SequentialEvaluator(
+        [nanobeir_evaluator, nanocodesearchnet_evaluator],
+        main_score_function=lambda scores: float(sum(scores) / len(scores)),
+    )
+
+    metrics = seq_evaluator(dummy_sparse_model)
+
+    assert "sequential_score" in metrics
+    assert any(key.startswith("NanoBEIR_mean_") for key in metrics)
+    assert any(key.startswith("NanoCodeSearchNet_mean_") for key in metrics)
+    assert "NanoBEIR_mean_dot_ndcg@10" in metrics

--- a/tests/sparse_encoder/test_nano_evaluator.py
+++ b/tests/sparse_encoder/test_nano_evaluator.py
@@ -148,10 +148,18 @@ def fake_datasets_module() -> Any:
 
 @pytest.fixture
 def patch_sparse_nano_eval(monkeypatch: pytest.MonkeyPatch, fake_datasets_module: Any) -> None:
-    nano_module = importlib.import_module("sentence_transformers.evaluation.NanoEvaluator")
-    monkeypatch.setattr(nano_module, "is_datasets_available", lambda: True)
+    nanobeir_module = importlib.import_module("sentence_transformers.evaluation.NanoBEIREvaluator")
+    nano_utils_module = importlib.import_module("sentence_transformers.evaluation._nano_utils")
+
+    monkeypatch.setattr(nano_utils_module, "is_datasets_available", lambda: True)
+    monkeypatch.setattr(nanobeir_module, "is_datasets_available", lambda: True)
     monkeypatch.setitem(sys.modules, "datasets", fake_datasets_module)
     monkeypatch.setattr(SparseNanoEvaluator, "information_retrieval_class", FakeSparseInformationRetrievalEvaluator)
+    monkeypatch.setattr(
+        SparseNanoBEIREvaluator,
+        "information_retrieval_class",
+        FakeSparseInformationRetrievalEvaluator,
+    )
 
 
 def test_sparse_nano_evaluator_auto_expand_splits_and_auto_names(
@@ -206,13 +214,13 @@ def test_sparse_nano_evaluator_single_split_path(
 
 
 def test_sparse_nano_evaluator_mapping_validates_split_exists(monkeypatch: pytest.MonkeyPatch) -> None:
-    nano_module = importlib.import_module("sentence_transformers.evaluation.NanoEvaluator")
+    nano_utils_module = importlib.import_module("sentence_transformers.evaluation._nano_utils")
 
     def get_dataset_split_names(dataset_id: str, subset: str) -> list[str]:
         del dataset_id, subset
         return ["NanoNQ"]
 
-    monkeypatch.setattr(nano_module, "is_datasets_available", lambda: True)
+    monkeypatch.setattr(nano_utils_module, "is_datasets_available", lambda: True)
     monkeypatch.setitem(
         sys.modules,
         "datasets",

--- a/tests/sparse_encoder/test_nano_evaluator.py
+++ b/tests/sparse_encoder/test_nano_evaluator.py
@@ -122,12 +122,6 @@ def test_sparse_nano_evaluator_auto_expand_splits_and_auto_names(
     evaluator = SparseNanoEvaluator(
         dataset_names=None,
         dataset_id="example/NanoFooBar",
-        mrr_at_k=[10],
-        ndcg_at_k=[10],
-        accuracy_at_k=[1],
-        precision_recall_at_k=[1],
-        map_at_k=[100],
-        score_functions={"dot": lambda a, b: a},
         write_csv=False,
     )
 
@@ -151,12 +145,6 @@ def test_sparse_nano_evaluator_single_split_path(
     evaluator = SparseNanoEvaluator(
         dataset_names=["python"],
         dataset_id="example/NanoFooBar",
-        mrr_at_k=[10],
-        ndcg_at_k=[10],
-        accuracy_at_k=[1],
-        precision_recall_at_k=[1],
-        map_at_k=[100],
-        score_functions={"dot": lambda a, b: a},
         write_csv=False,
     )
 
@@ -186,12 +174,6 @@ def test_sparse_nano_evaluator_mapping_validates_split_exists(monkeypatch: pytes
             dataset_id="sentence-transformers/NanoBEIR-en",
             dataset_name_to_human_readable={"msmarco": "MSMARCO"},
             split_prefix="Nano",
-            mrr_at_k=[10],
-            ndcg_at_k=[10],
-            accuracy_at_k=[1],
-            precision_recall_at_k=[1],
-            map_at_k=[100],
-            score_functions={"dot": lambda a, b: a},
             write_csv=False,
         )
 
@@ -205,12 +187,6 @@ def test_sparse_nano_evaluator_accepts_direct_split_names_with_mapping(
         dataset_id="example/NanoFooBar",
         dataset_name_to_human_readable={"msmarco": "MSMARCO"},
         split_prefix="Nano",
-        mrr_at_k=[10],
-        ndcg_at_k=[10],
-        accuracy_at_k=[1],
-        precision_recall_at_k=[1],
-        map_at_k=[100],
-        score_functions={"dot": lambda a, b: a},
         write_csv=False,
     )
 
@@ -227,12 +203,6 @@ def test_sparse_nano_evaluator_custom_name_metric_root(
         dataset_names=["python"],
         dataset_id="example/NanoFooBar",
         name="CustomSparseNano",
-        mrr_at_k=[10],
-        ndcg_at_k=[10],
-        accuracy_at_k=[1],
-        precision_recall_at_k=[1],
-        map_at_k=[100],
-        score_functions={"dot": lambda a, b: a},
         write_csv=False,
     )
 
@@ -248,23 +218,11 @@ def test_sequential_evaluator_with_sparse_nanobeir_and_nanocodesearchnet(
 ) -> None:
     nanobeir_evaluator = SparseNanoBEIREvaluator(
         dataset_names=["msmarco"],
-        mrr_at_k=[10],
-        ndcg_at_k=[10],
-        accuracy_at_k=[1],
-        precision_recall_at_k=[1],
-        map_at_k=[100],
-        score_functions={"dot": lambda a, b: a},
         write_csv=False,
     )
     nanocodesearchnet_evaluator = SparseNanoEvaluator(
         dataset_names=["python"],
         dataset_id="example/NanoFooBar",
-        mrr_at_k=[10],
-        ndcg_at_k=[10],
-        accuracy_at_k=[1],
-        precision_recall_at_k=[1],
-        map_at_k=[100],
-        score_functions={"dot": lambda a, b: a},
         write_csv=False,
     )
     seq_evaluator = SequentialEvaluator(

--- a/tests/sparse_encoder/test_nano_evaluator.py
+++ b/tests/sparse_encoder/test_nano_evaluator.py
@@ -94,7 +94,7 @@ def fake_datasets_module() -> Any:
     return build_fake_datasets_module(
         {
             "sentence-transformers/NanoBEIR-en": ["NanoMSMARCO", "NanoNQ"],
-            "example/FooBar": ["python", "java"],
+            "example/FooBar": ["ds_foo", "ds_bar"],
         }
     )
 
@@ -125,10 +125,10 @@ def test_sparse_nano_evaluator_auto_expand_splits_and_auto_names(
         write_csv=False,
     )
 
-    assert evaluator.dataset_names == ["python", "java"]
+    assert evaluator.dataset_names == ["ds_foo", "ds_bar"]
     assert [sub_evaluator.name for sub_evaluator in evaluator.evaluators] == [
-        "FooBar_python",
-        "FooBar_java",
+        "FooBar_ds_foo",
+        "FooBar_ds_bar",
     ]
 
     metrics = evaluator(dummy_sparse_model)
@@ -143,14 +143,14 @@ def test_sparse_nano_evaluator_single_split_path(
     dummy_sparse_model: Any,
 ) -> None:
     evaluator = SparseNanoEvaluator(
-        dataset_names=["python"],
+        dataset_names=["ds_foo"],
         dataset_id="example/FooBar",
         write_csv=False,
     )
 
     metrics = evaluator(dummy_sparse_model)
     assert evaluator.primary_metric == "FooBar_mean_dot_ndcg@10"
-    assert "FooBar_python_dot_ndcg@10" in metrics
+    assert "FooBar_ds_foo_dot_ndcg@10" in metrics
     assert "FooBar_mean_avg_flops" in metrics
 
 
@@ -183,14 +183,14 @@ def test_sparse_nano_evaluator_accepts_direct_split_names_with_mapping(
     dummy_sparse_model: Any,
 ) -> None:
     evaluator = SparseNanoEvaluator(
-        dataset_names=["python"],
+        dataset_names=["ds_foo"],
         dataset_id="example/FooBar",
         dataset_name_to_human_readable={"msmarco": "MSMARCO"},
         split_prefix="Nano",
         write_csv=False,
     )
 
-    assert [sub_evaluator.name for sub_evaluator in evaluator.evaluators] == ["python"]
+    assert [sub_evaluator.name for sub_evaluator in evaluator.evaluators] == ["ds_foo"]
     metrics = evaluator(dummy_sparse_model)
     assert "FooBar_mean_dot_ndcg@10" in metrics
 
@@ -200,14 +200,14 @@ def test_sparse_nano_evaluator_custom_name_metric_root(
     dummy_sparse_model: Any,
 ) -> None:
     evaluator = SparseNanoEvaluator(
-        dataset_names=["python"],
+        dataset_names=["ds_foo"],
         dataset_id="example/FooBar",
         name="CustomSparseNano",
         write_csv=False,
     )
 
     assert evaluator.name == "CustomSparseNano_mean"
-    assert [sub_evaluator.name for sub_evaluator in evaluator.evaluators] == ["CustomSparseNano_python"]
+    assert [sub_evaluator.name for sub_evaluator in evaluator.evaluators] == ["CustomSparseNano_ds_foo"]
     metrics = evaluator(dummy_sparse_model)
     assert "CustomSparseNano_mean_dot_ndcg@10" in metrics
 
@@ -221,7 +221,7 @@ def test_sequential_evaluator_with_sparse_nanobeir_and_generic_nano_dataset(
         write_csv=False,
     )
     generic_nano_evaluator = SparseNanoEvaluator(
-        dataset_names=["python"],
+        dataset_names=["ds_foo"],
         dataset_id="example/FooBar",
         write_csv=False,
     )

--- a/tests/sparse_encoder/test_nano_evaluator.py
+++ b/tests/sparse_encoder/test_nano_evaluator.py
@@ -196,6 +196,29 @@ def test_sparse_nano_evaluator_mapping_validates_split_exists(monkeypatch: pytes
         )
 
 
+def test_sparse_nano_evaluator_accepts_direct_split_names_with_mapping(
+    patch_sparse_nano_eval: None,
+    dummy_sparse_model: Any,
+) -> None:
+    evaluator = SparseNanoEvaluator(
+        dataset_names=["python"],
+        dataset_id="example/NanoFooBar",
+        dataset_name_to_human_readable={"msmarco": "MSMARCO"},
+        split_prefix="Nano",
+        mrr_at_k=[10],
+        ndcg_at_k=[10],
+        accuracy_at_k=[1],
+        precision_recall_at_k=[1],
+        map_at_k=[100],
+        score_functions={"dot": lambda a, b: a},
+        write_csv=False,
+    )
+
+    assert [sub_evaluator.name for sub_evaluator in evaluator.evaluators] == ["python"]
+    metrics = evaluator(dummy_sparse_model)
+    assert "NanoFooBar_mean_dot_ndcg@10" in metrics
+
+
 def test_sequential_evaluator_with_sparse_nanobeir_and_nanocodesearchnet(
     patch_sparse_nano_eval: None,
     dummy_sparse_model: Any,

--- a/tests/sparse_encoder/test_nano_evaluator.py
+++ b/tests/sparse_encoder/test_nano_evaluator.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import importlib
 import sys
-from collections.abc import Iterator
 from types import SimpleNamespace
 from typing import Any
 
@@ -11,27 +10,7 @@ import torch
 
 from sentence_transformers.evaluation import SequentialEvaluator
 from sentence_transformers.sparse_encoder.evaluation import SparseNanoBEIREvaluator, SparseNanoEvaluator
-
-
-class FakeDataset:
-    def __init__(self, rows: list[dict[str, Any]]) -> None:
-        self.rows = rows
-        self.column_names = list(rows[0].keys()) if rows else []
-
-    def __iter__(self) -> Iterator[dict[str, Any]]:
-        return iter(self.rows)
-
-    def __len__(self) -> int:
-        return len(self.rows)
-
-    def __getitem__(self, key: str | int) -> Any:
-        if isinstance(key, str):
-            return [row[key] for row in self.rows]
-        return self.rows[key]
-
-    def map(self, fn: Any, fn_kwargs: dict[str, Any] | None = None) -> FakeDataset:
-        kwargs = fn_kwargs or {}
-        return FakeDataset([fn(row, **kwargs) for row in self.rows])
+from tests.nano_evaluator_test_utils import build_fake_datasets_module
 
 
 class FakeSparseInformationRetrievalEvaluator:
@@ -112,38 +91,12 @@ def dummy_sparse_model() -> Any:
 
 @pytest.fixture
 def fake_datasets_module() -> Any:
-    data: dict[tuple[str, str, str], list[dict[str, Any]]] = {}
-
-    def add_split(dataset_id: str, split_name: str) -> None:
-        data[(dataset_id, "corpus", split_name)] = [
-            {"_id": f"{split_name}-d1", "text": "Document 1"},
-            {"_id": f"{split_name}-d2", "text": "Document 2"},
-        ]
-        data[(dataset_id, "queries", split_name)] = [{"_id": f"{split_name}-q1", "text": "Query 1"}]
-        data[(dataset_id, "qrels", split_name)] = [{"query-id": f"{split_name}-q1", "corpus-id": f"{split_name}-d1"}]
-
-    for split in ["NanoMSMARCO", "NanoNQ"]:
-        add_split("sentence-transformers/NanoBEIR-en", split)
-
-    for split in ["python", "java"]:
-        add_split("example/NanoFooBar", split)
-
-    split_names: dict[tuple[str, str], list[str]] = {
-        ("sentence-transformers/NanoBEIR-en", "corpus"): ["NanoMSMARCO", "NanoNQ"],
-        ("sentence-transformers/NanoBEIR-en", "queries"): ["NanoMSMARCO", "NanoNQ"],
-        ("sentence-transformers/NanoBEIR-en", "qrels"): ["NanoMSMARCO", "NanoNQ"],
-        ("example/NanoFooBar", "corpus"): ["python", "java"],
-        ("example/NanoFooBar", "queries"): ["python", "java"],
-        ("example/NanoFooBar", "qrels"): ["python", "java"],
-    }
-
-    def load_dataset(dataset_id: str, subset: str, split: str) -> FakeDataset:
-        return FakeDataset(data[(dataset_id, subset, split)])
-
-    def get_dataset_split_names(dataset_id: str, subset: str) -> list[str]:
-        return split_names[(dataset_id, subset)]
-
-    return SimpleNamespace(load_dataset=load_dataset, get_dataset_split_names=get_dataset_split_names)
+    return build_fake_datasets_module(
+        {
+            "sentence-transformers/NanoBEIR-en": ["NanoMSMARCO", "NanoNQ"],
+            "example/NanoFooBar": ["python", "java"],
+        }
+    )
 
 
 @pytest.fixture

--- a/tests/sparse_encoder/test_nano_evaluator.py
+++ b/tests/sparse_encoder/test_nano_evaluator.py
@@ -219,6 +219,29 @@ def test_sparse_nano_evaluator_accepts_direct_split_names_with_mapping(
     assert "NanoFooBar_mean_dot_ndcg@10" in metrics
 
 
+def test_sparse_nano_evaluator_custom_name_metric_root(
+    patch_sparse_nano_eval: None,
+    dummy_sparse_model: Any,
+) -> None:
+    evaluator = SparseNanoEvaluator(
+        dataset_names=["python"],
+        dataset_id="example/NanoFooBar",
+        name="CustomSparseNano",
+        mrr_at_k=[10],
+        ndcg_at_k=[10],
+        accuracy_at_k=[1],
+        precision_recall_at_k=[1],
+        map_at_k=[100],
+        score_functions={"dot": lambda a, b: a},
+        write_csv=False,
+    )
+
+    assert evaluator.name == "CustomSparseNano_mean"
+    assert [sub_evaluator.name for sub_evaluator in evaluator.evaluators] == ["CustomSparseNano_python"]
+    metrics = evaluator(dummy_sparse_model)
+    assert "CustomSparseNano_mean_dot_ndcg@10" in metrics
+
+
 def test_sequential_evaluator_with_sparse_nanobeir_and_nanocodesearchnet(
     patch_sparse_nano_eval: None,
     dummy_sparse_model: Any,

--- a/tests/sparse_encoder/test_nano_evaluator.py
+++ b/tests/sparse_encoder/test_nano_evaluator.py
@@ -94,7 +94,7 @@ def fake_datasets_module() -> Any:
     return build_fake_datasets_module(
         {
             "sentence-transformers/NanoBEIR-en": ["NanoMSMARCO", "NanoNQ"],
-            "example/NanoFooBar": ["python", "java"],
+            "example/FooBar": ["python", "java"],
         }
     )
 
@@ -121,21 +121,21 @@ def test_sparse_nano_evaluator_auto_expand_splits_and_auto_names(
 ) -> None:
     evaluator = SparseNanoEvaluator(
         dataset_names=None,
-        dataset_id="example/NanoFooBar",
+        dataset_id="example/FooBar",
         write_csv=False,
     )
 
     assert evaluator.dataset_names == ["python", "java"]
     assert [sub_evaluator.name for sub_evaluator in evaluator.evaluators] == [
-        "NanoFooBar_python",
-        "NanoFooBar_java",
+        "FooBar_python",
+        "FooBar_java",
     ]
 
     metrics = evaluator(dummy_sparse_model)
-    assert evaluator.primary_metric == "NanoFooBar_mean_dot_ndcg@10"
-    assert "NanoFooBar_mean_dot_ndcg@10" in metrics
-    assert "NanoFooBar_mean_query_active_dims" in metrics
-    assert "NanoFooBar_mean_avg_flops" in metrics
+    assert evaluator.primary_metric == "FooBar_mean_dot_ndcg@10"
+    assert "FooBar_mean_dot_ndcg@10" in metrics
+    assert "FooBar_mean_query_active_dims" in metrics
+    assert "FooBar_mean_avg_flops" in metrics
 
 
 def test_sparse_nano_evaluator_single_split_path(
@@ -144,14 +144,14 @@ def test_sparse_nano_evaluator_single_split_path(
 ) -> None:
     evaluator = SparseNanoEvaluator(
         dataset_names=["python"],
-        dataset_id="example/NanoFooBar",
+        dataset_id="example/FooBar",
         write_csv=False,
     )
 
     metrics = evaluator(dummy_sparse_model)
-    assert evaluator.primary_metric == "NanoFooBar_mean_dot_ndcg@10"
-    assert "NanoFooBar_python_dot_ndcg@10" in metrics
-    assert "NanoFooBar_mean_avg_flops" in metrics
+    assert evaluator.primary_metric == "FooBar_mean_dot_ndcg@10"
+    assert "FooBar_python_dot_ndcg@10" in metrics
+    assert "FooBar_mean_avg_flops" in metrics
 
 
 def test_sparse_nano_evaluator_mapping_validates_split_exists(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -184,7 +184,7 @@ def test_sparse_nano_evaluator_accepts_direct_split_names_with_mapping(
 ) -> None:
     evaluator = SparseNanoEvaluator(
         dataset_names=["python"],
-        dataset_id="example/NanoFooBar",
+        dataset_id="example/FooBar",
         dataset_name_to_human_readable={"msmarco": "MSMARCO"},
         split_prefix="Nano",
         write_csv=False,
@@ -192,7 +192,7 @@ def test_sparse_nano_evaluator_accepts_direct_split_names_with_mapping(
 
     assert [sub_evaluator.name for sub_evaluator in evaluator.evaluators] == ["python"]
     metrics = evaluator(dummy_sparse_model)
-    assert "NanoFooBar_mean_dot_ndcg@10" in metrics
+    assert "FooBar_mean_dot_ndcg@10" in metrics
 
 
 def test_sparse_nano_evaluator_custom_name_metric_root(
@@ -201,7 +201,7 @@ def test_sparse_nano_evaluator_custom_name_metric_root(
 ) -> None:
     evaluator = SparseNanoEvaluator(
         dataset_names=["python"],
-        dataset_id="example/NanoFooBar",
+        dataset_id="example/FooBar",
         name="CustomSparseNano",
         write_csv=False,
     )
@@ -212,7 +212,7 @@ def test_sparse_nano_evaluator_custom_name_metric_root(
     assert "CustomSparseNano_mean_dot_ndcg@10" in metrics
 
 
-def test_sequential_evaluator_with_sparse_nanobeir_and_nanocodesearchnet(
+def test_sequential_evaluator_with_sparse_nanobeir_and_generic_nano_dataset(
     patch_sparse_nano_eval: None,
     dummy_sparse_model: Any,
 ) -> None:
@@ -220,13 +220,13 @@ def test_sequential_evaluator_with_sparse_nanobeir_and_nanocodesearchnet(
         dataset_names=["msmarco"],
         write_csv=False,
     )
-    nanocodesearchnet_evaluator = SparseNanoEvaluator(
+    generic_nano_evaluator = SparseNanoEvaluator(
         dataset_names=["python"],
-        dataset_id="example/NanoFooBar",
+        dataset_id="example/FooBar",
         write_csv=False,
     )
     seq_evaluator = SequentialEvaluator(
-        [nanobeir_evaluator, nanocodesearchnet_evaluator],
+        [nanobeir_evaluator, generic_nano_evaluator],
         main_score_function=lambda scores: float(sum(scores) / len(scores)),
     )
 
@@ -234,5 +234,5 @@ def test_sequential_evaluator_with_sparse_nanobeir_and_nanocodesearchnet(
 
     assert "sequential_score" in metrics
     assert any(key.startswith("NanoBEIR_mean_") for key in metrics)
-    assert any(key.startswith("NanoFooBar_mean_") for key in metrics)
+    assert any(key.startswith("FooBar_mean_") for key in metrics)
     assert "NanoBEIR_mean_dot_ndcg@10" in metrics


### PR DESCRIPTION
Hello!

## Summary

This PR introduces a generic `NanoEvaluator` abstraction for sampled information-retrieval evaluation, while preserving backward compatibility for existing NanoBEIR evaluators.

`NanoBEIREvaluator` is very useful for large IR benchmarks because it evaluates sampled subsets with much lower cost. In the same spirit, this PR extends the approach beyond NanoBEIR so that other datasets with the same `corpus/queries/qrels` structure can be evaluated with the same evaluator family.

For example, this enables evaluation on datasets such as:
- https://huggingface.co/datasets/hotchpotch/NanoMLDR
- https://huggingface.co/datasets/hotchpotch/NanoMIRACL
- https://huggingface.co/datasets/hotchpotch/NanoCodeSearchNet

## Details

- Add `NanoEvaluator` as a generic parent evaluator for dense retrieval.
- Refactor `NanoBEIREvaluator` to subclass `NanoEvaluator` while keeping its public API and output key conventions.
- Add `CrossEncoderNanoEvaluator` and `SparseNanoEvaluator` as generic parents for cross-encoder and sparse settings.
- Keep `CrossEncoderNanoBEIREvaluator` and `SparseNanoBEIREvaluator` as NanoBEIR-specific wrappers with backward-compatible behavior.
- Add/expand examples for dense, sparse, and cross-encoder usage.

## Backward Compatibility

- Existing `NanoBEIREvaluator` usage remains valid.
- Existing `CrossEncoderNanoBEIREvaluator` and `SparseNanoBEIREvaluator` usage remains valid.
- Metric naming and expected primary metrics are preserved for NanoBEIR evaluators.
- I also ran the sample code in NanoBEIREvaluator.py and confirmed that the resulting values remained unchanged from previous behavior.

---

This is an initial implementation to make the idea concrete. I would greatly appreciate any feedback!