### PR TITLE
[`model card`] Set `ir_model` on the model card based on evaluators

### DIFF
--- a/sentence_transformers/base/model_card.py
+++ b/sentence_transformers/base/model_card.py
@@ -1291,6 +1291,20 @@ class BaseModelCardData(CardData):
                 self.ir_model = True
                 return
 
+    def try_to_set_ir_model_from_evaluators(self) -> None:
+        from sentence_transformers.base.evaluation import SequentialEvaluator
+        from sentence_transformers.sentence_transformer.evaluation import (
+            InformationRetrievalEvaluator,
+            NanoBEIREvaluator,
+        )
+
+        ir_classes = (InformationRetrievalEvaluator, NanoBEIREvaluator)
+        for evaluator in self.eval_results_dict or {}:
+            sub_evaluators = evaluator.evaluators if isinstance(evaluator, SequentialEvaluator) else [evaluator]
+            if any(isinstance(sub_evaluator, ir_classes) for sub_evaluator in sub_evaluators):
+                self.ir_model = True
+                return
+
     def set_model_id(self, model_id: str) -> None:
         self.model_id = model_id
 
@@ -1883,6 +1897,13 @@ class BaseModelCardData(CardData):
         # Set the model name
         if not self.model_name:
             self.model_name = self.get_default_model_name()
+
+        # Fallback IR detection from evaluators (architecture/prompts/dataset columns took priority)
+        if self.ir_model is None and self.eval_results_dict:
+            try:
+                self.try_to_set_ir_model_from_evaluators()
+            except Exception as exc:
+                logger.warning(f"Error while inferring ir_model from evaluators: {exc}")
 
         # Compute the similarity scores for the usage snippet
         try:

--- a/tests/base/test_model_card.py
+++ b/tests/base/test_model_card.py
@@ -1355,8 +1355,8 @@ def _make_similarity_evaluator():
 def _make_nano_beir_evaluator():
     from sentence_transformers.sentence_transformer.evaluation import NanoBEIREvaluator
 
-    # Construction does not download datasets
-    return NanoBEIREvaluator(dataset_names=["nq"])
+    # Bypass __init__ to skip downloading NanoBEIR datasets. We only need the class for isinstance.
+    return NanoBEIREvaluator.__new__(NanoBEIREvaluator)
 
 
 def _make_sparse_ir_evaluator():

--- a/tests/base/test_model_card.py
+++ b/tests/base/test_model_card.py
@@ -1334,3 +1334,94 @@ class TestGenerateModelCardUrlRewriting:
             # Relative src="assets/..." should have been rewritten
             assert 'src="assets/' not in model_card
             assert 'src="https://huggingface.co/user/my-model/resolve/main/assets/' in model_card
+
+
+def _make_ir_evaluator():
+    from sentence_transformers.sentence_transformer.evaluation import InformationRetrievalEvaluator
+
+    return InformationRetrievalEvaluator(
+        queries={"q1": "query"},
+        corpus={"d1": "document"},
+        relevant_docs={"q1": {"d1"}},
+    )
+
+
+def _make_similarity_evaluator():
+    from sentence_transformers.sentence_transformer.evaluation import EmbeddingSimilarityEvaluator
+
+    return EmbeddingSimilarityEvaluator(sentences1=["a"], sentences2=["b"], scores=[0.5])
+
+
+def _make_nano_beir_evaluator():
+    from sentence_transformers.sentence_transformer.evaluation import NanoBEIREvaluator
+
+    # Construction does not download datasets
+    return NanoBEIREvaluator(dataset_names=["nq"])
+
+
+def _make_sparse_ir_evaluator():
+    from sentence_transformers.sparse_encoder.evaluation import SparseInformationRetrievalEvaluator
+
+    # Subclass of InformationRetrievalEvaluator: exercises the isinstance path.
+    return SparseInformationRetrievalEvaluator(
+        queries={"q1": "query"},
+        corpus={"d1": "document"},
+        relevant_docs={"q1": {"d1"}},
+    )
+
+
+def _make_sequential_with_ir_evaluator():
+    from sentence_transformers.base.evaluation import SequentialEvaluator
+
+    return SequentialEvaluator([_make_similarity_evaluator(), _make_ir_evaluator()])
+
+
+class TestTryToSetIrModelFromEvaluators:
+    """Lazy IR-model fallback that fires when evaluators reveal IR intent."""
+
+    @pytest.mark.parametrize(
+        "evaluator_factory",
+        [
+            _make_ir_evaluator,
+            _make_nano_beir_evaluator,
+            _make_sparse_ir_evaluator,
+            _make_sequential_with_ir_evaluator,
+        ],
+        ids=["information_retrieval", "nano_beir", "sparse_ir_subclass", "sequential_with_ir"],
+    )
+    def test_ir_evaluator_sets_ir_model(self, evaluator_factory) -> None:
+        data = _make_model_card_data()
+        data.eval_results_dict[evaluator_factory()] = {"ndcg@10": 0.5}
+        data.try_to_set_ir_model_from_evaluators()
+        assert data.ir_model is True
+
+    def test_non_ir_evaluator_does_not_set_ir_model(self) -> None:
+        data = _make_model_card_data()
+        data.eval_results_dict[_make_similarity_evaluator()] = {"spearman_cosine": 0.7}
+        data.try_to_set_ir_model_from_evaluators()
+        assert data.ir_model is None
+
+    def test_to_dict_skips_when_already_set(self, stsb_bert_tiny_model: SentenceTransformer) -> None:
+        """to_dict guards the call so an already-set ir_model is never overwritten."""
+        model = stsb_bert_tiny_model
+        model.model_card_data.local_files_only = True
+        model.model_card_data.ir_model = True
+        model.model_card_data.eval_results_dict[_make_ir_evaluator()] = {"ndcg@10": 0.5}
+
+        model.model_card_data.to_dict()
+
+        assert model.model_card_data.ir_model is True
+
+    def test_to_dict_triggers_lazy_detection(self, stsb_bert_tiny_model: SentenceTransformer) -> None:
+        """End-to-end: to_dict() runs the fallback so the snippet uses encode_query/encode_document."""
+        model = stsb_bert_tiny_model
+        model.model_card_data.local_files_only = True
+        model.model_card_data.ir_model = None
+        model.model_card_data.usage_examples = ["q?", "d1", "d2"]
+        model.model_card_data.eval_results_dict[_make_ir_evaluator()] = {"ndcg@10": 0.5}
+
+        result = model.model_card_data.to_dict()
+
+        assert model.model_card_data.ir_model is True
+        assert "model.encode_query(queries)" in result["usage_snippet"]
+        assert "model.encode_document(documents)" in result["usage_snippet"]


### PR DESCRIPTION
Hello!

## Pull Request overview
* Infer `ir_model=True` on the model card when an IR evaluator is attached

## Details
Previously, `ir_model` was only set from architecture (e.g. a `Router` module), IR-style prompt names (`query`/`document`/`passage`/`corpus`), or train-dataset columns. If none of those applied, the model card fell back to the generic `encode` snippet even when the user clearly trained for retrieval.

This PR adds a small lazy fallback in `to_dict()`: if `ir_model` is still `None` and `eval_results_dict` is non-empty, iterate the evaluators and flip `ir_model` to `True` if any is an `InformationRetrievalEvaluator` or `NanoBEIREvaluator` (also unwrapping `SequentialEvaluator`). `SparseInformationRetrievalEvaluator` and `SparseNanoBEIREvaluator` are caught via `isinstance` on their base classes. CrossEncoders default `ir_model=True`, so this fallback is a no-op for them.

The result is that models trained with (Sparse)IR/NanoBEIR evaluators render the IR-style usage snippet (`encode_query`/`encode_document`) without any extra configuration from the user.

- Tom Aarsen
