### PR TITLE
[`fix`] Forward Hub auth to dynamic-module loader for private `trust_remote_code` models

### DIFF
--- a/sentence_transformers/base/model.py
+++ b/sentence_transformers/base/model.py
@@ -1097,7 +1097,14 @@ This pull request has been automatically generated to add {self.__class__.__name
         for module_config in modules_config:
             class_ref = module_config["type"]
             module_class: Module = self._load_module_class_from_ref(
-                class_ref, model_name_or_path, trust_remote_code, revision, model_kwargs
+                class_ref,
+                model_name_or_path,
+                trust_remote_code,
+                revision,
+                model_kwargs,
+                token=token,
+                cache_folder=cache_folder,
+                local_files_only=local_files_only,
             )
 
             # Backwards compatibility: if the module is older and its `load` method only supports one parameter,
@@ -1288,6 +1295,9 @@ This pull request has been automatically generated to add {self.__class__.__name
         trust_remote_code: bool,
         revision: str | None,
         model_kwargs: dict[str, Any] | None,
+        token: bool | str | None = None,
+        cache_folder: str | None = None,
+        local_files_only: bool = False,
     ) -> nn.Module:
         """
         Load a module class from a class reference string.
@@ -1298,6 +1308,9 @@ This pull request has been automatically generated to add {self.__class__.__name
             trust_remote_code: Whether to trust remote code
             revision: The model revision
             model_kwargs: Additional model kwargs
+            token: Hub auth token, required for private repos when fetching custom modeling files.
+            cache_folder: Optional override for the Hub cache directory.
+            local_files_only: Restrict to local cache (no Hub network calls).
 
         Returns:
             The module class
@@ -1309,6 +1322,9 @@ This pull request has been automatically generated to add {self.__class__.__name
             trust_remote_code=trust_remote_code,
             revision=revision,
             code_revision=code_revision,
+            token=token,
+            cache_folder=cache_folder,
+            local_files_only=local_files_only,
         )
 
     def evaluate(self, evaluator: BaseEvaluator, output_path: str | None = None) -> dict[str, float] | float:

--- a/sentence_transformers/base/modules/router.py
+++ b/sentence_transformers/base/modules/router.py
@@ -652,6 +652,9 @@ class Router(InputModule):
                 model_name_or_path=model_name_or_path,
                 trust_remote_code=trust_remote_code,
                 revision=revision,
+                token=token,
+                cache_folder=cache_folder,
+                local_files_only=local_files_only,
             )
             try:
                 module = module_class.load(

--- a/sentence_transformers/util/misc.py
+++ b/sentence_transformers/util/misc.py
@@ -83,6 +83,9 @@ def import_module_class(
     trust_remote_code: bool = False,
     revision: str | None = None,
     code_revision: str | None = None,
+    token: bool | str | None = None,
+    cache_folder: str | None = None,
+    local_files_only: bool = False,
 ) -> type:
     """
     Resolve a module class reference to a class object.
@@ -107,6 +110,10 @@ def import_module_class(
         revision: Hub revision to fetch the modeling file from.
         code_revision: Optional separate revision pinning for the modeling code (overrides
             ``revision`` when set).
+        token: Hugging Face Hub authentication token. Required for fetching modeling files
+            from private repositories.
+        cache_folder: Optional override for the Hugging Face Hub cache directory.
+        local_files_only: If True, only use cached files and never reach out to the Hub.
 
     Returns:
         The resolved class.
@@ -123,6 +130,9 @@ def import_module_class(
                 model_name_or_path,
                 revision=revision,
                 code_revision=code_revision,
+                token=token,
+                cache_dir=cache_folder,
+                local_files_only=local_files_only,
             )
         except (OSError, ValueError):
             # 1) the file does not exist, or 2) the class_ref is not correctly formatted/found

--- a/tests/base/modules/test_router.py
+++ b/tests/base/modules/test_router.py
@@ -643,9 +643,10 @@ def test_router_load_with_config(
 def test_router_load_forwards_trust_remote_code(
     static_embedding: StaticEmbedding, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Router.load() forwards trust_remote_code and revision to import_module_class so
-    repository-local custom child class refs (e.g. modeling_my_model.MyModule) can be
-    resolved via the dynamic-module mechanism."""
+    """Router.load() forwards trust_remote_code, revision, and Hub auth/cache kwargs to
+    import_module_class so repository-local custom child class refs (e.g.
+    modeling_my_model.MyModule) can be resolved via the dynamic-module mechanism, including
+    against private repos."""
     router = Router({"query": [static_embedding], "document": [static_embedding]}, default_route="query")
     SentenceTransformer(modules=[router]).save_pretrained(tmp_path)
 
@@ -657,12 +658,21 @@ def test_router_load_forwards_trust_remote_code(
 
     monkeypatch.setattr("sentence_transformers.base.modules.router.import_module_class", fake_import_module_class)
 
-    SentenceTransformer(str(tmp_path), trust_remote_code=True)
+    SentenceTransformer(
+        str(tmp_path),
+        trust_remote_code=True,
+        token="hf_test_token",
+        cache_folder="some/cache/dir",
+        local_files_only=True,
+    )
 
     assert len(captured) == 2  # one resolution per child route
     for call in captured:
         assert call["trust_remote_code"] is True
         assert call["model_name_or_path"] == str(tmp_path)
+        assert call["token"] == "hf_test_token"
+        assert call["cache_folder"] == "some/cache/dir"
+        assert call["local_files_only"] is True
         assert "revision" in call
         assert "StaticEmbedding" in call["class_ref"]
 

--- a/tests/util/test_misc.py
+++ b/tests/util/test_misc.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from sentence_transformers.util.misc import import_module_class
+
+
+def test_import_module_class_forwards_token_to_dynamic_module():
+    """Custom remote modules in private repos require the auth token to be forwarded to
+    `get_class_from_dynamic_module`. Without it, the modeling file fetch 401s, the OSError
+    is silently swallowed, and the user gets a confusing ImportError instead of an auth
+    error. See #3367.
+
+    Also covers `code_revision`: when a user pins a separate revision for the modeling code
+    (via `model_kwargs={"code_revision": ...}`), it must reach `get_class_from_dynamic_module`
+    so the right version of the modeling file is fetched.
+    """
+    with patch("transformers.dynamic_module_utils.get_class_from_dynamic_module") as mock_get:
+        mock_get.return_value = type("FakeClass", (), {})
+        import_module_class(
+            "modeling_dragon.DragonEmbedder",
+            model_name_or_path="ahmad-abd/dragon-embedding-model",
+            trust_remote_code=True,
+            revision="main",
+            code_revision="abc123",
+            token="hf_my_secret_token",
+            cache_folder="/tmp/my_cache",
+            local_files_only=False,
+        )
+
+    mock_get.assert_called_once()
+    call_kwargs = mock_get.call_args.kwargs
+    assert call_kwargs["token"] == "hf_my_secret_token"
+    assert call_kwargs["cache_dir"] == "/tmp/my_cache"
+    assert call_kwargs["local_files_only"] is False
+    assert call_kwargs["revision"] == "main"
+    assert call_kwargs["code_revision"] == "abc123"
+
+
+def test_import_module_class_sentence_transformers_namespace_skips_dynamic_loading():
+    """Built-in `sentence_transformers.*` classes should never trigger the dynamic-module
+    code path, even when token/trust_remote_code are passed.
+    """
+    with patch("transformers.dynamic_module_utils.get_class_from_dynamic_module") as mock_get:
+        cls = import_module_class(
+            "sentence_transformers.models.Pooling",
+            model_name_or_path="some/repo",
+            trust_remote_code=True,
+            token="hf_my_secret_token",
+        )
+
+    mock_get.assert_not_called()
+    from sentence_transformers.models import Pooling
+
+    assert cls is Pooling


### PR DESCRIPTION
Resolves #3367

Hello!

## Pull Request overview
* Forward `token`, `cache_folder`, and `local_files_only` to `transformers.dynamic_module_utils.get_class_from_dynamic_module` so loading private-repo models with `trust_remote_code=True` works on the first try

## Details
When a model's `modules.json` references a repo-local class (e.g. `modeling_dragon.DragonEmbedder`), `import_module_class` delegates to `get_class_from_dynamic_module` to fetch the modeling file from the Hub. We were never passing the auth token through, so for private repos the fetch 401'd, the `OSError` was silently swallowed by the existing `except (OSError, ValueError)` guard, and the loader fell back to `import_from_string`, which then failed with a confusing `ImportError` because the module isn't on the local Python path.

The fix threads `token`, `cache_folder` (as `cache_dir`), and `local_files_only` through the two callers of `import_module_class` (`BaseModel._load_module_class_from_ref` and `Router.load`) so the dynamic-module loader gets the same auth context as the rest of the load path.

I added a small unit test that mocks `get_class_from_dynamic_module` and asserts the kwargs are forwarded. I didn't try to set up a private-repo integration test in CI.

- Tom Aarsen