### PR TITLE
[`fix`] Inherit `model_type` from archetype on user subclasses

### DIFF
--- a/sentence_transformers/base/model.py
+++ b/sentence_transformers/base/model.py
@@ -70,6 +70,10 @@ class BaseModel(nn.Sequential, PeftAdapterMixin, ABC):
     _default_prompts: dict[str, str | None] = {}
     # The placeholder model ID in model card templates that gets replaced with the actual model ID.
     _model_card_model_id_placeholder: str = "sentence_transformers_model_id"
+    # The archetype identifier written to `config_sentence_transformers.json` and used to
+    # discriminate which loader path runs (see `_load_modules`). Subclasses inherit the
+    # archetype value by default; override on a subclass to opt out of that identity.
+    model_type: str
 
     def __init__(
         self,
@@ -165,7 +169,6 @@ class BaseModel(nn.Sequential, PeftAdapterMixin, ABC):
         self.module_kwargs = None
         self._model_card_vars = {}
         self._model_card_text = None
-        self.model_type = self.__class__.__name__
         self.backend = backend
 
         if cache_folder is None:

--- a/sentence_transformers/cross_encoder/model.py
+++ b/sentence_transformers/cross_encoder/model.py
@@ -140,6 +140,7 @@ class CrossEncoder(BaseModel, FitMixin):
     model_card_data_class = CrossEncoderModelCardData
     default_huggingface_organization: str | None = "cross-encoder"
     _model_card_model_id_placeholder = "cross_encoder_model_id"
+    model_type: str = "CrossEncoder"
 
     @cross_encoder_init_args_decorator
     def __init__(

--- a/sentence_transformers/sentence_transformer/model.py
+++ b/sentence_transformers/sentence_transformer/model.py
@@ -139,6 +139,7 @@ class SentenceTransformer(BaseModel, FitMixin):
     model_card_data_class = SentenceTransformerModelCardData
     default_huggingface_organization: str | None = "sentence-transformers"
     _default_prompts: dict[str, str | None] = {"query": None, "document": None}
+    model_type: str = "SentenceTransformer"
 
     @deprecated_kwargs(tokenizer_kwargs="processor_kwargs")
     def __init__(

--- a/sentence_transformers/sparse_encoder/model.py
+++ b/sentence_transformers/sparse_encoder/model.py
@@ -134,6 +134,7 @@ class SparseEncoder(BaseModel):
     default_huggingface_organization: str | None = "sparse-encoder"
     _default_prompts: dict[str, str | None] = {"query": None, "document": None}
     _model_card_model_id_placeholder = "sparse_encoder_model_id"
+    model_type: str = "SparseEncoder"
 
     @deprecated_kwargs(tokenizer_kwargs="processor_kwargs")
     def __init__(

--- a/tests/base/test_model_type_subclass.py
+++ b/tests/base/test_model_type_subclass.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from sentence_transformers import CrossEncoder, SentenceTransformer, SparseEncoder
+
+
+def test_model_type_inherited_for_sentence_transformer_subclass(stsb_bert_tiny_model: SentenceTransformer) -> None:
+    """A subclass of SentenceTransformer should still report `model_type == "SentenceTransformer"`,
+    so `_load_modules` takes the config path (not the conversion path) for pre-saved ST models.
+    Reproduces #3536."""
+    assert stsb_bert_tiny_model.model_type == "SentenceTransformer"
+
+    converted_called = False
+
+    class MySentenceTransformer(SentenceTransformer):
+        def _load_converted_modules(self, *args, **kwargs):
+            nonlocal converted_called
+            converted_called = True
+            return super()._load_converted_modules(*args, **kwargs)
+
+    subclassed = MySentenceTransformer("sentence-transformers-testing/stsb-bert-tiny-safetensors")
+    assert subclassed.model_type == "SentenceTransformer"
+    assert not converted_called, "Plain ST subclass should not hit the conversion loader path"
+
+
+def test_model_type_inherited_for_sparse_encoder_subclass(splade_bert_tiny_model: SparseEncoder) -> None:
+    """Same inheritance and routing for SparseEncoder subclasses."""
+    assert splade_bert_tiny_model.model_type == "SparseEncoder"
+
+    converted_called = False
+
+    class MySparseEncoder(SparseEncoder):
+        def _load_converted_modules(self, *args, **kwargs):
+            nonlocal converted_called
+            converted_called = True
+            return super()._load_converted_modules(*args, **kwargs)
+
+    subclassed = MySparseEncoder("sparse-encoder-testing/splade-bert-tiny-nq")
+    assert subclassed.model_type == "SparseEncoder"
+    assert not converted_called, "Plain SparseEncoder subclass should not hit the conversion loader path"
+
+
+def test_model_type_inherited_for_cross_encoder_subclass(reranker_bert_tiny_model: CrossEncoder) -> None:
+    """Same inheritance and routing for CrossEncoder subclasses."""
+    assert reranker_bert_tiny_model.model_type == "CrossEncoder"
+
+    converted_called = False
+
+    class MyCrossEncoder(CrossEncoder):
+        def _load_converted_modules(self, *args, **kwargs):
+            nonlocal converted_called
+            converted_called = True
+            return super()._load_converted_modules(*args, **kwargs)
+
+    subclassed = MyCrossEncoder("cross-encoder-testing/reranker-bert-tiny-gooaq-bce")
+    assert subclassed.model_type == "CrossEncoder"
+    assert not converted_called, "Plain CrossEncoder subclass should not hit the conversion loader path"
+
+
+def test_model_type_override_takes_precedence() -> None:
+    """A subclass that explicitly declares its own `model_type` opts out of the archetype
+    identity, restoring the pre-#3536 conversion-path behavior on archetype-typed models."""
+    converted_called = False
+
+    class OverrideSentenceTransformer(SentenceTransformer):
+        model_type = "OverrideSentenceTransformer"
+
+        def _load_converted_modules(self, *args, **kwargs):
+            nonlocal converted_called
+            converted_called = True
+            return super()._load_converted_modules(*args, **kwargs)
+
+    overridden = OverrideSentenceTransformer("sentence-transformers-testing/stsb-bert-tiny-safetensors")
+    assert overridden.model_type == "OverrideSentenceTransformer"
+    assert converted_called, "Overriding `model_type` should route through the conversion loader path"


### PR DESCRIPTION
Resolves #3536

Hello!

## Pull Request overview
* Declare `model_type` as a class attribute on each archetype so user subclasses inherit the archetype identity by default, while still being able to override it declaratively.

## Details
The reporter showed that a `class MySentenceTransformer(SentenceTransformer): pass` subclass loading a non-mean-pooled model (e.g. `BAAI/bge-small-en-v1.5`, which uses CLS pooling and has no `model_type` field in its `config_sentence_transformers.json`) silently fell into the default-pooling branch and returned wrong embeddings. The discrepancy is in `_load_modules`:

```python
model_type_being_loaded = self._get_model_type(...)  # "SentenceTransformer"
if model_type_being_loaded == self.model_type:        # "MySentenceTransformer"
    return self._load_config_modules(...)
return self._load_converted_modules(...)              # wrong path
```

`self.model_type` was being set to `self.__class__.__name__` inside `BaseModel.__init__`, so subclasses didn't match. I've moved `model_type` to a class attribute on each archetype (`SentenceTransformer`, `SparseEncoder`, `CrossEncoder`); Python's MRO handles the inheritance, so a plain subclass picks up the archetype value automatically. Subclasses that *want* a distinct identity (and therefore the conversion-path behavior on archetype loads) can still opt in by declaring their own `model_type` value on the class.

One small migration note: any model previously saved through a subclass under the old behavior has its subclass name baked into `config_sentence_transformers.json` and will now hit the conversion path on load. Re-saving under this fix (or editing the JSON to the archetype name) resolves it, though in practice those saved models were almost certainly already broken by the bug this PR addresses.

cc @NohTow I think you're overriding `_get_model_type`, so it wouldn't really affect you I believe.
cc @kddubey @AtharvaJaiswal005

- Tom Aarsen