### PR TITLE
[`fix`] Expose `preprocess`/`get_embedding_dimension` on DDP-wrapped models in losses

### DIFF
--- a/sentence_transformers/base/trainer.py
+++ b/sentence_transformers/base/trainer.py
@@ -419,6 +419,12 @@ class BaseTrainer(Trainer, ABC):
 
         for name, child in loss.named_children():
             if name == "model" and isinstance(child, BaseModel):
+                # DDP/compile wrappers don't expose BaseModel methods; bind the ones
+                # losses call inside `forward` (CE: `preprocess`, MatryoshkaLoss:
+                # `get_embedding_dimension`).
+                for attr in ("preprocess", "get_embedding_dimension"):
+                    if hasattr(child, attr) and not hasattr(model, attr):
+                        setattr(model, attr, getattr(child, attr))
                 loss.model = model
             elif isinstance(child, torch.nn.Module):
                 setattr(loss, name, self.override_model_in_loss(child, model))


### PR DESCRIPTION
Hello!

## Pull Request overview
* Fix `AttributeError: 'DistributedDataParallel' object has no attribute 'preprocess'` in CrossEncoder losses under DDP
* Also fix the same latent failure for `get_embedding_dimension` in `MatryoshkaLoss`

## Details
The trainer's `override_model_in_loss` swaps `loss.model` for the DDP wrapper so `self.model(...)` routes through DDP's forward and grad-sync fires. DDP's `__getattr__` only resolves parameters/buffers/modules though, so custom `BaseModel` methods raise `AttributeError`. SentenceTransformer/SparseEncoder don't hit this because preprocessing happens in the data collator on the unwrapped model, but CrossEncoder losses tokenize inside `forward` (needed for listwise mini-batching) and crash on the first step.

```
File ".../sentence_transformers/cross_encoder/losses/mse.py", line 97, in forward
    inputs = self.model.preprocess(pairs, prompt=prompt, task=task)
AttributeError: 'DistributedDataParallel' object has no attribute 'preprocess'
```

The fix binds the original's bound methods onto the wrapper before swapping; `__self__` still points at the unwrapped `BaseModel`, so calls keep working. I checked the other loss `forward` paths for the same pattern and found one more (`MatryoshkaLoss.get_embedding_dimension()`), so this covers both in one place.

- Tom Aarsen
