### PR TITLE
Add requests to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     "scipy>=1.0.0",
     "typing_extensions>=4.5.0",
     "tqdm>=4.0.0",
+    "requests>=2.33.1",
 ]
 
 [project.urls]


### PR DESCRIPTION
# Description
This PR adds `requests>=2.33.1` to the dependencies section of `pyproject.toml`.

## Rationale
`sentence-transformers` fails to import in environments where the `requests` module does not exist.  This can get missed during automated builds only to show up at run time.

Closes #3715