### PR TITLE
[`feat`] Allow Dense as CrossEncoder scoring head

### DIFF
--- a/sentence_transformers/cross_encoder/model.py
+++ b/sentence_transformers/cross_encoder/model.py
@@ -18,7 +18,7 @@ from typing_extensions import deprecated
 
 from sentence_transformers.base.modality_types import PairableInput, PairInput
 from sentence_transformers.base.model import BaseModel
-from sentence_transformers.base.modules import Transformer
+from sentence_transformers.base.modules import Dense, Transformer
 from sentence_transformers.cross_encoder.fit_mixin import FitMixin
 from sentence_transformers.cross_encoder.model_card import CrossEncoderModelCardData
 from sentence_transformers.cross_encoder.modules.logit_score import LogitScore
@@ -336,7 +336,7 @@ class CrossEncoder(BaseModel, FitMixin):
                     scores = sum(scores, [])
 
             elif convert_to_tensor:
-                scores = torch.tensor([], device=self.model.device)
+                scores = torch.tensor([], device=self.device)
             elif convert_to_numpy:
                 scores = np.array([])
             else:
@@ -400,37 +400,43 @@ class CrossEncoder(BaseModel, FitMixin):
 
     def get_default_activation_fn(self) -> Callable:
         activation_fn_path = None
-        if hasattr(self.config, "sentence_transformers") and "activation_fn" in self.config.sentence_transformers:
-            activation_fn_path = self.config.sentence_transformers["activation_fn"]
+        config = self.config
+        if hasattr(config, "sentence_transformers") and "activation_fn" in config.sentence_transformers:
+            activation_fn_path = config.sentence_transformers["activation_fn"]
 
         # Backwards compatibility with <v4.0: we stored the activation_fn under 'sbert_ce_default_activation_function'
         elif (
-            hasattr(self.config, "sbert_ce_default_activation_function")
-            and self.config.sbert_ce_default_activation_function is not None
+            hasattr(config, "sbert_ce_default_activation_function")
+            and config.sbert_ce_default_activation_function is not None
         ):
-            activation_fn_path = self.config.sbert_ce_default_activation_function
-            del self.config.sbert_ce_default_activation_function
+            activation_fn_path = config.sbert_ce_default_activation_function
+            del config.sbert_ce_default_activation_function
 
         if activation_fn_path is not None:
             resolved = self._resolve_activation_fn(activation_fn_path)
             if resolved is not None:
                 return resolved
 
-        if self.config.num_labels == 1:
+        if self.num_labels == 1:
             return nn.Sigmoid()
         return nn.Identity()
 
     @property
-    def config(self) -> PretrainedConfig:
-        return self[0].model.config
+    def config(self) -> PretrainedConfig | None:
+        transformers_model = self.transformers_model
+        if transformers_model is None:
+            return None
+        return transformers_model.config
 
     @property
-    def model(self) -> PreTrainedModel:
-        return self[0].model
+    def model(self) -> PreTrainedModel | None:
+        return self.transformers_model
 
     @property
     def num_labels(self) -> int:
         for module in reversed(self):
+            if isinstance(module, Dense) and module.module_output_name == "scores":
+                return module.out_features
             if isinstance(module, Transformer):
                 return module.model.config.num_labels
             if isinstance(module, LogitScore):
@@ -659,7 +665,7 @@ class CrossEncoder(BaseModel, FitMixin):
 
         # Here, device is either a single device string (e.g., "cuda:0", "cpu") for single-process encoding or None
         if device is None:
-            device = self.model.device
+            device = str(self.device)
 
         self.to(device)
 

--- a/tests/cross_encoder/test_model.py
+++ b/tests/cross_encoder/test_model.py
@@ -330,6 +330,81 @@ def test_num_labels_fresh_model():
     assert model.num_labels == 1
 
 
+@pytest.mark.parametrize("out_features", [1, 3, 7])
+def test_num_labels_from_dense_scores_module(static_embedding_model, out_features: int):
+    """A Dense module with ``module_output_name="scores"`` should dictate ``num_labels``."""
+    from sentence_transformers.base.modules import Dense
+    from sentence_transformers.sentence_transformer.modules import Pooling
+
+    pooling = Pooling(static_embedding_model.get_embedding_dimension(), "mean")
+    dense = Dense(
+        static_embedding_model.get_embedding_dimension(),
+        out_features,
+        activation_function=None,
+        module_output_name="scores",
+    )
+    model = CrossEncoder(modules=[static_embedding_model, pooling, dense])
+    assert model.num_labels == out_features
+
+
+def test_num_labels_ignores_dense_without_scores_output(static_embedding_model):
+    """A trailing Dense whose ``module_output_name`` is not ``"scores"`` must not be
+    treated as the classification head by ``num_labels``.
+    """
+    from sentence_transformers.base.modules import Dense
+    from sentence_transformers.sentence_transformer.modules import Pooling
+
+    pooling = Pooling(static_embedding_model.get_embedding_dimension(), "mean")
+    dense = Dense(
+        static_embedding_model.get_embedding_dimension(),
+        64,
+        activation_function=None,
+    )
+    model = CrossEncoder(modules=[static_embedding_model, pooling, dense])
+    # No Transformer/LogitScore in the stack, and the Dense doesn't expose "scores",
+    # so num_labels falls through to the default of 1 rather than picking up Dense.out_features.
+    assert model.num_labels == 1
+
+
+def test_config_and_model_none_without_transformer(static_embedding_model):
+    """``.config`` and ``.model`` must degrade to ``None`` when the module stack has no
+    underlying HuggingFace Transformer — rather than raising AttributeError on ``self[0].model``.
+    """
+    from sentence_transformers.base.modules import Dense
+    from sentence_transformers.sentence_transformer.modules import Pooling
+
+    pooling = Pooling(static_embedding_model.get_embedding_dimension(), "mean")
+    dense = Dense(static_embedding_model.get_embedding_dimension(), 1, module_output_name="scores")
+    model = CrossEncoder(modules=[static_embedding_model, pooling, dense])
+
+    assert model.config is None
+    assert model.model is None
+
+
+@pytest.mark.parametrize(
+    ["out_features", "expected_activation_cls"],
+    [(1, torch.nn.Sigmoid), (3, torch.nn.Identity)],
+)
+def test_default_activation_fn_without_transformer(
+    static_embedding_model, out_features: int, expected_activation_cls: type
+):
+    """``get_default_activation_fn`` must pick Sigmoid/Identity based on ``num_labels`` even
+    when there's no Transformer (and thus no ``config``) to inspect for a saved activation.
+    """
+    from sentence_transformers.base.modules import Dense
+    from sentence_transformers.sentence_transformer.modules import Pooling
+
+    pooling = Pooling(static_embedding_model.get_embedding_dimension(), "mean")
+    dense = Dense(
+        static_embedding_model.get_embedding_dimension(),
+        out_features,
+        activation_function=None,
+        module_output_name="scores",
+    )
+    model = CrossEncoder(modules=[static_embedding_model, pooling, dense])
+    assert isinstance(model.activation_fn, expected_activation_cls)
+
+
 def test_push_to_hub(
     reranker_bert_tiny_model: CrossEncoder, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:

--- a/tests/cross_encoder/test_model.py
+++ b/tests/cross_encoder/test_model.py
@@ -15,6 +15,7 @@ from pytest import FixtureRequest
 from transformers import __version__ as transformers_version
 
 from sentence_transformers import CrossEncoder
+from sentence_transformers.sentence_transformer.modules import StaticEmbedding
 from sentence_transformers.util import fullname
 from sentence_transformers.util.decorators import (
     cross_encoder_init_args_decorator,
@@ -331,51 +332,45 @@ def test_num_labels_fresh_model():
 
 
 @pytest.mark.parametrize("out_features", [1, 3, 7])
-def test_num_labels_from_dense_scores_module(static_embedding_model, out_features: int):
+def test_num_labels_from_dense_scores_module(static_embedding: StaticEmbedding, out_features: int):
     """A Dense module with ``module_output_name="scores"`` should dictate ``num_labels``."""
     from sentence_transformers.base.modules import Dense
-    from sentence_transformers.sentence_transformer.modules import Pooling
 
-    pooling = Pooling(static_embedding_model.get_embedding_dimension(), "mean")
     dense = Dense(
-        static_embedding_model.get_embedding_dimension(),
+        static_embedding.get_embedding_dimension(),
         out_features,
         activation_function=None,
         module_output_name="scores",
     )
-    model = CrossEncoder(modules=[static_embedding_model, pooling, dense])
+    model = CrossEncoder(modules=[static_embedding, dense])
     assert model.num_labels == out_features
 
 
-def test_num_labels_ignores_dense_without_scores_output(static_embedding_model):
+def test_num_labels_ignores_dense_without_scores_output(static_embedding: StaticEmbedding):
     """A trailing Dense whose ``module_output_name`` is not ``"scores"`` must not be
     treated as the classification head by ``num_labels``.
     """
     from sentence_transformers.base.modules import Dense
-    from sentence_transformers.sentence_transformer.modules import Pooling
 
-    pooling = Pooling(static_embedding_model.get_embedding_dimension(), "mean")
     dense = Dense(
-        static_embedding_model.get_embedding_dimension(),
+        static_embedding.get_embedding_dimension(),
         64,
         activation_function=None,
     )
-    model = CrossEncoder(modules=[static_embedding_model, pooling, dense])
+    model = CrossEncoder(modules=[static_embedding, dense])
     # No Transformer/LogitScore in the stack, and the Dense doesn't expose "scores",
     # so num_labels falls through to the default of 1 rather than picking up Dense.out_features.
     assert model.num_labels == 1
 
 
-def test_config_and_model_none_without_transformer(static_embedding_model):
+def test_config_and_model_none_without_transformer(static_embedding: StaticEmbedding):
     """``.config`` and ``.model`` must degrade to ``None`` when the module stack has no
-    underlying HuggingFace Transformer — rather than raising AttributeError on ``self[0].model``.
+    underlying HuggingFace Transformer rather than raising AttributeError on ``self[0].model``.
     """
     from sentence_transformers.base.modules import Dense
-    from sentence_transformers.sentence_transformer.modules import Pooling
 
-    pooling = Pooling(static_embedding_model.get_embedding_dimension(), "mean")
-    dense = Dense(static_embedding_model.get_embedding_dimension(), 1, module_output_name="scores")
-    model = CrossEncoder(modules=[static_embedding_model, pooling, dense])
+    dense = Dense(static_embedding.get_embedding_dimension(), 1, module_output_name="scores")
+    model = CrossEncoder(modules=[static_embedding, dense])
 
     assert model.config is None
     assert model.model is None
@@ -386,22 +381,20 @@ def test_config_and_model_none_without_transformer(static_embedding_model):
     [(1, torch.nn.Sigmoid), (3, torch.nn.Identity)],
 )
 def test_default_activation_fn_without_transformer(
-    static_embedding_model, out_features: int, expected_activation_cls: type
+    static_embedding: StaticEmbedding, out_features: int, expected_activation_cls: type
 ):
     """``get_default_activation_fn`` must pick Sigmoid/Identity based on ``num_labels`` even
     when there's no Transformer (and thus no ``config``) to inspect for a saved activation.
     """
     from sentence_transformers.base.modules import Dense
-    from sentence_transformers.sentence_transformer.modules import Pooling
 
-    pooling = Pooling(static_embedding_model.get_embedding_dimension(), "mean")
     dense = Dense(
-        static_embedding_model.get_embedding_dimension(),
+        static_embedding.get_embedding_dimension(),
         out_features,
         activation_function=None,
         module_output_name="scores",
     )
-    model = CrossEncoder(modules=[static_embedding_model, pooling, dense])
+    model = CrossEncoder(modules=[static_embedding, dense])
     assert isinstance(model.activation_fn, expected_activation_cls)
 
 

--- a/tests/cross_encoder/test_model.py
+++ b/tests/cross_encoder/test_model.py
@@ -331,6 +331,10 @@ def test_num_labels_fresh_model():
     assert model.num_labels == 1
 
 
+# The transformer-less stacks below aren't runnable end-to-end (no non-Transformer InputModule
+# currently preprocesses CrossEncoder pairs), but we technically allow them so the property logic
+# (config/model/num_labels/activation_fn) is exercised in isolation; it's what makes stacks like
+# Transformer + Pooling + Dense(scores) usable as rerankers.
 @pytest.mark.parametrize("out_features", [1, 3, 7])
 def test_num_labels_from_dense_scores_module(static_embedding: StaticEmbedding, out_features: int):
     """A Dense module with ``module_output_name="scores"`` should dictate ``num_labels``."""


### PR DESCRIPTION
Hello!

## Pull Request overview
* Allow `CrossEncoder` module stacks without a `Transformer` (e.g. `StaticEmbedding` + `Pooling` + `Dense`)
* Use a trailing `Dense(module_output_name="scores")` as the scoring head for `num_labels`

## Details
`CrossEncoder.config`, `.model`, and `.num_labels` previously assumed `self[0]` was a `Transformer`, so a headless stack like `StaticEmbedding` + `Pooling` + `Dense` crashed on `self[0].model`. I want to enable this shape so we can train fast distilled rerankers the same way we already train `StaticEmbedding` bi-encoders.

`config` and `model` now route through `self.transformers_model` and return `None` when no underlying HF model is present, `num_labels` falls back to a trailing `Dense.out_features` when its `module_output_name == "scores"`, and two `self.model.device` lookups become `self.device` so the no-Transformer path doesn't dereference `None`.

- Tom Aarsen
