### PR TITLE
Warn when transformers is too old to bidir. attention flags in model config

### DIFF
--- a/sentence_transformers/base/modules/transformer.py
+++ b/sentence_transformers/base/modules/transformer.py
@@ -1380,7 +1380,8 @@ class Transformer(InputModule):
 
         return AutoConfig.from_pretrained(model_name_or_path, **config_kwargs), False
 
-    def _warn_on_unsupported_attention_config(self, config: PeftConfig | PretrainedConfig) -> None:
+    @staticmethod
+    def _warn_on_unsupported_attention_config(config: PeftConfig | PretrainedConfig) -> None:
         """Warn if the config requests bidirectional attention settings not supported by the installed transformers version."""
         if not isinstance(config, PretrainedConfig):
             return
@@ -1399,7 +1400,7 @@ class Transformer(InputModule):
                 f"The model config specifies `{param}={expected_value}`, but the installed "
                 f"`transformers` version ({transformers_version}) may not support this parameter, "
                 "in which case it will be silently ignored and the model will fall back to causal "
-                "attention, likely producing degraded embeddings. Consider upgrading with "
+                "attention, likely producing degraded model outputs. Consider upgrading with "
                 f"`pip install -U transformers>={min_version}`."
             )
 

--- a/sentence_transformers/base/modules/transformer.py
+++ b/sentence_transformers/base/modules/transformer.py
@@ -114,6 +114,8 @@ _TRANSFORMERS_PROCESSOR_SUPPORTS_MODALITY_KWARGS = parse_version(transformers_ve
 _TRANSFORMERS_APPLY_CHAT_TEMPLATE_RECOMMENDS_PROCESSOR_KWARGS = parse_version(transformers_version) >= parse_version(
     "5.4.0.dev0"
 )
+_TRANSFORMERS_SUPPORTS_USE_BIDIRECTIONAL_ATTENTION = parse_version(transformers_version) >= parse_version("4.56.2")
+_TRANSFORMERS_SUPPORTS_IS_CAUSAL_FALSE = parse_version(transformers_version) >= parse_version("5.2.0")
 
 TransformerTask = Literal[
     "feature-extraction", "sequence-classification", "text-generation", "any-to-any", "fill-mask"
@@ -626,6 +628,7 @@ class Transformer(InputModule):
         self._method_signature_cache: dict[str, set[str]] = {}
 
         config, is_peft_model = self._load_config(model_name_or_path, backend, config_kwargs)
+        self._warn_on_unsupported_attention_config(config)
 
         if (
             transformer_task == "sequence-classification"
@@ -1376,6 +1379,34 @@ class Transformer(InputModule):
             return PeftConfig.from_pretrained(model_name_or_path, **config_kwargs), True
 
         return AutoConfig.from_pretrained(model_name_or_path, **config_kwargs), False
+
+    def _warn_on_unsupported_attention_config(self, config: PeftConfig | PretrainedConfig) -> None:
+        """Warn if the config requests bidirectional attention settings not supported by the installed transformers version."""
+        if not isinstance(config, PretrainedConfig):
+            return
+
+        configs_to_check: list[PretrainedConfig] = [config]
+        if hasattr(config, "sub_configs"):
+            for sub_config_name in config.sub_configs.keys():
+                sub_config = getattr(config, sub_config_name, None)
+                if isinstance(sub_config, PretrainedConfig):
+                    configs_to_check.append(sub_config)
+
+        def warn_if_unsupported(param: str, expected_value: bool, is_supported: bool, min_version: str) -> None:
+            if is_supported or not any(getattr(cfg, param, None) is expected_value for cfg in configs_to_check):
+                return
+            logger.warning(
+                f"The model config specifies `{param}={expected_value}`, but the installed "
+                f"`transformers` version ({transformers_version}) may not support this parameter, "
+                "in which case it will be silently ignored and the model will fall back to causal "
+                "attention, likely producing degraded embeddings. Consider upgrading with "
+                f"`pip install -U transformers>={min_version}`."
+            )
+
+        warn_if_unsupported(
+            "use_bidirectional_attention", True, _TRANSFORMERS_SUPPORTS_USE_BIDIRECTIONAL_ATTENTION, "4.56.2"
+        )
+        warn_if_unsupported("is_causal", False, _TRANSFORMERS_SUPPORTS_IS_CAUSAL_FALSE, "5.2.0")
 
     def _load_model(
         self,

--- a/sentence_transformers/base/modules/transformer.py
+++ b/sentence_transformers/base/modules/transformer.py
@@ -1401,7 +1401,7 @@ class Transformer(InputModule):
                 f"`transformers` version ({transformers_version}) may not support this parameter, "
                 "in which case it will be silently ignored and the model will fall back to causal "
                 "attention, likely producing degraded model outputs. Consider upgrading with "
-                f"`pip install -U transformers>={min_version}`."
+                f'`pip install -U "transformers>={min_version}"`.'
             )
 
         warn_if_unsupported(

--- a/sentence_transformers/base/modules/transformer.py
+++ b/sentence_transformers/base/modules/transformer.py
@@ -1399,8 +1399,8 @@ class Transformer(InputModule):
             logger.warning(
                 f"The model config specifies `{param}={expected_value}`, but the installed "
                 f"`transformers` version ({transformers_version}) may not support this parameter, "
-                "in which case it will be silently ignored and the model will fall back to causal "
-                "attention, likely producing degraded model outputs. Consider upgrading with "
+                "in which case it may be silently ignored and the model will fall back to its default attention "
+                "behavior (often causal), likely producing degraded model outputs. Consider upgrading with "
                 f'`pip install -U "transformers>={min_version}"`.'
             )
 

--- a/tests/base/modules/test_transformer.py
+++ b/tests/base/modules/test_transformer.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import logging
 import sys
+from copy import deepcopy
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -245,22 +246,30 @@ class TestWarnOnUnsupportedAttentionConfig:
         ],
     )
     def test_warn_on_unsupported_attention_config(
-        self, caplog, monkeypatch, param, value, support_flag, min_version, set_on, supports, expect_warn
+        self,
+        caplog,
+        monkeypatch,
+        bert_tiny_transformer,
+        param,
+        value,
+        support_flag,
+        min_version,
+        set_on,
+        supports,
+        expect_warn,
     ):
-        from transformers import AutoConfig
-
         monkeypatch.setattr(transformer_module, support_flag, supports)
-        config = AutoConfig.from_pretrained(TINY_BERT)
+        config = bert_tiny_transformer.config
         if set_on == "main":
             setattr(config, param, value)
         elif set_on == "sub":
-            sub = AutoConfig.from_pretrained(TINY_BERT)
+            sub = deepcopy(config)
             setattr(sub, param, value)
             config.sub_configs = {"text_config": type(sub)}
             config.text_config = sub
 
         with caplog.at_level(logging.WARNING):
-            Transformer._warn_on_unsupported_attention_config(None, config)
+            Transformer._warn_on_unsupported_attention_config(config)
 
         matching = [
             r

--- a/tests/base/modules/test_transformer.py
+++ b/tests/base/modules/test_transformer.py
@@ -221,6 +221,55 @@ class TestTransformerInit:
         assert transformer is not None
 
 
+class TestWarnOnUnsupportedAttentionConfig:
+    """Warn when the config requests attention settings not supported by the installed transformers version."""
+
+    _BIDIR = ("use_bidirectional_attention", True, "_TRANSFORMERS_SUPPORTS_USE_BIDIRECTIONAL_ATTENTION", "4.56.2")
+    _CAUSAL = ("is_causal", False, "_TRANSFORMERS_SUPPORTS_IS_CAUSAL_FALSE", "5.2.0")
+
+    @pytest.mark.parametrize(
+        ("param", "value", "support_flag", "min_version", "set_on", "supports", "expect_warn"),
+        [
+            # Warns when flag is set on the main config and version is unsupported
+            (*_BIDIR, "main", False, True),
+            (*_CAUSAL, "main", False, True),
+            # Warns when flag is set on a sub-config (e.g. multimodal text_config)
+            (*_BIDIR, "sub", False, True),
+            (*_CAUSAL, "sub", False, True),
+            # No warning when version supports the flag
+            (*_BIDIR, "main", True, False),
+            (*_CAUSAL, "main", True, False),
+            # No warning when flag is absent, even if version is unsupported
+            (*_BIDIR, None, False, False),
+            (*_CAUSAL, None, False, False),
+        ],
+    )
+    def test_warn_on_unsupported_attention_config(
+        self, caplog, monkeypatch, param, value, support_flag, min_version, set_on, supports, expect_warn
+    ):
+        from transformers import AutoConfig
+
+        monkeypatch.setattr(transformer_module, support_flag, supports)
+        config = AutoConfig.from_pretrained(TINY_BERT)
+        if set_on == "main":
+            setattr(config, param, value)
+        elif set_on == "sub":
+            sub = AutoConfig.from_pretrained(TINY_BERT)
+            setattr(sub, param, value)
+            config.sub_configs = {"text_config": type(sub)}
+            config.text_config = sub
+
+        with caplog.at_level(logging.WARNING):
+            Transformer._warn_on_unsupported_attention_config(None, config)
+
+        matching = [
+            r
+            for r in caplog.records
+            if f"{param}={value}" in r.message and f"transformers>={min_version}" in r.message
+        ]
+        assert bool(matching) is expect_warn
+
+
 class TestTransformerMaxSeqLength:
     """Test the max_seq_length property for both tokenizer-based and config-based models."""
 


### PR DESCRIPTION
Resolves #3725

Hello!

## Pull Request overview
* Warn when the installed `transformers` version silently ignores `use_bidirectional_attention=True` or `is_causal=False` in the model config

## Details
Some models (e.g. `google/embeddinggemma-300m`) rely on `use_bidirectional_attention=True` in their `config.json` to enable bidirectional attention. On `transformers<4.57.0` this flag is silently dropped into `**kwargs` and never read, so the model falls back to causal attention and produces noticeably degraded embeddings with no indication to the user. The same story applies to `is_causal=False`, which is only honored from `transformers>=5.2.0`.

After loading the config (and any sub-configs like `text_config` for multimodal models), I now check whether these flags are set and emit a `logger.warning` pointing users at the minimum `transformers` version they need to upgrade to. The version thresholds are `4.56.2` for `use_bidirectional_attention=True` and `5.2.0` for `is_causal=False`.

- Tom Aarsen
