### PR TITLE
[`ci`] Install model2vec with the distill extra

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Install dependencies (transformers < 5.0.0)
         if: ${{ matrix.transformers-version == '<5.0.0' }}
-        run: uv pip install '.[train, onnx, openvino, dev]' 'transformers<5.0.0' --system
+        run: uv pip install '.[train, onnx, openvino, dev]' 'transformers<5.0.0' 'datasets>=3.3.0' --system
 
       - name: Install dependencies (transformers >= 5.0.0)
         if: ${{ matrix.transformers-version == '>=5.0.0' }}


### PR DESCRIPTION
Hello!

## Pull Request overview
* Install model2vec with the distill extra

## Details
Cherry-picked from #3554. This is required due to changes in `model2vec`'s install.

- Tom Aarsen