### PR TITLE
[`model_card`] Fix newlines in datasets with large texts

### DIFF
--- a/sentence_transformers/base/model_card.py
+++ b/sentence_transformers/base/model_card.py
@@ -1808,7 +1808,7 @@ class BaseModelCardData(CardData):
         if isinstance(value, list) and len(value) > 5:
             return str(value[:5])[:-1] + ", ...]"
         if isinstance(value, str) and len(value) > 1000:
-            return value[:1000] + "..."
+            value = value[:1000] + "..."
         result = str(value).replace("\n", "<br>").replace("|", "\\|")
         return result
 


### PR DESCRIPTION
Hello!

## Pull Request overview
* Fix newlines in datasets with large texts

## Details
If a dataset had more than 1k tokens, it would not have its `\n` replaced with the table-safe `<br>`. This resulted in a messy table.

- Tom Aarsen