### PR TITLE
Migrate MS MARCO examples to hf datasets

### DIFF
--- a/examples/cross_encoder/training/ms_marco/eval_cross_encoder_trec_dl.py
+++ b/examples/cross_encoder/training/ms_marco/eval_cross_encoder_trec_dl.py
@@ -22,6 +22,7 @@ from collections import defaultdict
 import numpy as np
 import pytrec_eval
 import tqdm
+from datasets import load_dataset
 
 from sentence_transformers import CrossEncoder
 from sentence_transformers.util import http_get
@@ -29,46 +30,16 @@ from sentence_transformers.util import http_get
 data_folder = "trec2019-data"
 os.makedirs(data_folder, exist_ok=True)
 
-# Read test queries
-queries = {}
-queries_filepath = os.path.join(data_folder, "msmarco-test2019-queries.tsv.gz")
-if not os.path.exists(queries_filepath):
-    logging.info("Download " + os.path.basename(queries_filepath))
-    http_get(
-        "https://msmarco.z22.web.core.windows.net/msmarcoranking/msmarco-test2019-queries.tsv.gz", queries_filepath
-    )
-
-with gzip.open(queries_filepath, "rt", encoding="utf8") as fIn:
-    for line in fIn:
-        qid, query = line.strip().split("\t")
-        queries[qid] = query
-
+# The TREC-DL 2019 passage qrels are the `test` split of the maintained mteb/msmarco dataset.
 # Read which passages are relevant
 relevant_docs = defaultdict(lambda: defaultdict(int))
-qrels_filepath = os.path.join(data_folder, "2019qrels-pass.txt")
-
-if not os.path.exists(qrels_filepath):
-    logging.info("Download " + os.path.basename(qrels_filepath))
-    http_get("https://trec.nist.gov/data/deep/2019qrels-pass.txt", qrels_filepath)
-
-
-with open(qrels_filepath) as fIn:
-    for line in fIn:
-        qid, _, pid, score = line.strip().split()
-        score = int(score)
-        if score > 0:
-            relevant_docs[qid][pid] = score
-
-# Only use queries that have at least one relevant passage
-relevant_qid = []
-for qid in queries:
-    if len(relevant_docs[qid]) > 0:
-        relevant_qid.append(qid)
-
+for row in load_dataset("mteb/msmarco", "default", split="test"):
+    score = int(row["score"])
+    if score > 0:
+        relevant_docs[str(row["query-id"])][str(row["corpus-id"])] = score
 
 # Read the top 1000 passages that are supposed to be re-ranked
 passage_filepath = os.path.join(data_folder, "msmarco-passagetest2019-top1000.tsv.gz")
-
 if not os.path.exists(passage_filepath):
     logging.info("Download " + os.path.basename(passage_filepath))
     http_get(
@@ -76,15 +47,19 @@ if not os.path.exists(passage_filepath):
         passage_filepath,
     )
 
-
+queries = {}
 passage_cand = {}
 with gzip.open(passage_filepath, "rt", encoding="utf8") as fIn:
     for line in fIn:
         qid, pid, query, passage = line.strip().split("\t")
+        queries[qid] = query
         if qid not in passage_cand:
             passage_cand[qid] = []
 
         passage_cand[qid].append([pid, passage])
+
+# Only use queries that have at least one relevant passage
+relevant_qid = [qid for qid in queries if len(relevant_docs[qid]) > 0]
 
 logging.info(f"Queries: {len(queries)}")
 

--- a/examples/sentence_transformer/training/ms_marco/eval_msmarco.py
+++ b/examples/sentence_transformer/training/ms_marco/eval_msmarco.py
@@ -37,7 +37,7 @@ dev_rel_docs = {}  # Mapping qid => set with relevant pids
 needed_pids = set()  # Passage IDs we need
 needed_qids = set()  # Query IDs we need
 
-# Load the 6980 dev queries
+# Load the dev relevance judgments (6980 queries)
 for row in load_dataset("mteb/msmarco", "default", split="dev"):
     qid, pid = str(row["query-id"]), str(row["corpus-id"])
     dev_rel_docs.setdefault(qid, set()).add(pid)
@@ -50,11 +50,12 @@ for row in load_dataset("mteb/msmarco", "queries", split="queries"):
     if qid in needed_qids:
         dev_queries[qid] = row["text"].strip()
 
-# Read passages
-for row in load_dataset("sentence-transformers/msmarco", "corpus", split="train"):
-    pid = str(row["passage_id"])
+# Read passages (column access decodes the 8.8M-row corpus in one pass, much faster than row-by-row)
+corpus_dataset = load_dataset("sentence-transformers/msmarco", "corpus", split="train")
+for pid, passage in zip(corpus_dataset["passage_id"], corpus_dataset["passage"]):
+    pid = str(pid)
     if pid in needed_pids or corpus_max_size <= 0 or len(corpus) <= corpus_max_size:
-        corpus[pid] = row["passage"].strip()
+        corpus[pid] = passage.strip()
 
 
 # Run evaluator

--- a/examples/sentence_transformer/training/ms_marco/eval_msmarco.py
+++ b/examples/sentence_transformer/training/ms_marco/eval_msmarco.py
@@ -50,12 +50,13 @@ for row in load_dataset("mteb/msmarco", "queries", split="queries"):
     if qid in needed_qids:
         dev_queries[qid] = row["text"].strip()
 
-# Read passages (column access decodes the 8.8M-row corpus in one pass, much faster than row-by-row)
+# Read passages in batches (fast, bounded memory)
 corpus_dataset = load_dataset("sentence-transformers/msmarco", "corpus", split="train")
-for pid, passage in zip(corpus_dataset["passage_id"], corpus_dataset["passage"]):
-    pid = str(pid)
-    if pid in needed_pids or corpus_max_size <= 0 or len(corpus) <= corpus_max_size:
-        corpus[pid] = passage.strip()
+for batch in corpus_dataset.iter(batch_size=10000):
+    for pid, passage in zip(batch["passage_id"], batch["passage"]):
+        pid = str(pid)
+        if pid in needed_pids or corpus_max_size <= 0 or len(corpus) <= corpus_max_size:
+            corpus[pid] = passage.strip()
 
 
 # Run evaluator

--- a/examples/sentence_transformer/training/ms_marco/eval_msmarco.py
+++ b/examples/sentence_transformer/training/ms_marco/eval_msmarco.py
@@ -25,11 +25,11 @@ model_name = sys.argv[1]
 corpus_max_size = int(sys.argv[2]) * 1000 if len(sys.argv) >= 3 else 0
 
 
-####  Load model
+#  Load model
 
 model = SentenceTransformer(model_name)
 
-### Load data from the maintained Hugging Face datasets (replaces the raw MS MARCO downloads)
+# Read the MS MARCO dataset
 
 corpus = {}  # Our corpus pid => passage
 dev_queries = {}  # Our dev queries. qid => query
@@ -37,7 +37,7 @@ dev_rel_docs = {}  # Mapping qid => set with relevant pids
 needed_pids = set()  # Passage IDs we need
 needed_qids = set()  # Query IDs we need
 
-# Load which passages are relevant for which queries (standard MS MARCO dev-small, 6980 queries)
+# Load the 6980 dev queries
 for row in load_dataset("mteb/msmarco", "default", split="dev"):
     qid, pid = str(row["query-id"]), str(row["corpus-id"])
     dev_rel_docs.setdefault(qid, set()).add(pid)
@@ -57,7 +57,7 @@ for row in load_dataset("sentence-transformers/msmarco", "corpus", split="train"
         corpus[pid] = row["passage"].strip()
 
 
-## Run evaluator
+# Run evaluator
 logging.info(f"Queries: {len(dev_queries)}")
 logging.info(f"Corpus: {len(corpus)}")
 

--- a/examples/sentence_transformer/training/ms_marco/eval_msmarco.py
+++ b/examples/sentence_transformer/training/ms_marco/eval_msmarco.py
@@ -7,13 +7,12 @@ python eval_msmarco.py model_name [max_corpus_size_in_thousands]
 """
 
 import logging
-import os
 import sys
-import tarfile
+
+from datasets import load_dataset
 
 from sentence_transformers import SentenceTransformer
 from sentence_transformers.sentence_transformer.evaluation import InformationRetrievalEvaluator
-from sentence_transformers.util import http_get
 
 # Set the log level to INFO to get more information
 logging.basicConfig(format="%(asctime)s - %(message)s", datefmt="%Y-%m-%d %H:%M:%S", level=logging.INFO)
@@ -30,29 +29,7 @@ corpus_max_size = int(sys.argv[2]) * 1000 if len(sys.argv) >= 3 else 0
 
 model = SentenceTransformer(model_name)
 
-### Data files
-data_folder = "msmarco-data"
-os.makedirs(data_folder, exist_ok=True)
-
-collection_filepath = os.path.join(data_folder, "collection.tsv")
-dev_queries_file = os.path.join(data_folder, "queries.dev.small.tsv")
-qrels_filepath = os.path.join(data_folder, "qrels.dev.tsv")
-
-### Download files if needed
-if not os.path.exists(collection_filepath) or not os.path.exists(dev_queries_file):
-    tar_filepath = os.path.join(data_folder, "collectionandqueries.tar.gz")
-    if not os.path.exists(tar_filepath):
-        logging.info("Download: " + tar_filepath)
-        http_get("https://msmarco.z22.web.core.windows.net/msmarcoranking/collectionandqueries.tar.gz", tar_filepath)
-
-    with tarfile.open(tar_filepath, "r:gz") as tar:
-        tar.extractall(path=data_folder)
-
-
-if not os.path.exists(qrels_filepath):
-    http_get("https://msmarco.z22.web.core.windows.net/msmarcoranking/qrels.dev.tsv", qrels_filepath)
-
-### Load data
+### Load data from the maintained Hugging Face datasets (replaces the raw MS MARCO downloads)
 
 corpus = {}  # Our corpus pid => passage
 dev_queries = {}  # Our dev queries. qid => query
@@ -60,37 +37,24 @@ dev_rel_docs = {}  # Mapping qid => set with relevant pids
 needed_pids = set()  # Passage IDs we need
 needed_qids = set()  # Query IDs we need
 
-# Load the 6980 dev queries
-with open(dev_queries_file, encoding="utf8") as fIn:
-    for line in fIn:
-        qid, query = line.strip().split("\t")
-        dev_queries[qid] = query.strip()
+# Load which passages are relevant for which queries (standard MS MARCO dev-small, 6980 queries)
+for row in load_dataset("mteb/msmarco", "default", split="dev"):
+    qid, pid = str(row["query-id"]), str(row["corpus-id"])
+    dev_rel_docs.setdefault(qid, set()).add(pid)
+    needed_qids.add(qid)
+    needed_pids.add(pid)
 
-
-# Load which passages are relevant for which queries
-with open(qrels_filepath) as fIn:
-    for line in fIn:
-        qid, _, pid, _ = line.strip().split("\t")
-
-        if qid not in dev_queries:
-            continue
-
-        if qid not in dev_rel_docs:
-            dev_rel_docs[qid] = set()
-        dev_rel_docs[qid].add(pid)
-
-        needed_pids.add(pid)
-        needed_qids.add(qid)
-
+# Load the dev query texts
+for row in load_dataset("mteb/msmarco", "queries", split="queries"):
+    qid = str(row["_id"])
+    if qid in needed_qids:
+        dev_queries[qid] = row["text"].strip()
 
 # Read passages
-with open(collection_filepath, encoding="utf8") as fIn:
-    for line in fIn:
-        pid, passage = line.strip().split("\t")
-        passage = passage
-
-        if pid in needed_pids or corpus_max_size <= 0 or len(corpus) <= corpus_max_size:
-            corpus[pid] = passage.strip()
+for row in load_dataset("sentence-transformers/msmarco", "corpus", split="train"):
+    pid = str(row["passage_id"])
+    if pid in needed_pids or corpus_max_size <= 0 or len(corpus) <= corpus_max_size:
+        corpus[pid] = row["passage"].strip()
 
 
 ## Run evaluator

--- a/examples/sentence_transformer/training/ms_marco/multilingual/translate_queries.py
+++ b/examples/sentence_transformer/training/ms_marco/multilingual/translate_queries.py
@@ -11,11 +11,9 @@ python translate_queries [target_language]
 import logging
 import os
 import sys
-import tarfile
 
+from datasets import load_dataset
 from easynmt import EasyNMT
-
-from sentence_transformers.util import http_get
 
 # Set the log level to INFO to get more information
 logging.basicConfig(format="%(asctime)s - %(message)s", datefmt="%Y-%m-%d %H:%M:%S", level=logging.INFO)
@@ -23,7 +21,6 @@ logging.getLogger("httpx").setLevel(logging.WARNING)
 
 target_lang = sys.argv[1]
 output_folder = "multilingual-data"
-data_folder = "../msmarco-data"
 
 output_filename = os.path.join(output_folder, f"train_queries.en-{target_lang}.tsv")
 os.makedirs(output_folder, exist_ok=True)
@@ -37,38 +34,21 @@ if os.path.exists(output_filename):
             splits = line.strip().split("\t")
             translated_qids.add(splits[0])
 
-### Now we read the MS Marco dataset
-os.makedirs(data_folder, exist_ok=True)
+### Read the MS MARCO dataset from the maintained Hugging Face datasets (replaces the raw downloads)
 
-# Read qrels file for relevant positives per query
+# Train queries that have relevance judgements (the set the original script translated), minus the
+# ones already translated.
 train_queries = {}
-qrels_train = os.path.join(data_folder, "qrels.train.tsv")
-if not os.path.exists(qrels_train):
-    http_get("https://msmarco.z22.web.core.windows.net/msmarcoranking/qrels.train.tsv", qrels_train)
+for row in load_dataset("mteb/msmarco", "default", split="train"):
+    qid = str(row["query-id"])
+    if qid not in translated_qids:
+        train_queries[qid] = None
 
-with open(qrels_train) as fIn:
-    for line in fIn:
-        qid, _, pid, _ = line.strip().split()
-        if qid not in translated_qids:
-            train_queries[qid] = None
-
-# Read all queries
-queries_filepath = os.path.join(data_folder, "queries.train.tsv")
-if not os.path.exists(queries_filepath):
-    tar_filepath = os.path.join(data_folder, "queries.tar.gz")
-    if not os.path.exists(tar_filepath):
-        logging.info("Download queries.tar.gz")
-        http_get("https://msmarco.z22.web.core.windows.net/msmarcoranking/queries.tar.gz", tar_filepath)
-
-    with tarfile.open(tar_filepath, "r:gz") as tar:
-        tar.extractall(path=data_folder)
-
-
-with open(queries_filepath, encoding="utf8") as fIn:
-    for line in fIn:
-        qid, query = line.strip().split("\t")
-        if qid in train_queries:
-            train_queries[qid] = query.strip()
+# Fill in the query texts
+for row in load_dataset("mteb/msmarco", "queries", split="queries"):
+    qid = str(row["_id"])
+    if qid in train_queries:
+        train_queries[qid] = row["text"].strip()
 
 
 qids = [qid for qid in train_queries if train_queries[qid] is not None]

--- a/examples/sentence_transformer/training/ms_marco/multilingual/translate_queries.py
+++ b/examples/sentence_transformer/training/ms_marco/multilingual/translate_queries.py
@@ -26,7 +26,7 @@ output_filename = os.path.join(output_folder, f"train_queries.en-{target_lang}.t
 os.makedirs(output_folder, exist_ok=True)
 
 
-## Does the output file exists? If yes, read it so we can continue the translation
+# Does the output file exists? If yes, read it so we can continue the translation
 translated_qids = set()
 if os.path.exists(output_filename):
     with open(output_filename, encoding="utf8") as fIn:
@@ -34,10 +34,9 @@ if os.path.exists(output_filename):
             splits = line.strip().split("\t")
             translated_qids.add(splits[0])
 
-### Read the MS MARCO dataset from the maintained Hugging Face datasets (replaces the raw downloads)
+# Read the MS MARCO dataset
 
-# Train queries that have relevance judgements (the set the original script translated), minus the
-# ones already translated.
+# Train queries that have relevance judgements (the set the original script translated), minus the ones already translated.
 train_queries = {}
 for row in load_dataset("mteb/msmarco", "default", split="train"):
     qid = str(row["query-id"])


### PR DESCRIPTION
MS MARCO examples downloaded raw files from `msmarco.z22.web.core.windows.net` (a 1GB tarball
plus qrels/queries) and parsed them by hand. This replaces those raw downloads with the maintained
Hf datasets

## Files

- `training/ms_marco/eval_msmarco.py`
- `training/ms_marco/multilingual/translate_queries.py`
- `training/ms_marco/eval_cross_encoder_trec_dl.py`

## Data verification

- corpus: byte-identical (500/500 sampled passages match the azure `collection.tsv`; row count
  matches exactly at 8,841,823).
- query coverage: dev 6980/6980 and train 502939/502939 query ids are 100% present in the HF
  queries; qrels are equivalent 