### PR TITLE
[`fix`] Don't upcast bf16/fp16 to fp32 in flash-attention pooling path

### DIFF
--- a/sentence_transformers/sentence_transformer/modules/pooling.py
+++ b/sentence_transformers/sentence_transformer/modules/pooling.py
@@ -282,10 +282,13 @@ class Pooling(Module):
                     mean_sum = torch.zeros(num_seqs, hidden_dim, device=device, dtype=embeddings.dtype)
                     mean_sum = mean_sum.index_add(0, segment_ids, embeddings)
                 if mode == "mean":
-                    output_vectors.append(mean_sum / torch.clamp(effective_lengths.unsqueeze(1), min=1e-9))
+                    output_vectors.append(
+                        mean_sum / torch.clamp(effective_lengths.unsqueeze(1), min=1e-9).to(mean_sum.dtype)
+                    )
                 else:
                     output_vectors.append(
-                        mean_sum / torch.sqrt(torch.clamp(effective_lengths.unsqueeze(1).float(), min=1e-9))
+                        mean_sum
+                        / torch.sqrt(torch.clamp(effective_lengths.unsqueeze(1).float(), min=1e-9)).to(mean_sum.dtype)
                     )
 
             elif mode == "max":


### PR DESCRIPTION
Hello!

## Pull Request overview
* Preserve the embedding dtype through `mean` / `mean_sqrt_len_tokens` pooling on the flash-attention path

## Details
Loading a CrossEncoder with `model_kwargs={"attn_implementation": "flash_attention_2", "dtype": "bfloat16"}` could crash in the scoring `Dense` head with `RuntimeError: expected mat1 and mat2 to have the same dtype, but got: float != struct c10::BFloat16`.

The Dense weights were correctly bf16. The upcast happened in `Pooling._forward_flattened` (the path used when the Transformer emits `cu_seq_lens_q`): for `mean` / `mean_sqrt_len_tokens`, the divisor is built from `effective_lengths`, an `int64` tensor, and `torch.clamp(int64, min=1e-9)` returns `float32`. Dividing `bf16 / float32` then upcasts the pooled vector to fp32, which collides with the bf16 Dense weights downstream. Casting the clamped divisor back to `mean_sum.dtype` fixes it. The other flattened modes (`cls`, `lasttoken`, `max`, `weightedmean`) and all padded modes already preserve dtype.

- Tom Aarsen
