### PR TITLE
[`fix`] Use first non-pad token for CLS pooling with left-padding

### DIFF
--- a/sentence_transformers/sentence_transformer/modules/pooling.py
+++ b/sentence_transformers/sentence_transformer/modules/pooling.py
@@ -175,7 +175,18 @@ class Pooling(Module):
 
         for mode in modes:
             if mode == "cls":
-                output_vectors.append(features.get("cls_token_embeddings", token_embeddings[:, 0]))
+                if "cls_token_embeddings" in features:
+                    output_vectors.append(features["cls_token_embeddings"])
+                else:
+                    # argmax on a 0/1 mask returns the first real token per row: index 0
+                    # for right-padding, first non-pad index for left-padding.
+                    first_indices = attention_mask.to(torch.int).argmax(dim=1)
+                    if torch.all(first_indices == 0):
+                        output_vectors.append(token_embeddings[:, 0])
+                    else:
+                        bs, _, hidden_dim = token_embeddings.shape
+                        gather_indices = first_indices.unsqueeze(-1).unsqueeze(1).expand(bs, 1, hidden_dim)
+                        output_vectors.append(torch.gather(token_embeddings, 1, gather_indices).squeeze(1))
 
             elif mode == "max":
                 mask = attention_mask.unsqueeze(-1).expand_as(token_embeddings).to(token_embeddings.dtype)

--- a/sentence_transformers/sentence_transformer/modules/pooling.py
+++ b/sentence_transformers/sentence_transformer/modules/pooling.py
@@ -180,13 +180,10 @@ class Pooling(Module):
                 else:
                     # argmax on a 0/1 mask returns the first real token per row: index 0
                     # for right-padding, first non-pad index for left-padding.
+                    hidden_dim = token_embeddings.shape[-1]
                     first_indices = attention_mask.to(torch.int).argmax(dim=1)
-                    if torch.all(first_indices == 0):
-                        output_vectors.append(token_embeddings[:, 0])
-                    else:
-                        bs, _, hidden_dim = token_embeddings.shape
-                        gather_indices = first_indices.unsqueeze(-1).unsqueeze(1).expand(bs, 1, hidden_dim)
-                        output_vectors.append(torch.gather(token_embeddings, 1, gather_indices).squeeze(1))
+                    gather_indices = first_indices.unsqueeze(-1).unsqueeze(1).expand(-1, 1, hidden_dim)
+                    output_vectors.append(torch.gather(token_embeddings, 1, gather_indices).squeeze(1))
 
             elif mode == "max":
                 mask = attention_mask.unsqueeze(-1).expand_as(token_embeddings).to(token_embeddings.dtype)

--- a/tests/sentence_transformer/modules/test_pooling.py
+++ b/tests/sentence_transformer/modules/test_pooling.py
@@ -193,6 +193,34 @@ def test_pooling_flattened_cls_uses_cls_token_embeddings() -> None:
     assert torch.allclose(sentence_embedding, cls_token_embeddings)
 
 
+def test_pooling_cls_right_padded_uses_position_zero() -> None:
+    """For right-padded inputs, the first real token is at position 0."""
+    dim = 1
+    pooling = Pooling(embedding_dimension=dim, pooling_mode="cls")
+
+    token_embeddings = torch.tensor([[[1.0], [2.0], [3.0], [4.0]], [[5.0], [6.0], [7.0], [8.0]]])
+    attention_mask = torch.tensor([[1, 1, 1, 0], [1, 1, 0, 0]], dtype=torch.int64)
+
+    outputs = pooling({"token_embeddings": token_embeddings, "attention_mask": attention_mask})
+    assert torch.allclose(outputs["sentence_embedding"], torch.tensor([[1.0], [5.0]]))
+
+
+def test_pooling_cls_left_padded_finds_first_real_token() -> None:
+    """For left-padded inputs (decoder-style models), the first real token is the first 1 in the
+    attention mask, not position 0. Reproduces #3208.
+    """
+    dim = 1
+    pooling = Pooling(embedding_dimension=dim, pooling_mode="cls")
+
+    # Row 0: 2 pads then 2 real tokens -> first real token is at idx 2 (value 3.0)
+    # Row 1: 1 pad then 3 real tokens -> first real token is at idx 1 (value 6.0)
+    token_embeddings = torch.tensor([[[1.0], [2.0], [3.0], [4.0]], [[5.0], [6.0], [7.0], [8.0]]])
+    attention_mask = torch.tensor([[0, 0, 1, 1], [0, 1, 1, 1]], dtype=torch.int64)
+
+    outputs = pooling({"token_embeddings": token_embeddings, "attention_mask": attention_mask})
+    assert torch.allclose(outputs["sentence_embedding"], torch.tensor([[3.0], [6.0]]))
+
+
 def test_pooling_max_respects_attention_mask() -> None:
     dim = 1
     pooling = Pooling(embedding_dimension=dim, pooling_mode="max")


### PR DESCRIPTION
Resolves #3208

Hello!

## Pull Request overview
* Fix `Pooling` with `pooling_mode="cls"` to pick the first non-pad token on left-padded inputs
* Add tests for both right- and left-padded CLS pooling

## Details
Previously, the padded forward path extracted the CLS embedding via `token_embeddings[:, 0]`, which is only correct when the tokenizer right-pads. For left-padded inputs (common with decoder-style models), position 0 is a pad token, so the pooled embedding was meaningless. The bug silently produced incorrect embeddings without any warning (see #3208).

I've replaced the hardcoded `[:, 0]` with `attention_mask.argmax(dim=1)`, which returns the first index of the maximum value in the 0/1 mask: position 0 for right-padding, and the first non-pad index for left-padding. A fast path keeps the simple `[:, 0]` selection when all first-indices are 0 (the common encoder case); otherwise `torch.gather` picks the correct row per sequence.

This also closes a silent discrepancy with the flattened / unpadded (FA2) path, which already extracted CLS via `all_embeddings[cu_seq_lens_q[:-1]]` and was correct by construction since the packed format has no padding. Pre-fix, the same model and input could produce different sentence embeddings depending on whether unpadding was active.

- Tom Aarsen
