### PR TITLE
[`fix`] Treat numpy string/object arrays as batches in encode/predict

### DIFF
--- a/sentence_transformers/base/model.py
+++ b/sentence_transformers/base/model.py
@@ -576,7 +576,12 @@ class BaseModel(nn.Sequential, PeftAdapterMixin, ABC):
                 list_types += (Column,)
             except ImportError:
                 pass
-        return not isinstance(inputs, list_types)
+        if isinstance(inputs, list_types):
+            return False
+        # Numpy arrays of strings/bytes/objects are batches
+        if isinstance(inputs, np.ndarray) and inputs.ndim >= 1 and inputs.dtype.kind in ("U", "S", "O"):
+            return False
+        return True
 
     def save(
         self,

--- a/sentence_transformers/base/model.py
+++ b/sentence_transformers/base/model.py
@@ -578,8 +578,8 @@ class BaseModel(nn.Sequential, PeftAdapterMixin, ABC):
                 pass
         if isinstance(inputs, list_types):
             return False
-        # Numpy arrays of strings/bytes/objects are batches
-        if isinstance(inputs, np.ndarray) and inputs.ndim >= 1 and inputs.dtype.kind in ("U", "S", "O"):
+        # Numpy arrays of unicode strings or objects are batches
+        if isinstance(inputs, np.ndarray) and inputs.ndim >= 1 and inputs.dtype.kind in ("U", "O"):
             return False
         return True
 

--- a/sentence_transformers/cross_encoder/model.py
+++ b/sentence_transformers/cross_encoder/model.py
@@ -623,7 +623,7 @@ class CrossEncoder(BaseModel, FitMixin):
         # Cast an individual pair to a list with length 1
         is_singular_input = self.is_singular_input(inputs)
         if is_singular_input:
-            # A 1D numpy string array is a single pair; convert to list so downstream sees ("q", "d").
+            # A 1D numpy string array is a single pair; convert to a list so downstream sees ["q", "d"].
             if isinstance(inputs, np.ndarray):
                 inputs = inputs.tolist()
             inputs = [inputs]
@@ -845,8 +845,10 @@ class CrossEncoder(BaseModel, FitMixin):
                 pass
         if isinstance(inputs, list_types):
             return len(inputs) > 0 and not isinstance(inputs[0], list_types)
-        # Numpy string/bytes/object arrays: 1D is a single pair, 2D+ is a batch of pairs.
-        if isinstance(inputs, np.ndarray) and inputs.dtype.kind in ("U", "S", "O"):
+        # Numpy string/object arrays: 1D is a single pair, 2D+ is a batch, empty is an empty batch
+        if isinstance(inputs, np.ndarray) and inputs.dtype.kind in ("U", "O"):
+            if inputs.size == 0:
+                return False
             return inputs.ndim < 2
         return True
 

--- a/sentence_transformers/cross_encoder/model.py
+++ b/sentence_transformers/cross_encoder/model.py
@@ -623,10 +623,13 @@ class CrossEncoder(BaseModel, FitMixin):
         # Cast an individual pair to a list with length 1
         is_singular_input = self.is_singular_input(inputs)
         if is_singular_input:
+            # A 1D numpy string array is a single pair; convert to list so downstream sees ("q", "d").
+            if isinstance(inputs, np.ndarray):
+                inputs = inputs.tolist()
             inputs = [inputs]
         elif not isinstance(inputs, list):
             # Materialize e.g. datasets.Column to avoid slow Arrow deserialization on each index
-            inputs = list(inputs)
+            inputs = inputs.tolist() if isinstance(inputs, np.ndarray) else list(inputs)
 
         # If pool or a list of devices is provided, use multi-process prediction
         if pool is not None or (isinstance(device, list) and len(device) > 0):
@@ -840,7 +843,12 @@ class CrossEncoder(BaseModel, FitMixin):
                 list_types += (Column,)
             except ImportError:
                 pass
-        return (not isinstance(inputs, list_types)) or (len(inputs) > 0 and not isinstance(inputs[0], list_types))
+        if isinstance(inputs, list_types):
+            return len(inputs) > 0 and not isinstance(inputs[0], list_types)
+        # Numpy string/bytes/object arrays: 1D is a single pair, 2D+ is a batch of pairs.
+        if isinstance(inputs, np.ndarray) and inputs.dtype.kind in ("U", "S", "O"):
+            return inputs.ndim < 2
+        return True
 
     def _get_model_config(self) -> dict[str, Any]:
         return super()._get_model_config() | {

--- a/sentence_transformers/sentence_transformer/model.py
+++ b/sentence_transformers/sentence_transformer/model.py
@@ -579,7 +579,7 @@ class SentenceTransformer(BaseModel, FitMixin):
             inputs = [inputs]
         elif not isinstance(inputs, list):
             # Materialize e.g. datasets.Column to avoid slow Arrow deserialization on each index
-            inputs = list(inputs)
+            inputs = inputs.tolist() if isinstance(inputs, np.ndarray) else list(inputs)
 
         # Validate kwargs
         model_kwargs = self.get_model_kwargs()

--- a/sentence_transformers/sparse_encoder/model.py
+++ b/sentence_transformers/sparse_encoder/model.py
@@ -453,7 +453,7 @@ class SparseEncoder(BaseModel):
             inputs = [inputs]
         elif not isinstance(inputs, list):
             # Materialize e.g. datasets.Column to avoid slow Arrow deserialization on each index
-            inputs = list(inputs)
+            inputs = inputs.tolist() if isinstance(inputs, np.ndarray) else list(inputs)
 
         # Throw an error if unused kwargs are passed, except 'task' which is always allowed, even
         # when it does not do anything (as e.g. there's no Router module in the model)

--- a/tests/base/test_model.py
+++ b/tests/base/test_model.py
@@ -747,13 +747,58 @@ def test_is_singular_input_tuple(stsb_bert_tiny_model: SentenceTransformer) -> N
 
 
 def test_is_singular_input_numpy(stsb_bert_tiny_model: SentenceTransformer) -> None:
-    """A numpy array should be singular (not a list type)."""
+    """A numeric numpy array should be singular (treated as an audio waveform)."""
     assert stsb_bert_tiny_model.is_singular_input(np.array([1, 2, 3])) is True
 
 
 def test_is_singular_input_tensor(stsb_bert_tiny_model: SentenceTransformer) -> None:
     """A torch tensor should be singular (not a list type)."""
     assert stsb_bert_tiny_model.is_singular_input(torch.tensor([1, 2, 3])) is True
+
+
+def test_is_singular_input_numpy_1d_strings(stsb_bert_tiny_model: SentenceTransformer) -> None:
+    """A 1D numpy string array is a batch of texts (e.g. from np.unique), not a single audio input."""
+    assert stsb_bert_tiny_model.is_singular_input(np.array(["hello", "world"])) is False
+    assert stsb_bert_tiny_model.is_singular_input(np.unique(["a", "b", "a"])) is False
+
+
+def test_is_singular_input_numpy_2d_strings(stsb_bert_tiny_model: SentenceTransformer) -> None:
+    """A 2D numpy string array is a batch of text pairs."""
+    assert stsb_bert_tiny_model.is_singular_input(np.array([["q1", "d1"], ["q2", "d2"]])) is False
+
+
+def test_is_singular_input_numpy_bytes(stsb_bert_tiny_model: SentenceTransformer) -> None:
+    """A 1D numpy byte-string array is a batch of texts."""
+    assert stsb_bert_tiny_model.is_singular_input(np.array([b"hello", b"world"])) is False
+
+
+def test_is_singular_input_numpy_object(stsb_bert_tiny_model: SentenceTransformer) -> None:
+    """A numpy object array is a batch (no valid single-sample type is an object ndarray)."""
+    assert stsb_bert_tiny_model.is_singular_input(np.array(["hello", "world"], dtype=object)) is False
+
+
+def test_is_singular_input_numpy_0d_string(stsb_bert_tiny_model: SentenceTransformer) -> None:
+    """A 0-dim numpy string array represents a single text."""
+    assert stsb_bert_tiny_model.is_singular_input(np.array("hello")) is True
+
+
+def test_encode_numpy_1d_string_array(stsb_bert_tiny_model: SentenceTransformer) -> None:
+    """Regression test for #3718: encoding a 1D numpy string array should not raise and
+    should produce one embedding per element."""
+    texts = np.array(["Access Management", "Press Coordination", "Financial Reports"])
+    embeddings = stsb_bert_tiny_model.encode(texts, show_progress_bar=False)
+    expected = stsb_bert_tiny_model.encode(texts.tolist(), show_progress_bar=False)
+    assert embeddings.shape[0] == 3
+    assert np.allclose(embeddings, expected)
+
+
+def test_encode_numpy_2d_string_array(stsb_bert_tiny_model: SentenceTransformer) -> None:
+    """Encoding a 2D numpy string array should match encoding the equivalent nested list."""
+    pairs = np.array([["what is AI?", "AI is artificial intelligence."], ["what is ML?", "ML is machine learning."]])
+    embeddings = stsb_bert_tiny_model.encode(pairs, show_progress_bar=False)
+    expected = stsb_bert_tiny_model.encode(pairs.tolist(), show_progress_bar=False)
+    assert embeddings.shape[0] == 2
+    assert np.allclose(embeddings, expected)
 
 
 @pytest.mark.parametrize(

--- a/tests/base/test_model.py
+++ b/tests/base/test_model.py
@@ -768,8 +768,9 @@ def test_is_singular_input_numpy_2d_strings(stsb_bert_tiny_model: SentenceTransf
 
 
 def test_is_singular_input_numpy_bytes(stsb_bert_tiny_model: SentenceTransformer) -> None:
-    """A 1D numpy byte-string array is a batch of texts."""
-    assert stsb_bert_tiny_model.is_singular_input(np.array([b"hello", b"world"])) is False
+    """A numpy byte-string array is not treated as a text batch (downstream modality inference
+    does not handle Python ``bytes``), so it falls through to the default singular interpretation."""
+    assert stsb_bert_tiny_model.is_singular_input(np.array([b"hello", b"world"])) is True
 
 
 def test_is_singular_input_numpy_object(stsb_bert_tiny_model: SentenceTransformer) -> None:
@@ -799,6 +800,13 @@ def test_encode_numpy_2d_string_array(stsb_bert_tiny_model: SentenceTransformer)
     expected = stsb_bert_tiny_model.encode(pairs.tolist(), show_progress_bar=False)
     assert embeddings.shape[0] == 2
     assert np.allclose(embeddings, expected)
+
+
+def test_encode_numpy_empty(stsb_bert_tiny_model: SentenceTransformer) -> None:
+    """Encoding an empty string ndarray should return an empty result, like ``encode([])``."""
+    embeddings = stsb_bert_tiny_model.encode(np.array([], dtype=str), show_progress_bar=False)
+    expected = stsb_bert_tiny_model.encode([], show_progress_bar=False)
+    assert np.array_equal(embeddings, expected)
 
 
 @pytest.mark.parametrize(

--- a/tests/cross_encoder/test_model.py
+++ b/tests/cross_encoder/test_model.py
@@ -154,6 +154,36 @@ def test_predict_single_input(model_name: str):
         assert pair_score.shape == (model.num_labels,)
 
 
+def test_is_singular_input_numpy_1d_pair(reranker_bert_tiny_model: CrossEncoder) -> None:
+    """A 1D numpy string array represents a single (query, document) pair."""
+    assert reranker_bert_tiny_model.is_singular_input(np.array(["query", "document"])) is True
+
+
+def test_is_singular_input_numpy_2d_pairs(reranker_bert_tiny_model: CrossEncoder) -> None:
+    """A 2D numpy string array is a batch of pairs."""
+    assert reranker_bert_tiny_model.is_singular_input(np.array([["q1", "d1"], ["q2", "d2"]])) is False
+
+
+def test_predict_numpy_1d_pair(reranker_bert_tiny_model: CrossEncoder) -> None:
+    """Predicting on a 1D numpy string array (a single pair) should match the tuple equivalent
+    and return a scalar score. Exercises the singular-branch .tolist() conversion."""
+    model = reranker_bert_tiny_model
+    pair = np.array(["what is AI?", "AI is artificial intelligence."])
+    score = model.predict(pair, show_progress_bar=False)
+    expected = model.predict(tuple(pair.tolist()), show_progress_bar=False)
+    assert isinstance(score, np.float32)
+    assert np.allclose(score, expected)
+
+
+def test_predict_numpy_2d_pairs(reranker_bert_tiny_model: CrossEncoder) -> None:
+    """Predicting on a 2D numpy string array should match predicting on the equivalent nested list."""
+    pairs = np.array([["what is AI?", "AI is artificial intelligence."], ["what is ML?", "ML is machine learning."]])
+    scores = reranker_bert_tiny_model.predict(pairs, show_progress_bar=False)
+    expected = reranker_bert_tiny_model.predict(pairs.tolist(), show_progress_bar=False)
+    assert scores.shape == (2,)
+    assert np.allclose(scores, expected)
+
+
 def test_predict_batch_size_1(reranker_bert_tiny_model: CrossEncoder) -> None:
     """Regression test: batch_size=1 with num_labels=1 used to fail because squeeze produced a 0-d tensor.
 

--- a/tests/cross_encoder/test_model.py
+++ b/tests/cross_encoder/test_model.py
@@ -164,6 +164,19 @@ def test_is_singular_input_numpy_2d_pairs(reranker_bert_tiny_model: CrossEncoder
     assert reranker_bert_tiny_model.is_singular_input(np.array([["q1", "d1"], ["q2", "d2"]])) is False
 
 
+def test_is_singular_input_numpy_empty(reranker_bert_tiny_model: CrossEncoder) -> None:
+    """An empty 1D string ndarray is an empty batch, not a singular pair, matching ``predict([])``."""
+    assert reranker_bert_tiny_model.is_singular_input(np.array([], dtype=str)) is False
+
+
+def test_predict_numpy_empty(reranker_bert_tiny_model: CrossEncoder) -> None:
+    """Predicting on an empty string ndarray should return an empty array, like ``predict([])``."""
+    scores = reranker_bert_tiny_model.predict(np.array([], dtype=str), show_progress_bar=False)
+    expected = reranker_bert_tiny_model.predict([], show_progress_bar=False)
+    assert scores.shape == (0,)
+    assert np.array_equal(scores, expected)
+
+
 def test_predict_numpy_1d_pair(reranker_bert_tiny_model: CrossEncoder) -> None:
     """Predicting on a 1D numpy string array (a single pair) should match the tuple equivalent
     and return a scalar score. Exercises the singular-branch .tolist() conversion."""

--- a/tests/sparse_encoder/test_model.py
+++ b/tests/sparse_encoder/test_model.py
@@ -433,6 +433,26 @@ def test_encode_with_dataset_column(splade_bert_tiny_model: SparseEncoder) -> No
     assert embeddings.shape == (2, model.get_embedding_dimension())
 
 
+def test_encode_numpy_1d_string_array(splade_bert_tiny_model: SparseEncoder) -> None:
+    """Regression test for #3718: encoding a 1D numpy string array should produce one embedding per element."""
+    model = splade_bert_tiny_model
+    texts = np.array(["Access Management", "Press Coordination", "Financial Reports"])
+    embeddings = model.encode(texts, convert_to_tensor=True, save_to_cpu=True)
+    expected = model.encode(texts.tolist(), convert_to_tensor=True, save_to_cpu=True)
+    assert embeddings.shape == (3, model.get_embedding_dimension())
+    assert torch.allclose(embeddings.to_dense(), expected.to_dense())
+
+
+def test_encode_numpy_2d_string_array(splade_bert_tiny_model: SparseEncoder) -> None:
+    """Encoding a 2D numpy string array should match encoding the equivalent nested list."""
+    model = splade_bert_tiny_model
+    pairs = np.array([["what is AI?", "AI is artificial intelligence."], ["what is ML?", "ML is machine learning."]])
+    embeddings = model.encode(pairs, convert_to_tensor=True, save_to_cpu=True)
+    expected = model.encode(pairs.tolist(), convert_to_tensor=True, save_to_cpu=True)
+    assert embeddings.shape == (2, model.get_embedding_dimension())
+    assert torch.allclose(embeddings.to_dense(), expected.to_dense())
+
+
 @pytest.mark.parametrize("convert_to_tensor", [True, False])
 @pytest.mark.parametrize("convert_to_sparse_tensor", [True, False])
 @pytest.mark.parametrize("save_to_cpu", [True, False])

--- a/tests/sparse_encoder/test_model.py
+++ b/tests/sparse_encoder/test_model.py
@@ -453,6 +453,15 @@ def test_encode_numpy_2d_string_array(splade_bert_tiny_model: SparseEncoder) -> 
     assert torch.allclose(embeddings.to_dense(), expected.to_dense())
 
 
+def test_encode_numpy_empty(splade_bert_tiny_model: SparseEncoder) -> None:
+    """Encoding an empty string ndarray should return an empty tensor, like ``encode([])``."""
+    model = splade_bert_tiny_model
+    embeddings = model.encode(np.array([], dtype=str), convert_to_tensor=True, save_to_cpu=True)
+    expected = model.encode([], convert_to_tensor=True, save_to_cpu=True)
+    assert embeddings.numel() == 0
+    assert torch.equal(embeddings.to_dense(), expected.to_dense())
+
+
 @pytest.mark.parametrize("convert_to_tensor", [True, False])
 @pytest.mark.parametrize("convert_to_sparse_tensor", [True, False])
 @pytest.mark.parametrize("save_to_cpu", [True, False])


### PR DESCRIPTION
Resolves #3718

Hello!

## Pull Request overview
* Treat 1D+ numpy string/object arrays as batches in `encode`/`predict` instead of single inputs
* Add tests to show the above works

## Details
Passing a 1D numpy string array (e.g. the output of `np.unique(...)`) to `SentenceTransformer.encode`, `SparseEncoder.encode`, or `CrossEncoder.predict` was being misclassified as a single sample, so the model produced one bogus embedding for the entire array rather than one embedding per element. The reason is that `is_singular_input` used `not isinstance(inputs, (list, tuple, Column))` as its sole heuristic, which lumps every `np.ndarray` (including string arrays) into the singular branch. We can't just blanket-exclude `np.ndarray` either, since a numeric ndarray is a legitimate single input for the multimodal/audio path.

I narrowed the heuristic by inspecting `dtype.kind`: arrays with kind `"U"` or `"O"` and `ndim >= 1` are now treated as batches, while numeric arrays keep their existing singular interpretation. `CrossEncoder.is_singular_input` uses the same dtype check but with `ndim < 2` for the singular case, since a 1D string array there represents one `(query, document)` pair and a 2D array is a batch of pairs.



- Tom Aarsen
