### PR TITLE
fix TSDAE weight tying on transformers v5

### DIFF
--- a/sentence_transformers/sentence_transformer/losses/denoising_auto_encoder.py
+++ b/sentence_transformers/sentence_transformer/losses/denoising_auto_encoder.py
@@ -14,22 +14,22 @@ logger = logging.getLogger(__name__)
 
 
 def _tie_encoder_decoder_weights(encoder: nn.Module, decoder: nn.Module) -> None:
-    """Share the encoder's parameters with the identically-named decoder parameters.
+    """Tie the encoder's parameters to the decoder's: each encoder parameter is replaced by the
+    identically-named decoder parameter, so the two share storage and the decoder's values become
+    the shared initialization.
 
-    Replaces ``transformers.PreTrainedModel._tie_encoder_decoder_weights``, removed in
-    transformers 5.0.0 (which moved tying to an in-model ``_tied_weights_keys`` mapping that
-    cannot span two separate model instances). Tying requires encoder and decoder to share an
-    architecture, so the decoder's parameters map onto the encoder by name; the decoder-only
-    cross-attention parameters simply have no encoder counterpart and are skipped.
+    The encoder and decoder must share an architecture for the parameter names to line up.
+    Decoder-only parameters, such as the cross-attention weights, have no encoder counterpart
+    and are skipped.
     """
     encoder_modules = dict(encoder.named_modules())
-    tied = 0
+    tied = False
     for name, param in decoder.named_parameters(remove_duplicate=False):
         module_name, _, attr = name.rpartition(".")
-        module = encoder_modules.get(module_name)
-        if module is not None and hasattr(module, attr):
-            setattr(module, attr, param)  # encoder param now references the decoder's
-            tied += 1
+        encoder_module = encoder_modules.get(module_name)
+        if encoder_module is not None and hasattr(encoder_module, attr):
+            setattr(encoder_module, attr, param)  # encoder param now references the decoder's
+            tied = True
     if not tied:
         logger.warning("No encoder weights were tied to the decoder; are they the same architecture?")
 
@@ -168,8 +168,7 @@ class DenoisingAutoEncoderLoss(nn.Module):
                 logger.warning(
                     "Since the encoder vocabulary has been changed and --tie_encoder_decoder=True, now the new vocabulary has also been used for the decoder."
                 )
-            # Tie locally so it works on transformers >= 5.0.0, which removed
-            # PreTrainedModel._tie_encoder_decoder_weights (see _tie_encoder_decoder_weights above).
+            # Tie the encoder and decoder so they share weights during training.
             decoder_base = self.decoder._modules[self.decoder.base_model_prefix]
             _tie_encoder_decoder_weights(model.transformers_model, decoder_base)
 

--- a/sentence_transformers/sentence_transformer/losses/denoising_auto_encoder.py
+++ b/sentence_transformers/sentence_transformer/losses/denoising_auto_encoder.py
@@ -24,7 +24,7 @@ def _tie_encoder_decoder_weights(encoder: nn.Module, decoder: nn.Module) -> None
     """
     encoder_modules = dict(encoder.named_modules())
     tied = False
-    for name, param in decoder.named_parameters(remove_duplicate=False):
+    for name, param in decoder.named_parameters():
         module_name, _, attr = name.rpartition(".")
         encoder_module = encoder_modules.get(module_name)
         if encoder_module is not None and hasattr(encoder_module, attr):

--- a/sentence_transformers/sentence_transformer/losses/denoising_auto_encoder.py
+++ b/sentence_transformers/sentence_transformer/losses/denoising_auto_encoder.py
@@ -4,15 +4,34 @@ import logging
 from collections.abc import Iterable
 from typing import Any
 
-from packaging.version import Version, parse
 from torch import Tensor, nn
-from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer, PreTrainedModel
-from transformers import __version__ as transformers_version
+from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer
 
 from sentence_transformers.sentence_transformer.model import SentenceTransformer
 from sentence_transformers.sentence_transformer.modules import StaticEmbedding
 
 logger = logging.getLogger(__name__)
+
+
+def _tie_encoder_decoder_weights(encoder: nn.Module, decoder: nn.Module) -> None:
+    """Share the encoder's parameters with the identically-named decoder parameters.
+
+    Replaces ``transformers.PreTrainedModel._tie_encoder_decoder_weights``, removed in
+    transformers 5.0.0 (which moved tying to an in-model ``_tied_weights_keys`` mapping that
+    cannot span two separate model instances). Tying requires encoder and decoder to share an
+    architecture, so the decoder's parameters map onto the encoder by name; the decoder-only
+    cross-attention parameters simply have no encoder counterpart and are skipped.
+    """
+    encoder_modules = dict(encoder.named_modules())
+    tied = 0
+    for name, param in decoder.named_parameters(remove_duplicate=False):
+        module_name, _, attr = name.rpartition(".")
+        module = encoder_modules.get(module_name)
+        if module is not None and hasattr(module, attr):
+            setattr(module, attr, param)  # encoder param now references the decoder's
+            tied += 1
+    if not tied:
+        logger.warning("No encoder weights were tied to the decoder; are they the same architecture?")
 
 
 class DenoisingAutoEncoderLoss(nn.Module):
@@ -142,12 +161,6 @@ class DenoisingAutoEncoderLoss(nn.Module):
             )
 
         if tie_encoder_decoder:
-            if parse(transformers_version) >= Version("5.0.0"):
-                raise RuntimeError(
-                    "Tying encoder and decoder weights is not currently supported for transformers version >= 5.0.0. "
-                    "Please either install transformers<5.0.0 or set tie_encoder_decoder=False."
-                )
-
             assert not self.need_retokenization, "The tokenizers should be the same when tie_encoder_decoder=True."
             if len(self.tokenizer_encoder) != len(self.tokenizer_decoder):  # The vocabulary has been changed.
                 self.tokenizer_decoder = self.tokenizer_encoder
@@ -155,22 +168,10 @@ class DenoisingAutoEncoderLoss(nn.Module):
                 logger.warning(
                     "Since the encoder vocabulary has been changed and --tie_encoder_decoder=True, now the new vocabulary has also been used for the decoder."
                 )
-            decoder_base_model_prefix = self.decoder.base_model_prefix
-            try:
-                # Compatibility with transformers <4.40.0
-                PreTrainedModel._tie_encoder_decoder_weights(
-                    model.transformers_model,
-                    self.decoder._modules[decoder_base_model_prefix],
-                    self.decoder.base_model_prefix,
-                )
-            except TypeError:
-                # Compatibility with transformers >=4.40.0
-                PreTrainedModel._tie_encoder_decoder_weights(
-                    model.transformers_model,
-                    self.decoder._modules[decoder_base_model_prefix],
-                    self.decoder.base_model_prefix,
-                    encoder_name_or_path,
-                )
+            # Tie locally so it works on transformers >= 5.0.0, which removed
+            # PreTrainedModel._tie_encoder_decoder_weights (see _tie_encoder_decoder_weights above).
+            decoder_base = self.decoder._modules[self.decoder.base_model_prefix]
+            _tie_encoder_decoder_weights(model.transformers_model, decoder_base)
 
     def retokenize(self, sentence_features: dict[str, Tensor]) -> dict[str, Tensor]:
         input_ids = sentence_features["input_ids"]

--- a/tests/sentence_transformer/losses/test_denoising_auto_encoder.py
+++ b/tests/sentence_transformer/losses/test_denoising_auto_encoder.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import torch
+
+from sentence_transformers import SentenceTransformer
+from sentence_transformers.sentence_transformer.losses import DenoisingAutoEncoderLoss
+
+TINY_MODEL = "sentence-transformers-testing/stsb-bert-tiny-safetensors"
+
+
+def _base_params(loss: DenoisingAutoEncoderLoss) -> tuple[dict, dict]:
+    """Return ``(encoder_params, decoder_base_params)`` keyed by name, for the shared base models."""
+    encoder = loss.encoder.transformers_model
+    decoder_base = loss.decoder._modules[loss.decoder.base_model_prefix]
+    return dict(encoder.named_parameters()), dict(decoder_base.named_parameters())
+
+
+def test_tie_encoder_decoder_does_not_raise(stsb_bert_tiny_model: SentenceTransformer) -> None:
+    """Regression for #3737: tying raised a RuntimeError on transformers>=5.0.0, which removed
+    the ``PreTrainedModel._tie_encoder_decoder_weights`` helper this loss relied on."""
+    DenoisingAutoEncoderLoss(stsb_bert_tiny_model, tie_encoder_decoder=True)
+
+
+def test_tied_weights_share_storage(stsb_bert_tiny_model: SentenceTransformer) -> None:
+    """With tying, every parameter shared by name between encoder and decoder is the *same object*."""
+    loss = DenoisingAutoEncoderLoss(stsb_bert_tiny_model, tie_encoder_decoder=True)
+    encoder_params, decoder_params = _base_params(loss)
+
+    # The word embeddings are the canonical tied weight: assert true aliasing, not just equal values.
+    name = "embeddings.word_embeddings.weight"
+    assert encoder_params[name] is decoder_params[name]
+
+    # Every parameter the two share by name is tied to the same storage. The encoder's pooler is
+    # encoder-only (the decoder's base model is built with add_pooling_layer=False), so it is
+    # correctly excluded here rather than asserted as tied.
+    common = encoder_params.keys() & decoder_params.keys()
+    assert common, "expected the encoder and decoder to share parameters by name"
+    untied = [n for n in common if encoder_params[n].data_ptr() != decoder_params[n].data_ptr()]
+    assert not untied, f"these shared-name weights were not tied: {untied}"
+
+
+def test_decoder_only_weights_are_not_tied(stsb_bert_tiny_model: SentenceTransformer) -> None:
+    """Cross-attention is decoder-only, so it has no encoder counterpart and must be skipped."""
+    loss = DenoisingAutoEncoderLoss(stsb_bert_tiny_model, tie_encoder_decoder=True)
+    encoder_params, decoder_params = _base_params(loss)
+
+    cross_attention = [n for n in decoder_params if "crossattention" in n]
+    assert cross_attention, "expected the decoder to carry cross-attention parameters"
+    assert all(n not in encoder_params for n in cross_attention)
+
+
+def test_untied_weights_are_independent(stsb_bert_tiny_model: SentenceTransformer) -> None:
+    """Without tying, the encoder and decoder keep independent storage."""
+    loss = DenoisingAutoEncoderLoss(stsb_bert_tiny_model, decoder_name_or_path=TINY_MODEL, tie_encoder_decoder=False)
+    encoder_params, decoder_params = _base_params(loss)
+
+    name = "embeddings.word_embeddings.weight"
+    assert encoder_params[name].data_ptr() != decoder_params[name].data_ptr()
+
+
+def test_forward_backward_flows_grad_to_tied_weight(stsb_bert_tiny_model: SentenceTransformer) -> None:
+    """A train step produces a finite scalar and flows gradient into the tied embedding."""
+    loss = DenoisingAutoEncoderLoss(stsb_bert_tiny_model, tie_encoder_decoder=True)
+    loss = loss.to(stsb_bert_tiny_model.device)  # the trainer normally handles device placement
+
+    features = stsb_bert_tiny_model.preprocess(["A noisy input sentence for tsdae"])
+    features = {
+        k: v.to(stsb_bert_tiny_model.device) if isinstance(v, torch.Tensor) else v for k, v in features.items()
+    }
+
+    value = loss([features, features], labels=None)
+    assert value.dim() == 0
+    assert torch.isfinite(value)
+
+    value.backward()
+    shared = loss.encoder.transformers_model.embeddings.word_embeddings.weight
+    assert shared.grad is not None
+
+
+def test_tie_without_decoder_name_does_not_require_it(stsb_bert_tiny_model: SentenceTransformer) -> None:
+    """When tying, ``decoder_name_or_path`` may be omitted: it defaults to the encoder's checkpoint."""
+    loss = DenoisingAutoEncoderLoss(stsb_bert_tiny_model, tie_encoder_decoder=True)
+    assert loss.decoder is not None

--- a/tests/sentence_transformer/losses/test_denoising_auto_encoder.py
+++ b/tests/sentence_transformer/losses/test_denoising_auto_encoder.py
@@ -49,6 +49,21 @@ def test_decoder_only_weights_are_not_tied(stsb_bert_tiny_model: SentenceTransfo
     assert all(n not in encoder_params for n in cross_attention)
 
 
+def test_tying_preserves_decoder_lm_head(stsb_bert_tiny_model: SentenceTransformer) -> None:
+    """The decoder's weight-tied LM head must stay bound to the shared input embeddings. Tying the
+    encoder *to* the decoder keeps all three as one tensor; reversing the direction would rebind the
+    decoder's input embeddings to the encoder's and orphan the LM head (silently untying it)."""
+    loss = DenoisingAutoEncoderLoss(stsb_bert_tiny_model, tie_encoder_decoder=True)
+
+    encoder_in = loss.encoder.transformers_model.embeddings.word_embeddings.weight
+    decoder_base = loss.decoder._modules[loss.decoder.base_model_prefix]
+    decoder_in = decoder_base.embeddings.word_embeddings.weight
+    lm_head = loss.decoder.get_output_embeddings().weight
+
+    # The test model has tie_word_embeddings=True, so input embeddings and LM head share one tensor.
+    assert encoder_in is decoder_in is lm_head
+
+
 def test_untied_weights_are_independent(stsb_bert_tiny_model: SentenceTransformer) -> None:
     """Without tying, the encoder and decoder keep independent storage."""
     loss = DenoisingAutoEncoderLoss(stsb_bert_tiny_model, decoder_name_or_path=TINY_MODEL, tie_encoder_decoder=False)


### PR DESCRIPTION
`DenoisingAutoEncoderLoss` raised a `RuntimeError` on transformers >= 5.0.0 whenever `tie_encoder_decoder=True` (the default). Since tying is the recommended TSDAE setting, this effectively broke TSDAE on v5 unless you pinned an older transformers.  


| loss code | transformers 4.57.6 (<5) | transformers 5.9.0 (>=5) |
|---|---|---|
| before this PR | ✅ works | ❌ `RuntimeError` |
| with this PR | ✅ works | ✅ works |  

The loss tied the encoder and decoder through the private `PreTrainedModel._tie_encoder_decoder_weights`. transformers v5 removed that helper and moved tying to a per model `_tied_weights_keys` mapping that only applies within a single `PreTrainedModel`. TSDAE keeps the encoder and decoder as two separate models, so the native v5 machinery cannot bridge them, and #3619 added the `RuntimeError` as a stopgap.

Fixes #3737