### PR TITLE
[`tests`] Add slow reproduction tests for most common models

### DIFF
--- a/tests/cross_encoder/test_pretrained.py
+++ b/tests/cross_encoder/test_pretrained.py
@@ -76,7 +76,7 @@ MODELS_TO_SIMILARITIES = {
 
 @pytest.mark.parametrize("model_name, expected_score", MODELS_TO_SIMILARITIES.items())
 @pytest.mark.slow  # Also marked as slow to avoid running it with CI: results in too many requests/downloads to the Hugging Face Hub
-def test_pretrained_model(model_name: str, expected_score: float) -> None:
+def test_pretrained_model(model_name: str, expected_score: list[float]) -> None:
     model = CrossEncoder(model_name, trust_remote_code=True, model_kwargs={"torch_dtype": torch.float32})
     predictions = model.predict(PAIRS)
     assert np.allclose(predictions, expected_score, atol=0.01), (

--- a/tests/sparse_encoder/test_pretrained.py
+++ b/tests/sparse_encoder/test_pretrained.py
@@ -63,7 +63,7 @@ MODELS_TO_SIMILARITIES = {
 
 @pytest.mark.parametrize("model_name, expected_score", MODELS_TO_SIMILARITIES.items())
 @pytest.mark.slow  # Also marked as slow to avoid running it with CI: results in too many requests/downloads to the Hugging Face Hub
-def test_pretrained_model(model_name: str, expected_score: float) -> None:
+def test_pretrained_model(model_name: str, expected_score: list[float]) -> None:
     model = SparseEncoder(model_name, trust_remote_code=True, model_kwargs={"torch_dtype": torch.float32})
     query_embedding = model.encode_query(QUERY)
     document_embeddings = model.encode_document(DOCUMENTS)

--- a/tests/test_pretrained.py
+++ b/tests/test_pretrained.py
@@ -99,7 +99,7 @@ MODELS_TO_SIMILARITIES = {
 
 @pytest.mark.parametrize("model_name, expected_score", MODELS_TO_SIMILARITIES.items())
 @pytest.mark.slow  # Also marked as slow to avoid running it with CI: results in too many requests/downloads to the Hugging Face Hub
-def test_pretrained_model(model_name: str, expected_score: float) -> None:
+def test_pretrained_model(model_name: str, expected_score: list[float]) -> None:
     model = SentenceTransformer(model_name, trust_remote_code=True, model_kwargs={"torch_dtype": torch.float32})
     query_embedding = model.encode_query(QUERY)
     document_embeddings = model.encode_document(DOCUMENTS)


### PR DESCRIPTION
Hello!

## Pull Request overview
* Add slow reproduction tests for the most common `SentenceTransformer`, `CrossEncoder`, and `SparseEncoder` models

## Details
This PR adds a broad test suite covering ~75 `SentenceTransformer` models, ~53 `CrossEncoder` models, and ~40 `SparseEncoder` models, all marked `slow` so they don't run in CI. The goal is to make sure that I'm not introducing regressions in upcoming refactors.

The snapshots were computed with:
- Sentence Transformers v5.3.0.dev0
- Transformers 4.57.6
- Torch 2.10.0+cu128

- Tom Aarsen
