### PR TITLE
[`model card`] stats are computed over 100 samples, not 1000

### DIFF
--- a/sentence_transformers/base/model_card_template.md
+++ b/sentence_transformers/base/model_card_template.md
@@ -147,7 +147,7 @@ You can finetune this model on your own dataset.
 {%- if 'revision' in dataset and 'id' in dataset %} at [{{ dataset['revision'][:7] }}](https://huggingface.co/datasets/{{ dataset['id'] }}/tree/{{ dataset['revision'] }}){% endif %}{% endif %}
 {% if dataset['size'] %}* Size: {{ "{:,}".format(dataset['size']) }} {{ dataset_type }} samples
 {% endif %}* Columns: {% if dataset['columns'] | length == 1 %}{{ dataset['columns'][0] }}{% elif dataset['columns'] | length == 2 %}{{ dataset['columns'][0] }} and {{ dataset['columns'][1] }}{% else %}{{ dataset['columns'][:-1] | join(', ') }}, and {{ dataset['columns'][-1] }}{% endif %}
-{% if dataset['stats_table'] %}* Approximate statistics based on the first {{ [dataset['size'], 1000] | min }} samples:
+{% if dataset['stats_table'] %}* Approximate statistics based on the first {{ [dataset['size'], 100] | min }} samples:
 {{ dataset['stats_table'] }}{% endif %}{% if dataset['examples_table'] %}* Samples:
 {{ dataset['examples_table'] }}{% endif %}* Loss: {% if dataset["loss"]["fullname"].startswith("sentence_transformers.") %}[<code>{{ dataset["loss"]["fullname"].split(".")[-1] }}</code>](https://sbert.net/docs/package_reference/sentence_transformer/losses.html#{{ dataset["loss"]["fullname"].split(".")[-1].lower() }}){% else %}<code>{{ dataset["loss"]["fullname"] }}</code>{% endif %}{% if "config_code" in dataset["loss"] %} with these parameters:
 {{ dataset["loss"]["config_code"] }}{% endif %}

--- a/sentence_transformers/cross_encoder/model_card_template.md
+++ b/sentence_transformers/cross_encoder/model_card_template.md
@@ -149,7 +149,7 @@ You can finetune this model on your own dataset.
 {%- if 'revision' in dataset and 'id' in dataset %} at [{{ dataset['revision'][:7] }}](https://huggingface.co/datasets/{{ dataset['id'] }}/tree/{{ dataset['revision'] }}){% endif %}{% endif %}
 {% if dataset['size'] %}* Size: {{ "{:,}".format(dataset['size']) }} {{ dataset_type }} samples
 {% endif %}* Columns: {% if dataset['columns'] | length == 1 %}{{ dataset['columns'][0] }}{% elif dataset['columns'] | length == 2 %}{{ dataset['columns'][0] }} and {{ dataset['columns'][1] }}{% else %}{{ dataset['columns'][:-1] | join(', ') }}, and {{ dataset['columns'][-1] }}{% endif %}
-{% if dataset['stats_table'] %}* Approximate statistics based on the first {{ [dataset['size'], 1000] | min }} samples:
+{% if dataset['stats_table'] %}* Approximate statistics based on the first {{ [dataset['size'], 100] | min }} samples:
 {{ dataset['stats_table'] }}{% endif %}{% if dataset['examples_table'] %}* Samples:
 {{ dataset['examples_table'] }}{% endif %}* Loss: {% if dataset["loss"]["fullname"].startswith("sentence_transformers.") %}[<code>{{ dataset["loss"]["fullname"].split(".")[-1] }}</code>](https://sbert.net/docs/package_reference/cross_encoder/losses.html#{{ dataset["loss"]["fullname"].split(".")[-1].lower() }}){% else %}<code>{{ dataset["loss"]["fullname"] }}</code>{% endif %}{% if "config_code" in dataset["loss"] %} with these parameters:
 {{ dataset["loss"]["config_code"] }}{% endif %}

--- a/sentence_transformers/sentence_transformer/model_card_template.md
+++ b/sentence_transformers/sentence_transformer/model_card_template.md
@@ -147,7 +147,7 @@ You can finetune this model on your own dataset.
 {%- if 'revision' in dataset and 'id' in dataset %} at [{{ dataset['revision'][:7] }}](https://huggingface.co/datasets/{{ dataset['id'] }}/tree/{{ dataset['revision'] }}){% endif %}{% endif %}
 {% if dataset['size'] %}* Size: {{ "{:,}".format(dataset['size']) }} {{ dataset_type }} samples
 {% endif %}* Columns: {% if dataset['columns'] | length == 1 %}{{ dataset['columns'][0] }}{% elif dataset['columns'] | length == 2 %}{{ dataset['columns'][0] }} and {{ dataset['columns'][1] }}{% else %}{{ dataset['columns'][:-1] | join(', ') }}, and {{ dataset['columns'][-1] }}{% endif %}
-{% if dataset['stats_table'] %}* Approximate statistics based on the first {{ [dataset['size'], 1000] | min }} samples:
+{% if dataset['stats_table'] %}* Approximate statistics based on the first {{ [dataset['size'], 100] | min }} samples:
 {{ dataset['stats_table'] }}{% endif %}{% if dataset['examples_table'] %}* Samples:
 {{ dataset['examples_table'] }}{% endif %}* Loss: {% if dataset["loss"]["fullname"].startswith("sentence_transformers.") %}[<code>{{ dataset["loss"]["fullname"].split(".")[-1] }}</code>](https://sbert.net/docs/package_reference/sentence_transformer/losses.html#{{ dataset["loss"]["fullname"].split(".")[-1].lower() }}){% else %}<code>{{ dataset["loss"]["fullname"] }}</code>{% endif %}{% if "config_code" in dataset["loss"] %} with these parameters:
 {{ dataset["loss"]["config_code"] }}{% endif %}

--- a/sentence_transformers/sparse_encoder/model_card_template.md
+++ b/sentence_transformers/sparse_encoder/model_card_template.md
@@ -147,7 +147,7 @@ You can finetune this model on your own dataset.
 {%- if 'revision' in dataset and 'id' in dataset %} at [{{ dataset['revision'][:7] }}](https://huggingface.co/datasets/{{ dataset['id'] }}/tree/{{ dataset['revision'] }}){% endif %}{% endif %}
 {% if dataset['size'] %}* Size: {{ "{:,}".format(dataset['size']) }} {{ dataset_type }} samples
 {% endif %}* Columns: {% if dataset['columns'] | length == 1 %}{{ dataset['columns'][0] }}{% elif dataset['columns'] | length == 2 %}{{ dataset['columns'][0] }} and {{ dataset['columns'][1] }}{% else %}{{ dataset['columns'][:-1] | join(', ') }}, and {{ dataset['columns'][-1] }}{% endif %}
-{% if dataset['stats_table'] %}* Approximate statistics based on the first {{ [dataset['size'], 1000] | min }} samples:
+{% if dataset['stats_table'] %}* Approximate statistics based on the first {{ [dataset['size'], 100] | min }} samples:
 {{ dataset['stats_table'] }}{% endif %}{% if dataset['examples_table'] %}* Samples:
 {{ dataset['examples_table'] }}{% endif %}* Loss: {% if dataset["loss"]["fullname"].startswith("sentence_transformers.") %}[<code>{{ dataset["loss"]["fullname"].split(".")[-1] }}</code>](https://sbert.net/docs/package_reference/sparse_encoder/losses.html#{{ dataset["loss"]["fullname"].split(".")[-1].lower() }}){% else %}<code>{{ dataset["loss"]["fullname"] }}</code>{% endif %}{% if "config_code" in dataset["loss"] %} with these parameters:
 {{ dataset["loss"]["config_code"] }}{% endif %}


### PR DESCRIPTION
Hello!

## Pull Request overview
* Update model card templates to say "first 100 samples" instead of "first 1000 samples"

## Details
#3733 capped `_compute_column_stats` at 100 rows (`n_total = min(len(dataset), 100)`) to avoid OOM on typed `Image`/`Audio` and media-path columns, but the model card templates still advertised "first 1000 samples". This aligns the templates with what the code actually iterates over.

- Tom Aarsen
