### PR TITLE
[`fix`] Collapse single-key multimodal dicts to bare modality

### DIFF
--- a/sentence_transformers/base/modality.py
+++ b/sentence_transformers/base/modality.py
@@ -12,6 +12,7 @@ import numpy as np
 import torch
 
 from sentence_transformers.base.modality_types import (
+    MULTIMODAL_DICT_KEYS,
     AudioInput,
     MessageFormat,
     Modality,
@@ -273,6 +274,10 @@ class InputFormatter:
 
             modality = infer_modality(item, supported_modalities=self.supported_modalities)  # type: ignore[arg-type]  # non-text pairs filtered above
 
+            # Unwrap single-key multimodal dict: {"image": pil} -> use pil as the value
+            if isinstance(item, dict) and modality in MULTIMODAL_DICT_KEYS and item.keys() == {modality}:
+                item = item[modality]
+
             # For dict-wrapped audio/video (including inside a multimodal dict), unwrap the array
             # and collect extra kwargs. For a single message dict, wrap it in a list.
             # All other values pass through as-is.
@@ -362,6 +367,9 @@ class InputFormatter:
             # matching the behavior of to_message() for multi-modal inputs.
             if isinstance(modality, tuple) and isinstance(item, dict):
                 return [{"type": mod, mod: item[mod]} for mod in modality if mod in item]
+            # Unwrap single-key multimodal dict: {"image": pil} -> use pil as the value
+            if isinstance(item, dict) and modality in MULTIMODAL_DICT_KEYS and item.keys() == {modality}:
+                item = item[modality]
             return [{"type": modality, modality: item}]
 
         return [
@@ -551,7 +559,8 @@ def infer_modality(
             This prevents misclassification of text that happens to contain media URLs.
 
     Returns:
-        The detected modality string, or a tuple of modality strings for multimodal dict inputs.
+        The detected modality string, or a tuple of modality strings for multimodal dict inputs
+        with 2+ keys. A 1-key dict like ``{"image": pil}`` collapses to the bare modality string.
 
     Raises:
         ValueError: If the input type/structure is not recognized.
@@ -596,14 +605,17 @@ def infer_modality(
                 f"Got keys: {set(sample.keys())}"
             )
         case dict() if sample:
-            # Multimodal dict: keys are modality names (sorted for consistent route lookups)
-            valid_modalities = {"text", "image", "audio", "video"}
-            invalid_keys = set(sample.keys()) - valid_modalities
+            # Single-key dicts collapse to the bare modality string so {"image": pil} matches
+            # the same support/routing as a raw PIL input.
+            invalid_keys = set(sample.keys()) - MULTIMODAL_DICT_KEYS
             if invalid_keys:
                 raise ValueError(
                     f"Multimodal dict input contains unrecognized modality keys: {invalid_keys}. "
-                    f"Expected keys from: {valid_modalities}"
+                    f"Expected keys from: {sorted(MULTIMODAL_DICT_KEYS)}"
                 )
+            if len(sample) == 1:
+                return next(iter(sample))
+            # Multimodal dict: keys are modality names (sorted for consistent route lookups)
             return tuple(sorted(sample.keys()))
         case dict():
             raise ValueError("Empty dict input is not a valid input sample.")

--- a/sentence_transformers/base/modality_types.py
+++ b/sentence_transformers/base/modality_types.py
@@ -65,3 +65,5 @@ MODALITY_TO_PROCESSOR_ARG: dict[Modality, ProcessorArgName] = {
     "video": "videos",
     "message": "message",
 }
+
+MULTIMODAL_DICT_KEYS = frozenset({"text", "image", "audio", "video"})

--- a/tests/base/test_modality.py
+++ b/tests/base/test_modality.py
@@ -213,6 +213,15 @@ class TestInferModality:
         sample_b = {"image": "cat.jpg", "text": "a photo"}
         assert infer_modality(sample_a) == infer_modality(sample_b)
 
+    def test_single_key_multimodal_dict_collapses_to_bare_modality(self):
+        # A 1-key multimodal dict should be equivalent to a raw value of that modality.
+        PIL = pytest.importorskip("PIL.Image")
+        img = PIL.new("RGB", (10, 10))
+        assert infer_modality({"image": img}) == "image"
+        assert infer_modality({"text": "hello"}) == "text"
+        assert infer_modality({"audio": np.zeros(16000)}) == "audio"
+        assert infer_modality({"video": np.zeros((8, 3, 224, 224))}) == "video"
+
     def test_unsupported_type_raises(self):
         with pytest.raises(ValueError, match="Unsupported input type"):
             infer_modality(12345)
@@ -586,16 +595,33 @@ class TestParseInputs:
         """A ``{"audio": array}`` wrapper with a raw array should behave like bare audio inputs."""
         arr = np.zeros(16000)
         modality, inputs, extra = self.fmt.parse_inputs([{"audio": arr}])
-        assert modality == ("audio",)
+        assert modality == "audio"
         assert len(inputs["audio"]) == 1
         assert inputs["audio"][0] is arr
+        assert dict(extra) == {}
+
+    def test_single_key_image_dict_unwraps(self):
+        """A ``{"image": pil}`` wrapper should behave like a bare PIL image input."""
+        PIL = pytest.importorskip("PIL.Image")
+        img = PIL.new("RGB", (10, 10))
+        modality, inputs, extra = self.fmt.parse_inputs([{"image": img}])
+        assert modality == "image"
+        assert len(inputs["image"]) == 1
+        assert inputs["image"][0] is img
+        assert dict(extra) == {}
+
+    def test_single_key_text_dict_unwraps(self):
+        """A ``{"text": "hello"}`` wrapper should behave like a bare text input."""
+        modality, inputs, extra = self.fmt.parse_inputs([{"text": "hello"}])
+        assert modality == "text"
+        assert inputs == {"text": ["hello"]}
         assert dict(extra) == {}
 
     def test_multimodal_dict_unwraps_nested_audio_dict(self):
         """A ``{"audio": {"array": ..., "sampling_rate": ...}}`` wrapper should unwrap the nested dict."""
         arr = np.zeros(16000)
         modality, inputs, extra = self.fmt.parse_inputs([{"audio": {"array": arr, "sampling_rate": 16000}}])
-        assert modality == ("audio",)
+        assert modality == "audio"
         assert len(inputs["audio"]) == 1
         assert inputs["audio"][0] is arr
         assert extra["audio"]["sampling_rate"] == 16000
@@ -604,7 +630,7 @@ class TestParseInputs:
         """A ``{"video": {"array": ..., "video_metadata": ...}}`` wrapper should unwrap the nested dict."""
         arr = np.zeros((8, 3, 224, 224))
         modality, inputs, extra = self.fmt.parse_inputs([{"video": {"array": arr, "video_metadata": {"fps": 30}}}])
-        assert modality == ("video",)
+        assert modality == "video"
         assert len(inputs["video"]) == 1
         assert inputs["video"][0] is arr
         assert extra["video"]["video_metadata"] == [{"fps": 30}]
@@ -639,7 +665,7 @@ class TestParseInputs:
         decoder = AudioDecoder(torch.frombuffer(buf.getvalue(), dtype=torch.uint8))
 
         modality, inputs, extra = self.fmt.parse_inputs([{"audio": decoder}])
-        assert modality == ("audio",)
+        assert modality == "audio"
         assert isinstance(inputs["audio"][0], np.ndarray)
         assert extra["audio"]["sampling_rate"] == sample_rate
 
@@ -670,7 +696,7 @@ class TestParseInputs:
         decoder = VideoDecoder(torch.frombuffer(buf.getvalue(), dtype=torch.uint8))
 
         modality, inputs, extra = self.fmt.parse_inputs([{"video": decoder}])
-        assert modality == ("video",)
+        assert modality == "video"
         assert inputs["video"][0].shape[0] == num_frames
         assert extra["video"]["video_metadata"][0]["total_num_frames"] == num_frames
 
@@ -971,6 +997,16 @@ class TestPairToMessages:
         # Each item should have its modality as the key (not a tuple key)
         for item in doc_content:
             assert isinstance(item["type"], str)
+
+    def test_single_key_dict_in_pair_unwraps(self):
+        """A ``{"image": pil}`` wrapper inside a pair should unwrap to the bare PIL value."""
+        fmt = InputFormatter(model_type="test", message_format="structured")
+        img = Image.new("RGB", (32, 32))
+        result = fmt.pair_to_messages(("a query", {"image": img}))
+        assert len(result) == 2
+        assert result[1]["role"] == "document"
+        # The content should reference the unwrapped image, not the wrapping dict
+        assert result[1]["content"] == [{"type": "image", "image": img}]
 
 
 class TestParseInputsPairs:


### PR DESCRIPTION
Hello!

## Pull Request overview
* Treat single-key multimodal dicts (e.g. `{"image": pil}`) as equivalent to bare modality inputs

## Details
MTEB passes image inputs as `{"image": pil}` dicts when running vision-retrieval benchmarks (see https://github.com/embeddings-benchmark/mteb/pull/4310#issuecomment-4431589032). These were previously classified as the tuple modality `("image",)` and routed through the multimodal path, which fails the `supports()` check for models that only declare `"image"` support (e.g. BGE-VL).

With this PR, `infer_modality` collapses a single-key multimodal dict to the bare modality string. `{"image": pil}` now returns `"image"` instead of `("image",)`. `parse_inputs` and `pair_to_messages` correspondingly unwrap the dict so downstream sees the raw value, matching what they would have seen for a bare PIL input.

The existing `{"audio": ...}` / `{"video": ...}` wrapper tests are updated to expect the bare modality (they were already going through the same unwrap path), and new tests cover `parse_inputs` and `pair_to_messages` for the image/text cases that the previous tuple-based handling silently masked.

Notably, this fixes:
```python

from sentence_transformers import SentenceTransformer

model = SentenceTransformer('BAAI/BGE-VL-base', trust_remote_code=True)
embedding = model.encode({"image": "https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/blog/ettin-reranker/mteb_ndcg10_all-MiniLM-L6-v2.png"})
print(embedding)
```
```
Traceback (most recent call last):
  File "c:\code\sentence-transformers\demo_bge_vl.py", line 5, in <module>
    embedding = model.encode({"image": "https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/blog/ettin-reranker/mteb_ndcg10_all-MiniLM-L6-v2.png"})
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\tom\.conda\envs\sentence-transformers\Lib\site-packages\torch\utils\_contextlib.py", line 124, in decorate_context
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "c:\code\sentence-transformers\sentence_transformers\util\decorators.py", line 41, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "c:\code\sentence-transformers\sentence_transformers\sentence_transformer\model.py", line 650, in encode
    features = self.preprocess(inputs_batch, prompt=prompt, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "c:\code\sentence-transformers\sentence_transformers\base\model.py", line 542, in preprocess
    raise ValueError(message)
ValueError: Modality 'image' is not supported by this SentenceTransformer model. Supported modalities: text, image, image+text
This model supports image individually, but not in the same input. Please process each modality separately.
```

- Tom Aarsen
