### PR TITLE
fix: forward cache_dir to ONNX and OpenVINO model loading

### DIFF
--- a/sentence_transformers/backend/load.py
+++ b/sentence_transformers/backend/load.py
@@ -11,7 +11,7 @@ from sentence_transformers.backend.utils import _save_pretrained_wrapper, backen
 logger = logging.getLogger(__name__)
 
 
-def load_onnx_model(model_name_or_path: str, config: PretrainedConfig, task_name: str, **model_kwargs):
+def load_onnx_model(model_name_or_path: str, config: PretrainedConfig, task_name: str, cache_dir: str | None = None, **model_kwargs):
     """
     Load and perhaps export an ONNX model using the Optimum library.
 
@@ -74,6 +74,7 @@ def load_onnx_model(model_name_or_path: str, config: PretrainedConfig, task_name
         model_name_or_path,
         config=config,
         export=export,
+        cache_dir=cache_dir,
         **model_kwargs,
     )
 
@@ -87,7 +88,7 @@ def load_onnx_model(model_name_or_path: str, config: PretrainedConfig, task_name
     return model
 
 
-def load_openvino_model(model_name_or_path: str, config: PretrainedConfig, task_name: str, **model_kwargs):
+def load_openvino_model(model_name_or_path: str, config: PretrainedConfig, task_name: str, cache_dir: str | None = None, **model_kwargs):
     """
     Load and perhaps export an OpenVINO model using the Optimum library.
 
@@ -158,6 +159,7 @@ def load_openvino_model(model_name_or_path: str, config: PretrainedConfig, task_
         model_name_or_path,
         config=config,
         export=export,
+        cache_dir=cache_dir,
         **model_kwargs,
     )
 

--- a/sentence_transformers/models/Transformer.py
+++ b/sentence_transformers/models/Transformer.py
@@ -275,6 +275,7 @@ class Transformer(InputModule):
                 model_name_or_path=model_name_or_path,
                 config=config,
                 task_name="feature-extraction",
+                cache_dir=cache_dir,
                 **model_args,
             )
         elif backend == "openvino":
@@ -282,6 +283,7 @@ class Transformer(InputModule):
                 model_name_or_path=model_name_or_path,
                 config=config,
                 task_name="feature-extraction",
+                cache_dir=cache_dir,
                 **model_args,
             )
         else:


### PR DESCRIPTION
## Summary
- Forward `cache_dir` from `Transformer._load_model()` to `load_onnx_model()` and `load_openvino_model()`
- Forward `cache_dir` to the underlying `model_cls.from_pretrained()` calls in both functions
- Fixes ONNX/OpenVINO backend failing with `ValueError` when `cache_folder` is specified alongside `local_files_only=True`

## Root Cause
When using `backend="onnx"` (or `"openvino"`) with a custom `cache_folder`, the `cache_dir` parameter was not forwarded through the loading chain:

1. `Transformer._load_model()` receives `cache_dir` but did not pass it to `load_onnx_model()` / `load_openvino_model()` (unlike the torch backend which passes `cache_dir` to `AutoModel.from_pretrained()`)
2. `load_onnx_model()` / `load_openvino_model()` did not accept or forward `cache_dir` to `model_cls.from_pretrained()`

This meant the ONNX/OpenVINO model loader had no knowledge of where cached files were stored, causing it to fail when `local_files_only=True`.

## Reproduction
```python
from sentence_transformers import SentenceTransformer

# Step 1: Download to cache (works)
model = SentenceTransformer(
    "sentence-transformers/all-MiniLM-L6-v2",
    cache_folder="./model_cache/",
    backend="onnx",
    local_files_only=False,
)

# Step 2: Load from cache (fails before fix)
model = SentenceTransformer(
    "sentence-transformers/all-MiniLM-L6-v2",
    cache_folder="./model_cache/",
    backend="onnx",
    local_files_only=True,
)
```

## Changes
- `sentence_transformers/backend/load.py`: Added `cache_dir` parameter to `load_onnx_model()` and `load_openvino_model()`, forwarded to `from_pretrained()`
- `sentence_transformers/models/Transformer.py`: Pass `cache_dir` when calling `load_onnx_model()` and `load_openvino_model()` in `_load_model()`

Fixes #3562
