### PR TITLE
fix: use caller's class name as default model_type for subclasses

### DIFF
--- a/sentence_transformers/SentenceTransformer.py
+++ b/sentence_transformers/SentenceTransformer.py
@@ -2525,8 +2525,8 @@ print(similarities)
         )
 
         if config_sentence_transformers_json_path is None:
-            return "SentenceTransformer"
+            return self.__class__.__name__
 
         with open(config_sentence_transformers_json_path, encoding="utf8") as fIn:
             config = json.load(fIn)
-            return config.get("model_type", "SentenceTransformer")  # Default to "SentenceTransformer" if not specified
+            return config.get("model_type", self.__class__.__name__)  # Default to caller's class if not specified


### PR DESCRIPTION
## Summary
- Use `self.__class__.__name__` instead of hardcoded `"SentenceTransformer"` as the default `model_type` in `_get_model_type()`
- Fixes subclassed `SentenceTransformer` loading older models (without `model_type` in config) with wrong pooling defaults

## Root Cause
`_get_model_type()` hardcoded the fallback to `"SentenceTransformer"` in two places:
1. When no `config_sentence_transformers.json` exists
2. When the config exists but has no `model_type` key

Meanwhile, `_model_config["model_type"]` is set to `self.__class__.__name__` (e.g. `"MySentenceTransformer"`). This mismatch caused the comparison at line 325 to fail, falling through to `_load_auto_model` instead of `_load_sbert_model`, resulting in wrong pooling defaults (mean pooling instead of CLS token).

## Reproduction
```python
from sentence_transformers import SentenceTransformer

class MySentenceTransformer(SentenceTransformer): ...

model = MySentenceTransformer("BAAI/bge-small-en-v1.5")
# Before fix: "No sentence-transformers model found... Creating a new one with mean pooling."
# After fix: loads correctly with CLS token pooling
```

## Changes
- `sentence_transformers/SentenceTransformer.py`: Changed default from `"SentenceTransformer"` to `self.__class__.__name__` in both fallback paths of `_get_model_type()`

Fixes #3536
