### PR TITLE
Modify dataset parameters to include IterableDataset

### DIFF
--- a/sentence_transformers/cross_encoder/trainer.py
+++ b/sentence_transformers/cross_encoder/trainer.py
@@ -103,8 +103,8 @@ class CrossEncoderTrainer(SentenceTransformerTrainer):
         self,
         model: CrossEncoder | None = None,
         args: CrossEncoderTrainingArguments | None = None,
-        train_dataset: Dataset | DatasetDict | dict[str, Dataset] | None = None,
-        eval_dataset: Dataset | DatasetDict | dict[str, Dataset] | None = None,
+        train_dataset: Dataset | DatasetDict | IterableDataset | dict[str, Dataset] | None = None,
+        eval_dataset: Dataset | DatasetDict | IterableDataset | dict[str, Dataset] | None = None,
         loss: nn.Module
         | dict[str, nn.Module]
         | Callable[[CrossEncoder], torch.nn.Module]


### PR DESCRIPTION
Updated CrossEncoderTrainer to accept IterableDataset for train and eval dataset parameters.
Keep it consistent with the parent SentenceTransformerTrainer class.
## Problem
The accepted types for train_datasets and eval_datasets in CrossEncoderTrainer are inconsistent with those in the SentenceTransformerTrainer class. Fix this issue.
## Solution
Align subclass type hints with SentenceTransformerTrainer.
