### PR TITLE
[`fix`] Unwrap DDP/torch.compile wrappers in `AdaptiveLayerLoss`

### DIFF
--- a/sentence_transformers/sentence_transformer/losses/adaptive_layer.py
+++ b/sentence_transformers/sentence_transformer/losses/adaptive_layer.py
@@ -195,8 +195,9 @@ class AdaptiveLayerLoss(nn.Module):
                 unwrapped_model = unwrapped_model.module
             else:
                 raise TypeError(
-                    f"AdaptiveLayerLoss could not unwrap {type(self.model).__name__} to a BaseModel; "
-                    "expected DistributedDataParallel, torch.compile's OptimizedModule, or a BaseModel."
+                    f"AdaptiveLayerLoss could not unwrap {type(self.model).__name__} to a BaseModel "
+                    f"(stopped at {type(unwrapped_model).__name__}). "
+                    "Expected DistributedDataParallel, torch.compile's OptimizedModule, or a BaseModel."
                 )
 
         # Decorate the forward function of the transformer to cache the embeddings of all layers

--- a/sentence_transformers/sentence_transformer/losses/adaptive_layer.py
+++ b/sentence_transformers/sentence_transformer/losses/adaptive_layer.py
@@ -10,6 +10,7 @@ from torch import Tensor, nn
 from torch.nn import functional as F
 
 from sentence_transformers import SentenceTransformer
+from sentence_transformers.base.model import BaseModel
 from sentence_transformers.base.modules import Transformer
 from sentence_transformers.sentence_transformer.losses.cached_gist_embed import CachedGISTEmbedLoss
 from sentence_transformers.sentence_transformer.losses.cached_multiple_negatives_ranking import (
@@ -184,15 +185,29 @@ class AdaptiveLayerLoss(nn.Module):
             warnings.warn(f"MatryoshkaLoss is not compatible with {loss.__class__.__name__}.", stacklevel=2)
 
     def forward(self, sentence_features: Iterable[dict[str, Tensor]], labels: Tensor) -> Tensor:
+        # Unwrap DDP (`.module`) / torch.compile (`_orig_mod`) wrappers so `self.model[0]`
+        # decoration still works under multi-GPU or compiled training.
+        unwrapped_model = self.model
+        while not isinstance(unwrapped_model, BaseModel):
+            if hasattr(unwrapped_model, "_orig_mod"):
+                unwrapped_model = unwrapped_model._orig_mod
+            elif hasattr(unwrapped_model, "module"):
+                unwrapped_model = unwrapped_model.module
+            else:
+                raise TypeError(
+                    f"AdaptiveLayerLoss could not unwrap {type(self.model).__name__} to a BaseModel; "
+                    "expected DistributedDataParallel, torch.compile's OptimizedModule, or a BaseModel."
+                )
+
         # Decorate the forward function of the transformer to cache the embeddings of all layers
-        original_transformer_forward = self.model[0].forward
-        transformer_decorator = TransformerDecorator(self.model[0], original_transformer_forward)
-        self.model[0].forward = transformer_decorator
+        original_transformer_forward = unwrapped_model[0].forward
+        transformer_decorator = TransformerDecorator(unwrapped_model[0], original_transformer_forward)
+        unwrapped_model[0].forward = transformer_decorator
 
         # Decorate the forward function of the model to get the embeddings after all modules (e.g. pooling)
-        original_forward = self.model.forward
+        original_forward = unwrapped_model.forward
         forward_decorator = ForwardDecorator(original_forward)
-        self.model.forward = forward_decorator
+        unwrapped_model.forward = forward_decorator
 
         try:
             # Run the loss normally: i.e. the final layer, but 1) use the transformers decorator to cache
@@ -229,8 +244,8 @@ class AdaptiveLayerLoss(nn.Module):
                     )
                     loss = loss + kl_div_loss * self.kl_temperature * self.kl_div_weight
         finally:
-            self.model[0].forward = original_transformer_forward
-            self.model.forward = original_forward
+            unwrapped_model[0].forward = original_transformer_forward
+            unwrapped_model.forward = original_forward
 
         return loss
 

--- a/tests/sentence_transformer/losses/test_adaptive_layer.py
+++ b/tests/sentence_transformer/losses/test_adaptive_layer.py
@@ -129,3 +129,14 @@ def test_adaptive_layer_loss_raises_on_unrecognised_wrapper(stsb_bert_tiny_model
     features, labels = _features_and_labels(stsb_bert_tiny_model)
     with pytest.raises(TypeError, match="could not unwrap"):
         adaptive(features, labels)
+
+
+def test_adaptive_layer_loss_error_names_inner_stuck_point(stsb_bert_tiny_model: SentenceTransformer) -> None:
+    """For nested wrappers the error should name both the outer wrapper (what the user
+    passed in) and the inner object the unwrap got stuck on."""
+    adaptive = _make_loss(stsb_bert_tiny_model)
+    adaptive.model = _FakeDDP(nn.Linear(2, 2))  # DDP wraps an unrecognised inner
+
+    features, labels = _features_and_labels(stsb_bert_tiny_model)
+    with pytest.raises(TypeError, match=r"could not unwrap _FakeDDP .*stopped at Linear"):
+        adaptive(features, labels)

--- a/tests/sentence_transformer/losses/test_adaptive_layer.py
+++ b/tests/sentence_transformer/losses/test_adaptive_layer.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import pytest
+import torch
+from torch import nn
+
+from sentence_transformers import SentenceTransformer
+from sentence_transformers.base.trainer import BaseTrainer
+from sentence_transformers.sentence_transformer.losses import AdaptiveLayerLoss, MultipleNegativesRankingLoss
+
+
+class _FakeDDP(nn.Module):
+    """Stand-in for `torch.nn.parallel.DistributedDataParallel` that exposes the wrapped
+    module via `.module` and proxies `forward` like real DDP. Notably it does NOT support
+    `__getitem__`, so `model[0]` raises TypeError."""
+
+    def __init__(self, module: nn.Module) -> None:
+        super().__init__()
+        self.module = module
+
+    def forward(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+        return self.module(*args, **kwargs)
+
+
+class _FakeCompile(nn.Module):
+    """Stand-in for `torch._dynamo.OptimizedModule` (output of `torch.compile`): exposes
+    the wrapped module via `_orig_mod` and proxies `forward`. Also not subscriptable."""
+
+    def __init__(self, module: nn.Module) -> None:
+        super().__init__()
+        self._orig_mod = module
+
+    def forward(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+        return self._orig_mod(*args, **kwargs)
+
+
+class _StubTrainer:
+    """Borrow `BaseTrainer.override_model_in_loss` without instantiating the full trainer.
+    The method only uses `self` for its recursive call, so any object with the same bound
+    attribute works."""
+
+    override_model_in_loss = BaseTrainer.override_model_in_loss
+
+
+def _make_loss(model: SentenceTransformer) -> AdaptiveLayerLoss:
+    inner_loss = MultipleNegativesRankingLoss(model)
+    return AdaptiveLayerLoss(model, inner_loss)
+
+
+def _features_and_labels(model: SentenceTransformer) -> tuple[list[dict], torch.Tensor]:
+    features = [
+        {k: v.to(model.device) if isinstance(v, torch.Tensor) else v for k, v in feats.items()}
+        for feats in [model.preprocess(["a", "b"]), model.preprocess(["c", "d"])]
+    ]
+    labels = torch.tensor([0, 1], device=model.device)
+    return features, labels
+
+
+def test_adaptive_layer_loss_runs_without_wrapper(stsb_bert_tiny_model: SentenceTransformer) -> None:
+    """Sanity check for the non-DDP, non-compile path: a bare SentenceTransformer skips
+    the unwrap loop entirely."""
+    adaptive = _make_loss(stsb_bert_tiny_model)
+    features, labels = _features_and_labels(stsb_bert_tiny_model)
+    loss = adaptive(features, labels)
+    assert torch.isfinite(loss)
+
+
+@pytest.mark.parametrize(
+    "wrapper_cls",
+    [_FakeDDP, _FakeCompile],
+    ids=["ddp", "torch_compile"],
+)
+def test_adaptive_layer_loss_unwraps_wrapped_model(
+    stsb_bert_tiny_model: SentenceTransformer,
+    wrapper_cls: type[nn.Module],
+) -> None:
+    """AdaptiveLayerLoss.forward reaches into `self.model[0]`. Under DDP / torch.compile
+    the trainer rebinds `loss.model` to the wrapper (and binds BaseModel methods like
+    `preprocess` onto it). Verify the loss still unwraps to the inner BaseModel for the
+    `model[0]` decoration. See #3170.
+    """
+    adaptive = _make_loss(stsb_bert_tiny_model)
+    wrapped = wrapper_cls(stsb_bert_tiny_model)
+    with pytest.raises(TypeError):
+        _ = wrapped[0]  # type: ignore[index]
+
+    # Run the real trainer codepath: this also setattrs `preprocess` /
+    # `get_embedding_dimension` onto the wrapper, which would fool a
+    # `hasattr(model, "preprocess")` stop condition.
+    _StubTrainer().override_model_in_loss(adaptive, wrapped)  # type: ignore[arg-type]
+    assert adaptive.model is wrapped
+    assert hasattr(wrapped, "preprocess")
+
+    features, labels = _features_and_labels(stsb_bert_tiny_model)
+    loss = adaptive(features, labels)
+    assert loss.dim() == 0
+    assert torch.isfinite(loss)
+
+
+@pytest.mark.parametrize(
+    "wrap",
+    [
+        lambda m: _FakeCompile(_FakeDDP(m)),
+        lambda m: _FakeDDP(_FakeCompile(m)),
+    ],
+    ids=["compile_of_ddp", "ddp_of_compile"],
+)
+def test_adaptive_layer_loss_unwraps_nested_wrappers(
+    stsb_bert_tiny_model: SentenceTransformer,
+    wrap,
+) -> None:
+    """Compile-of-DDP and DDP-of-compile both need to unwrap to the inner BaseModel."""
+    adaptive = _make_loss(stsb_bert_tiny_model)
+    wrapped = wrap(stsb_bert_tiny_model)
+    _StubTrainer().override_model_in_loss(adaptive, wrapped)  # type: ignore[arg-type]
+
+    features, labels = _features_and_labels(stsb_bert_tiny_model)
+    loss = adaptive(features, labels)
+    assert loss.dim() == 0
+    assert torch.isfinite(loss)
+
+
+def test_adaptive_layer_loss_raises_on_unrecognised_wrapper(stsb_bert_tiny_model: SentenceTransformer) -> None:
+    """If `self.model` is something we can't unwrap to a BaseModel, fail loudly instead of
+    silently raising the cryptic `'X' object is not subscriptable`."""
+    adaptive = _make_loss(stsb_bert_tiny_model)
+    adaptive.model = nn.Linear(2, 2)  # neither a BaseModel nor a recognised wrapper
+
+    features, labels = _features_and_labels(stsb_bert_tiny_model)
+    with pytest.raises(TypeError, match="could not unwrap"):
+        adaptive(features, labels)


### PR DESCRIPTION
Resolves #3170

Hello!

## Pull Request overview
* Unwrap DDP / `torch.compile` wrappers in `AdaptiveLayerLoss.forward` so `self.model[0]` decoration still works under multi-GPU / compiled training

## Details
`AdaptiveLayerLoss.forward` decorates `self.model[0].forward` (the transformer module) and `self.model.forward` (the whole model) to cache intermediate-layer outputs for the KL-divergence term. Under DDP, `BaseTrainer.override_model_in_loss` rebinds `loss.model` to the `DistributedDataParallel` wrapper, which exposes the inner model via `.module` and is not subscriptable. The first line of `forward` then raises `TypeError: 'DistributedDataParallel' object is not subscriptable`. The same shape applies to `torch.compile`'s `OptimizedModule`, which uses `_orig_mod`.

#3746 already added `preprocess`/`get_embedding_dimension` onto the DDP-wrapped model in losses, which fixes the same general problem for losses that only need those methods on the wrapper. `AdaptiveLayerLoss` is different: it indexes into the model with `model[0]`, which can't be solved by binding extra attrs.

The fix walks past `_orig_mod` and `.module` at the top of `forward` until we land on a `BaseModel`, and uses that for the decoration / restoration. The stop condition is a positive `isinstance(BaseModel)` check rather than `hasattr(preprocess)`. The trainer-side fix from #3746 binds `preprocess` onto the wrapper, which would otherwise short-circuit a `hasattr`-based check. If we can't reach a `BaseModel`, the loss raises a clear `TypeError` instead of letting the cryptic subscript error propagate.

The added tests cover bare models (sanity), DDP and `torch.compile` wrappers individually, nested compile-of-DDP and DDP-of-compile, and the failure path for unrecognised wrappers. The wrapped cases run the real `BaseTrainer.override_model_in_loss` codepath, so the trainer-side monkey-patching is part of what's being exercised. I didn't try to reproduce a full multi-GPU run in CI, just the subscriptability path that was breaking in #3170.

- Tom Aarsen
