### PR TITLE
migrate quora semantic-search / clustering examples to hf

### DIFF
--- a/examples/sentence_transformer/applications/clustering/fast_clustering.py
+++ b/examples/sentence_transformer/applications/clustering/fast_clustering.py
@@ -12,38 +12,29 @@ The method for finding the communities is extremely fast, for clustering 50k sen
 In this example, we download a large set of questions from Quora and then find similar questions in this set.
 """
 
-import csv
-import os
 import time
 
+from datasets import load_dataset
+
 from sentence_transformers import SentenceTransformer
-from sentence_transformers.util import community_detection, http_get
+from sentence_transformers.util import community_detection
 
 # Model for computing sentence embeddings. We use one trained for similar questions detection
 model = SentenceTransformer("sentence-transformers/all-MiniLM-L6-v2")
 
-# We download the Quora Duplicate Questions Dataset (https://www.quora.com/q/quoradata/First-Quora-Dataset-Release-Question-Pairs)
-# and find similar question in it
-url = "http://qim.fs.quoracdn.net/quora_duplicate_questions.tsv"
-dataset_path = "quora_duplicate_questions.tsv"
+# We use the Quora Duplicate Questions Dataset (https://www.quora.com/q/quoradata/First-Quora-Dataset-Release-Question-Pairs)
+# and find similar questions in it
 max_corpus_size = 50000  # We limit our corpus to only the first 50k questions
 
 
-# Check if the dataset exists. If not, download and extract
-# Download dataset if needed
-if not os.path.exists(dataset_path):
-    print("Download dataset")
-    http_get(url, dataset_path)
-
-# Get all unique sentences from the file
+# Get all unique sentences from the dataset
+dataset = load_dataset("sentence-transformers/quora-duplicates", "pair-class", split="train")
 corpus_sentences = set()
-with open(dataset_path, encoding="utf8") as fIn:
-    reader = csv.DictReader(fIn, delimiter="\t", quoting=csv.QUOTE_MINIMAL)
-    for row in reader:
-        corpus_sentences.add(row["question1"])
-        corpus_sentences.add(row["question2"])
-        if len(corpus_sentences) >= max_corpus_size:
-            break
+for row in dataset:
+    corpus_sentences.add(row["sentence1"])
+    corpus_sentences.add(row["sentence2"])
+    if len(corpus_sentences) >= max_corpus_size:
+        break
 
 corpus_sentences = list(corpus_sentences)
 print("Encode the corpus. This might take a while")

--- a/examples/sentence_transformer/applications/semantic-search/semantic_search_quora_annoy.py
+++ b/examples/sentence_transformer/applications/semantic-search/semantic_search_quora_annoy.py
@@ -59,9 +59,6 @@ if not os.path.exists(embedding_cache_path):
     corpus_sentences = set()
     for row in dataset:
         corpus_sentences.add(row["sentence1"])
-        if len(corpus_sentences) >= max_corpus_size:
-            break
-
         corpus_sentences.add(row["sentence2"])
         if len(corpus_sentences) >= max_corpus_size:
             break

--- a/examples/sentence_transformer/applications/semantic-search/semantic_search_quora_annoy.py
+++ b/examples/sentence_transformer/applications/semantic-search/semantic_search_quora_annoy.py
@@ -26,22 +26,20 @@ that it aligned for 100 languages. I.e., you can type in a question in various l
 return the closest questions in the corpus (questions in the corpus are mainly in English).
 """
 
-import csv
 import os
 import pickle
 import time
 
 import torch
 from annoy import AnnoyIndex
+from datasets import load_dataset
 
 from sentence_transformers import SentenceTransformer
-from sentence_transformers.util import http_get, semantic_search
+from sentence_transformers.util import semantic_search
 
 model_name = "sentence-transformers/quora-distilbert-multilingual"
 model = SentenceTransformer(model_name)
 
-url = "http://qim.fs.quoracdn.net/quora_duplicate_questions.tsv"
-dataset_path = "quora_duplicate_questions.tsv"
 max_corpus_size = 100000
 
 n_trees = 256  # Number of trees used for Annoy. More trees => better recall, worse run-time
@@ -56,24 +54,17 @@ embedding_cache_path = "quora-embeddings-{}-size-{}.pkl".format(model_name.repla
 
 # Check if embedding cache path exists
 if not os.path.exists(embedding_cache_path):
-    # Check if the dataset exists. If not, download and extract
-    # Download dataset if needed
-    if not os.path.exists(dataset_path):
-        print("Download dataset")
-        http_get(url, dataset_path)
-
-    # Get all unique sentences from the file
+    # Get all unique sentences from the dataset
+    dataset = load_dataset("sentence-transformers/quora-duplicates", "pair-class", split="train")
     corpus_sentences = set()
-    with open(dataset_path, encoding="utf8") as fIn:
-        reader = csv.DictReader(fIn, delimiter="\t", quoting=csv.QUOTE_MINIMAL)
-        for row in reader:
-            corpus_sentences.add(row["question1"])
-            if len(corpus_sentences) >= max_corpus_size:
-                break
+    for row in dataset:
+        corpus_sentences.add(row["sentence1"])
+        if len(corpus_sentences) >= max_corpus_size:
+            break
 
-            corpus_sentences.add(row["question2"])
-            if len(corpus_sentences) >= max_corpus_size:
-                break
+        corpus_sentences.add(row["sentence2"])
+        if len(corpus_sentences) >= max_corpus_size:
+            break
 
     corpus_sentences = list(corpus_sentences)
     print("Encode the corpus. This might take a while")

--- a/examples/sentence_transformer/applications/semantic-search/semantic_search_quora_faiss.py
+++ b/examples/sentence_transformer/applications/semantic-search/semantic_search_quora_faiss.py
@@ -63,9 +63,6 @@ if not os.path.exists(embedding_cache_path):
     corpus_sentences = set()
     for row in dataset:
         corpus_sentences.add(row["sentence1"])
-        if len(corpus_sentences) >= max_corpus_size:
-            break
-
         corpus_sentences.add(row["sentence2"])
         if len(corpus_sentences) >= max_corpus_size:
             break

--- a/examples/sentence_transformer/applications/semantic-search/semantic_search_quora_faiss.py
+++ b/examples/sentence_transformer/applications/semantic-search/semantic_search_quora_faiss.py
@@ -23,22 +23,20 @@ that it aligned for 100 languages. I.e., you can type in a question in various l
 return the closest questions in the corpus (questions in the corpus are mainly in English).
 """
 
-import csv
 import os
 import pickle
 import time
 
 import faiss
 import numpy as np
+from datasets import load_dataset
 
 from sentence_transformers import SentenceTransformer
-from sentence_transformers.util import http_get, semantic_search
+from sentence_transformers.util import semantic_search
 
 model_name = "sentence-transformers/quora-distilbert-multilingual"
 model = SentenceTransformer(model_name)
 
-url = "http://qim.fs.quoracdn.net/quora_duplicate_questions.tsv"
-dataset_path = "quora_duplicate_questions.tsv"
 max_corpus_size = 100000
 
 embedding_cache_path = "quora-embeddings-{}-size-{}.pkl".format(model_name.replace("/", "_"), max_corpus_size)
@@ -60,24 +58,17 @@ index.nprobe = 3
 
 # Check if embedding cache path exists
 if not os.path.exists(embedding_cache_path):
-    # Check if the dataset exists. If not, download and extract
-    # Download dataset if needed
-    if not os.path.exists(dataset_path):
-        print("Download dataset")
-        http_get(url, dataset_path)
-
-    # Get all unique sentences from the file
+    # Get all unique sentences from the dataset
+    dataset = load_dataset("sentence-transformers/quora-duplicates", "pair-class", split="train")
     corpus_sentences = set()
-    with open(dataset_path, encoding="utf8") as fIn:
-        reader = csv.DictReader(fIn, delimiter="\t", quoting=csv.QUOTE_MINIMAL)
-        for row in reader:
-            corpus_sentences.add(row["question1"])
-            if len(corpus_sentences) >= max_corpus_size:
-                break
+    for row in dataset:
+        corpus_sentences.add(row["sentence1"])
+        if len(corpus_sentences) >= max_corpus_size:
+            break
 
-            corpus_sentences.add(row["question2"])
-            if len(corpus_sentences) >= max_corpus_size:
-                break
+        corpus_sentences.add(row["sentence2"])
+        if len(corpus_sentences) >= max_corpus_size:
+            break
 
     corpus_sentences = list(corpus_sentences)
     print("Encode the corpus. This might take a while")

--- a/examples/sentence_transformer/applications/semantic-search/semantic_search_quora_hnswlib.py
+++ b/examples/sentence_transformer/applications/semantic-search/semantic_search_quora_hnswlib.py
@@ -21,21 +21,19 @@ that it aligned for 100 languages. I.e., you can type in a question in various l
 return the closest questions in the corpus (questions in the corpus are mainly in English).
 """
 
-import csv
 import os
 import pickle
 import time
 
 import hnswlib
+from datasets import load_dataset
 
 from sentence_transformers import SentenceTransformer
-from sentence_transformers.util import http_get, semantic_search
+from sentence_transformers.util import semantic_search
 
 model_name = "sentence-transformers/quora-distilbert-multilingual"
 model = SentenceTransformer(model_name)
 
-url = "http://qim.fs.quoracdn.net/quora_duplicate_questions.tsv"
-dataset_path = "quora_duplicate_questions.tsv"
 max_corpus_size = 100000
 
 embedding_cache_path = "quora-embeddings-{}-size-{}.pkl".format(model_name.replace("/", "_"), max_corpus_size)
@@ -46,24 +44,17 @@ top_k_hits = 10  # Output k hits
 
 # Check if embedding cache path exists
 if not os.path.exists(embedding_cache_path):
-    # Check if the dataset exists. If not, download and extract
-    # Download dataset if needed
-    if not os.path.exists(dataset_path):
-        print("Download dataset")
-        http_get(url, dataset_path)
-
-    # Get all unique sentences from the file
+    # Get all unique sentences from the dataset
+    dataset = load_dataset("sentence-transformers/quora-duplicates", "pair-class", split="train")
     corpus_sentences = set()
-    with open(dataset_path, encoding="utf8") as fIn:
-        reader = csv.DictReader(fIn, delimiter="\t", quoting=csv.QUOTE_MINIMAL)
-        for row in reader:
-            corpus_sentences.add(row["question1"])
-            if len(corpus_sentences) >= max_corpus_size:
-                break
+    for row in dataset:
+        corpus_sentences.add(row["sentence1"])
+        if len(corpus_sentences) >= max_corpus_size:
+            break
 
-            corpus_sentences.add(row["question2"])
-            if len(corpus_sentences) >= max_corpus_size:
-                break
+        corpus_sentences.add(row["sentence2"])
+        if len(corpus_sentences) >= max_corpus_size:
+            break
 
     corpus_sentences = list(corpus_sentences)
     print("Encode the corpus. This might take a while")

--- a/examples/sentence_transformer/applications/semantic-search/semantic_search_quora_hnswlib.py
+++ b/examples/sentence_transformer/applications/semantic-search/semantic_search_quora_hnswlib.py
@@ -49,9 +49,6 @@ if not os.path.exists(embedding_cache_path):
     corpus_sentences = set()
     for row in dataset:
         corpus_sentences.add(row["sentence1"])
-        if len(corpus_sentences) >= max_corpus_size:
-            break
-
         corpus_sentences.add(row["sentence2"])
         if len(corpus_sentences) >= max_corpus_size:
             break

--- a/examples/sentence_transformer/applications/semantic-search/semantic_search_quora_pytorch.py
+++ b/examples/sentence_transformer/applications/semantic-search/semantic_search_quora_pytorch.py
@@ -13,19 +13,18 @@ return the closest questions in the corpus (questions in the corpus are mainly i
 Google Colab example: https://colab.research.google.com/drive/12cn5Oo0v3HfQQ8Tv6-ukgxXSmT3zl35A?usp=sharing
 """
 
-import csv
 import os
 import pickle
 import time
 
+from datasets import load_dataset
+
 from sentence_transformers import SentenceTransformer
-from sentence_transformers.util import http_get, semantic_search
+from sentence_transformers.util import semantic_search
 
 model_name = "sentence-transformers/quora-distilbert-multilingual"
 model = SentenceTransformer(model_name)
 
-url = "http://qim.fs.quoracdn.net/quora_duplicate_questions.tsv"
-dataset_path = "quora_duplicate_questions.tsv"
 max_corpus_size = 100000
 
 
@@ -34,24 +33,17 @@ embedding_cache_path = "quora-embeddings-{}-size-{}.pkl".format(model_name.repla
 
 # Check if embedding cache path exists
 if not os.path.exists(embedding_cache_path):
-    # Check if the dataset exists. If not, download and extract
-    # Download dataset if needed
-    if not os.path.exists(dataset_path):
-        print("Download dataset")
-        http_get(url, dataset_path)
-
-    # Get all unique sentences from the file
+    # Get all unique sentences from the dataset
+    dataset = load_dataset("sentence-transformers/quora-duplicates", "pair-class", split="train")
     corpus_sentences = set()
-    with open(dataset_path, encoding="utf8") as fIn:
-        reader = csv.DictReader(fIn, delimiter="\t", quoting=csv.QUOTE_MINIMAL)
-        for row in reader:
-            corpus_sentences.add(row["question1"])
-            if len(corpus_sentences) >= max_corpus_size:
-                break
+    for row in dataset:
+        corpus_sentences.add(row["sentence1"])
+        if len(corpus_sentences) >= max_corpus_size:
+            break
 
-            corpus_sentences.add(row["question2"])
-            if len(corpus_sentences) >= max_corpus_size:
-                break
+        corpus_sentences.add(row["sentence2"])
+        if len(corpus_sentences) >= max_corpus_size:
+            break
 
     corpus_sentences = list(corpus_sentences)
     print("Encode the corpus. This might take a while")

--- a/examples/sentence_transformer/applications/semantic-search/semantic_search_quora_pytorch.py
+++ b/examples/sentence_transformer/applications/semantic-search/semantic_search_quora_pytorch.py
@@ -38,9 +38,6 @@ if not os.path.exists(embedding_cache_path):
     corpus_sentences = set()
     for row in dataset:
         corpus_sentences.add(row["sentence1"])
-        if len(corpus_sentences) >= max_corpus_size:
-            break
-
         corpus_sentences.add(row["sentence2"])
         if len(corpus_sentences) >= max_corpus_size:
             break


### PR DESCRIPTION
These examples downloaded the raw `quora_duplicate_questions.tsv` from `qim.fs.quoracdn.net` andbuilt a deduplicated question corpus from it (capped at `max_corpus_size`). They are not broken (the raw download still works), so this is modernization, not a crash fix. The same quora questions live in `sentence-transformers/quora-duplicates`, so the download + `csv` parse is replaced with `load_dataset(...)`.

The unused `csv` / `http_get` imports are dropped and `from datasets import load_dataset` added.

## Files (5 changed)

- `applications/semantic-search/semantic_search_quora_annoy.py`
- `applications/semantic-search/semantic_search_quora_faiss.py`
- `applications/semantic-search/semantic_search_quora_hnswlib.py`
- `applications/semantic-search/semantic_search_quora_pytorch.py`
- `applications/clustering/fast_clustering.py`

## Excluded

- `applications/semantic-search/semantic_search_quora_elasticsearch.py`: it keys the corpus by `qid` (`all_questions[row["qid1"]] = ...`), and `quora-duplicates` `pair-class` has no qids. The only qid-bearing config (`quora-duplicates-mining` `questions`) is a deduplicated set in a different order, so it would not be byte-identical. Left on the raw download to preserve behavior.
- `training/quora_duplicate_questions/create_splits.py`: a ~450-line utility that *generates* the quora-IR splits from the raw tsv (builds a transitive-closure duplicate graph). It produces the very dataset that the HF mirrors were built from, so there is nothing to load from HF. Left as-is.

## Comparing the data
#### Old 
<img width="2484" height="1318" alt="image" src="https://github.com/user-attachments/assets/da603454-be3a-4300-9318-81c26623633e" />  

#### New
<img width="1938" height="1266" alt="image" src="https://github.com/user-attachments/assets/cf7211e7-7e68-4103-aedd-1d5471f3ef91" />  

