### PR TITLE
Unwrap audio/video inside multimodal dict inputs

### DIFF
--- a/sentence_transformers/base/modality.py
+++ b/sentence_transformers/base/modality.py
@@ -12,10 +12,12 @@ import numpy as np
 import torch
 
 from sentence_transformers.base.modality_types import (
+    AudioInput,
     MessageFormat,
     Modality,
     PairInput,
     SingleInput,
+    VideoInput,
 )
 
 try:
@@ -97,6 +99,43 @@ def _is_non_text_pair(sample: Any) -> bool:
         if isinstance(elem, list) and elem and isinstance(elem[0], dict):
             return False
     return True
+
+
+def _unwrap_audio(audio_value: AudioInput, extra_modality_kwargs: dict[str, dict[str, Any]]) -> Any:
+    """Unwrap dict-wrapped audio or an ``AudioDecoder`` into a raw array, collecting ``sampling_rate``.
+
+    Passes through unchanged if ``audio_value`` is already a raw array/tensor/URL/path.
+    """
+    if isinstance(audio_value, dict):
+        extra_modality_kwargs["audio"]["sampling_rate"] = audio_value["sampling_rate"]
+        return audio_value["array"]
+    if AudioDecoder is not None and isinstance(audio_value, AudioDecoder):
+        samples = audio_value.get_all_samples()
+        # AudioDecoder returns (channels, samples); mean over channels to get 1D numpy
+        extra_modality_kwargs["audio"]["sampling_rate"] = samples.sample_rate
+        return samples.data.mean(dim=0).numpy()
+    return audio_value
+
+
+def _unwrap_video(video_value: VideoInput, extra_modality_kwargs: dict[str, dict[str, Any]]) -> Any:
+    """Unwrap dict-wrapped video or a ``VideoDecoder`` into a raw array, collecting ``video_metadata``.
+
+    Passes through unchanged if ``video_value`` is already a raw array/tensor/URL/path.
+    """
+    if isinstance(video_value, dict):
+        extra_modality_kwargs["video"].setdefault("video_metadata", []).append(video_value["video_metadata"])
+        return video_value["array"]
+    if VideoDecoder is not None and isinstance(video_value, VideoDecoder):
+        frame_batch = video_value.get_frames_in_range(0, len(video_value))
+        extra_modality_kwargs["video"].setdefault("video_metadata", []).append(
+            {
+                "fps": video_value.metadata.average_fps,
+                "total_num_frames": video_value.metadata.num_frames,
+                "frames_indices": list(range(frame_batch.data.shape[0])),
+            }
+        )
+        return frame_batch.data
+    return video_value
 
 
 class InputFormatter:
@@ -222,30 +261,19 @@ class InputFormatter:
 
             modality = infer_modality(item, supported_modalities=self.supported_modalities)  # type: ignore[arg-type]  # non-text pairs filtered above
 
-            # For dict-wrapped audio/video, unwrap the array and collect extra kwargs.
-            # For a single message dict, wrap it in a list. All other values pass through as-is.
-            if modality == "audio" and isinstance(item, dict):
-                value = item["array"]
-                extra_modality_kwargs["audio"]["sampling_rate"] = item["sampling_rate"]
-            elif modality == "audio" and AudioDecoder is not None and isinstance(item, AudioDecoder):
-                samples = item.get_all_samples()
-                # AudioDecoder returns (channels, samples); mean over channels to get 1D numpy
-                value = samples.data.mean(dim=0).numpy()
-                extra_modality_kwargs["audio"]["sampling_rate"] = samples.sample_rate
-            elif modality == "video" and isinstance(item, dict):
-                value = item["array"]
-                extra_modality_kwargs["video"].setdefault("video_metadata", []).append(item["video_metadata"])
-            elif modality == "video" and VideoDecoder is not None and isinstance(item, VideoDecoder):
-                num_frames = len(item)
-                frame_batch = item.get_frames_in_range(0, num_frames)
-                value = frame_batch.data
-                extra_modality_kwargs["video"].setdefault("video_metadata", []).append(
-                    {
-                        "fps": item.metadata.average_fps,
-                        "total_num_frames": item.metadata.num_frames,
-                        "frames_indices": list(range(frame_batch.data.shape[0])),
-                    }
-                )
+            # For dict-wrapped audio/video (including inside a multimodal dict), unwrap the array
+            # and collect extra kwargs. For a single message dict, wrap it in a list.
+            # All other values pass through as-is.
+            if modality == "audio":
+                value = _unwrap_audio(item, extra_modality_kwargs)
+            elif modality == "video":
+                value = _unwrap_video(item, extra_modality_kwargs)
+            elif isinstance(modality, tuple):
+                value = dict(item)
+                if "audio" in value:
+                    value["audio"] = _unwrap_audio(value["audio"], extra_modality_kwargs)
+                if "video" in value:
+                    value["video"] = _unwrap_video(value["video"], extra_modality_kwargs)
             elif modality == "message" and isinstance(item, dict):
                 value = [item]
             else:

--- a/sentence_transformers/base/modality.py
+++ b/sentence_transformers/base/modality.py
@@ -107,7 +107,8 @@ def _unwrap_audio(audio_value: AudioInput, extra_modality_kwargs: dict[str, dict
     Passes through unchanged if ``audio_value`` is already a raw array/tensor/URL/path.
     """
     if isinstance(audio_value, dict):
-        extra_modality_kwargs["audio"]["sampling_rate"] = audio_value["sampling_rate"]
+        if "sampling_rate" in audio_value:
+            extra_modality_kwargs["audio"]["sampling_rate"] = audio_value["sampling_rate"]
         return audio_value["array"]
     if AudioDecoder is not None and isinstance(audio_value, AudioDecoder):
         samples = audio_value.get_all_samples()
@@ -123,7 +124,8 @@ def _unwrap_video(video_value: VideoInput, extra_modality_kwargs: dict[str, dict
     Passes through unchanged if ``video_value`` is already a raw array/tensor/URL/path.
     """
     if isinstance(video_value, dict):
-        extra_modality_kwargs["video"].setdefault("video_metadata", []).append(video_value["video_metadata"])
+        if "video_metadata" in video_value:
+            extra_modality_kwargs["video"].setdefault("video_metadata", []).append(video_value["video_metadata"])
         return video_value["array"]
     if VideoDecoder is not None and isinstance(video_value, VideoDecoder):
         frame_batch = video_value.get_frames_in_range(0, len(video_value))

--- a/tests/base/test_modality.py
+++ b/tests/base/test_modality.py
@@ -640,9 +640,7 @@ class TestParseInputs:
                 stream.height = height
                 stream.pix_fmt = "yuv420p"
                 for _ in range(num_frames):
-                    frame = av.VideoFrame.from_ndarray(
-                        np.zeros((height, width, 3), dtype=np.uint8), format="rgb24"
-                    )
+                    frame = av.VideoFrame.from_ndarray(np.zeros((height, width, 3), dtype=np.uint8), format="rgb24")
                     for packet in stream.encode(frame):
                         container.mux(packet)
                 for packet in stream.encode():

--- a/tests/base/test_modality.py
+++ b/tests/base/test_modality.py
@@ -633,17 +633,22 @@ class TestParseInputs:
 
         num_frames, fps, height, width = 4, 30, 32, 32
         buf = io.BytesIO()
-        with av.open(buf, mode="w", format="mp4") as container:
-            stream = container.add_stream("h264", rate=fps)
-            stream.width = width
-            stream.height = height
-            stream.pix_fmt = "yuv420p"
-            for _ in range(num_frames):
-                frame = av.VideoFrame.from_ndarray(np.zeros((height, width, 3), dtype=np.uint8), format="rgb24")
-                for packet in stream.encode(frame):
+        try:
+            with av.open(buf, mode="w", format="mp4") as container:
+                stream = container.add_stream("h264", rate=fps)
+                stream.width = width
+                stream.height = height
+                stream.pix_fmt = "yuv420p"
+                for _ in range(num_frames):
+                    frame = av.VideoFrame.from_ndarray(
+                        np.zeros((height, width, 3), dtype=np.uint8), format="rgb24"
+                    )
+                    for packet in stream.encode(frame):
+                        container.mux(packet)
+                for packet in stream.encode():
                     container.mux(packet)
-            for packet in stream.encode():
-                container.mux(packet)
+        except Exception as exc:
+            pytest.skip(f"H.264 encoding support is unavailable in this PyAV/FFmpeg build: {exc}")
         decoder = VideoDecoder(torch.frombuffer(buf.getvalue(), dtype=torch.uint8))
 
         modality, inputs, extra = self.fmt.parse_inputs([{"video": decoder}])

--- a/tests/base/test_modality.py
+++ b/tests/base/test_modality.py
@@ -562,6 +562,95 @@ class TestParseInputs:
         modality, inputs, extra = self.fmt.parse_inputs(dicts)
         assert list(inputs.keys()) == ["image", "text"]
 
+    def test_multimodal_dict_audio_only_wrapper_raw_array(self):
+        """A ``{"audio": array}`` wrapper with a raw array should behave like bare audio inputs."""
+        arr = np.zeros(16000)
+        modality, inputs, extra = self.fmt.parse_inputs([{"audio": arr}])
+        assert modality == ("audio",)
+        assert len(inputs["audio"]) == 1
+        assert inputs["audio"][0] is arr
+        assert dict(extra) == {}
+
+    def test_multimodal_dict_unwraps_nested_audio_dict(self):
+        """A ``{"audio": {"array": ..., "sampling_rate": ...}}`` wrapper should unwrap the nested dict."""
+        arr = np.zeros(16000)
+        modality, inputs, extra = self.fmt.parse_inputs([{"audio": {"array": arr, "sampling_rate": 16000}}])
+        assert modality == ("audio",)
+        assert len(inputs["audio"]) == 1
+        assert inputs["audio"][0] is arr
+        assert extra["audio"]["sampling_rate"] == 16000
+
+    def test_multimodal_dict_unwraps_nested_video_dict(self):
+        """A ``{"video": {"array": ..., "video_metadata": ...}}`` wrapper should unwrap the nested dict."""
+        arr = np.zeros((8, 3, 224, 224))
+        modality, inputs, extra = self.fmt.parse_inputs([{"video": {"array": arr, "video_metadata": {"fps": 30}}}])
+        assert modality == ("video",)
+        assert len(inputs["video"]) == 1
+        assert inputs["video"][0] is arr
+        assert extra["video"]["video_metadata"] == [{"fps": 30}]
+
+    def test_multimodal_dict_unwraps_audio_alongside_text(self):
+        """Audio should unwrap even when combined with other modalities in the same dict."""
+        arr = np.zeros(16000)
+        modality, inputs, extra = self.fmt.parse_inputs(
+            [{"audio": {"array": arr, "sampling_rate": 16000}, "text": "describe this"}]
+        )
+        assert modality == ("audio", "text")
+        assert inputs["audio"][0] is arr
+        assert inputs["text"] == ["describe this"]
+        assert extra["audio"]["sampling_rate"] == 16000
+
+    def test_multimodal_dict_unwraps_audio_decoder(self):
+        """A ``{"audio": AudioDecoder}`` wrapper should unwrap the decoder into a raw array."""
+        pytest.importorskip("torchcodec")
+        import io
+        import wave
+
+        from torchcodec.decoders import AudioDecoder
+
+        sample_rate = 16000
+        pcm = np.zeros(sample_rate, dtype=np.int16)
+        buf = io.BytesIO()
+        with wave.open(buf, "wb") as f:
+            f.setnchannels(1)
+            f.setsampwidth(2)
+            f.setframerate(sample_rate)
+            f.writeframes(pcm.tobytes())
+        decoder = AudioDecoder(torch.frombuffer(buf.getvalue(), dtype=torch.uint8))
+
+        modality, inputs, extra = self.fmt.parse_inputs([{"audio": decoder}])
+        assert modality == ("audio",)
+        assert isinstance(inputs["audio"][0], np.ndarray)
+        assert extra["audio"]["sampling_rate"] == sample_rate
+
+    def test_multimodal_dict_unwraps_video_decoder(self):
+        """A ``{"video": VideoDecoder}`` wrapper should unwrap the decoder and collect metadata."""
+        pytest.importorskip("torchcodec")
+        av = pytest.importorskip("av")
+        import io
+
+        from torchcodec.decoders import VideoDecoder
+
+        num_frames, fps, height, width = 4, 30, 32, 32
+        buf = io.BytesIO()
+        with av.open(buf, mode="w", format="mp4") as container:
+            stream = container.add_stream("h264", rate=fps)
+            stream.width = width
+            stream.height = height
+            stream.pix_fmt = "yuv420p"
+            for _ in range(num_frames):
+                frame = av.VideoFrame.from_ndarray(np.zeros((height, width, 3), dtype=np.uint8), format="rgb24")
+                for packet in stream.encode(frame):
+                    container.mux(packet)
+            for packet in stream.encode():
+                container.mux(packet)
+        decoder = VideoDecoder(torch.frombuffer(buf.getvalue(), dtype=torch.uint8))
+
+        modality, inputs, extra = self.fmt.parse_inputs([{"video": decoder}])
+        assert modality == ("video",)
+        assert inputs["video"][0].shape[0] == num_frames
+        assert extra["video"]["video_metadata"][0]["total_num_frames"] == num_frames
+
     def test_mixed_modalities_batch_to_message(self):
         PIL = pytest.importorskip("PIL.Image")
         img = PIL.new("RGB", (10, 10))


### PR DESCRIPTION
Resolves #3732

Hello!

## Pull Request overview
* Unwrap dict-wrapped and `AudioDecoder`/`VideoDecoder`-wrapped audio/video inside multimodal dict inputs

## Details
Previously, an input like `{"audio": {"array": arr, "sampling_rate": 16000}, "text": "describe this"}` would reach the processor with the inner audio dict still wrapped. The unwrap branches in `InputFormatter.parse_inputs` only fired when the input was not a multimodal dict. 

I pulled the unwrap logic (i.e. grabbing the array and placing `sampling_rate` etc. into `extra_modality_kwargs`) out into `_unwrap_audio` and `_unwrap_video` helpers and added a new branch for `isinstance(modality, tuple)` that walks the multimodal dict and unwraps any `"audio"`/`"video"` entries in place, while still falling through for raw arrays, tensors, URLs, and paths. The standalone audio/video branches now reuse the same helpers, so the behavior for bare inputs like `{"array": arr, "sampling_rate": 16000}` or an `AudioDecoder` is unchanged.

Tests cover the raw-array pass-through, nested dict unwrap, `AudioDecoder`/`VideoDecoder` unwrap, and the audio-alongside-text case inside a single multimodal dict.

cc @Samoed 

The three snippets from #3732 now pass, so long as you update the 2nd audio snippet to use `decoder = make_random_audio_decoder(sample_rate=16_000)` (as the processor requires 16khz)

Also, this is a bit of an unrelated sidenote, but the bothersome
```
WARNING:root:System prompt modified, audio output may not work as expected. Audio output mode only works when using default system prompt 'You are Qwen, a virtual human developed by the Qwen Team, Alibaba Group, capable of perceiving auditory and visual inputs, as well as generating text and speech.'
```
will stop triggering in the next version of `transformers`.

- Tom Aarsen
