### PR TITLE
[feat] Per-call processing_kwargs override in Transformer.preprocess

### DIFF
--- a/sentence_transformers/base/model.py
+++ b/sentence_transformers/base/model.py
@@ -502,6 +502,10 @@ class BaseModel(nn.Sequential, PeftAdapterMixin, ABC):
             prompt (str, optional): A prompt string to prepend to text inputs. Defaults to None.
                 If the model supports the ``message`` modality, the prompt will be added as a system message to the
                 input messages instead of being prepended to text.
+            **kwargs: Forwarded to the input module's ``preprocess``. For :class:`~sentence_transformers.base.modules.Transformer`
+                input modules this notably includes ``processing_kwargs``, which overrides the processor kwargs
+                configured on the module for this call only (see
+                :meth:`Transformer.preprocess <sentence_transformers.base.modules.Transformer.preprocess>`).
 
         Returns:
             dict[str, Tensor | Any]: A dictionary of tensors with the preprocessed inputs.

--- a/sentence_transformers/base/modules/transformer.py
+++ b/sentence_transformers/base/modules/transformer.py
@@ -575,6 +575,7 @@ class Transformer(InputModule):
         "unpad_inputs",
     ]
     save_in_root: bool = True
+    _VALID_PROCESSING_KWARGS_KEYS: set[str] = {"common", "text", "audio", "image", "video", "chat_template"}
 
     @transformer_kwargs_decorator
     def __init__(
@@ -612,12 +613,11 @@ class Transformer(InputModule):
         if config_kwargs is None:
             config_kwargs = {}
         self.processing_kwargs: ProcessingKwargs = processing_kwargs or {}
-        valid_keys = {"common", "text", "audio", "image", "video", "chat_template"}
-        unknown_keys = set(self.processing_kwargs) - valid_keys
+        unknown_keys = set(self.processing_kwargs) - self._VALID_PROCESSING_KWARGS_KEYS
         if unknown_keys:
             logger.warning(
                 f"Unknown keys in `processing_kwargs`: {unknown_keys}. "
-                f"Valid keys are: {sorted(valid_keys)}. "
+                f"Valid keys are: {sorted(self._VALID_PROCESSING_KWARGS_KEYS)}. "
                 "Unknown keys will be ignored. Did you mean to nest them under "
                 "'common' or a modality key ('text', 'audio', 'image', 'video')?"
             )
@@ -887,6 +887,7 @@ class Transformer(InputModule):
         self,
         inputs: list[SingleInput | PairInput],
         prompt: str | None = None,
+        processing_kwargs: ProcessingKwargs | None = None,
         **kwargs,
     ) -> dict[str, Any]:
         """Preprocess inputs into model-ready features.
@@ -895,6 +896,12 @@ class Transformer(InputModule):
             inputs: List of inputs. Can contain strings, dicts with modality keys, PIL images,
                 or numpy/torch arrays for audio/video.
             prompt: Optional prompt to prepend to text inputs or inject as a system message.
+            processing_kwargs: Per-call overrides for the processor kwargs configured on the module
+                via the ``processing_kwargs`` constructor argument. Same nested structure (modality
+                keys plus ``"common"`` and ``"chat_template"``); per-call values are merged on top of
+                the instance-level kwargs with shallow per-modality merge, so individual settings
+                (e.g. only ``max_length``) can be overridden without replacing the entire modality
+                dict. Defaults to None.
             **kwargs: Additional keyword arguments forwarded to prompt length computation
                 (e.g. ``task``). Only used when ``prompt`` is provided for text inputs.
 
@@ -918,12 +925,13 @@ class Transformer(InputModule):
             # padding=True ("longest") which would override that default. Restore "max_length".
             modality_kwargs["audio"]["padding"] = "max_length"
 
-        # Apply user-configured processing_kwargs on top of the defaults
-        if "common" in self.processing_kwargs:
-            common_kwargs.update(self.processing_kwargs["common"])
+        effective_processing_kwargs = self._merge_processing_kwargs(processing_kwargs)
+        if "common" in effective_processing_kwargs:
+            common_kwargs.update(effective_processing_kwargs["common"])
         for modality_key in modality_kwargs:
-            if overrides := self.processing_kwargs.get(modality_key):  # type: ignore[arg-type]
+            if overrides := effective_processing_kwargs.get(modality_key):  # type: ignore[arg-type]
                 modality_kwargs[modality_key].update(overrides)
+        chat_template_kwargs = effective_processing_kwargs.get("chat_template", {})
 
         modality, processor_inputs, extra_modality_kwargs = self.input_formatter.parse_inputs(inputs)
 
@@ -971,7 +979,13 @@ class Transformer(InputModule):
             num_images_per_sample, num_videos_per_sample = _count_media_per_sample(processor_inputs["message"])
 
         with suggest_extra_on_exception():
-            processor_output = self._call_processor(modality, processor_inputs, modality_kwargs, common_kwargs)
+            processor_output = self._call_processor(
+                modality,
+                processor_inputs,
+                modality_kwargs,
+                common_kwargs,
+                chat_template_kwargs=chat_template_kwargs,
+            )
 
         if num_images_per_sample is not None and "image_grid_thw" in processor_output:
             processor_output["num_images_per_sample"] = torch.tensor(num_images_per_sample, dtype=torch.long)
@@ -999,6 +1013,32 @@ class Transformer(InputModule):
             processor_output["logits_to_keep"] = 1
 
         return processor_output
+
+    def _merge_processing_kwargs(self, per_call: ProcessingKwargs | None) -> ProcessingKwargs:
+        """Merge per-call ``processing_kwargs`` on top of the instance-level ``self.processing_kwargs``.
+
+        The merge is shallow per top-level key: for each modality (or ``"common"`` /
+        ``"chat_template"``), per-call entries override individual instance entries, leaving
+        non-overridden settings intact. Unknown top-level keys in ``per_call`` are warned about
+        and ignored.
+        """
+        if not per_call:
+            return self.processing_kwargs
+
+        unknown_keys = set(per_call) - self._VALID_PROCESSING_KWARGS_KEYS
+        if unknown_keys:
+            logger.warning_once(
+                f"Unknown keys in per-call `processing_kwargs`: {unknown_keys}. "
+                f"Valid keys are: {sorted(self._VALID_PROCESSING_KWARGS_KEYS)}. Unknown keys will be ignored."
+            )
+
+        merged: ProcessingKwargs = {}
+        for key in self._VALID_PROCESSING_KWARGS_KEYS:
+            instance_value = self.processing_kwargs.get(key, {})
+            per_call_value = per_call.get(key, {})
+            if instance_value or per_call_value:
+                merged[key] = {**instance_value, **per_call_value}
+        return merged
 
     def forward(self, features: dict[str, Any], **kwargs) -> dict[str, Any]:
         """Forward pass through the transformer model.
@@ -1154,6 +1194,7 @@ class Transformer(InputModule):
         processor_inputs: dict[str, list],
         modality_kwargs: dict[str, dict[str, Any]],
         common_kwargs: dict[str, Any],
+        chat_template_kwargs: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         """Call the appropriate processor with the correct arguments.
 
@@ -1174,12 +1215,19 @@ class Transformer(InputModule):
                 ``"audio"``, ``"video"``).
             common_kwargs: Common kwargs passed to all processor calls (e.g. ``padding``,
                 ``return_tensors``).
+            chat_template_kwargs: Kwargs forwarded to ``apply_chat_template`` when the modality
+                is ``"message"``. Ignored for non-message modalities.
 
         Returns:
             Processor output dictionary.
         """
         if modality == "message":
-            return self._process_chat_messages(processor_inputs["message"], modality_kwargs, common_kwargs)
+            return self._process_chat_messages(
+                processor_inputs["message"],
+                modality_kwargs,
+                common_kwargs,
+                chat_template_kwargs=chat_template_kwargs,
+            )
 
         if isinstance(self.processor, ProcessorMixin):
             return self._call_multimodal_processor(modality, processor_inputs, modality_kwargs, common_kwargs)
@@ -1258,8 +1306,12 @@ class Transformer(InputModule):
         messages: list[list[MessageInput]],
         modality_kwargs: dict[str, dict[str, Any]],
         common_kwargs: dict[str, Any],
+        chat_template_kwargs: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
-        """Process chat messages using the processor's chat template."""
+        """Process chat messages using the processor's chat template.
+
+        ``chat_template_kwargs`` is forwarded to ``apply_chat_template``.
+        """
         if "message" not in self.modality_config:
             raise ValueError(
                 f"The model does not support 'message' modality, but the input looks like a chat message. "
@@ -1268,7 +1320,7 @@ class Transformer(InputModule):
 
         # Ideally we'd use the same code path for both ProcessorMixin and Tokenizers, but the latter expects
         # the text kwargs to be passed at the top level instead of in a nested "text_kwargs" dict.
-        chat_template_kwargs = self.processing_kwargs.get("chat_template", {})
+        chat_template_kwargs = chat_template_kwargs or {}
         if isinstance(self.processor, ProcessorMixin):
             # Transformers v5.4.0 prefers us to pass processor_kwargs as a single dict, but there's still some top level
             # kwargs that need to be hoisted out for backwards compatibility.

--- a/sentence_transformers/cross_encoder/model.py
+++ b/sentence_transformers/cross_encoder/model.py
@@ -592,6 +592,12 @@ class CrossEncoder(BaseModel, FitMixin):
                 Defaults to None.
             chunk_size (int, optional): Size of chunks for multiprocessing. If None, a sensible default is calculated.
                 Only used when ``pool`` is not None or ``device`` is a list. Defaults to None.
+            **kwargs: Additional keyword arguments forwarded to the model's ``preprocess`` and ``forward``. A notable
+                one is ``processing_kwargs``, which lets you override the processor kwargs configured on the
+                underlying :class:`~sentence_transformers.base.modules.Transformer` for this call only (e.g.
+                ``processing_kwargs={"text": {"max_length": 256, "truncation": True}}``). See
+                :meth:`Transformer.preprocess <sentence_transformers.base.modules.Transformer.preprocess>` for the
+                accepted structure.
 
         Returns:
             Union[List[torch.Tensor], np.ndarray, torch.Tensor]: Predictions for the passed input pairs.

--- a/sentence_transformers/sentence_transformer/model.py
+++ b/sentence_transformers/sentence_transformer/model.py
@@ -547,6 +547,11 @@ class SentenceTransformer(BaseModel, FitMixin):
                 ``start_multi_process_pool()``.
             chunk_size (int, optional): Size of chunks for multi-process encoding.
             **kwargs: Additional keyword arguments to pass to the model's ``preprocess`` and ``forward`` methods.
+                A notable one is ``processing_kwargs``, which lets you override the processor kwargs configured on
+                the underlying :class:`~sentence_transformers.base.modules.Transformer` for this call only (e.g.
+                ``processing_kwargs={"text": {"max_length": 256, "truncation": True}}``). See
+                :meth:`Transformer.preprocess <sentence_transformers.base.modules.Transformer.preprocess>` for the
+                accepted structure.
 
         Returns:
             Union[List[Tensor], ndarray, Tensor, dict[str, Tensor], list[dict[str, Tensor]]]: By default, a 2d numpy
@@ -583,7 +588,7 @@ class SentenceTransformer(BaseModel, FitMixin):
 
         # Validate kwargs
         model_kwargs = self.get_model_kwargs()
-        if unused_kwargs := set(kwargs) - set(model_kwargs) - {"task"}:
+        if unused_kwargs := set(kwargs) - set(model_kwargs) - {"task", "processing_kwargs"}:
             raise ValueError(
                 f"{self.__class__.__name__}.encode() has been called with additional keyword arguments that this model does not use: {list(unused_kwargs)}. "
                 + (

--- a/sentence_transformers/sparse_encoder/model.py
+++ b/sentence_transformers/sparse_encoder/model.py
@@ -414,6 +414,12 @@ class SparseEncoder(BaseModel):
             chunk_size (int, optional): Size of chunks for multi-process encoding. Only used with multiprocessing, i.e.
                 when ``pool`` is not None or ``device`` is a list. If None, a sensible default is calculated.
                 Defaults to None.
+            **kwargs: Additional keyword arguments forwarded to the model's ``preprocess`` and ``forward``. A notable
+                one is ``processing_kwargs``, which lets you override the processor kwargs configured on the
+                underlying :class:`~sentence_transformers.base.modules.Transformer` for this call only (e.g.
+                ``processing_kwargs={"text": {"max_length": 256, "truncation": True}}``). See
+                :meth:`Transformer.preprocess <sentence_transformers.base.modules.Transformer.preprocess>` for the
+                accepted structure.
 
         Returns:
             Union[list[Tensor], Tensor]: By default, a 2d torch sparse tensor with shape [num_inputs, output_dimension]
@@ -458,7 +464,7 @@ class SparseEncoder(BaseModel):
         # Throw an error if unused kwargs are passed, except 'task' which is always allowed, even
         # when it does not do anything (as e.g. there's no Router module in the model)
         model_kwargs = self.get_model_kwargs()
-        if unused_kwargs := set(kwargs) - set(model_kwargs) - {"task"}:
+        if unused_kwargs := set(kwargs) - set(model_kwargs) - {"task", "processing_kwargs"}:
             raise ValueError(
                 f"{self.__class__.__name__}.encode() has been called with additional keyword arguments that this model does not use: {list(unused_kwargs)}. "
                 + (

--- a/tests/base/modules/test_transformer.py
+++ b/tests/base/modules/test_transformer.py
@@ -428,6 +428,60 @@ class TestPreprocess:
         result = transformer.preprocess(["hello world"])
         assert isinstance(result["input_ids"], np.ndarray)
 
+    def test_preprocess_per_call_processing_kwargs_text_override(self, bert_tiny_transformer):
+        """Per-call processing_kwargs should override defaults for that call only."""
+        result = bert_tiny_transformer.preprocess(
+            ["this is a longer sentence that should get truncated"],
+            processing_kwargs={"text": {"max_length": 5, "truncation": True}},
+        )
+        assert result["input_ids"].shape[1] == 5
+
+        # Without per-call overrides, the default behaviour is restored
+        next_result = bert_tiny_transformer.preprocess(["this is a longer sentence that should get truncated"])
+        assert next_result["input_ids"].shape[1] > 5
+
+    def test_preprocess_per_call_processing_kwargs_common_override(self, bert_tiny_transformer):
+        """Per-call processing_kwargs 'common' should override return_tensors for that call only."""
+        result = bert_tiny_transformer.preprocess(
+            ["hello world"],
+            processing_kwargs={"common": {"return_tensors": "np"}},
+        )
+        assert isinstance(result["input_ids"], np.ndarray)
+
+        next_result = bert_tiny_transformer.preprocess(["hello world"])
+        assert isinstance(next_result["input_ids"], torch.Tensor)
+
+    def test_preprocess_per_call_merges_with_instance_processing_kwargs(self):
+        """Per-call values override matching instance values; non-overridden settings are preserved."""
+        transformer = Transformer(
+            TINY_BERT,
+            processing_kwargs={"text": {"max_length": 5, "truncation": True}},
+        )
+        # Per-call only changes max_length; truncation from the instance must still apply
+        result = transformer.preprocess(
+            ["this is a longer sentence that should get truncated"],
+            processing_kwargs={"text": {"max_length": 8}},
+        )
+        assert result["input_ids"].shape[1] == 8
+
+    def test_preprocess_per_call_processing_kwargs_unknown_keys_warning(self, bert_tiny_transformer, caplog):
+        """Unknown top-level keys in per-call processing_kwargs should emit a warning."""
+        with caplog.at_level(logging.WARNING):
+            bert_tiny_transformer.preprocess(
+                ["hello world"],
+                processing_kwargs={"texts": {"max_length": 5}},
+            )
+        assert "Unknown keys in per-call `processing_kwargs`" in caplog.text
+
+    def test_preprocess_per_call_processing_kwargs_does_not_mutate_instance(self, bert_tiny_transformer):
+        """Per-call overrides must not leak into self.processing_kwargs."""
+        before = deepcopy(bert_tiny_transformer.processing_kwargs)
+        bert_tiny_transformer.preprocess(
+            ["hello world"],
+            processing_kwargs={"text": {"max_length": 5, "truncation": True}},
+        )
+        assert bert_tiny_transformer.processing_kwargs == before
+
 
 class TestForward:
     def test_missing_method_error(self, bert_tiny_transformer):
@@ -616,7 +670,7 @@ class TestProcessChatMessages:
             )
 
     def test_processing_kwargs_chat_template_passed_through(self, bert_tiny_transformer, monkeypatch):
-        """processing_kwargs['chat_template'] should be forwarded to apply_chat_template."""
+        """Instance ``processing_kwargs['chat_template']`` should reach ``apply_chat_template`` via preprocess."""
         model = bert_tiny_transformer
         model.processing_kwargs = {"chat_template": {"add_generation_prompt": True, "continue_final_message": False}}
         model.modality_config["message"] = {"method": "forward", "method_output_name": "last_hidden_state"}
@@ -628,13 +682,28 @@ class TestProcessChatMessages:
             return {"input_ids": torch.tensor([[1, 2, 3]]), "attention_mask": torch.tensor([[1, 1, 1]])}
 
         monkeypatch.setattr(model.processor, "apply_chat_template", mock_apply_chat_template)
-        model._process_chat_messages(
-            messages=[[{"role": "user", "content": "test"}]],
-            modality_kwargs={"text": {}, "audio": {}, "image": {}, "video": {}},
-            common_kwargs={"return_tensors": "pt"},
-        )
+        model.preprocess([[{"role": "user", "content": "test"}]])
         assert captured_kwargs["add_generation_prompt"] is True
         assert captured_kwargs["continue_final_message"] is False
+
+    def test_per_call_chat_template_overrides_instance_via_preprocess(self, bert_tiny_transformer, monkeypatch):
+        """Per-call ``processing_kwargs={'chat_template': ...}`` should override instance-level via preprocess."""
+        model = bert_tiny_transformer
+        model.processing_kwargs = {"chat_template": {"add_generation_prompt": False}}
+        model.modality_config["message"] = {"method": "forward", "method_output_name": "last_hidden_state"}
+
+        captured_kwargs = {}
+
+        def mock_apply_chat_template(messages, **kwargs):
+            captured_kwargs.update(kwargs)
+            return {"input_ids": torch.tensor([[1, 2, 3]]), "attention_mask": torch.tensor([[1, 1, 1]])}
+
+        monkeypatch.setattr(model.processor, "apply_chat_template", mock_apply_chat_template)
+        model.preprocess(
+            [[{"role": "user", "content": "test"}]],
+            processing_kwargs={"chat_template": {"add_generation_prompt": True}},
+        )
+        assert captured_kwargs["add_generation_prompt"] is True
 
 
 class TestModelLoading:
@@ -1211,7 +1280,7 @@ class TestConditionalFlattening:
         monkeypatch.setattr(
             transformer,
             "_call_processor",
-            lambda modality, inputs, modality_kwargs, common_kwargs: {
+            lambda modality, inputs, modality_kwargs, common_kwargs, **_: {
                 "input_ids": torch.tensor([[1, 2, 3]]),
                 "attention_mask": torch.tensor([[1, 1, 1]]),
             },
@@ -1235,7 +1304,7 @@ class TestConditionalFlattening:
         monkeypatch.setattr(
             transformer,
             "_call_processor",
-            lambda modality, inputs, modality_kwargs, common_kwargs: {"input_ids": [[1, 2, 3]]},
+            lambda modality, inputs, modality_kwargs, common_kwargs, **_: {"input_ids": [[1, 2, 3]]},
         )
 
         transformer.preprocess(["dummy"])

--- a/tests/cross_encoder/test_model.py
+++ b/tests/cross_encoder/test_model.py
@@ -767,6 +767,22 @@ def test_predict_with_dataset_column(reranker_bert_tiny_model: CrossEncoder) -> 
     assert embeddings.shape == (2,)
 
 
+def test_predict_per_call_processing_kwargs(reranker_bert_tiny_model: CrossEncoder) -> None:
+    """Per-call ``processing_kwargs`` should be accepted by ``predict`` and reach ``preprocess``.
+
+    If the kwarg were silently dropped, truncated and full predictions on the same pair would
+    produce identical scores.
+    """
+    model = reranker_bert_tiny_model
+    pair = ["this is a moderately long query sentence", "this is a moderately long candidate sentence"]
+    truncated = model.predict(
+        [pair],
+        processing_kwargs={"text": {"max_length": 4, "truncation": True}},
+    )
+    full = model.predict([pair])
+    assert not np.isclose(truncated[0], full[0])
+
+
 # Test suite converted from demo_3406_simple_og.py
 def format_queries(query, instruction=None):
     """Helper function to format queries with the template."""

--- a/tests/sentence_transformer/test_model.py
+++ b/tests/sentence_transformer/test_model.py
@@ -1208,6 +1208,24 @@ def test_encode_with_dataset_column(stsb_bert_tiny_model: SentenceTransformer) -
     assert embeddings.shape == (2, model.get_embedding_dimension())
 
 
+def test_encode_per_call_processing_kwargs(stsb_bert_tiny_model: SentenceTransformer) -> None:
+    """Per-call ``processing_kwargs`` should be accepted by ``encode`` and reach ``preprocess``.
+
+    If the kwarg were silently dropped (or rejected by encode's allowlist), truncated and full
+    encodings of the same text would either raise or produce identical embeddings.
+    """
+    model = stsb_bert_tiny_model
+    text = "this sentence is much longer than four tokens for sure"
+    truncated = model.encode(
+        [text],
+        convert_to_tensor=True,
+        processing_kwargs={"text": {"max_length": 4, "truncation": True}},
+    )
+    full = model.encode([text], convert_to_tensor=True)
+    assert truncated.shape == full.shape
+    assert not torch.allclose(truncated, full)
+
+
 def test_get_model_kwargs(stsb_bert_tiny_model: SentenceTransformer) -> None:
     """Test that get_model_kwargs returns the correct keyword arguments."""
     model = stsb_bert_tiny_model

--- a/tests/sparse_encoder/test_model.py
+++ b/tests/sparse_encoder/test_model.py
@@ -433,6 +433,25 @@ def test_encode_with_dataset_column(splade_bert_tiny_model: SparseEncoder) -> No
     assert embeddings.shape == (2, model.get_embedding_dimension())
 
 
+def test_encode_per_call_processing_kwargs(splade_bert_tiny_model: SparseEncoder) -> None:
+    """Per-call ``processing_kwargs`` should be accepted by ``encode`` and reach ``preprocess``.
+
+    If the kwarg were silently dropped (or rejected by encode's allowlist), truncated and full
+    encodings of the same text would either raise or produce identical sparse embeddings.
+    """
+    model = splade_bert_tiny_model
+    text = "this sentence is much longer than four tokens for sure"
+    truncated = model.encode(
+        [text],
+        convert_to_tensor=True,
+        save_to_cpu=True,
+        processing_kwargs={"text": {"max_length": 4, "truncation": True}},
+    )
+    full = model.encode([text], convert_to_tensor=True, save_to_cpu=True)
+    assert truncated.shape == full.shape
+    assert not torch.allclose(truncated.to_dense(), full.to_dense())
+
+
 def test_encode_numpy_1d_string_array(splade_bert_tiny_model: SparseEncoder) -> None:
     """Regression test for #3718: encoding a 1D numpy string array should produce one embedding per element."""
     model = splade_bert_tiny_model


### PR DESCRIPTION
Hello!

## Pull Request overview
* Add per-call `processing_kwargs` override to `Transformer.preprocess`
* Allowlist it through `encode`/`predict` and document it on the entry points

## Details
A dependent project wanted to pass different `processing_kwargs` on each call rather than only at construction time. I've added a `processing_kwargs` parameter to `Transformer.preprocess` that merges on top of the instance-level `self.processing_kwargs` with shallow per-modality semantics, so individual settings (e.g. only `max_length`) can be overridden without replacing the whole modality dict.

The merged dict is also threaded through `_call_processor` to `_process_chat_messages`, since the `chat_template` slot was read directly from `self.processing_kwargs` rather than via the existing `modality_kwargs`/`common_kwargs` plumbing. Without this, per-call `{"chat_template": {...}}` overrides would silently no-op. `SentenceTransformer.encode` and `SparseEncoder.encode` now allowlist `processing_kwargs` alongside `task`; `CrossEncoder.predict` and `BaseModel.preprocess` already forward `**kwargs` through.

cc @NohTow 

- Tom Aarsen
