### PR TITLE
Be less specific in CE model card template

### DIFF
--- a/sentence_transformers/cross_encoder/model_card_template.md
+++ b/sentence_transformers/cross_encoder/model_card_template.md
@@ -215,7 +215,7 @@ Carbon emissions were measured using [CodeCarbon](https://github.com/mlco2/codec
 
 - [Training and Finetuning Reranker Models with Sentence Transformers](https://huggingface.co/blog/train-reranker): the end-to-end guide for training or finetuning Cross Encoder (reranker) models.
 - [Multimodal Embedding & Reranker Models with Sentence Transformers](https://huggingface.co/blog/multimodal-sentence-transformers): use text, image, audio, and video reranker models through the same API.
-- [Training and Finetuning Multimodal Embedding & Reranker Models with Sentence Transformers](https://huggingface.co/blog/train-multimodal-sentence-transformers): training multimodal Cross Encoders, including Any-to-Any and Feature Extraction architectures.
+- [Training and Finetuning Multimodal Embedding & Reranker Models with Sentence Transformers](https://huggingface.co/blog/train-multimodal-sentence-transformers): training multimodal Cross Encoders.
 
 ## Citation
 


### PR DESCRIPTION
Hello!

## Pull Request overview
* Be less specific in CE model card template

## Details
I don't want to be so specific with the various supported architectures after this link, just training multimodal CrossEncoders is fine.

- Tom Aarsen