### PR TITLE
[`fix`] Allow Router children to load via dynamic-module mechanism

### DIFF
--- a/sentence_transformers/base/model.py
+++ b/sentence_transformers/base/model.py
@@ -22,7 +22,7 @@ from huggingface_hub import CardData, HfApi
 from packaging import version
 from torch import Tensor, nn
 from transformers import PreTrainedModel, is_datasets_available, is_torch_npu_available
-from transformers.dynamic_module_utils import get_class_from_dynamic_module, get_relative_import_files
+from transformers.dynamic_module_utils import get_relative_import_files
 from transformers.utils import logging as transformers_logging
 
 from sentence_transformers import __version__
@@ -34,7 +34,7 @@ from sentence_transformers.base.modules import Module, Router, Transformer
 from sentence_transformers.base.peft_mixin import PeftAdapterMixin
 from sentence_transformers.util import (
     get_device_name,
-    import_from_string,
+    import_module_class,
     load_dir_path,
     load_file_path,
     save_to_hub_args_decorator,
@@ -1298,25 +1298,14 @@ This pull request has been automatically generated to add {self.__class__.__name
         Returns:
             The module class
         """
-        # If the class is from sentence_transformers, we can directly import it,
-        # otherwise, we try to import it dynamically, and if that fails, we fall back to the default import
-        if class_ref.startswith("sentence_transformers."):
-            return import_from_string(class_ref)
-
-        if trust_remote_code or os.path.exists(model_name_or_path):
-            code_revision = model_kwargs.pop("code_revision", None) if model_kwargs else None
-            try:
-                return get_class_from_dynamic_module(
-                    class_ref,
-                    model_name_or_path,
-                    revision=revision,
-                    code_revision=code_revision,
-                )
-            except (OSError, ValueError):
-                # Ignore the error if 1) the file does not exist, or 2) the class_ref is not correctly formatted/found
-                pass
-
-        return import_from_string(class_ref)
+        code_revision = model_kwargs.pop("code_revision", None) if model_kwargs else None
+        return import_module_class(
+            class_ref,
+            model_name_or_path=model_name_or_path,
+            trust_remote_code=trust_remote_code,
+            revision=revision,
+            code_revision=code_revision,
+        )
 
     def evaluate(self, evaluator: BaseEvaluator, output_path: str | None = None) -> dict[str, float] | float:
         """

--- a/sentence_transformers/base/modules/router.py
+++ b/sentence_transformers/base/modules/router.py
@@ -16,7 +16,7 @@ from sentence_transformers.base.modality import format_modality, infer_batch_mod
 from sentence_transformers.base.modality_types import MODALITY_TO_PROCESSOR_ARG, Modality, PairInput, SingleInput
 from sentence_transformers.base.modules.input_module import InputModule
 from sentence_transformers.base.modules.module import Module
-from sentence_transformers.util import import_from_string, load_dir_path
+from sentence_transformers.util import import_module_class, load_dir_path
 
 logger = logging.get_logger(__name__)
 
@@ -638,6 +638,7 @@ class Router(InputModule):
             "revision": revision,
             "local_files_only": local_files_only,
         }
+        trust_remote_code = kwargs.get("trust_remote_code", False)
         # Try the official config file first, then fall back to the legacy config file
         config = cls.load_config(model_name_or_path=model_name_or_path, subfolder=subfolder, **hub_kwargs)
         if not config:
@@ -646,7 +647,12 @@ class Router(InputModule):
             )
         modules = {}
         for model_id, model_type in config["types"].items():
-            module_class: Module = import_from_string(model_type)
+            module_class: Module = import_module_class(
+                model_type,
+                model_name_or_path=model_name_or_path,
+                trust_remote_code=trust_remote_code,
+                revision=revision,
+            )
             try:
                 module = module_class.load(
                     model_name_or_path, subfolder=Path(subfolder, model_id).as_posix(), **hub_kwargs, **kwargs

--- a/sentence_transformers/base/modules/transformer.py
+++ b/sentence_transformers/base/modules/transformer.py
@@ -913,8 +913,9 @@ class Transformer(InputModule):
             "video": {},
         }
         if self.config.model_type == "whisper":
-            # Whisper requires inputs to be exactly 30 seconds long, while its WhisperFeatureExtractor defaults to
-            # padding=True (a.k.a. "longest"), instead of defaulting to the required "max_length".
+            # Whisper requires inputs to be exactly 30 seconds long. WhisperFeatureExtractor pads
+            # to that length by default, but ST's general "audio" modality kwargs above set
+            # padding=True ("longest") which would override that default. Restore "max_length".
             modality_kwargs["audio"]["padding"] = "max_length"
 
         # Apply user-configured processing_kwargs on top of the defaults

--- a/sentence_transformers/util/__init__.py
+++ b/sentence_transformers/util/__init__.py
@@ -19,6 +19,7 @@ from .misc import (
     disable_logging,
     fullname,
     import_from_string,
+    import_module_class,
 )
 from .quantization import quantize_embeddings
 from .retrieval import (
@@ -77,6 +78,7 @@ __all__ = [
     # From misc.py
     "fullname",
     "import_from_string",
+    "import_module_class",
     "disable_datasets_caching",
     "disable_logging",
     "append_to_last_row",

--- a/sentence_transformers/util/misc.py
+++ b/sentence_transformers/util/misc.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import csv
 import importlib
 import logging
+import os
 import warnings
 from contextlib import contextmanager
 from inspect import isclass
@@ -73,6 +74,61 @@ def import_from_string(dotted_path: str) -> type:
     except AttributeError:
         msg = f'Module "{module_path}" does not define a "{class_name}" attribute/class'
         raise ImportError(msg)
+
+
+def import_module_class(
+    class_ref: str,
+    model_name_or_path: str | None = None,
+    *,
+    trust_remote_code: bool = False,
+    revision: str | None = None,
+    code_revision: str | None = None,
+) -> type:
+    """
+    Resolve a module class reference to a class object.
+
+    For class refs in the ``sentence_transformers.*`` namespace, this imports directly via
+    :func:`import_from_string`. For other class refs (e.g. repository-local custom classes
+    like ``modeling_my_model.CustomTransformer``), it first tries
+    :func:`transformers.dynamic_module_utils.get_class_from_dynamic_module` to fetch the
+    modeling file from the model directory, then falls back to :func:`import_from_string`
+    if dynamic loading is not applicable or fails.
+
+    Dynamic loading is attempted when ``trust_remote_code`` is set, or when
+    ``model_name_or_path`` resolves to a local directory (i.e. the user already has the
+    file on disk and is implicitly trusted).
+
+    Args:
+        class_ref: Dotted class path. Either a fully-qualified ``sentence_transformers.*``
+            path or a repository-local reference like ``modeling_<name>.<ClassName>``.
+        model_name_or_path: Hub repo id or local directory used to source repository-local
+            modeling files. Required for dynamic loading.
+        trust_remote_code: Whether to permit dynamic loading from an unverified Hub repo.
+        revision: Hub revision to fetch the modeling file from.
+        code_revision: Optional separate revision pinning for the modeling code (overrides
+            ``revision`` when set).
+
+    Returns:
+        The resolved class.
+    """
+    if class_ref.startswith("sentence_transformers."):
+        return import_from_string(class_ref)
+
+    if model_name_or_path is not None and (trust_remote_code or os.path.exists(model_name_or_path)):
+        from transformers.dynamic_module_utils import get_class_from_dynamic_module
+
+        try:
+            return get_class_from_dynamic_module(
+                class_ref,
+                model_name_or_path,
+                revision=revision,
+                code_revision=code_revision,
+            )
+        except (OSError, ValueError):
+            # 1) the file does not exist, or 2) the class_ref is not correctly formatted/found
+            pass
+
+    return import_from_string(class_ref)
 
 
 @contextmanager

--- a/tests/base/modules/test_router.py
+++ b/tests/base/modules/test_router.py
@@ -640,6 +640,33 @@ def test_router_load_with_config(
     assert loaded_router.default_route == router.default_route
 
 
+def test_router_load_forwards_trust_remote_code(
+    static_embedding: StaticEmbedding, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Router.load() forwards trust_remote_code and revision to import_module_class so
+    repository-local custom child class refs (e.g. modeling_my_model.MyModule) can be
+    resolved via the dynamic-module mechanism."""
+    router = Router({"query": [static_embedding], "document": [static_embedding]}, default_route="query")
+    SentenceTransformer(modules=[router]).save_pretrained(tmp_path)
+
+    captured = []
+
+    def fake_import_module_class(class_ref, **kwargs):
+        captured.append({"class_ref": class_ref, **kwargs})
+        return StaticEmbedding
+
+    monkeypatch.setattr("sentence_transformers.base.modules.router.import_module_class", fake_import_module_class)
+
+    SentenceTransformer(str(tmp_path), trust_remote_code=True)
+
+    assert len(captured) == 2  # one resolution per child route
+    for call in captured:
+        assert call["trust_remote_code"] is True
+        assert call["model_name_or_path"] == str(tmp_path)
+        assert "revision" in call
+        assert "StaticEmbedding" in call["class_ref"]
+
+
 def test_router_as_middle_module(static_embedding: StaticEmbedding, tmp_path: Path):
     """Test SentenceTransformer with multiple modules including a Router."""
 

--- a/tests/base/test_model.py
+++ b/tests/base/test_model.py
@@ -459,7 +459,7 @@ def test_load_module_class_from_ref_trust_remote_code_fallback(
         raise OSError("not found")
 
     monkeypatch.setattr(
-        "sentence_transformers.base.model.get_class_from_dynamic_module",
+        "transformers.dynamic_module_utils.get_class_from_dynamic_module",
         mock_get_class,
     )
 
@@ -484,7 +484,7 @@ def test_load_module_class_from_ref_code_revision(
         raise ValueError("not found")
 
     monkeypatch.setattr(
-        "sentence_transformers.base.model.get_class_from_dynamic_module",
+        "transformers.dynamic_module_utils.get_class_from_dynamic_module",
         mock_get_class,
     )
 


### PR DESCRIPTION
Hello!

## Pull Request overview
* Allow `Router` children to load via the `trust_remote_code` dynamic-module mechanism
* Extract shared `import_module_class` helper in `util/misc.py`

## Details
`Router.load()` resolved each child's class reference with bare `import_from_string`, so a Router with a repository-local custom class (e.g. `modeling_my_model.MyModule`) couldn't load even though `trust_remote_code=True` was forwarded to it. The right resolution logic already lived in `BaseModel._load_module_class_from_ref`, so I pulled it into a shared `import_module_class` helper in `util/misc.py` and switched both call sites to it. Also clarified an unrelated Whisper-specific comment in `Transformer`.

- Tom Aarsen
