### PR TITLE
[`fix`] Robust file_io error handling for local paths and Hub failures

### DIFF
--- a/sentence_transformers/base/model.py
+++ b/sentence_transformers/base/model.py
@@ -903,10 +903,14 @@ This pull request has been automatically generated to add {self.__class__.__name
                 if replace_model_card:
                     create_model_card_for_path = True
                 else:
-                    # If replace_model_card=False, skip model card creation only if there's already a README.md
-                    existing_readme = load_file_path(
-                        repo_id, "README.md", token=token, revision=revision, local_files_only=False
-                    )
+                    # If replace_model_card=False, skip model card creation only if there's already a README.md.
+                    # README is optional metadata; a transient Hub error here shouldn't block the push.
+                    try:
+                        existing_readme = load_file_path(
+                            repo_id, "README.md", token=token, revision=revision, local_files_only=False
+                        )
+                    except Exception:
+                        existing_readme = None
                     create_model_card_for_path = existing_readme is None
                 self.save(
                     tmp_dir,
@@ -1064,15 +1068,19 @@ This pull request has been automatically generated to add {self.__class__.__name
 
             self._parse_model_config(model_config)
 
-        # Check if a readme exists
-        model_card_path = load_file_path(
-            model_name_or_path,
-            "README.md",
-            token=token,
-            cache_folder=cache_folder,
-            revision=revision,
-            local_files_only=local_files_only,
-        )
+        # Check if a readme exists. README is optional metadata; a transient Hub error
+        # here shouldn't block model loading.
+        try:
+            model_card_path = load_file_path(
+                model_name_or_path,
+                "README.md",
+                token=token,
+                cache_folder=cache_folder,
+                revision=revision,
+                local_files_only=local_files_only,
+            )
+        except Exception:
+            model_card_path = None
         if model_card_path is not None:
             try:
                 with open(model_card_path, encoding="utf8") as fIn:

--- a/sentence_transformers/base/model.py
+++ b/sentence_transformers/base/model.py
@@ -904,14 +904,19 @@ This pull request has been automatically generated to add {self.__class__.__name
                     create_model_card_for_path = True
                 else:
                     # If replace_model_card=False, skip model card creation only if there's already a README.md.
-                    # README is optional metadata; a transient Hub error here shouldn't block the push.
+                    # On a transient Hub error during the probe, default to skipping card creation so we
+                    # don't accidentally overwrite an existing README we couldn't verify.
                     try:
                         existing_readme = load_file_path(
                             repo_id, "README.md", token=token, revision=revision, local_files_only=False
                         )
-                    except Exception:
-                        existing_readme = None
-                    create_model_card_for_path = existing_readme is None
+                        create_model_card_for_path = existing_readme is None
+                    except Exception as exc:
+                        logger.warning(
+                            f"Could not check for an existing README.md on {repo_id!r} ({type(exc).__name__}: {exc}). "
+                            "Skipping model card creation to avoid overwriting any existing card."
+                        )
+                        create_model_card_for_path = False
                 self.save(
                     tmp_dir,
                     model_name=repo_id,
@@ -1079,7 +1084,11 @@ This pull request has been automatically generated to add {self.__class__.__name
                 revision=revision,
                 local_files_only=local_files_only,
             )
-        except Exception:
+        except Exception as exc:
+            logger.warning(
+                f"Could not fetch README.md from {model_name_or_path!r} ({type(exc).__name__}: {exc}). "
+                "Model will load without a model card."
+            )
             model_card_path = None
         if model_card_path is not None:
             try:

--- a/sentence_transformers/util/file_io.py
+++ b/sentence_transformers/util/file_io.py
@@ -4,6 +4,7 @@ import os
 from pathlib import Path
 
 from huggingface_hub import hf_hub_download, snapshot_download
+from huggingface_hub.utils import EntryNotFoundError, HFValidationError, LocalEntryNotFoundError
 from tqdm.autonotebook import tqdm
 
 
@@ -44,8 +45,15 @@ def is_sentence_transformer_model(
         revision (Optional[str]): The revision of the model. Defaults to None.
         local_files_only (bool): Whether to only use local files for the model. Defaults to False.
 
+    Raises:
+        Exception: Propagates errors from the Hub that are not "file not found" (e.g.
+            authentication, rate-limit, or network errors). The probe deliberately surfaces
+            these instead of returning ``False``, so callers don't mistake a flaky Hub for
+            "this isn't a SentenceTransformer".
+
     Returns:
-        bool: True if the model is a SentenceTransformer model, False otherwise.
+        bool: True if the model is a SentenceTransformer model, False if it exists but
+        does not contain a ``modules.json``.
     """
     return bool(
         load_file_path(
@@ -80,13 +88,24 @@ def load_file_path(
         revision (Optional[str], optional): The revision of the file (if applicable). Defaults to None.
         local_files_only (bool, optional): Whether to only consider local files. Defaults to False.
 
+    Raises:
+        Exception: Errors that are not unambiguously "this file is not on the Hub"
+            propagate to the caller (e.g. authentication, rate-limit, network). Only
+            ``EntryNotFoundError``, ``HFValidationError``, and ``LocalEntryNotFoundError``
+            are converted to a ``None`` return.
+
     Returns:
-        Optional[str]: The path to the loaded file, or None if the file could not be found or loaded.
+        Optional[str]: The path to the loaded file, or ``None`` if the file is not present
+        locally and the Hub confirms it is not in the repo (or no valid repo id was given).
     """
     # If file is local
     file_path = Path(model_name_or_path, subfolder, filename)
     if file_path.exists():
         return str(file_path)
+
+    # Skip the Hub fallback when the parent is a real local dir. Avoids a wasted call.
+    if Path(model_name_or_path).is_dir():
+        return None
 
     # If file is remote
     file_path = Path(subfolder, filename)
@@ -101,7 +120,9 @@ def load_file_path(
             cache_dir=cache_folder,
             local_files_only=local_files_only,
         )
-    except Exception:
+    except (EntryNotFoundError, HFValidationError, LocalEntryNotFoundError):
+        # Unambiguous "not found" cases. Other errors (auth, rate limit, network)
+        # propagate so callers don't silently fall back to a different model.
         return None
 
 
@@ -124,8 +145,16 @@ def load_dir_path(
         revision (Optional[str], optional): The revision of the model. Defaults to None.
         local_files_only (bool, optional): Whether to only use local files. Defaults to False.
 
+    Raises:
+        Exception: Errors that are not unambiguously "this is not on the Hub" propagate
+            to the caller. ``HFValidationError`` and ``LocalEntryNotFoundError`` are
+            converted to a ``None`` return. Other failures (auth, rate-limit, network)
+            trigger a single cache-only retry; if the cache also lacks the file, the
+            original exception is re-raised (a cache miss would mask the real cause).
+
     Returns:
-        Optional[str]: The subfolder path if it exists, otherwise None.
+        Optional[str]: The subfolder path, or ``None`` if the parent is a local directory
+        without the subfolder, or no valid repo id was given.
     """
     if isinstance(subfolder, Path):
         subfolder = subfolder.as_posix()
@@ -134,6 +163,10 @@ def load_dir_path(
     dir_path = Path(model_name_or_path, subfolder)
     if dir_path.exists():
         return str(dir_path)
+
+    # Skip the Hub fallback when the parent is a real local dir. Avoids a wasted call.
+    if Path(model_name_or_path).is_dir():
+        return None
 
     download_kwargs = {
         "repo_id": model_name_or_path,
@@ -148,10 +181,19 @@ def load_dir_path(
     # Try to download from the remote
     try:
         repo_path = snapshot_download(**download_kwargs)
-    except Exception:
-        # Otherwise, try local (i.e. cache) only
+    except (HFValidationError, LocalEntryNotFoundError):
+        # Unambiguous "not found" / "not cached" cases.
+        return None
+    except Exception as first_error:
+        # Transient (auth, rate limit, network), try cache as fallback.
         download_kwargs["local_files_only"] = True
-        repo_path = snapshot_download(**download_kwargs)
+        try:
+            repo_path = snapshot_download(**download_kwargs)
+        except LocalEntryNotFoundError:
+            # Cache miss after a transient first failure: re-raise the original error
+            # (with `from None` to suppress the cache miss from the traceback) so the
+            # user sees the real cause, e.g. rate limit, not the misleading cache miss.
+            raise first_error from None
     return str(Path(repo_path, subfolder))
 
 

--- a/sentence_transformers/util/file_io.py
+++ b/sentence_transformers/util/file_io.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
+import logging
 import os
 from pathlib import Path
 
 from huggingface_hub import hf_hub_download, snapshot_download
 from huggingface_hub.utils import EntryNotFoundError, HFValidationError, LocalEntryNotFoundError
 from tqdm.autonotebook import tqdm
+
+logger = logging.getLogger(__name__)
 
 
 class disabled_tqdm(tqdm):
@@ -120,9 +123,10 @@ def load_file_path(
             cache_dir=cache_folder,
             local_files_only=local_files_only,
         )
-    except (EntryNotFoundError, HFValidationError, LocalEntryNotFoundError):
+    except (EntryNotFoundError, HFValidationError, LocalEntryNotFoundError) as exc:
         # Unambiguous "not found" cases. Other errors (auth, rate limit, network)
         # propagate so callers don't silently fall back to a different model.
+        logger.debug(f"Could not load {filename!r} from {model_name_or_path!r}: {exc}")
         return None
 
 
@@ -181,8 +185,9 @@ def load_dir_path(
     # Try to download from the remote
     try:
         repo_path = snapshot_download(**download_kwargs)
-    except (HFValidationError, LocalEntryNotFoundError):
+    except (HFValidationError, LocalEntryNotFoundError) as exc:
         # Unambiguous "not found" / "not cached" cases.
+        logger.debug(f"Could not load subfolder {subfolder!r} from {model_name_or_path!r}: {exc}")
         return None
     except Exception as first_error:
         # Transient (auth, rate limit, network), try cache as fallback.

--- a/tests/util/test_file_io.py
+++ b/tests/util/test_file_io.py
@@ -1,15 +1,15 @@
 from __future__ import annotations
 
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 from huggingface_hub.utils import EntryNotFoundError, HFValidationError, LocalEntryNotFoundError
-from pytest_mock import MockerFixture
 
 from sentence_transformers.util.file_io import load_dir_path, load_file_path
 
 
-def test_load_file_path_local_missing_short_circuits(tmp_path: Path, mocker: MockerFixture) -> None:
+def test_load_file_path_local_missing_short_circuits(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """When the parent is a real local directory but the requested file is missing,
     `load_file_path` should return ``None`` without calling `hf_hub_download`.
 
@@ -18,7 +18,8 @@ def test_load_file_path_local_missing_short_circuits(tmp_path: Path, mocker: Moc
     list), so a plain return-value assertion would not detect a regression: this
     test explicitly checks that the Hub call is never issued.
     """
-    hub_mock = mocker.patch("sentence_transformers.util.file_io.hf_hub_download")
+    hub_mock = MagicMock()
+    monkeypatch.setattr("sentence_transformers.util.file_io.hf_hub_download", hub_mock)
 
     result = load_file_path(str(tmp_path), "modules.json", local_files_only=True)
 
@@ -36,14 +37,12 @@ def test_load_file_path_local_exists(tmp_path: Path) -> None:
     assert Path(result) == target
 
 
-def test_load_file_path_nonlocal_path_calls_hub(mocker: MockerFixture) -> None:
+def test_load_file_path_nonlocal_path_calls_hub(monkeypatch: pytest.MonkeyPatch) -> None:
     """When the path is not an existing local directory, the local-dir guard must
     not fire and `hf_hub_download` should still be invoked.
     """
-    hub_mock = mocker.patch(
-        "sentence_transformers.util.file_io.hf_hub_download",
-        return_value="/fake/cache/modules.json",
-    )
+    hub_mock = MagicMock(return_value="/fake/cache/modules.json")
+    monkeypatch.setattr("sentence_transformers.util.file_io.hf_hub_download", hub_mock)
 
     result = load_file_path("some-org/some-model", "modules.json", local_files_only=True)
 
@@ -51,12 +50,13 @@ def test_load_file_path_nonlocal_path_calls_hub(mocker: MockerFixture) -> None:
     hub_mock.assert_called_once()
 
 
-def test_load_dir_path_local_missing_short_circuits(tmp_path: Path, mocker: MockerFixture) -> None:
+def test_load_dir_path_local_missing_short_circuits(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Regression test for #3370. The local-dir guard short-circuits to ``None`` and
     `snapshot_download` is never called, so callers don't see a confusing
     `HFValidationError` for what's actually just a missing local file.
     """
-    snapshot_mock = mocker.patch("sentence_transformers.util.file_io.snapshot_download")
+    snapshot_mock = MagicMock()
+    monkeypatch.setattr("sentence_transformers.util.file_io.snapshot_download", snapshot_mock)
 
     result = load_dir_path(str(tmp_path), "1_Pooling", local_files_only=True)
 
@@ -74,14 +74,12 @@ def test_load_dir_path_local_subfolder_exists(tmp_path: Path) -> None:
     assert Path(result) == subfolder
 
 
-def test_load_dir_path_nonlocal_path_calls_hub(mocker: MockerFixture) -> None:
+def test_load_dir_path_nonlocal_path_calls_hub(monkeypatch: pytest.MonkeyPatch) -> None:
     """When the path is not an existing local directory, the local-dir guard must
     not fire and `snapshot_download` should still be invoked.
     """
-    snapshot_mock = mocker.patch(
-        "sentence_transformers.util.file_io.snapshot_download",
-        return_value="/fake/cache/path",
-    )
+    snapshot_mock = MagicMock(return_value="/fake/cache/path")
+    monkeypatch.setattr("sentence_transformers.util.file_io.snapshot_download", snapshot_mock)
 
     result = load_dir_path("some-org/some-model", "1_Pooling", local_files_only=True)
 
@@ -89,71 +87,65 @@ def test_load_dir_path_nonlocal_path_calls_hub(mocker: MockerFixture) -> None:
     snapshot_mock.assert_called_once()
 
 
-def test_load_file_path_entry_not_found_returns_none(mocker: MockerFixture) -> None:
+def test_load_file_path_entry_not_found_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
     """`EntryNotFoundError` (file genuinely missing from the repo) should be swallowed
     and return ``None`` so callers can fall back to defaults (e.g. wrapping
     `bert-base-uncased` as a SentenceTransformer when `modules.json` doesn't exist).
     """
-    mocker.patch(
+    monkeypatch.setattr(
         "sentence_transformers.util.file_io.hf_hub_download",
-        side_effect=EntryNotFoundError("file not in repo"),
+        MagicMock(side_effect=EntryNotFoundError("file not in repo")),
     )
 
     result = load_file_path("some-org/some-model", "modules.json")
     assert result is None
 
 
-def test_load_file_path_transient_error_propagates(mocker: MockerFixture) -> None:
+def test_load_file_path_transient_error_propagates(monkeypatch: pytest.MonkeyPatch) -> None:
     """Transient/auth errors (rate limit, 401, network) must propagate. Returning
     ``None`` silently would let `_load_modules` fall back to a vanilla transformer
     when the user actually has a SentenceTransformer model behind the failed call.
     """
-    mocker.patch(
+    monkeypatch.setattr(
         "sentence_transformers.util.file_io.hf_hub_download",
-        side_effect=RuntimeError("simulated rate limit"),
+        MagicMock(side_effect=RuntimeError("simulated rate limit")),
     )
 
     with pytest.raises(RuntimeError, match="simulated rate limit"):
         load_file_path("some-org/some-model", "modules.json")
 
 
-def test_load_dir_path_local_entry_not_found_returns_none(mocker: MockerFixture) -> None:
+def test_load_dir_path_local_entry_not_found_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
     """`LocalEntryNotFoundError` from the first `snapshot_download` (e.g. offline +
     nothing cached) should short-circuit to ``None`` without retrying the cache,
     since the retry would do the same thing.
     """
-    snapshot_mock = mocker.patch(
-        "sentence_transformers.util.file_io.snapshot_download",
-        side_effect=LocalEntryNotFoundError("not cached"),
-    )
+    snapshot_mock = MagicMock(side_effect=LocalEntryNotFoundError("not cached"))
+    monkeypatch.setattr("sentence_transformers.util.file_io.snapshot_download", snapshot_mock)
 
     result = load_dir_path("some-org/some-model", "1_Pooling", local_files_only=True)
     assert result is None
     snapshot_mock.assert_called_once()
 
 
-def test_load_dir_path_hf_validation_error_returns_none(mocker: MockerFixture) -> None:
+def test_load_dir_path_hf_validation_error_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
     """`HFValidationError` (malformed repo id) is unambiguously "not on the Hub" —
     short-circuit to ``None`` rather than retrying.
     """
-    snapshot_mock = mocker.patch(
-        "sentence_transformers.util.file_io.snapshot_download",
-        side_effect=HFValidationError("bad repo id"),
-    )
+    snapshot_mock = MagicMock(side_effect=HFValidationError("bad repo id"))
+    monkeypatch.setattr("sentence_transformers.util.file_io.snapshot_download", snapshot_mock)
 
     result = load_dir_path("not a repo id", "1_Pooling")
     assert result is None
     snapshot_mock.assert_called_once()
 
 
-def test_load_dir_path_transient_with_cache_hit(mocker: MockerFixture) -> None:
+def test_load_dir_path_transient_with_cache_hit(monkeypatch: pytest.MonkeyPatch) -> None:
     """When the first `snapshot_download` fails with a transient error but the cache
     has the model, `load_dir_path` should return the cached path.
     """
-    snapshot_mock = mocker.patch(
-        "sentence_transformers.util.file_io.snapshot_download",
-        side_effect=[RuntimeError("simulated network error"), "/fake/cache/path"],
-    )
+    snapshot_mock = MagicMock(side_effect=[RuntimeError("simulated network error"), "/fake/cache/path"])
+    monkeypatch.setattr("sentence_transformers.util.file_io.snapshot_download", snapshot_mock)
 
     result = load_dir_path("some-org/some-model", "1_Pooling")
     assert result == str(Path("/fake/cache/path", "1_Pooling"))
@@ -161,15 +153,15 @@ def test_load_dir_path_transient_with_cache_hit(mocker: MockerFixture) -> None:
     assert snapshot_mock.call_args_list[1].kwargs["local_files_only"] is True
 
 
-def test_load_dir_path_transient_with_cache_miss_reraises_original(mocker: MockerFixture) -> None:
+def test_load_dir_path_transient_with_cache_miss_reraises_original(monkeypatch: pytest.MonkeyPatch) -> None:
     """When the first call fails with a transient error and the cache also lacks the
     model, the original transient error is re-raised (not the cache miss). The cache
     miss would mask the real cause; users see the rate-limit/auth/network error instead.
     """
-    snapshot_mock = mocker.patch(
-        "sentence_transformers.util.file_io.snapshot_download",
+    snapshot_mock = MagicMock(
         side_effect=[RuntimeError("simulated network error"), LocalEntryNotFoundError("not cached")],
     )
+    monkeypatch.setattr("sentence_transformers.util.file_io.snapshot_download", snapshot_mock)
 
     with pytest.raises(RuntimeError, match="simulated network error"):
         load_dir_path("some-org/some-model", "1_Pooling")

--- a/tests/util/test_file_io.py
+++ b/tests/util/test_file_io.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from huggingface_hub.utils import EntryNotFoundError, HFValidationError, LocalEntryNotFoundError
+from pytest_mock import MockerFixture
+
+from sentence_transformers.util.file_io import load_dir_path, load_file_path
+
+
+def test_load_file_path_local_missing_short_circuits(tmp_path: Path, mocker: MockerFixture) -> None:
+    """When the parent is a real local directory but the requested file is missing,
+    `load_file_path` should return ``None`` without calling `hf_hub_download`.
+
+    Without the #3370 guard the call would still return ``None`` (the
+    `HFValidationError` raised by the Hub for a Windows-style path is in the catch
+    list), so a plain return-value assertion would not detect a regression: this
+    test explicitly checks that the Hub call is never issued.
+    """
+    hub_mock = mocker.patch("sentence_transformers.util.file_io.hf_hub_download")
+
+    result = load_file_path(str(tmp_path), "modules.json", local_files_only=True)
+
+    assert result is None
+    hub_mock.assert_not_called()
+
+
+def test_load_file_path_local_exists(tmp_path: Path) -> None:
+    """`load_file_path` returns the local path when the file is present."""
+    target = tmp_path / "config.json"
+    target.write_text("{}")
+
+    result = load_file_path(str(tmp_path), "config.json", local_files_only=True)
+    assert result is not None
+    assert Path(result) == target
+
+
+def test_load_file_path_nonlocal_path_calls_hub(mocker: MockerFixture) -> None:
+    """When the path is not an existing local directory, the local-dir guard must
+    not fire and `hf_hub_download` should still be invoked.
+    """
+    hub_mock = mocker.patch(
+        "sentence_transformers.util.file_io.hf_hub_download",
+        return_value="/fake/cache/modules.json",
+    )
+
+    result = load_file_path("some-org/some-model", "modules.json", local_files_only=True)
+
+    assert result == "/fake/cache/modules.json"
+    hub_mock.assert_called_once()
+
+
+def test_load_dir_path_local_missing_short_circuits(tmp_path: Path, mocker: MockerFixture) -> None:
+    """Regression test for #3370. The local-dir guard short-circuits to ``None`` and
+    `snapshot_download` is never called, so callers don't see a confusing
+    `HFValidationError` for what's actually just a missing local file.
+    """
+    snapshot_mock = mocker.patch("sentence_transformers.util.file_io.snapshot_download")
+
+    result = load_dir_path(str(tmp_path), "1_Pooling", local_files_only=True)
+
+    assert result is None
+    snapshot_mock.assert_not_called()
+
+
+def test_load_dir_path_local_subfolder_exists(tmp_path: Path) -> None:
+    """`load_dir_path` returns the resolved local path when the subfolder exists."""
+    subfolder = tmp_path / "1_Pooling"
+    subfolder.mkdir()
+
+    result = load_dir_path(str(tmp_path), "1_Pooling", local_files_only=True)
+    assert result is not None
+    assert Path(result) == subfolder
+
+
+def test_load_dir_path_nonlocal_path_calls_hub(mocker: MockerFixture) -> None:
+    """When the path is not an existing local directory, the local-dir guard must
+    not fire and `snapshot_download` should still be invoked.
+    """
+    snapshot_mock = mocker.patch(
+        "sentence_transformers.util.file_io.snapshot_download",
+        return_value="/fake/cache/path",
+    )
+
+    result = load_dir_path("some-org/some-model", "1_Pooling", local_files_only=True)
+
+    assert result == str(Path("/fake/cache/path", "1_Pooling"))
+    snapshot_mock.assert_called_once()
+
+
+def test_load_file_path_entry_not_found_returns_none(mocker: MockerFixture) -> None:
+    """`EntryNotFoundError` (file genuinely missing from the repo) should be swallowed
+    and return ``None`` so callers can fall back to defaults (e.g. wrapping
+    `bert-base-uncased` as a SentenceTransformer when `modules.json` doesn't exist).
+    """
+    mocker.patch(
+        "sentence_transformers.util.file_io.hf_hub_download",
+        side_effect=EntryNotFoundError("file not in repo"),
+    )
+
+    result = load_file_path("some-org/some-model", "modules.json")
+    assert result is None
+
+
+def test_load_file_path_transient_error_propagates(mocker: MockerFixture) -> None:
+    """Transient/auth errors (rate limit, 401, network) must propagate. Returning
+    ``None`` silently would let `_load_modules` fall back to a vanilla transformer
+    when the user actually has a SentenceTransformer model behind the failed call.
+    """
+    mocker.patch(
+        "sentence_transformers.util.file_io.hf_hub_download",
+        side_effect=RuntimeError("simulated rate limit"),
+    )
+
+    with pytest.raises(RuntimeError, match="simulated rate limit"):
+        load_file_path("some-org/some-model", "modules.json")
+
+
+def test_load_dir_path_local_entry_not_found_returns_none(mocker: MockerFixture) -> None:
+    """`LocalEntryNotFoundError` from the first `snapshot_download` (e.g. offline +
+    nothing cached) should short-circuit to ``None`` without retrying the cache,
+    since the retry would do the same thing.
+    """
+    snapshot_mock = mocker.patch(
+        "sentence_transformers.util.file_io.snapshot_download",
+        side_effect=LocalEntryNotFoundError("not cached"),
+    )
+
+    result = load_dir_path("some-org/some-model", "1_Pooling", local_files_only=True)
+    assert result is None
+    snapshot_mock.assert_called_once()
+
+
+def test_load_dir_path_hf_validation_error_returns_none(mocker: MockerFixture) -> None:
+    """`HFValidationError` (malformed repo id) is unambiguously "not on the Hub" —
+    short-circuit to ``None`` rather than retrying.
+    """
+    snapshot_mock = mocker.patch(
+        "sentence_transformers.util.file_io.snapshot_download",
+        side_effect=HFValidationError("bad repo id"),
+    )
+
+    result = load_dir_path("not a repo id", "1_Pooling")
+    assert result is None
+    snapshot_mock.assert_called_once()
+
+
+def test_load_dir_path_transient_with_cache_hit(mocker: MockerFixture) -> None:
+    """When the first `snapshot_download` fails with a transient error but the cache
+    has the model, `load_dir_path` should return the cached path.
+    """
+    snapshot_mock = mocker.patch(
+        "sentence_transformers.util.file_io.snapshot_download",
+        side_effect=[RuntimeError("simulated network error"), "/fake/cache/path"],
+    )
+
+    result = load_dir_path("some-org/some-model", "1_Pooling")
+    assert result == str(Path("/fake/cache/path", "1_Pooling"))
+    assert snapshot_mock.call_count == 2
+    assert snapshot_mock.call_args_list[1].kwargs["local_files_only"] is True
+
+
+def test_load_dir_path_transient_with_cache_miss_reraises_original(mocker: MockerFixture) -> None:
+    """When the first call fails with a transient error and the cache also lacks the
+    model, the original transient error is re-raised (not the cache miss). The cache
+    miss would mask the real cause; users see the rate-limit/auth/network error instead.
+    """
+    snapshot_mock = mocker.patch(
+        "sentence_transformers.util.file_io.snapshot_download",
+        side_effect=[RuntimeError("simulated network error"), LocalEntryNotFoundError("not cached")],
+    )
+
+    with pytest.raises(RuntimeError, match="simulated network error"):
+        load_dir_path("some-org/some-model", "1_Pooling")
+    assert snapshot_mock.call_count == 2


### PR DESCRIPTION
Resolves #3370

Hello!

## Pull Request overview
* Fix `HFValidationError` when loading a local model from a path that doesn't pass HF repo-id validation (e.g. Windows absolute paths)
* Narrow the exception catch in `load_file_path` and `load_dir_path` so transient Hub errors propagate instead of being silently swallowed
* Wrap README probes during model load and `push_to_hub` so transient Hub errors don't block the operation
* Add unit tests for `load_file_path` and `load_dir_path` covering the new error semantics

## Details

The original bug: calling `SentenceTransformer("D:\\path\\to\\model")` (or any absolute local path that exists but is missing one of the expected subfolders/files) used to fall through to `hf_hub_download`/`snapshot_download` with the local path passed as the repo id. The Hub then raised `HFValidationError` complaining about the path string, and in `load_dir_path` the existing retry block re-raised on the second attempt, so the error propagated to the caller and produced a confusing message blaming the user's Windows path.

I've added a `Path(model_name_or_path).is_dir()` guard right after the local-file existence check in both functions. When the parent is a real local directory, we return `None` immediately instead of asking the Hub to interpret the path as a repo id. One small behavior change worth noting: if a user has a local directory whose name collides with a Hub repo id, the local directory now wins even when incomplete — I think that's the more correct behavior, since silently shadowing a local path with a Hub fallback was surprising, but it's a change.

While I was in there, I also narrowed the broad `except Exception` blocks in both functions. The old catch silently turned auth errors, rate limits, and network failures into `None`, which let `_load_modules` fall back to a vanilla transformer (or whatever the model type's default architecture is) when the user actually had a real model behind the failed call. For users loading a custom-architecture model (CSR, SPLADE, a custom CrossEncoder head), that meant getting a silently broken model on a flaky connection instead of a clear error.

The new behavior:

- `load_file_path` catches `EntryNotFoundError`, `HFValidationError`, and `LocalEntryNotFoundError` and returns `None`. Everything else propagates.
- `load_dir_path` catches `HFValidationError` and `LocalEntryNotFoundError` and returns `None`. Other failures trigger a single cache-only retry; if that also fails with `LocalEntryNotFoundError`, the original transient exception is re-raised (with `from None` to suppress the misleading cache miss from the traceback) so the user sees the real cause.

Critical loads (`modules.json`, `config_sentence_transformers.json`, module subfolders) now fail loudly on transient errors, which is the safe default. For optional metadata, specifically the README probes during model init at and during `push_to_hub`, I wrapped the `load_file_path` calls in `try/except Exception` so that a transient Hub error doesn't block model loading or pushing for what is purely cosmetic data.

Docstrings on `is_sentence_transformer_model`, `load_file_path`, and `load_dir_path` now have explicit `Raises:` sections so callers know the contract has tightened.

Tests in `tests/util/test_file_io.py` cover the local-dir short-circuit (verified by mocking `hf_hub_download`/`snapshot_download` and asserting they're not called), the narrow catch list for each function, the cache-retry path for transient errors with both cache hit and cache miss, and the re-raise-original behavior on cache miss after a transient first failure.

- Tom Aarsen