### PR TITLE
Fix example datasets that crash on datasets 4.x

### DIFF
--- a/examples/sentence_transformer/applications/computing-embeddings/computing_embeddings_streaming.py
+++ b/examples/sentence_transformer/applications/computing-embeddings/computing_embeddings_streaming.py
@@ -28,7 +28,7 @@ if __name__ == "__main__":
     encode_batch_size = 128  # Batch size of the model
 
     # Load a large dataset in streaming mode. more info: https://huggingface.co/docs/datasets/stream
-    dataset = load_dataset("yahoo_answers_topics", split="train", streaming=True)
+    dataset = load_dataset("community-datasets/yahoo_answers_topics", split="train", streaming=True)
     dataloader = DataLoader(dataset.with_format("torch"), batch_size=data_stream_size)
 
     # Define the model

--- a/examples/sentence_transformer/applications/embedding-quantization/README.md
+++ b/examples/sentence_transformer/applications/embedding-quantization/README.md
@@ -110,7 +110,7 @@ from datasets import load_dataset
 model = SentenceTransformer("mixedbread-ai/mxbai-embed-large-v1")
 
 # 2. Prepare an example calibration dataset
-corpus = load_dataset("nq_open", split="train[:1000]")["question"]
+corpus = load_dataset("google-research-datasets/nq_open", split="train[:1000]")["question"]
 calibration_embeddings = model.encode(corpus)
 
 # 3. Encode some text without quantization & apply quantization afterwards

--- a/examples/sentence_transformer/applications/embedding-quantization/semantic_search_faiss.py
+++ b/examples/sentence_transformer/applications/embedding-quantization/semantic_search_faiss.py
@@ -6,10 +6,10 @@ from sentence_transformers import SentenceTransformer
 from sentence_transformers.util.quantization import quantize_embeddings, semantic_search_faiss
 
 # 1. Load the quora corpus with questions
-dataset = load_dataset("quora", split="train").map(
-    lambda batch: {"text": [text for sample in batch["questions"] for text in sample["text"]]},
+dataset = load_dataset("sentence-transformers/quora-duplicates", "pair-class", split="train").map(
+    lambda batch: {"text": [question for pair in zip(batch["sentence1"], batch["sentence2"]) for question in pair]},
     batched=True,
-    remove_columns=["questions", "is_duplicate"],
+    remove_columns=["sentence1", "sentence2", "label"],
 )
 max_corpus_size = 100_000
 corpus = dataset["text"][:max_corpus_size]

--- a/examples/sentence_transformer/applications/embedding-quantization/semantic_search_faiss_benchmark.py
+++ b/examples/sentence_transformer/applications/embedding-quantization/semantic_search_faiss_benchmark.py
@@ -4,10 +4,10 @@ from sentence_transformers import SentenceTransformer
 from sentence_transformers.util.quantization import quantize_embeddings, semantic_search_faiss
 
 # 1. Load the quora corpus with questions
-dataset = load_dataset("quora", split="train").map(
-    lambda batch: {"text": [text for sample in batch["questions"] for text in sample["text"]]},
+dataset = load_dataset("sentence-transformers/quora-duplicates", "pair-class", split="train").map(
+    lambda batch: {"text": [question for pair in zip(batch["sentence1"], batch["sentence2"]) for question in pair]},
     batched=True,
-    remove_columns=["questions", "is_duplicate"],
+    remove_columns=["sentence1", "sentence2", "label"],
 )
 max_corpus_size = 100_000
 corpus = dataset["text"][:max_corpus_size]

--- a/examples/sentence_transformer/applications/embedding-quantization/semantic_search_recommended.py
+++ b/examples/sentence_transformer/applications/embedding-quantization/semantic_search_recommended.py
@@ -28,10 +28,10 @@ model = SentenceTransformer(
 )
 
 # Load a corpus with texts
-dataset = load_dataset("quora", split="train").map(
-    lambda batch: {"text": [text for sample in batch["questions"] for text in sample["text"]]},
+dataset = load_dataset("sentence-transformers/quora-duplicates", "pair-class", split="train").map(
+    lambda batch: {"text": [question for pair in zip(batch["sentence1"], batch["sentence2"]) for question in pair]},
     batched=True,
-    remove_columns=["questions", "is_duplicate"],
+    remove_columns=["sentence1", "sentence2", "label"],
 )
 max_corpus_size = 100_000
 corpus = dataset["text"][:max_corpus_size]

--- a/examples/sentence_transformer/applications/embedding-quantization/semantic_search_usearch.py
+++ b/examples/sentence_transformer/applications/embedding-quantization/semantic_search_usearch.py
@@ -6,10 +6,10 @@ from sentence_transformers import SentenceTransformer
 from sentence_transformers.util.quantization import quantize_embeddings, semantic_search_usearch
 
 # 1. Load the quora corpus with questions
-dataset = load_dataset("quora", split="train", trust_remote_code=True).map(
-    lambda batch: {"text": [text for sample in batch["questions"] for text in sample["text"]]},
+dataset = load_dataset("sentence-transformers/quora-duplicates", "pair-class", split="train").map(
+    lambda batch: {"text": [question for pair in zip(batch["sentence1"], batch["sentence2"]) for question in pair]},
     batched=True,
-    remove_columns=["questions", "is_duplicate"],
+    remove_columns=["sentence1", "sentence2", "label"],
 )
 max_corpus_size = 100_000
 corpus = dataset["text"][:max_corpus_size]

--- a/examples/sentence_transformer/applications/embedding-quantization/semantic_search_usearch_benchmark.py
+++ b/examples/sentence_transformer/applications/embedding-quantization/semantic_search_usearch_benchmark.py
@@ -4,10 +4,10 @@ from sentence_transformers import SentenceTransformer
 from sentence_transformers.util.quantization import quantize_embeddings, semantic_search_usearch
 
 # 1. Load the quora corpus with questions
-dataset = load_dataset("quora", split="train").map(
-    lambda batch: {"text": [text for sample in batch["questions"] for text in sample["text"]]},
+dataset = load_dataset("sentence-transformers/quora-duplicates", "pair-class", split="train").map(
+    lambda batch: {"text": [question for pair in zip(batch["sentence1"], batch["sentence2"]) for question in pair]},
     batched=True,
-    remove_columns=["questions", "is_duplicate"],
+    remove_columns=["sentence1", "sentence2", "label"],
 )
 max_corpus_size = 100_000
 corpus = dataset["text"][:max_corpus_size]


### PR DESCRIPTION
Several examples crash at startup on the current `datasets` 4.x / `huggingface_hub` 1.x stack, for
two related reasons:

- **script-based datasets were removed** (quora):
  ```text
  RuntimeError: Dataset scripts are no longer supported, but found quora.py
  ```
- **bare single-segment dataset ids are no longer allowed** (yahoo_answers_topics, nq_open):
  ```text
  HfUriError: Repository id must be 'namespace/name', got 'yahoo_answers_topics'
  ```

This swaps each broken id for a maintained Hugging Face dataset. The data is preserved (verified),
only the loading id (and, for quora, the access pattern) changes.

## Data verification

- quora: corpus is byte-identical, proven over the full list. The old code flattens the 404290 quora
  pairs into 808580 questions (with duplicates, in pair order). Flattening `quora-duplicates`
  `pair-class` the same way yields a list that is exactly equal (`old == new`, all 808580 elements,
  same order) to the raw quora tsv flattened. See `scripts/verify_quora_corpus_identical.py`.
- yahoo, nq_open: the bare ids redirect to the namespaced repos and resolve to the same commit
  sha, so the data is byte-identical (only the namespace changes).
