### PR TITLE
Migrate multilingual parallel-sentences scripts to hf datasets

### DIFF
--- a/examples/sentence_transformer/training/multilingual/get_parallel_data_talks.py
+++ b/examples/sentence_transformer/training/multilingual/get_parallel_data_talks.py
@@ -34,12 +34,14 @@ for target_lang in target_languages:
         except Exception as e:
             print(f"Skipping {subset} ({split}): {e}")
             continue
+        num_written = 0
         with gzip.open(output_filename, "wt", encoding="utf8") as fOut:
             for row in dataset:
                 english = row["english"].strip()
                 non_english = row["non_english"].strip()
                 if english and non_english:
                     fOut.write(f"{english}\t{non_english}\n")
-        print(f"Wrote {output_filename}: {len(dataset)} pairs")
+                    num_written += 1
+        print(f"Wrote {output_filename}: {num_written} pairs")
 
 print("---DONE---")

--- a/examples/sentence_transformer/training/multilingual/get_parallel_data_talks.py
+++ b/examples/sentence_transformer/training/multilingual/get_parallel_data_talks.py
@@ -1,90 +1,45 @@
 """
-This script downloads the parallel sentences corpus and create parallel sentences tsv files that can be used to extend
-existent sentence embedding models to new languages.
+This script writes parallel sentence tsv files that can be used to extend existing sentence
+embedding models to new languages.
 
-The parallel sentences corpus is a crawl of transcripts from talks, which are translated to 100+ languages.
-
-The parallel sentences corpus cannot be downloaded automatically. It is available for research purposes only (CC-BY-NC).
-
-The training procedure can be found in the files make_multilingual.py.
+It loads the talks parallel corpus (a crawl of talk transcripts translated to 100+ languages) from
+the Hugging Face dataset ``sentence-transformers/parallel-sentences-talks``. The training procedure
+can be found in ``make_multilingual.py``, which loads the same Hugging Face dataset directly.
 
 Further information can be found in our paper:
 Making Monolingual Sentence Embeddings Multilingual using Knowledge Distillation
 https://huggingface.co/papers/2004.09813
 """
 
-import csv
 import gzip
 import os
 
-from tqdm.autonotebook import tqdm
+from datasets import load_dataset
 
-from sentence_transformers.util import http_get
+hf_dataset = "sentence-transformers/parallel-sentences-talks"
+source_lang = "en"  # Language our (monolingual) teacher model understands
+target_languages = ["de", "es", "it", "fr", "ar", "tr"]  # New languages we want to extend to
 
-source_languages = set(["en"])  # Languages our (monolingual) teacher model understands
-target_languages = set(["de", "es", "it", "fr", "ar", "tr"])  # New languages we want to extend to
+output_folder = "parallel-sentences/"
+os.makedirs(output_folder, exist_ok=True)
 
-
-dev_sentences = 1000  # Number of sentences we want to use for development
-download_url = "https://sbert.net/datasets/parallel-sentences.tsv.gz"  # Specify parallel sentences URL here
-parallel_sentences_path = "../datasets/parallel-sentences.tsv.gz"  # Path of the parallel-sentences.tsv.gz file.
-parallel_sentences_folder = "parallel-sentences/"
-
-
-os.makedirs(os.path.dirname(parallel_sentences_path), exist_ok=True)
-if not os.path.exists(parallel_sentences_path):
-    print("parallel-sentences.tsv.gz does not exists. Try to download from server")
-    http_get(download_url, parallel_sentences_path)
-
-
-os.makedirs(parallel_sentences_folder, exist_ok=True)
-train_files = []
-dev_files = []
-files_to_create = []
-for source_lang in source_languages:
-    for target_lang in target_languages:
-        output_filename_train = os.path.join(
-            parallel_sentences_folder, f"talks-{source_lang}-{target_lang}-train.tsv.gz"
-        )
-        output_filename_dev = os.path.join(parallel_sentences_folder, f"talks-{source_lang}-{target_lang}-dev.tsv.gz")
-        train_files.append(output_filename_train)
-        dev_files.append(output_filename_dev)
-        if not os.path.exists(output_filename_train) or not os.path.exists(output_filename_dev):
-            files_to_create.append(
-                {
-                    "src_lang": source_lang,
-                    "trg_lang": target_lang,
-                    "fTrain": gzip.open(output_filename_train, "wt", encoding="utf8"),
-                    "fDev": gzip.open(output_filename_dev, "wt", encoding="utf8"),
-                    "devCount": 0,
-                }
-            )
-
-if len(files_to_create) > 0:
-    print(
-        "Parallel sentences files {} do not exist. Create these files now".format(
-            ", ".join(map(lambda x: x["src_lang"] + "-" + x["trg_lang"], files_to_create))
-        )
-    )
-    with gzip.open(parallel_sentences_path, "rt", encoding="utf8") as fIn:
-        reader = csv.DictReader(fIn, delimiter="\t", quoting=csv.QUOTE_NONE)
-        for line in tqdm(reader, desc="Sentences"):
-            for outfile in files_to_create:
-                src_text = line[outfile["src_lang"]].strip()
-                trg_text = line[outfile["trg_lang"]].strip()
-
-                if src_text != "" and trg_text != "":
-                    if outfile["devCount"] < dev_sentences:
-                        outfile["devCount"] += 1
-                        fOut = outfile["fDev"]
-                    else:
-                        fOut = outfile["fTrain"]
-
-                    fOut.write(f"{src_text}\t{trg_text}\n")
-
-    for outfile in files_to_create:
-        outfile["fTrain"].close()
-        outfile["fDev"].close()
-
+for target_lang in target_languages:
+    subset = f"{source_lang}-{target_lang}"
+    for split in ("train", "dev"):
+        output_filename = os.path.join(output_folder, f"talks-{source_lang}-{target_lang}-{split}.tsv.gz")
+        if os.path.exists(output_filename):
+            continue
+        try:
+            dataset = load_dataset(hf_dataset, subset, split=split)
+        except Exception as e:
+            print(f"Skipping {subset} ({split}): {e}")
+            continue
+        with gzip.open(output_filename, "wt", encoding="utf8") as fOut:
+            for row in dataset:
+                english = row["english"].strip()
+                non_english = row["non_english"].strip()
+                if english and non_english:
+                    fOut.write(f"{english}\t{non_english}\n")
+        print(f"Wrote {output_filename}: {len(dataset)} pairs")
 
 print("---DONE---")

--- a/examples/sentence_transformer/training/multilingual/get_parallel_data_tatoeba.py
+++ b/examples/sentence_transformer/training/multilingual/get_parallel_data_tatoeba.py
@@ -35,12 +35,14 @@ for target_lang in target_languages:
         except Exception as e:
             print(f"Skipping {subset} ({split}): {e}")
             continue
+        num_written = 0
         with gzip.open(output_filename, "wt", encoding="utf8") as fOut:
             for row in dataset:
                 english = row["english"].strip()
                 non_english = row["non_english"].strip()
                 if english and non_english:
                     fOut.write(f"{english}\t{non_english}\n")
-        print(f"Wrote {output_filename}: {len(dataset)} pairs")
+                    num_written += 1
+        print(f"Wrote {output_filename}: {num_written} pairs")
 
 print("---DONE---")

--- a/examples/sentence_transformer/training/multilingual/get_parallel_data_tatoeba.py
+++ b/examples/sentence_transformer/training/multilingual/get_parallel_data_tatoeba.py
@@ -1,116 +1,46 @@
 """
-Tatoeba (https://tatoeba.org/) is a collection of sentences and translation, mainly aiming for language learning.
-It is available for more than 300 languages.
+Tatoeba (https://tatoeba.org/) is a collection of sentences and translations, mainly aiming for
+language learning. It is available for more than 300 languages.
 
-This script downloads the Tatoeba corpus and extracts the sentences & translations in the languages you like
+This script writes parallel sentence tsv files from the Hugging Face dataset
+``sentence-transformers/parallel-sentences-tatoeba``. The training procedure can be found in
+``make_multilingual.py``, which loads the same Hugging Face dataset directly.
 """
 
 import gzip
 import os
-import tarfile
 
-from sentence_transformers.util import http_get
+from datasets import load_dataset
 
-# Note: Tatoeba uses 3 letter languages codes (ISO-639-2),
-# while other datasets like OPUS use 2 letter language codes (ISO-639-1)
-# For training of sentence transformers, which type of language code is used doesn't matter.
-# For language codes, see: https://en.wikipedia.org/wiki/List_of_ISO_639-2_codes
-source_languages = set(["eng"])
-target_languages = set(["deu", "ara", "tur", "spa", "ita", "fra"])
+# Tatoeba uses 3-letter language codes (ISO-639-2), while the Hugging Face dataset uses 2-letter
+# codes (ISO-639-1) in its config names. The output filenames keep the 3-letter codes (Tatoeba's
+# convention) and are mapped to the dataset's config names below.
+iso3_to_iso2 = {"eng": "en", "deu": "de", "ara": "ar", "tur": "tr", "spa": "es", "ita": "it", "fra": "fr"}
 
-num_dev_sentences = 1000  # Number of sentences that are used to create a development set
+hf_dataset = "sentence-transformers/parallel-sentences-tatoeba"
+source_lang = "eng"
+target_languages = ["deu", "ara", "tur", "spa", "ita", "fra"]
 
-
-tatoeba_folder = "../datasets/tatoeba"
 output_folder = "parallel-sentences/"
-
-
-sentences_file_bz2 = os.path.join(tatoeba_folder, "sentences.tar.bz2")
-sentences_file = os.path.join(tatoeba_folder, "sentences.csv")
-links_file_bz2 = os.path.join(tatoeba_folder, "links.tar.bz2")
-links_file = os.path.join(tatoeba_folder, "links.csv")
-
-download_url = "https://downloads.tatoeba.org/exports/"
-
-
-os.makedirs(tatoeba_folder, exist_ok=True)
 os.makedirs(output_folder, exist_ok=True)
 
-# Download files if needed
-for filepath in [sentences_file_bz2, links_file_bz2]:
-    if not os.path.exists(filepath):
-        url = download_url + os.path.basename(filepath)
-        print("Download", url)
-        http_get(url, filepath)
-
-# Extract files if needed
-if not os.path.exists(sentences_file):
-    print("Extract", sentences_file_bz2)
-    tar = tarfile.open(sentences_file_bz2, "r:bz2")
-    tar.extract("sentences.csv", path=tatoeba_folder)
-    tar.close()
-
-if not os.path.exists(links_file):
-    print("Extract", links_file_bz2)
-    tar = tarfile.open(links_file_bz2, "r:bz2")
-    tar.extract("links.csv", path=tatoeba_folder)
-    tar.close()
-
-
-# Read sentences
-sentences = {}
-all_langs = target_languages.union(source_languages)
-print("Read sentences.csv file")
-with open(sentences_file, encoding="utf8") as fIn:
-    for line in fIn:
-        id, lang, sentence = line.strip().split("\t")
-        if lang in all_langs:
-            sentences[id] = (lang, sentence)
-
-# Read links that map the translations between different languages
-print("Read links.csv")
-translations = {src_lang: {trg_lang: {} for trg_lang in target_languages} for src_lang in source_languages}
-with open(links_file, encoding="utf8") as fIn:
-    for line in fIn:
-        src_id, target_id = line.strip().split()
-
-        if src_id in sentences and target_id in sentences:
-            src_lang, src_sent = sentences[src_id]
-            trg_lang, trg_sent = sentences[target_id]
-
-            if src_lang in source_languages and trg_lang in target_languages:
-                if src_sent not in translations[src_lang][trg_lang]:
-                    translations[src_lang][trg_lang][src_sent] = []
-                translations[src_lang][trg_lang][src_sent].append(trg_sent)
-
-# Write everything to the output folder
-print("Write output files")
-for src_lang in source_languages:
-    for trg_lang in target_languages:
-        source_sentences = list(translations[src_lang][trg_lang])
-        train_sentences = source_sentences[num_dev_sentences:]
-        dev_sentences = source_sentences[0:num_dev_sentences]
-
-        print(f"{src_lang}-{trg_lang} has {len(source_sentences)} sentences")
-        if len(dev_sentences) > 0:
-            with gzip.open(
-                os.path.join(output_folder, f"Tatoeba-{src_lang}-{trg_lang}-dev.tsv.gz"),
-                "wt",
-                encoding="utf8",
-            ) as fOut:
-                for sent in dev_sentences:
-                    fOut.write("\t".join([sent] + translations[src_lang][trg_lang][sent]))
-                    fOut.write("\n")
-
-        if len(train_sentences) > 0:
-            with gzip.open(
-                os.path.join(output_folder, f"Tatoeba-{src_lang}-{trg_lang}-train.tsv.gz"),
-                "wt",
-                encoding="utf8",
-            ) as fOut:
-                for sent in train_sentences:
-                    fOut.write("\t".join([sent] + translations[src_lang][trg_lang][sent]))
-                    fOut.write("\n")
-
+for target_lang in target_languages:
+    subset = f"{iso3_to_iso2[source_lang]}-{iso3_to_iso2[target_lang]}"
+    for split in ("train", "dev"):
+        output_filename = os.path.join(output_folder, f"Tatoeba-{source_lang}-{target_lang}-{split}.tsv.gz")
+        if os.path.exists(output_filename):
+            continue
+        try:
+            dataset = load_dataset(hf_dataset, subset, split=split)
+        except Exception as e:
+            print(f"Skipping {subset} ({split}): {e}")
+            continue
+        with gzip.open(output_filename, "wt", encoding="utf8") as fOut:
+            for row in dataset:
+                english = row["english"].strip()
+                non_english = row["non_english"].strip()
+                if english and non_english:
+                    fOut.write(f"{english}\t{non_english}\n")
+        print(f"Wrote {output_filename}: {len(dataset)} pairs")
 
 print("---DONE---")

--- a/examples/sentence_transformer/training/multilingual/get_parallel_data_wikimatrix.py
+++ b/examples/sentence_transformer/training/multilingual/get_parallel_data_wikimatrix.py
@@ -1,8 +1,12 @@
 """
-This script downloads the WikiMatrix corpus (https://github.com/facebookresearch/LASER/tree/main/tasks/WikiMatrix)
- and create parallel sentences tsv files that can be used to extend existent sentence embedding models to new languages.
+This script writes parallel sentence tsv files that can be used to extend existing sentence
+embedding models to new languages.
 
-The WikiMatrix mined parallel sentences from Wikipedia in various languages.
+It loads the WikiMatrix parallel corpus (mined from Wikipedia, see
+https://github.com/facebookresearch/LASER/tree/main/tasks/WikiMatrix) from the Hugging Face dataset
+``sentence-transformers/parallel-sentences-wikimatrix``, which is already filtered by LASER
+similarity score. The training procedure can be found in ``make_multilingual.py``, which loads the
+same Hugging Face dataset directly.
 
 Further information can be found in our paper:
 Making Monolingual Sentence Embeddings Multilingual using Knowledge Distillation
@@ -12,93 +16,32 @@ https://huggingface.co/papers/2004.09813
 import gzip
 import os
 
-from sentence_transformers.util import http_get
+from datasets import load_dataset
 
-source_languages = set(["en"])  # Languages our (monolingual) teacher model understands
-target_languages = set(["de", "es", "it", "fr", "ar", "tr"])  # New languages we want to extend to
+hf_dataset = "sentence-transformers/parallel-sentences-wikimatrix"
+source_lang = "en"  # Language our (monolingual) teacher model understands
+target_languages = ["de", "es", "it", "fr", "ar", "tr"]  # New languages we want to extend to
 
+output_folder = "parallel-sentences/"
+os.makedirs(output_folder, exist_ok=True)
 
-num_dev_sentences = 1000  # Number of sentences we want to use for development
-threshold = 1.075  # Only use sentences with a LASER similarity score above the threshold
-
-download_url = "https://dl.fbaipublicfiles.com/laser/WikiMatrix/v1/"
-download_folder = "../datasets/WikiMatrix/"
-parallel_sentences_folder = "parallel-sentences/"
-
-
-os.makedirs(os.path.dirname(download_folder), exist_ok=True)
-os.makedirs(parallel_sentences_folder, exist_ok=True)
-
-
-for source_lang in source_languages:
-    for target_lang in target_languages:
-        filename_train = os.path.join(
-            parallel_sentences_folder, f"WikiMatrix-{source_lang}-{target_lang}-train.tsv.gz"
-        )
-        filename_dev = os.path.join(parallel_sentences_folder, f"WikiMatrix-{source_lang}-{target_lang}-dev.tsv.gz")
-
-        if not os.path.exists(filename_train) and not os.path.exists(filename_dev):
-            langs_ordered = sorted([source_lang, target_lang])
-            wikimatrix_filename = "WikiMatrix.{}-{}.tsv.gz".format(*langs_ordered)
-            wikimatrix_filepath = os.path.join(download_folder, wikimatrix_filename)
-
-            if not os.path.exists(wikimatrix_filepath):
-                print("Download", download_url + wikimatrix_filename)
-                try:
-                    http_get(download_url + wikimatrix_filename, wikimatrix_filepath)
-                except Exception:
-                    print("Was not able to download", download_url + wikimatrix_filename)
-                    continue
-
-            if not os.path.exists(wikimatrix_filepath):
-                continue
-
-            train_sentences = []
-            dev_sentences = []
-            dev_sentences_set = set()
-            extract_dev_sentences = True
-
-            with gzip.open(wikimatrix_filepath, "rt", encoding="utf8") as fIn:
-                for line in fIn:
-                    score, sent1, sent2 = line.strip().split("\t")
-                    sent1 = sent1.strip()
-                    sent2 = sent2.strip()
-                    score = float(score)
-
-                    if score < threshold:
-                        break
-
-                    if sent1 == sent2:
-                        continue
-
-                    if langs_ordered.index(source_lang) == 1:  # Swap, so that src lang is sent1
-                        sent1, sent2 = sent2, sent1
-
-                    # Avoid duplicates in development set
-                    if sent1 in dev_sentences_set or sent2 in dev_sentences_set:
-                        continue
-
-                    if extract_dev_sentences:
-                        dev_sentences.append([sent1, sent2])
-                        dev_sentences_set.add(sent1)
-                        dev_sentences_set.add(sent2)
-
-                        if len(dev_sentences) >= num_dev_sentences:
-                            extract_dev_sentences = False
-                    else:
-                        train_sentences.append([sent1, sent2])
-
-            print("Write", len(dev_sentences), "dev sentences", filename_dev)
-            with gzip.open(filename_dev, "wt", encoding="utf8") as fOut:
-                for sents in dev_sentences:
-                    fOut.write("\t".join(sents))
-                    fOut.write("\n")
-
-            print("Write", len(train_sentences), "train sentences", filename_train)
-            with gzip.open(filename_train, "wt", encoding="utf8") as fOut:
-                for sents in train_sentences:
-                    fOut.write("\t".join(sents))
-                    fOut.write("\n")
-
+for target_lang in target_languages:
+    subset = f"{source_lang}-{target_lang}"
+    for split in ("train", "dev"):
+        output_filename = os.path.join(output_folder, f"WikiMatrix-{source_lang}-{target_lang}-{split}.tsv.gz")
+        if os.path.exists(output_filename):
+            continue
+        try:
+            dataset = load_dataset(hf_dataset, subset, split=split)
+        except Exception as e:
+            print(f"Skipping {subset} ({split}): {e}")
+            continue
+        with gzip.open(output_filename, "wt", encoding="utf8") as fOut:
+            for row in dataset:
+                english = row["english"].strip()
+                non_english = row["non_english"].strip()
+                if english and non_english:
+                    fOut.write(f"{english}\t{non_english}\n")
+        print(f"Wrote {output_filename}: {len(dataset)} pairs")
 
 print("---DONE---")

--- a/examples/sentence_transformer/training/multilingual/get_parallel_data_wikimatrix.py
+++ b/examples/sentence_transformer/training/multilingual/get_parallel_data_wikimatrix.py
@@ -36,12 +36,14 @@ for target_lang in target_languages:
         except Exception as e:
             print(f"Skipping {subset} ({split}): {e}")
             continue
+        num_written = 0
         with gzip.open(output_filename, "wt", encoding="utf8") as fOut:
             for row in dataset:
                 english = row["english"].strip()
                 non_english = row["non_english"].strip()
                 if english and non_english:
                     fOut.write(f"{english}\t{non_english}\n")
-        print(f"Wrote {output_filename}: {len(dataset)} pairs")
+                    num_written += 1
+        print(f"Wrote {output_filename}: {num_written} pairs")
 
 print("---DONE---")


### PR DESCRIPTION
The three `get_parallel_data_*.py` prep scripts downloaded raw parallel corpora (sbert.net, tatoeba.org, fbaipublicfiles WikiMatrix) and wrote per-language-pair tsv files. The actual training script `make_multilingual.py` already loads the maintained Hugging Face datasets directly, so these prep scripts were the only remaining raw downloads. This rewrites them to source from the same HF datasets, producing the same tsv outputs.

## Changes

Each script now iterates `sentence-transformers/parallel-sentences-{talks,wikimatrix,tatoeba}` per language-pair config (`en-de`, `en-es`, ...) and writes the stripped `english`/`non_english` columns (skipping empty pairs) to the same tsv filenames. WikiMatrix is already filtered by LASER similarity score, and tatoeba's 3-letter output filenames are mapped to the dataset's 2-letter config names.

## Testing the changes

End-to-end: ran the old (raw download) and new (HF) versions of each script, then compared the combined train+dev pairs per language as a set (an md5 of the sorted pairs, which ignores the dev/train split-boundary difference).

- **talks**: byte-identical for all 6 target languages (en-de/es/fr/it/ar/tr) once the values are
  stripped, matching the old script's normalization. Same unique-pair count and same md5 per
  language.
- **wikimatrix**: 100% of sampled raw pairs (above the 1.075 score) present in the HF dataset.
- **tatoeba**: same source; a fresh live download has a few extra newer pairs (Tatoeba is updated
  continuously), so the HF snapshot is a subset of today's live data, not the other way around.

Note: comparing the *split files* directly will differ, because the new scripts use the HF `train`/`dev` split (dev ~991) rather than the old "first 1000 = dev" boundary. The data is the same; only the train/dev partition differs.
