### PR TITLE
[`ci`] Reduce hub calls in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,7 +19,10 @@ if is_datasets_available():
 # Sentence Transformers
 @pytest.fixture(scope="session")
 def _stsb_bert_tiny_model() -> SentenceTransformer:
-    model = SentenceTransformer("sentence-transformers-testing/stsb-bert-tiny-safetensors")
+    model_id = "sentence-transformers-testing/stsb-bert-tiny-safetensors"
+    model = SentenceTransformer(model_id)
+    if not model.model_card_data.base_model:
+        model.model_card_data.base_model = model_id
     model.model_card_data.generate_widget_examples = False  # Disable widget examples generation for testing
     return model
 
@@ -31,7 +34,10 @@ def stsb_bert_tiny_model(_stsb_bert_tiny_model: SentenceTransformer) -> Sentence
 
 @pytest.fixture(scope="session")
 def _avg_word_embeddings_levy() -> SentenceTransformer:
-    model = SentenceTransformer("sentence-transformers/average_word_embeddings_levy_dependency")
+    model_id = "sentence-transformers/average_word_embeddings_levy_dependency"
+    model = SentenceTransformer(model_id)
+    if not model.model_card_data.base_model:
+        model.model_card_data.base_model = model_id
     model.model_card_data.generate_widget_examples = False  # Disable widget examples generation for testing
     return model
 
@@ -58,7 +64,10 @@ def paraphrase_distilroberta_base_v1_model() -> SentenceTransformer:
 
 @pytest.fixture(scope="session")
 def _static_retrieval_mrl_en_v1_model() -> SentenceTransformer:
-    model = SentenceTransformer("sentence-transformers/static-retrieval-mrl-en-v1")
+    model_id = "sentence-transformers/static-retrieval-mrl-en-v1"
+    model = SentenceTransformer(model_id)
+    if not model.model_card_data.base_model:
+        model.model_card_data.base_model = model_id
     return model
 
 
@@ -74,9 +83,12 @@ def clip_vit_b_32_model() -> SentenceTransformer:
 
 @pytest.fixture(scope="session")
 def _distilbert_base_uncased_model() -> SentenceTransformer:
-    word_embedding_model = Transformer("distilbert/distilbert-base-uncased")
+    model_id = "distilbert/distilbert-base-uncased"
+    word_embedding_model = Transformer(model_id)
     pooling_model = Pooling(word_embedding_model.get_embedding_dimension())
     model = SentenceTransformer(modules=[word_embedding_model, pooling_model])
+    if not model.model_card_data.base_model:
+        model.model_card_data.base_model = model_id
     return model
 
 
@@ -88,7 +100,10 @@ def distilbert_base_uncased_model(_distilbert_base_uncased_model: SentenceTransf
 # Cross Encoders
 @pytest.fixture(scope="session")
 def _reranker_bert_tiny_model() -> CrossEncoder:
-    model = CrossEncoder("cross-encoder-testing/reranker-bert-tiny-gooaq-bce")
+    model_id = "cross-encoder-testing/reranker-bert-tiny-gooaq-bce"
+    model = CrossEncoder(model_id)
+    if not model.model_card_data.base_model:
+        model.model_card_data.base_model = model_id
     model.model_card_data.generate_widget_examples = False  # Disable widget examples generation for testing
     return model
 
@@ -101,7 +116,10 @@ def reranker_bert_tiny_model(_reranker_bert_tiny_model) -> CrossEncoder:
 # Sparse Encoders
 @pytest.fixture(scope="session")
 def _splade_bert_tiny_model() -> SparseEncoder:
-    model = SparseEncoder("sparse-encoder-testing/splade-bert-tiny-nq")
+    model_id = "sparse-encoder-testing/splade-bert-tiny-nq"
+    model = SparseEncoder(model_id)
+    if not model.model_card_data.base_model:
+        model.model_card_data.base_model = model_id
     model.model_card_data.generate_widget_examples = False  # Disable widget examples generation for testing
     return model
 
@@ -113,7 +131,10 @@ def splade_bert_tiny_model(_splade_bert_tiny_model: SparseEncoder) -> SparseEnco
 
 @pytest.fixture(scope="session")
 def _inference_free_splade_bert_tiny_model() -> SparseEncoder:
-    model = SparseEncoder("sparse-encoder-testing/inference-free-splade-bert-tiny-nq")
+    model_id = "sparse-encoder-testing/inference-free-splade-bert-tiny-nq"
+    model = SparseEncoder(model_id)
+    if not model.model_card_data.base_model:
+        model.model_card_data.base_model = model_id
     model.model_card_data.generate_widget_examples = False  # Disable widget examples generation for testing
     return model
 
@@ -125,7 +146,10 @@ def inference_free_splade_bert_tiny_model(_inference_free_splade_bert_tiny_model
 
 @pytest.fixture(scope="session")
 def _csr_bert_tiny_model() -> SparseEncoder:
-    model = SparseEncoder("sentence-transformers-testing/stsb-bert-tiny-safetensors")
+    model_id = "sentence-transformers-testing/stsb-bert-tiny-safetensors"
+    model = SparseEncoder(model_id)
+    if not model.model_card_data.base_model:
+        model.model_card_data.base_model = model_id
     model[-1].k = 16
     model[-1].k_aux = 32
     model.model_card_data.generate_widget_examples = False  # Disable widget examples generation for testing

--- a/tests/sparse_encoder/test_opensearch_models.py
+++ b/tests/sparse_encoder/test_opensearch_models.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+import pytest
 import torch
 
 from sentence_transformers.sparse_encoder import SparseEncoder
 from sentence_transformers.sparse_encoder.modules import Router, SparseStaticEmbedding, SpladePooling, Transformer
 
 
+@pytest.mark.slow
 def test_opensearch_v2_distill_similarity():
     """Test OpenSearch v2 distill model produces expected similarity scores."""
     # Setup the model
@@ -81,6 +83,7 @@ def test_opensearch_v2_distill_similarity():
         )
 
 
+@pytest.mark.slow
 def test_opensearch_v3_distill_similarity():
     """Test OpenSearch v3 distill model produces expected similarity scores."""
     # Setup the model

--- a/tests/sparse_encoder/test_pretrained.py
+++ b/tests/sparse_encoder/test_pretrained.py
@@ -132,7 +132,7 @@ def test_pretrained_model_bf16_sdpa(
 @pytest.mark.parametrize(
     "model_name",
     [
-        ("sentence-transformers/all-MiniLM-L6-v2"),
+        ("sentence-transformers-testing/stsb-bert-tiny-safetensors"),
     ],
 )
 def test_load_and_encode(model_name: str) -> None:

--- a/tests/util/test_retrieval.py
+++ b/tests/util/test_retrieval.py
@@ -32,6 +32,7 @@ def test_semantic_search() -> None:
             assert np.abs(hits[qid][hit_num]["score"] - cos_scores_values[qid][hit_num]) < 0.001
 
 
+@pytest.mark.slow
 def test_paraphrase_mining() -> None:
     model = SentenceTransformer("sentence-transformers/all-MiniLM-L6-v2")
     sentences = [


### PR DESCRIPTION
Hello!

## Pull Request overview
* Mark tests that load production Hub models as `@pytest.mark.slow` so they don't run in default CI
* Fall back to a known `base_model` id in session-scoped model fixtures when the Hub call in `set_base_model` was rate-limited

## Details
CI occasionally hits `429 Too Many Requests` and the same handful of tests fail. `test_opensearch_v{2,3}_distill_similarity` and `test_paraphrase_mining` both need real pretrained models to be meaningful, so they're now `@pytest.mark.slow` alongside the similar `test_pretrained_model_bf16_sdpa`. `test_load_and_encode` only verified that `SparseEncoder` can wrap a base model, so it now uses `sentence-transformers-testing/stsb-bert-tiny-safetensors` (already cache-warm via other fixtures) instead of `all-MiniLM-L6-v2`.

`test_model_card_base` was flakier: `set_base_model` calls `huggingface_hub.model_info` during fixture load to fetch the canonical id and revision SHA, and when that gets rate-limited it silently leaves `base_model=None`, so the rendered card says "trained using" instead of "finetuned from [...]" and the substring assertion fails. The session-scoped fixtures in `tests/conftest.py` now set `base_model` themselves as a fallback .

- Tom Aarsen
