### PR TITLE
Update model card link format 

### DIFF
--- a/docs/_static/html/models_en_sentence_embeddings.html
+++ b/docs/_static/html/models_en_sentence_embeddings.html
@@ -214,7 +214,7 @@
                             </tr>
                             <tr>
                                 <th>Model Card:</th>
-                                <td><a :href="'https://huggingface.co/sentence-transformers/'+item.name" target="_blank">https://huggingface.co/sentence-transformers/{{item.name}}</a></td>
+                                <td><a :href="'https://huggingface.co/'+item.name" target="_blank">https://huggingface.co/{{item.name}}</a></td>
                             </tr>
                             </tbody>
                         </table>


### PR DESCRIPTION
Remove hard coded sentence-transformers namespace from template since model data now includes that (https://github.com/huggingface/sentence-transformers/commit/f36f7c2665c4d1a3492e80b059095d9bde765b90). 

Currently this creates URLs like:

https://huggingface.co/sentence-transformers/sentence-transformers/all-mpnet-base-v2

instead of

https://huggingface.co/sentence-transformers/all-mpnet-base-v2