### PR TITLE
ci: declare contents:read on min-versions workflow

### DIFF
--- a/.github/workflows/min-versions.yml
+++ b/.github/workflows/min-versions.yml
@@ -19,6 +19,9 @@ env:
   TRANSFORMERS_IS_CI: 1
   HF_HUB_DISABLE_PROGRESS_BARS: 1
 
+permissions:
+  contents: read
+
 jobs:
   test_min_versions:
     name: Test minimum dependency versions


### PR DESCRIPTION
This adds a workflow-level `permissions: contents: read` to `.github/workflows/min-versions.yml`. The job checks out the repo, sets up Python, installs the package against minimum-version dependencies, then runs `pytest`. Nothing in that path needs anything beyond read access to repo contents.

Worth doing even when the inherited default is already read-only, because of two distinct gains. First, drift protection: if the org or repo default `GITHUB_TOKEN` scope is ever widened, this workflow stays capped. Second, OpenSSF Scorecard's Token-Permissions check only credits explicit per-workflow declarations, so an in-file block is what registers. The bigger picture is the runtime supply-chain threat CVE-2025-30066 surfaced (the March 2025 `tj-actions/changed-files` compromise) where a compromised third-party action leaks `GITHUB_TOKEN` with whatever scope was issued; per-workflow caps bound that blast radius.

Diff validated locally with `yaml.safe_load`.
