### PR TITLE
[`fix`] Delegate `model.config` to underlying transformers model

### DIFF
--- a/sentence_transformers/base/model.py
+++ b/sentence_transformers/base/model.py
@@ -12,7 +12,7 @@ from abc import ABC, abstractmethod
 from collections import OrderedDict
 from multiprocessing import Queue
 from pathlib import Path
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 import numpy as np
 import torch
@@ -40,6 +40,9 @@ from sentence_transformers.util import (
     save_to_hub_args_decorator,
 )
 from sentence_transformers.util.misc import ORIGINAL_TRANSFORMER_MODELS
+
+if TYPE_CHECKING:
+    from transformers import PretrainedConfig
 
 logger = transformers_logging.get_logger(__name__)
 
@@ -1520,6 +1523,21 @@ This pull request has been automatically generated to add {self.__class__.__name
             if isinstance(module, PreTrainedModel):
                 return module
         return None
+
+    @property
+    def config(self) -> PretrainedConfig | None:
+        """The transformers ``PretrainedConfig`` of the underlying model.
+
+        Several integrations (most notably Deepspeed and ``transformers.Trainer``) read
+        ``model.config.hidden_size`` directly. Without this delegation those integrations
+        crash with ``AttributeError: 'SentenceTransformer' object has no attribute 'config'``
+        because :class:`BaseModel` is an ``nn.Sequential`` rather than a ``PreTrainedModel``.
+
+        Returns the config of :attr:`transformers_model`, or ``None`` when no underlying
+        transformers model can be located (e.g. a pure StaticEmbedding-only setup).
+        """
+        underlying = self.transformers_model
+        return getattr(underlying, "config", None)
 
     @property
     def _target_device(self) -> torch.device:

--- a/sentence_transformers/cross_encoder/model.py
+++ b/sentence_transformers/cross_encoder/model.py
@@ -422,13 +422,6 @@ class CrossEncoder(BaseModel, FitMixin):
         return nn.Identity()
 
     @property
-    def config(self) -> PretrainedConfig | None:
-        transformers_model = self.transformers_model
-        if transformers_model is None:
-            return None
-        return transformers_model.config
-
-    @property
     def model(self) -> PreTrainedModel | None:
         return self.transformers_model
 

--- a/tests/base/test_model.py
+++ b/tests/base/test_model.py
@@ -148,6 +148,24 @@ def test_preprocess_skips_modality_check_for_empty_inputs(
     assert isinstance(features, dict)
 
 
+def test_config_delegates_to_underlying_transformers_model(stsb_bert_tiny_model: SentenceTransformer) -> None:
+    """`model.config` should return the underlying transformers PretrainedConfig so
+    integrations like Deepspeed and transformers.Trainer can read `hidden_size` etc.
+    """
+    assert stsb_bert_tiny_model.config is not None
+    assert hasattr(stsb_bert_tiny_model.config, "hidden_size")
+    assert stsb_bert_tiny_model.config.hidden_size == stsb_bert_tiny_model.transformers_model.config.hidden_size
+
+
+def test_config_returns_none_when_no_underlying_transformers_model(
+    static_embedding_model: SentenceTransformer,
+) -> None:
+    """If the model has no underlying transformers PreTrainedModel (e.g. StaticEmbedding-only),
+    `model.config` returns `None` instead of raising.
+    """
+    assert static_embedding_model.config is None
+
+
 def test_sentence_transformer(stsb_bert_tiny_model: SentenceTransformer) -> None:
     assert stsb_bert_tiny_model.supports("text")
     assert not stsb_bert_tiny_model.supports("image")


### PR DESCRIPTION
Resolves #3531

Hello!

## Pull Request overview
* Add a `model.config` property that delegates to the underlying transformers model's `PretrainedConfig`, so Deepspeed and similar integrations can read `model.config.hidden_size` directly.

## Details
@mrpeerat in #3531 hit `AttributeError: 'SentenceTransformer' object has no attribute 'config'` during Deepspeed's `trainer_config_finalize`, which reads `model.config.hidden_size` to size the ZeRO partitions. The same access pattern shows up in a few other transformers integrations.

`BaseModel` is an `nn.Sequential` subclass rather than a `PreTrainedModel`, so it doesn't carry a `config` of its own. The fix delegates: `model.config` returns the config of `model.transformers_model`, or `None` for StaticEmbedding-only setups where there is no underlying transformers model. As a side benefit I've also removed an equivalent property override in `CrossEncoder` that this base-class implementation makes redundant.

This restores Deepspeed ZeRO-1/2/3 for typical bi-encoder shapes without requiring users to manually patch `model.config = model[0].auto_model.config`.

cc @mrpeerat

- Tom Aarsen
