### PR TITLE
Fix: infer_modality misclassifies 1D numpy string arrays as audio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,7 @@ tmp
 .DS_Store
 /runs
 /tmp_trainer/
+
+# Lock files
+poetry.lock
+uv.lock

--- a/sentence_transformers/base/modality.py
+++ b/sentence_transformers/base/modality.py
@@ -196,7 +196,9 @@ class InputFormatter:
                 - tuple/list of mixed types: Non-text pairs (e.g. image + text)
                 - dict: Chat messages, audio data, or multimodal inputs
                 - PIL.Image.Image: Image inputs
-                - np.ndarray/torch.Tensor: Audio (1-2D) or video (3-5D) inputs
+                - np.ndarray/torch.Tensor: Audio (1-2D), image (3D), or video (4-5D) inputs.
+                  Numpy string arrays (dtype kind ``'U'`` or ``'S'``) are treated as text
+                  regardless of ndim.
 
         Returns:
             Tuple of (modality, processor_inputs_dict, extra_modality_kwargs) where:
@@ -567,6 +569,12 @@ def infer_modality(
             return tuple(sorted(sample.keys()))
         case dict():
             raise ValueError("Empty dict input is not a valid input sample.")
+        case np.ndarray() if sample.dtype.kind in ("U", "S"):
+            # Numpy Unicode (<U...) and byte-string (|S...) arrays contain text.
+            # They are produced by e.g. np.array(["hello"]) or np.unique(list_of_str).
+            # Without this guard the ndim-based branch below would misclassify a 1D
+            # string array as audio (ndim=1 → "mono waveform").
+            return "text"
         case np.ndarray() | torch.Tensor():
             if sample.ndim in (1, 2):  # mono or multi-channel waveform
                 return "audio"

--- a/tests/base/test_modality.py
+++ b/tests/base/test_modality.py
@@ -134,6 +134,40 @@ class TestInferModality:
         img = PIL.new("RGB", (10, 10))
         assert infer_modality(img) == "image"
 
+    def test_ndarray_unicode_dtype_1d_is_text(self):
+        # Regression: 1D numpy Unicode string array (dtype=<U...) must be "text", not "audio".
+        # np.array(list_of_str) and np.unique() both produce this dtype.
+        arr = np.array(["Access Management", "Financial Reports", "Press Coordination"])
+        assert arr.dtype.kind == "U"
+        assert infer_modality(arr) == "text"
+
+    def test_ndarray_unicode_dtype_from_unique_is_text(self):
+        # Regression: np.unique() returns a Unicode string array — must route to "text".
+        arr = np.unique(["Finance", "Finance", "Press"])
+        assert infer_modality(arr) == "text"
+
+    def test_ndarray_bytes_dtype_1d_is_text(self):
+        # Byte-string arrays (dtype=|S...) are also text content.
+        arr = np.array([b"hello", b"world"])
+        assert arr.dtype.kind == "S"
+        assert infer_modality(arr) == "text"
+
+    @pytest.mark.parametrize(
+        ("dtype", "expected_kind"),
+        [
+            pytest.param(np.int16, "i", id="signed-integer"),
+            pytest.param(np.uint8, "u", id="unsigned-integer"),
+            pytest.param(np.float32, "f", id="float32"),
+            pytest.param(np.float64, "f", id="float64"),
+            pytest.param(np.complex64, "c", id="complex64"),
+        ],
+    )
+    def test_ndarray_numeric_1d_is_still_audio(self, dtype: np.dtype, expected_kind: str):
+        # Regression: dtype.kind guards for string-like arrays must not affect numeric arrays.
+        arr = np.zeros(16000, dtype=dtype)
+        assert arr.dtype.kind == expected_kind
+        assert infer_modality(arr) == "audio"
+
     def test_ndarray_1d_is_audio(self):
         assert infer_modality(np.zeros(16000)) == "audio"
 


### PR DESCRIPTION
## Description

Fixes #3718.

`infer_modality` was routing 1D numpy string arrays (dtype kind `'U'` or `'S'`, produced by e.g. `np.array(list_of_strings)` or `np.unique()`) into the `np.ndarray | torch.Tensor` branch, which classifies 1D arrays as audio (mono waveform). This caused `SentenceTransformer.encode()` to raise:

```
ValueError: Modality 'audio' is not supported by this SentenceTransformer model. Supported modalities: text
```

## Root Cause

The `case np.ndarray() | torch.Tensor():` match in `infer_modality` only inspects `ndim`, so a 1D string array (e.g. from `np.unique()`) was indistinguishable from an audio waveform.

## Fix

Added an early `case` guard in `infer_modality` that checks `sample.dtype.kind in ("U", "S")` before the ndim-based branch and returns `"text"` for those arrays. Also updated the `InputFormatter.get_inputs` docstring to document this behaviour.

## Tests

Added regression tests in `tests/base/test_modality.py` covering:

- 1D Unicode string array (`dtype=<U...`) → `"text"`
- Result of `np.unique()` → `"text"`
- 1D byte-string array (`dtype=|S...`) → `"text"`
- Numeric 1D arrays (int16, uint8, float32, float64, complex64) still correctly route to `"audio"`