### PR TITLE
[`chore`] Replace evaluation_strategy with eval_strategy in a few more places

### DIFF
--- a/examples/sentence_transformer/training/sts/training_stsbenchmark.py
+++ b/examples/sentence_transformer/training/sts/training_stsbenchmark.py
@@ -71,7 +71,7 @@ args = SentenceTransformerTrainingArguments(
     fp16=True,  # Set to False if you get an error that your GPU can't run on FP16
     bf16=False,  # Set to True if you have a GPU that supports BF16
     # Optional tracking/debugging parameters:
-    evaluation_strategy="steps",
+    eval_strategy="steps",
     eval_steps=100,
     save_strategy="steps",
     save_steps=100,

--- a/sentence_transformers/base/model_card.py
+++ b/sentence_transformers/base/model_card.py
@@ -130,6 +130,7 @@ class BaseModelCardCallback(TrainerCallback):
             "logging_first_step",
             "logging_steps",
             "evaluation_strategy",
+            "eval_strategy",
             "eval_steps",
             "eval_delay",
             "save_strategy",


### PR DESCRIPTION
Hello!

## Pull Request overview
* Replace evaluation_strategy with eval_strategy in a few more places

## Details
Transformers 4.52 or so replaced evaluation_strategy with eval_strategy. This carries that forward in a training script and also in ignoring these values in the model card. 

- Tom Aarsen