### PR TITLE
[`tests`] Future-proof getting model keys as MODEL_MAPPING_NAMES is being removed

### DIFF
--- a/tests/base/modules/transformer/test_any_to_any.py
+++ b/tests/base/modules/transformer/test_any_to_any.py
@@ -34,9 +34,18 @@ from .conftest import (
 )
 
 try:
-    from transformers.models.auto.modeling_auto import MODEL_FOR_MULTIMODAL_LM_MAPPING_NAMES, MODEL_MAPPING_NAMES
+    from transformers.models.auto.modeling_auto import MODEL_FOR_MULTIMODAL_LM_MAPPING_NAMES
 except ImportError:
     pytest.skip("any-to-any requires transformers v5+", allow_module_level=True)
+
+try:
+    from transformers.models.auto.modeling_auto import MODEL_MAPPING_NAMES
+
+    MODEL_KEYS = list(MODEL_MAPPING_NAMES.keys())
+except ImportError:
+    from transformers.models.auto.configuration_auto import CONFIG_MAPPING_NAMES
+
+    MODEL_KEYS = list(CONFIG_MAPPING_NAMES.keys())
 
 
 EXPECT_FORWARD_FAIL = EXPECT_FORWARD_FAIL.copy() | {
@@ -71,7 +80,7 @@ def _get_any_to_any_archs() -> list[str]:
         and (key not in TRANSFORMERS_V4_XFAIL_ARCHITECTURES or Version(transformers_version) >= Version("5.0.0"))
         and key not in FAULTY_CHECKPOINTS
         and key in MODEL_FOR_MULTIMODAL_LM_MAPPING_NAMES
-        and key in MODEL_MAPPING_NAMES
+        and key in MODEL_KEYS
     ]
 
 

--- a/tests/base/modules/transformer/test_feature_extraction.py
+++ b/tests/base/modules/transformer/test_feature_extraction.py
@@ -15,7 +15,15 @@ import pytest
 import torch
 from packaging.version import Version
 from transformers import __version__ as transformers_version
-from transformers.models.auto.modeling_auto import MODEL_MAPPING_NAMES
+
+try:
+    from transformers.models.auto.modeling_auto import MODEL_MAPPING_NAMES
+
+    MODEL_KEYS = list(MODEL_MAPPING_NAMES.keys())
+except ImportError:
+    from transformers.models.auto.configuration_auto import CONFIG_MAPPING_NAMES
+
+    MODEL_KEYS = list(CONFIG_MAPPING_NAMES.keys())
 
 from sentence_transformers.base.modality_types import Modality
 from sentence_transformers.base.model import BaseModel
@@ -59,7 +67,7 @@ XFAIL_FEATURE_EXTRACTION = [
         and key not in XFAIL_FEATURE_EXTRACTION
         and (key not in TRANSFORMERS_V4_XFAIL_ARCHITECTURES or Version(transformers_version) >= Version("5.0.0"))
         and key not in FAULTY_CHECKPOINTS
-        and key in MODEL_MAPPING_NAMES
+        and key in MODEL_KEYS
     ],
     scope="class",
 )

--- a/tests/base/modules/transformer/test_fill_mask.py
+++ b/tests/base/modules/transformer/test_fill_mask.py
@@ -12,7 +12,16 @@ import pytest
 import torch
 from packaging.version import Version
 from transformers import __version__ as transformers_version
-from transformers.models.auto.modeling_auto import MODEL_FOR_MASKED_LM_MAPPING_NAMES, MODEL_MAPPING_NAMES
+from transformers.models.auto.modeling_auto import MODEL_FOR_MASKED_LM_MAPPING_NAMES
+
+try:
+    from transformers.models.auto.modeling_auto import MODEL_MAPPING_NAMES
+
+    MODEL_KEYS = list(MODEL_MAPPING_NAMES.keys())
+except ImportError:
+    from transformers.models.auto.configuration_auto import CONFIG_MAPPING_NAMES
+
+    MODEL_KEYS = list(CONFIG_MAPPING_NAMES.keys())
 
 from sentence_transformers.base.modules import Transformer
 from sentence_transformers.util.tensor import batch_to_device
@@ -43,7 +52,7 @@ def _get_fill_mask_archs() -> list[str]:
         and (key not in TRANSFORMERS_V4_XFAIL_ARCHITECTURES or Version(transformers_version) >= Version("5.0.0"))
         and key not in FAULTY_CHECKPOINTS
         and key in MODEL_FOR_MASKED_LM_MAPPING_NAMES
-        and key in MODEL_MAPPING_NAMES
+        and key in MODEL_KEYS
     ]
 
 

--- a/tests/base/modules/transformer/test_sequence_classification.py
+++ b/tests/base/modules/transformer/test_sequence_classification.py
@@ -12,10 +12,16 @@ import pytest
 import torch
 from packaging.version import Version
 from transformers import __version__ as transformers_version
-from transformers.models.auto.modeling_auto import (
-    MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING_NAMES,
-    MODEL_MAPPING_NAMES,
-)
+from transformers.models.auto.modeling_auto import MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING_NAMES
+
+try:
+    from transformers.models.auto.modeling_auto import MODEL_MAPPING_NAMES
+
+    MODEL_KEYS = list(MODEL_MAPPING_NAMES.keys())
+except ImportError:
+    from transformers.models.auto.configuration_auto import CONFIG_MAPPING_NAMES
+
+    MODEL_KEYS = list(CONFIG_MAPPING_NAMES.keys())
 
 from sentence_transformers.base.modules import Transformer
 from sentence_transformers.util.tensor import batch_to_device
@@ -55,7 +61,7 @@ def _get_seq_cls_archs() -> list[str]:
         and (key not in TRANSFORMERS_V4_XFAIL_ARCHITECTURES or Version(transformers_version) >= Version("5.0.0"))
         and key not in FAULTY_CHECKPOINTS
         and key in MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING_NAMES
-        and key in MODEL_MAPPING_NAMES  # Ensure we also have a base model
+        and key in MODEL_KEYS  # Ensure we also have a base model
     ]
 
 

--- a/tests/base/modules/transformer/test_text_generation.py
+++ b/tests/base/modules/transformer/test_text_generation.py
@@ -12,7 +12,16 @@ import pytest
 import torch
 from packaging.version import Version
 from transformers import __version__ as transformers_version
-from transformers.models.auto.modeling_auto import MODEL_FOR_CAUSAL_LM_MAPPING_NAMES, MODEL_MAPPING_NAMES
+from transformers.models.auto.modeling_auto import MODEL_FOR_CAUSAL_LM_MAPPING_NAMES
+
+try:
+    from transformers.models.auto.modeling_auto import MODEL_MAPPING_NAMES
+
+    MODEL_KEYS = list(MODEL_MAPPING_NAMES.keys())
+except ImportError:
+    from transformers.models.auto.configuration_auto import CONFIG_MAPPING_NAMES
+
+    MODEL_KEYS = list(CONFIG_MAPPING_NAMES.keys())
 
 from sentence_transformers.base.modules import Transformer
 from sentence_transformers.util.tensor import batch_to_device
@@ -51,7 +60,7 @@ def _get_text_generation_archs() -> list[str]:
         and (key not in TRANSFORMERS_V4_XFAIL_ARCHITECTURES or Version(transformers_version) >= Version("5.0.0"))
         and key not in FAULTY_CHECKPOINTS
         and key in MODEL_FOR_CAUSAL_LM_MAPPING_NAMES
-        and key in MODEL_MAPPING_NAMES
+        and key in MODEL_KEYS
     ]
 
 

--- a/tests/base/modules/transformer/update_transformers_tiny_models.py
+++ b/tests/base/modules/transformer/update_transformers_tiny_models.py
@@ -5,7 +5,15 @@ import time
 from pathlib import Path
 
 from huggingface_hub import list_models
-from transformers.models.auto.modeling_auto import MODEL_MAPPING_NAMES
+
+try:
+    from transformers.models.auto.modeling_auto import MODEL_MAPPING_NAMES
+
+    MODEL_KEYS = list(MODEL_MAPPING_NAMES.keys())
+except ImportError:
+    from transformers.models.auto.configuration_auto import CONFIG_MAPPING_NAMES
+
+    MODEL_KEYS = list(CONFIG_MAPPING_NAMES.keys())
 
 
 def find_model_for_architecture(architecture):
@@ -89,7 +97,7 @@ if __name__ == "__main__":
         tiny_model_mapping = json.load(f)
 
     # Add any missing architectures with None value
-    for arch in sorted(set(MODEL_MAPPING_NAMES.keys()) - set(tiny_model_mapping.keys())):
+    for arch in sorted(set(MODEL_KEYS) - set(tiny_model_mapping.keys())):
         tiny_model_mapping[arch] = None
     tiny_model_mapping = dict(sorted(tiny_model_mapping.items()))
 


### PR DESCRIPTION
Hello!

## Pull Request overview
* Future-proof tests against the upcoming removal of `MODEL_MAPPING_NAMES` in `transformers`

## Details
A future `transformers` release will remove `MODEL_MAPPING_NAMES`. The affected test files use it only to filter architectures, so I wrap the import in a `try`/`except ImportError` and fall back to `CONFIG_MAPPING_NAMES` (a superset of the same keys), exposing the keys as a `MODEL_KEYS` list.

- Tom Aarsen
