### PR TITLE
Fix causal LM reranker scoring when max_length truncates chat-template suffix

### DIFF
--- a/sentence_transformers/base/modules/transformer.py
+++ b/sentence_transformers/base/modules/transformer.py
@@ -117,9 +117,8 @@ _TRANSFORMERS_APPLY_CHAT_TEMPLATE_RECOMMENDS_PROCESSOR_KWARGS = parse_version(tr
 _TRANSFORMERS_SUPPORTS_USE_BIDIRECTIONAL_ATTENTION = parse_version(transformers_version) >= parse_version("4.56.2")
 _TRANSFORMERS_SUPPORTS_IS_CAUSAL_FALSE = parse_version(transformers_version) >= parse_version("5.2.0")
 
-# apply_chat_template wants these as top-level kwargs, not nested in tokenizer_kwargs/common_kwargs.
+# The size/output kwargs of apply_chat_template, which a bare tokenizer wants as top-level kwargs.
 _APPLY_CHAT_TEMPLATE_TOP_LEVEL_KWARGS = frozenset({"padding", "truncation", "max_length", "return_tensors"})
-# Size bound for the per-structure chat-template suffix cache, since its key includes the prompt.
 _CHAT_TEMPLATE_SUFFIX_CACHE_SIZE = 256
 
 TransformerTask = Literal[
@@ -1405,8 +1404,8 @@ class Transformer(InputModule):
                 **chat_template_kwargs,
             )
 
-        # apply_chat_template expects padding/truncation/max_length/return_tensors as top-level kwargs, not
-        # nested inside tokenizer_kwargs or common_kwargs, so we hoist them out of copies.
+        # A bare tokenizer's apply_chat_template wants padding/truncation/max_length/return_tensors as
+        # top-level kwargs, not nested in tokenizer_kwargs or common_kwargs, so we hoist them out of copies.
         text_kwargs = dict(modality_kwargs["text"])
         common_kwargs = dict(common_kwargs)
         top_level_kwargs = {

--- a/sentence_transformers/base/modules/transformer.py
+++ b/sentence_transformers/base/modules/transformer.py
@@ -1328,17 +1328,14 @@ class Transformer(InputModule):
                 f"Supported modalities: {list(self.modality_config.keys())}"
             )
 
-        # Ideally we'd use the same code path for both ProcessorMixin and Tokenizers, but the latter expects
-        # the text kwargs to be passed at the top level instead of in a nested "text_kwargs" dict.
+        # ProcessorMixin and bare tokenizers need different kwarg routing (nested vs top-level text kwargs).
         chat_template_kwargs = dict(chat_template_kwargs or {})
 
-        # `restore_suffix` toggles the truncation suffix restore below. It's a Sentence Transformers concept,
-        # not an apply_chat_template argument, so pop it (default on) before forwarding the rest.
+        # `restore_suffix` is a Sentence Transformers flag, not an apply_chat_template arg, so pop it (default on).
         restore_suffix = chat_template_kwargs.pop("restore_suffix", True)
 
         # Read truncation/max_length before the hoist below pops them (text kwargs take priority over common).
-        # The restore is gated on truncation (and `restore_suffix`); max_length lets it skip work entirely
-        # when the batch never reached the limit (nothing was truncated).
+        # max_length lets the restore skip work entirely when nothing reached the limit (no truncation).
         text_kwargs = modality_kwargs.get("text", {})
         truncation = text_kwargs.get("truncation", common_kwargs.get("truncation"))
         restore_chat_template_suffix = restore_suffix and bool(truncation) and truncation != "do_not_truncate"

--- a/sentence_transformers/base/modules/transformer.py
+++ b/sentence_transformers/base/modules/transformer.py
@@ -546,7 +546,11 @@ class Transformer(InputModule):
             (``"text"``, ``"audio"``, ``"image"``, ``"video"``), ``"common"`` for kwargs shared across all
             modalities, or ``"chat_template"`` for kwargs forwarded to ``apply_chat_template`` (e.g.
             ``{"add_generation_prompt": True}``). Modality and common kwargs override the built-in defaults.
-            Saved to and loaded from the model configuration file. Defaults to None.
+            The ``"chat_template"`` dict also accepts ``"restore_suffix"`` (default ``True``), a Sentence
+            Transformers flag: when truncation would drop the fixed tokens a chat template appends after the
+            content (e.g. an assistant prefill or a trailing EOS), they are restored onto the truncated tail
+            so models that read the final token position keep working. Set ``False`` to disable. Saved to and
+            loaded from the model configuration file. Defaults to None.
         backend (str, optional): Backend used for model inference. Can be ``"torch"`` (default), ``"onnx"``,
             or ``"openvino"``. Defaults to ``"torch"``.
         modality_config (dict, optional): Custom modality configuration mapping modality names to method and
@@ -1329,11 +1333,15 @@ class Transformer(InputModule):
         # the text kwargs to be passed at the top level instead of in a nested "text_kwargs" dict.
         chat_template_kwargs = dict(chat_template_kwargs or {})
 
+        # `restore_suffix` toggles the truncation suffix restore below. It's a Sentence Transformers concept,
+        # not an apply_chat_template argument, so pop it (default on) before forwarding the rest.
+        restore_suffix = chat_template_kwargs.pop("restore_suffix", True)
+
         # Read truncation before the hoist below pops it (text kwargs take priority over common). The
-        # restore in _restore_chat_template_suffix is gated on it.
+        # restore in _restore_chat_template_suffix is gated on it (and on `restore_suffix`).
         text_kwargs = modality_kwargs.get("text", {})
         truncation = text_kwargs.get("truncation", common_kwargs.get("truncation"))
-        restore_chat_template_suffix = bool(truncation) and truncation != "do_not_truncate"
+        restore_chat_template_suffix = restore_suffix and bool(truncation) and truncation != "do_not_truncate"
 
         if isinstance(self.processor, ProcessorMixin):
             # Transformers v5.4.0 prefers us to pass processor_kwargs as a single dict, but there's still some top level

--- a/sentence_transformers/base/modules/transformer.py
+++ b/sentence_transformers/base/modules/transformer.py
@@ -1336,11 +1336,17 @@ class Transformer(InputModule):
         # not an apply_chat_template argument, so pop it (default on) before forwarding the rest.
         restore_suffix = chat_template_kwargs.pop("restore_suffix", True)
 
-        # Read truncation before the hoist below pops it (text kwargs take priority over common). The
-        # restore in _restore_chat_template_suffix is gated on it (and on `restore_suffix`).
+        # Read truncation/max_length before the hoist below pops them (text kwargs take priority over common).
+        # The restore is gated on truncation (and `restore_suffix`); max_length lets it skip work entirely
+        # when the batch never reached the limit (nothing was truncated).
         text_kwargs = modality_kwargs.get("text", {})
         truncation = text_kwargs.get("truncation", common_kwargs.get("truncation"))
         restore_chat_template_suffix = restore_suffix and bool(truncation) and truncation != "do_not_truncate"
+        max_length = None
+        if restore_chat_template_suffix:
+            max_length = text_kwargs.get("max_length", common_kwargs.get("max_length"))
+            if max_length is None and self.tokenizer is not None:
+                max_length = self.tokenizer.model_max_length
 
         if isinstance(self.processor, ProcessorMixin):
             # Transformers v5.4.0 prefers us to pass processor_kwargs as a single dict, but there's still some top level
@@ -1399,7 +1405,9 @@ class Transformer(InputModule):
             suffix_tokenizer_kwargs = {
                 key: value for key, value in text_kwargs.items() if key not in _APPLY_CHAT_TEMPLATE_TOP_LEVEL_KWARGS
             }
-            self._restore_chat_template_suffix(features, messages, chat_template_kwargs, suffix_tokenizer_kwargs)
+            self._restore_chat_template_suffix(
+                features, messages, chat_template_kwargs, suffix_tokenizer_kwargs, max_length
+            )
         return features
 
     def _restore_chat_template_suffix(
@@ -1408,6 +1416,7 @@ class Transformer(InputModule):
         messages: list[list[MessageInput]],
         chat_template_kwargs: dict[str, Any],
         tokenizer_kwargs: dict[str, Any],
+        max_length: int | None = None,
     ) -> None:
         """Restore the trailing chat-template suffix that truncation may have removed (in place).
 
@@ -1422,8 +1431,9 @@ class Transformer(InputModule):
         content while keeping the suffix.
 
         The suffix is derived per row (cached per structure), so a batch mixing different role layouts is
-        handled correctly. Rows that fit already end with the suffix, so the tail comparison leaves them
-        untouched, as does ``truncation=False``.
+        handled correctly. If the longest real row is shorter than ``max_length`` nothing was truncated, so
+        the whole pass is skipped. Otherwise every row is checked and a row that already ends with the suffix
+        is left untouched, as is ``truncation=False``.
         """
         input_ids = features.get("input_ids")
         if input_ids is None:
@@ -1435,37 +1445,32 @@ class Transformer(InputModule):
                 return
             # unsqueeze returns a view, so the in-place writes below propagate to features["input_ids"]
             ids = input_ids if input_ids.dim() == 2 else input_ids.unsqueeze(0)
-            n_rows = ids.shape[0]
-        else:
-            # Flattening path (feature-extraction + can_flatten_inputs, see preprocess): return_tensors is
-            # dropped, so apply_chat_template returns ragged, unpadded token lists. Each row's tail is real.
-            rows = input_ids if input_ids and isinstance(input_ids[0], list) else [input_ids]
-            n_rows = len(rows)
-
-        # Derive the per-row suffixes first (cached). Multimodal rows yield [], so an all-media batch returns
-        # here, before the attention-mask reductions below (cheap, but pointless if nothing will be restored).
-        suffixes = [
-            self._chat_template_suffix_ids(messages[index], chat_template_kwargs, tokenizer_kwargs)
-            for index in range(min(n_rows, len(messages)))
-        ]
-        if not any(suffixes):
-            return
-
-        if is_tensor:
             width = ids.shape[-1]
-            # Find each row's real tail from the mask so the suffix lands on real tokens even when padding
-            # extends a truncated row (pad_to_multiple_of): the real tokens end at `width` for left padding
-            # (first token is pad), else at their count.
+            # Each row's real-token count and padding side, from the mask, so the suffix lands on real tokens
+            # even under padding: the tail ends at `width` for left padding, else at the real length.
             attention_mask = features.get("attention_mask")
             if isinstance(attention_mask, torch.Tensor) and attention_mask.numel():
                 am = attention_mask if attention_mask.dim() == 2 else attention_mask.unsqueeze(0)
                 real_lengths = am.sum(dim=1).tolist()
                 left_padded = (am[:, 0] == 0).tolist()
             else:
-                real_lengths = [width] * n_rows
-                left_padded = [False] * n_rows
+                real_lengths = [width] * ids.shape[0]
+                left_padded = [False] * ids.shape[0]
+            n_rows = ids.shape[0]
+        else:
+            # Flattening path (feature-extraction + can_flatten_inputs, see preprocess): return_tensors is
+            # dropped, so apply_chat_template returns ragged, unpadded token lists. Each row's tail is real.
+            rows = input_ids if input_ids and isinstance(input_ids[0], list) else [input_ids]
+            real_lengths = [len(row) for row in rows]
+            n_rows = len(rows)
 
-        for index, suffix in enumerate(suffixes):
+        # If the longest real row is below max_length, nothing was truncated. Real lengths (not padded
+        # width) stay correct when pad_to_multiple_of pads a truncated row past max_length.
+        if max_length is not None and max(real_lengths, default=0) < max_length:
+            return
+
+        for index in range(min(n_rows, len(messages))):
+            suffix = self._chat_template_suffix_ids(messages[index], chat_template_kwargs, tokenizer_kwargs)
             if not suffix:
                 continue
             if is_tensor:
@@ -1478,7 +1483,7 @@ class Transformer(InputModule):
                     ids[index, end - keep : end] = suffix_tensor
             else:
                 row = rows[index]
-                keep = min(len(suffix), len(row))
+                keep = min(len(suffix), real_lengths[index])
                 if keep and row[-keep:] != suffix[-keep:]:
                     row[-keep:] = suffix[-keep:]
 

--- a/sentence_transformers/base/modules/transformer.py
+++ b/sentence_transformers/base/modules/transformer.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib
 import inspect
+from collections import OrderedDict
 from collections.abc import Callable
 from contextlib import contextmanager
 from dataclasses import fields
@@ -119,6 +120,8 @@ _TRANSFORMERS_SUPPORTS_IS_CAUSAL_FALSE = parse_version(transformers_version) >= 
 
 # apply_chat_template wants these as top-level kwargs, not nested in tokenizer_kwargs/common_kwargs.
 _APPLY_CHAT_TEMPLATE_TOP_LEVEL_KWARGS = frozenset({"padding", "truncation", "max_length", "return_tensors"})
+# LRU bound for the per-structure chat-template suffix cache, since its key includes the prompt.
+_CHAT_TEMPLATE_SUFFIX_CACHE_SIZE = 256
 
 TransformerTask = Literal[
     "feature-extraction", "sequence-classification", "text-generation", "any-to-any", "fill-mask"
@@ -629,7 +632,7 @@ class Transformer(InputModule):
         self.track_media_counts = False
         self._prompt_length_mapping = {}
         self._method_signature_cache: dict[str, set[str]] = {}
-        self._chat_template_suffix_cache: dict[Any, list[int]] = {}
+        self._chat_template_suffix_cache: OrderedDict[Any, list[int]] = OrderedDict()
 
         config, is_peft_model = self._load_config(model_name_or_path, backend, config_kwargs)
         self._warn_on_unsupported_attention_config(config)
@@ -1433,7 +1436,7 @@ class Transformer(InputModule):
             n_rows = len(rows)
 
         # Derive the per-row suffixes first (cached). Multimodal rows yield [], so an all-media batch returns
-        # here, before the attention-mask reduction below and its two device-to-host syncs.
+        # here, before the attention-mask reductions below (cheap, but pointless if nothing will be restored).
         suffixes = [
             self._chat_template_suffix_ids(messages[index], chat_template_kwargs, tokenizer_kwargs)
             for index in range(min(n_rows, len(messages)))
@@ -1482,20 +1485,33 @@ class Transformer(InputModule):
 
         The suffix is the run of tokens the template appends after the user content (e.g. the assistant
         prefill). It is found by rendering the conversation's role layout with two different fillers and
-        taking the longest common token suffix, so no per-model count is hard-coded.
+        taking the longest common token suffix, so no per-model count is hard-coded. ``system`` messages (the
+        prompt/instruction) are kept fixed rather than fillered, so a prompt the template renders in the tail
+        is captured too. The cache keys on their content so different prompts get their own suffix.
         """
         # Skip rows with actual media: image/audio/video placeholder tokens can't be cut without desyncing
         # them from their media features (the model would then error), so there's nothing safe to restore.
         # Text-only inputs to a multimodal model still qualify.
         if not conversation or not self.input_formatter.is_text_only_messages([conversation]):
             return []
-        # Cache per template-kwargs + tokenizer-kwargs + role layout. Any of these may carry unhashable
-        # values (e.g. a ``tools`` list), so guard the lookup and fall back to re-deriving without caching.
+        # Cache per template-kwargs + tokenizer-kwargs + role layout + prompt. Kept (system) prompts can land
+        # in the suffix, so their content is part of the key (repr keeps structured content hashable). Any of
+        # these may be unhashable (e.g. a ``tools`` list), so guard the lookup and re-derive uncached if so.
         roles = tuple(m.get("role") if isinstance(m, dict) else None for m in conversation)
+        prompts = tuple(
+            repr(m.get("content")) for m in conversation if isinstance(m, dict) and m.get("role") == "system"
+        )
+        cache = self._chat_template_suffix_cache
         try:
-            cache_key = (tuple(sorted(chat_template_kwargs.items())), tuple(sorted(tokenizer_kwargs.items())), roles)
-            if cache_key in self._chat_template_suffix_cache:
-                return self._chat_template_suffix_cache[cache_key]
+            cache_key = (
+                tuple(sorted(chat_template_kwargs.items())),
+                tuple(sorted(tokenizer_kwargs.items())),
+                roles,
+                prompts,
+            )
+            if cache_key in cache:
+                cache.move_to_end(cache_key)  # mark most-recently-used
+                return cache[cache_key]
         except TypeError:
             cache_key = None
 
@@ -1510,13 +1526,19 @@ class Transformer(InputModule):
                 if left != right:
                     break
                 count += 1
-            suffix = first[len(first) - count :]  # count == 0 slices at len(first), i.e. []
+            # count == min(len) means the renders never diverged (e.g. a conversation with no variable
+            # content), so the common run would include filler/content. Only trust a strictly bounded tail.
+            if 0 < count < min(len(first), len(second)):
+                suffix = first[len(first) - count :]
         except Exception as exc:  # never let suffix derivation break tokenization
             logger.debug(f"Could not derive the chat-template suffix: {exc}")
 
-        # Cache the result, including an empty/failed derivation, so it isn't recomputed on every call.
+        # Cache the result (including an empty/failed derivation), evicting the least-recently-used entry past
+        # the cap so a workload with many distinct prompts can't grow it without bound.
         if cache_key is not None:
-            self._chat_template_suffix_cache[cache_key] = suffix
+            cache[cache_key] = suffix
+            if len(cache) > _CHAT_TEMPLATE_SUFFIX_CACHE_SIZE:
+                cache.popitem(last=False)
         return suffix
 
     def _render_message_skeleton(
@@ -1526,15 +1548,18 @@ class Transformer(InputModule):
         chat_template_kwargs: dict[str, Any],
         tokenizer_kwargs: dict[str, Any],
     ) -> list[int]:
-        """Tokenize one conversation with each text content replaced by ``filler`` (untruncated).
+        """Tokenize one conversation with each non-system content replaced by ``filler`` (untruncated).
 
-        The short filler keeps the rendered prompt tiny, so this stays cheap regardless of the real input
-        length. ``tokenizer_kwargs`` mirrors the real call's text kwargs so the suffix is tokenized
-        identically (e.g. the same ``add_special_tokens``); ``return_tensors=None`` asks for plain lists.
+        ``system`` messages (the prompt/instruction) are kept verbatim so the diff can capture a prompt the
+        template renders in the tail. Everything else is per-row content and gets fillered, which keeps the
+        rendered prompt tiny and cheap regardless of input length (a long kept system prompt is the one
+        exception). ``tokenizer_kwargs`` mirrors the real call's text kwargs so the suffix is tokenized
+        identically (e.g. the same ``add_special_tokens``). ``return_tensors=None`` asks for plain lists.
         """
         skeleton = []
         for message in conversation:
-            if not isinstance(message, dict):
+            # Keep system messages (the prompt) fixed so the diff captures them if rendered in the tail.
+            if not isinstance(message, dict) or message.get("role") == "system":
                 skeleton.append(message)
                 continue
             new_content = [{"type": "text", "text": filler}] if isinstance(message.get("content"), list) else filler

--- a/sentence_transformers/base/modules/transformer.py
+++ b/sentence_transformers/base/modules/transformer.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import importlib
 import inspect
-from collections import OrderedDict
 from collections.abc import Callable
 from contextlib import contextmanager
 from dataclasses import fields
@@ -120,7 +119,7 @@ _TRANSFORMERS_SUPPORTS_IS_CAUSAL_FALSE = parse_version(transformers_version) >= 
 
 # apply_chat_template wants these as top-level kwargs, not nested in tokenizer_kwargs/common_kwargs.
 _APPLY_CHAT_TEMPLATE_TOP_LEVEL_KWARGS = frozenset({"padding", "truncation", "max_length", "return_tensors"})
-# LRU bound for the per-structure chat-template suffix cache, since its key includes the prompt.
+# Size bound for the per-structure chat-template suffix cache, since its key includes the prompt.
 _CHAT_TEMPLATE_SUFFIX_CACHE_SIZE = 256
 
 TransformerTask = Literal[
@@ -636,7 +635,7 @@ class Transformer(InputModule):
         self.track_media_counts = False
         self._prompt_length_mapping = {}
         self._method_signature_cache: dict[str, set[str]] = {}
-        self._chat_template_suffix_cache: OrderedDict[Any, list[int]] = OrderedDict()
+        self._chat_template_suffix_cache: dict[Any, list[int]] = {}
 
         config, is_peft_model = self._load_config(model_name_or_path, backend, config_kwargs)
         self._warn_on_unsupported_attention_config(config)
@@ -1503,25 +1502,21 @@ class Transformer(InputModule):
         if not conversation or not self.input_formatter.is_text_only_messages([conversation]):
             return []
         # Cache per template-kwargs + tokenizer-kwargs + role layout + prompt. Kept (system) prompts can land
-        # in the suffix, so their content is part of the key (repr keeps structured content hashable). Any of
-        # these may be unhashable (e.g. a ``tools`` list), so guard the lookup and re-derive uncached if so.
+        # in the suffix, so their content is part of the key. repr() keeps the key hashable even when a value
+        # is a list (e.g. a ``tools`` arg), and is how the prompt content is keyed anyway.
         roles = tuple(m.get("role") if isinstance(m, dict) else None for m in conversation)
         prompts = tuple(
             repr(m.get("content")) for m in conversation if isinstance(m, dict) and m.get("role") == "system"
         )
         cache = self._chat_template_suffix_cache
-        try:
-            cache_key = (
-                tuple(sorted(chat_template_kwargs.items())),
-                tuple(sorted(tokenizer_kwargs.items())),
-                roles,
-                prompts,
-            )
-            if cache_key in cache:
-                cache.move_to_end(cache_key)  # mark most-recently-used
-                return cache[cache_key]
-        except TypeError:
-            cache_key = None
+        cache_key = (
+            repr(sorted(chat_template_kwargs.items())),
+            repr(sorted(tokenizer_kwargs.items())),
+            roles,
+            prompts,
+        )
+        if cache_key in cache:
+            return cache[cache_key]
 
         suffix: list[int] = []
         try:
@@ -1541,12 +1536,11 @@ class Transformer(InputModule):
         except Exception as exc:  # never let suffix derivation break tokenization
             logger.debug(f"Could not derive the chat-template suffix: {exc}")
 
-        # Cache the result (including an empty/failed derivation), evicting the least-recently-used entry past
-        # the cap so a workload with many distinct prompts can't grow it without bound.
-        if cache_key is not None:
-            cache[cache_key] = suffix
-            if len(cache) > _CHAT_TEMPLATE_SUFFIX_CACHE_SIZE:
-                cache.popitem(last=False)
+        # Cache the result (including an empty/failed derivation), evicting the oldest entry past the cap so a
+        # workload with many distinct prompts can't grow it without bound.
+        cache[cache_key] = suffix
+        if len(cache) > _CHAT_TEMPLATE_SUFFIX_CACHE_SIZE:
+            cache.pop(next(iter(cache)))
         return suffix
 
     def _render_message_skeleton(

--- a/sentence_transformers/base/modules/transformer.py
+++ b/sentence_transformers/base/modules/transformer.py
@@ -116,7 +116,9 @@ _TRANSFORMERS_APPLY_CHAT_TEMPLATE_RECOMMENDS_PROCESSOR_KWARGS = parse_version(tr
 )
 _TRANSFORMERS_SUPPORTS_USE_BIDIRECTIONAL_ATTENTION = parse_version(transformers_version) >= parse_version("4.56.2")
 _TRANSFORMERS_SUPPORTS_IS_CAUSAL_FALSE = parse_version(transformers_version) >= parse_version("5.2.0")
-DEFAULT_CHAT_TEMPLATE_PRESERVE_FINAL_TOKENS = 16
+
+# apply_chat_template wants these as top-level kwargs, not nested in tokenizer_kwargs/common_kwargs.
+_APPLY_CHAT_TEMPLATE_TOP_LEVEL_KWARGS = frozenset({"padding", "truncation", "max_length", "return_tensors"})
 
 TransformerTask = Literal[
     "feature-extraction", "sequence-classification", "text-generation", "any-to-any", "fill-mask"
@@ -627,6 +629,7 @@ class Transformer(InputModule):
         self.track_media_counts = False
         self._prompt_length_mapping = {}
         self._method_signature_cache: dict[str, set[str]] = {}
+        self._chat_template_suffix_cache: dict[Any, list[int]] = {}
 
         config, is_peft_model = self._load_config(model_name_or_path, backend, config_kwargs)
         self._warn_on_unsupported_attention_config(config)
@@ -1322,11 +1325,18 @@ class Transformer(InputModule):
         # Ideally we'd use the same code path for both ProcessorMixin and Tokenizers, but the latter expects
         # the text kwargs to be passed at the top level instead of in a nested "text_kwargs" dict.
         chat_template_kwargs = dict(chat_template_kwargs or {})
+
+        # Read truncation before the hoist below pops it (text kwargs take priority over common). The
+        # restore in _restore_chat_template_suffix is gated on it.
+        text_kwargs = modality_kwargs.get("text", {})
+        truncation = text_kwargs.get("truncation", common_kwargs.get("truncation"))
+        restore_chat_template_suffix = bool(truncation) and truncation != "do_not_truncate"
+
         if isinstance(self.processor, ProcessorMixin):
             # Transformers v5.4.0 prefers us to pass processor_kwargs as a single dict, but there's still some top level
             # kwargs that need to be hoisted out for backwards compatibility.
             if _TRANSFORMERS_APPLY_CHAT_TEMPLATE_RECOMMENDS_PROCESSOR_KWARGS:
-                return self.processor.apply_chat_template(
+                features = self.processor.apply_chat_template(
                     messages,
                     tokenize=True,
                     return_dict=True,
@@ -1342,7 +1352,7 @@ class Transformer(InputModule):
                     **chat_template_kwargs,
                 )
             else:
-                return self.processor.apply_chat_template(
+                features = self.processor.apply_chat_template(
                     messages,
                     tokenize=True,
                     return_dict=True,
@@ -1353,96 +1363,210 @@ class Transformer(InputModule):
                     common_kwargs=common_kwargs,
                     **chat_template_kwargs,
                 )
-
-        # apply_chat_template expects padding/truncation/max_length/return_tensors as top-level kwargs,
-        # not nested inside tokenizer_kwargs or common_kwargs, so we hoist them out.
-        top_level_kwarg_names = {"padding", "truncation", "max_length", "return_tensors"}
-        top_level_kwargs = {key: common_kwargs.pop(key) for key in top_level_kwarg_names & common_kwargs.keys()}
-        top_level_kwargs |= {
-            key: modality_kwargs["text"].pop(key) for key in top_level_kwarg_names & modality_kwargs["text"].keys()
-        }
-        preserve_final_tokens = chat_template_kwargs.pop(
-            "preserve_final_tokens", DEFAULT_CHAT_TEMPLATE_PRESERVE_FINAL_TOKENS
-        )
-        truncation = top_level_kwargs.get("truncation", False)
-        max_length = top_level_kwargs.get("max_length")
-        if max_length is None and truncation and self.tokenizer is not None:
-            max_length = self.tokenizer.model_max_length
-
-        if (
-            preserve_final_tokens
-            and self.transformer_task in ("text-generation", "any-to-any")
-            and self.input_formatter.is_text_only_messages(messages)
-            and truncation
-            and max_length is not None
-        ):
-            return self._apply_chat_template_preserving_tail(
-                messages=messages,
-                modality_kwargs=modality_kwargs,
+        else:
+            # apply_chat_template expects padding/truncation/max_length/return_tensors as top-level kwargs,
+            # not nested inside tokenizer_kwargs or common_kwargs, so we hoist them out.
+            top_level_kwargs = {
+                key: common_kwargs.pop(key) for key in _APPLY_CHAT_TEMPLATE_TOP_LEVEL_KWARGS & common_kwargs.keys()
+            }
+            top_level_kwargs |= {
+                key: modality_kwargs["text"].pop(key)
+                for key in _APPLY_CHAT_TEMPLATE_TOP_LEVEL_KWARGS & modality_kwargs["text"].keys()
+            }
+            features = self.processor.apply_chat_template(
+                messages,
+                tokenize=True,
+                return_dict=True,
+                tokenizer_kwargs=modality_kwargs["text"],
                 common_kwargs=common_kwargs,
-                chat_template_kwargs=chat_template_kwargs,
-                top_level_kwargs=top_level_kwargs,
-                max_length=max_length,
-                preserve_final_tokens=preserve_final_tokens,
+                **top_level_kwargs,
+                **chat_template_kwargs,
             )
 
-        return self.processor.apply_chat_template(
-            messages,
-            tokenize=True,
-            return_dict=True,
-            tokenizer_kwargs=modality_kwargs["text"],
-            common_kwargs=common_kwargs,
-            **top_level_kwargs,
-            **chat_template_kwargs,
-        )
+        if restore_chat_template_suffix:
+            # Forward the text kwargs (minus the size/truncation ones) so the derived suffix is tokenized
+            # like the real call.
+            suffix_tokenizer_kwargs = {
+                key: value for key, value in text_kwargs.items() if key not in _APPLY_CHAT_TEMPLATE_TOP_LEVEL_KWARGS
+            }
+            self._restore_chat_template_suffix(features, messages, chat_template_kwargs, suffix_tokenizer_kwargs)
+        return features
 
-    def _apply_chat_template_preserving_tail(
+    def _restore_chat_template_suffix(
         self,
+        features: dict[str, Any],
         messages: list[list[MessageInput]],
-        modality_kwargs: dict[str, dict[str, Any]],
-        common_kwargs: dict[str, Any],
         chat_template_kwargs: dict[str, Any],
-        top_level_kwargs: dict[str, Any],
-        max_length: int,
-        preserve_final_tokens: int,
-    ) -> dict[str, Any]:
-        tokenizer_kwargs = {**modality_kwargs["text"], "verbose": False}
-        full = self.processor.apply_chat_template(
-            messages,
-            tokenize=True,
-            return_dict=True,
-            tokenizer_kwargs=tokenizer_kwargs,
-            common_kwargs=common_kwargs,
-            padding=False,
-            truncation=False,
-            return_tensors=None,
-            **chat_template_kwargs,
-        )
-        input_ids = full["input_ids"]
-        if isinstance(input_ids, torch.Tensor):
-            input_ids = input_ids.tolist()
-        if input_ids and isinstance(input_ids[0], int):
-            input_ids = [input_ids]
+        tokenizer_kwargs: dict[str, Any],
+    ) -> None:
+        """Restore the trailing chat-template suffix that truncation may have removed (in place).
 
-        preserve_final_tokens = min(preserve_final_tokens, max_length)
-        head_length = max_length - preserve_final_tokens
-        input_ids = [
-            ids[:head_length] + ids[-preserve_final_tokens:] if len(ids) > max_length else ids
-            for ids in input_ids
+        Chat templates append a fixed suffix after the user content (e.g. the ``<|im_end|> ... assistant``
+        prefill or a trailing EOS). Right-truncation cuts that suffix off first, which is harmless for
+        mean/CLS pooling but breaks any model that reads from the final position: causal-LM rerankers
+        (last-token logits) and last-token-pooling embedders. ``apply_chat_template`` is allowed to truncate
+        as usual, then this overwrites the final tokens of any row whose tail was cut with the suffix.
+
+        This runs post-hoc (after truncation) because ``apply_chat_template`` renders to a flat string and
+        the tokenizer truncates it blind to template structure: there is no upstream option to trim only the
+        content while keeping the suffix.
+
+        The suffix is derived per row (cached per structure), so a batch mixing different role layouts is
+        handled correctly. Rows that fit already end with the suffix, so the tail comparison leaves them
+        untouched, as does ``truncation=False``.
+        """
+        input_ids = features.get("input_ids")
+        if input_ids is None:
+            return
+
+        is_tensor = isinstance(input_ids, torch.Tensor)
+        if is_tensor:
+            if input_ids.numel() == 0:
+                return
+            # unsqueeze returns a view, so the in-place writes below propagate to features["input_ids"]
+            ids = input_ids if input_ids.dim() == 2 else input_ids.unsqueeze(0)
+            n_rows = ids.shape[0]
+        else:
+            # Flattening path (feature-extraction + can_flatten_inputs, see preprocess): return_tensors is
+            # dropped, so apply_chat_template returns ragged, unpadded token lists. Each row's tail is real.
+            rows = input_ids if input_ids and isinstance(input_ids[0], list) else [input_ids]
+            n_rows = len(rows)
+
+        # Derive the per-row suffixes first (cached). Multimodal rows yield [], so an all-media batch returns
+        # here, before the attention-mask reduction below and its two device-to-host syncs.
+        suffixes = [
+            self._chat_template_suffix_ids(messages[index], chat_template_kwargs, tokenizer_kwargs)
+            for index in range(min(n_rows, len(messages)))
         ]
-        return self.processor.pad(
-            {"input_ids": input_ids},
-            padding=top_level_kwargs.get("padding", False),
-            max_length=max_length if top_level_kwargs.get("padding") == "max_length" else None,
-            return_tensors=top_level_kwargs.get("return_tensors"),
-            verbose=False,
+        if not any(suffixes):
+            return
+
+        if is_tensor:
+            width = ids.shape[-1]
+            # Final real-token index per row from the attention mask, so this is correct for either padding
+            # side (left padding is only enforced for the causal-LM tasks, not e.g. embedders).
+            attention_mask = features.get("attention_mask")
+            if isinstance(attention_mask, torch.Tensor) and attention_mask.numel():
+                am = attention_mask if attention_mask.dim() == 2 else attention_mask.unsqueeze(0)
+                last_idx = (am * torch.arange(width, device=ids.device)).argmax(dim=1).tolist()
+                real_lengths = am.sum(dim=1).tolist()
+            else:
+                last_idx = [width - 1] * n_rows
+                real_lengths = [width] * n_rows
+
+        for index, suffix in enumerate(suffixes):
+            if not suffix:
+                continue
+            if is_tensor:
+                keep = min(len(suffix), real_lengths[index])
+                if keep == 0:
+                    continue
+                end = last_idx[index] + 1
+                suffix_tensor = torch.as_tensor(suffix[-keep:], dtype=ids.dtype, device=ids.device)
+                if (ids[index, end - keep : end] != suffix_tensor).any():
+                    ids[index, end - keep : end] = suffix_tensor
+            else:
+                row = rows[index]
+                keep = min(len(suffix), len(row))
+                if keep and row[-keep:] != suffix[-keep:]:
+                    row[-keep:] = suffix[-keep:]
+
+    def _chat_template_suffix_ids(
+        self,
+        conversation: list[MessageInput],
+        chat_template_kwargs: dict[str, Any],
+        tokenizer_kwargs: dict[str, Any],
+    ) -> list[int]:
+        """Pre-tokenize one conversation's trailing chat-template suffix, cached per structure.
+
+        The suffix is the run of tokens the template appends after the user content (e.g. the assistant
+        prefill). It is found by rendering the conversation's role layout with two different fillers and
+        taking the longest common token suffix, so no per-model count is hard-coded.
+        """
+        # Skip rows with actual media: image/audio/video placeholder tokens can't be cut without desyncing
+        # them from their media features (the model would then error), so there's nothing safe to restore.
+        # Text-only inputs to a multimodal model still qualify.
+        if not conversation or not self.input_formatter.is_text_only_messages([conversation]):
+            return []
+        # Cache per template-kwargs + tokenizer-kwargs + role layout. Any of these may carry unhashable
+        # values (e.g. a ``tools`` list), so guard the lookup and fall back to re-deriving without caching.
+        roles = tuple(m.get("role") if isinstance(m, dict) else None for m in conversation)
+        try:
+            cache_key = (tuple(sorted(chat_template_kwargs.items())), tuple(sorted(tokenizer_kwargs.items())), roles)
+            if cache_key in self._chat_template_suffix_cache:
+                return self._chat_template_suffix_cache[cache_key]
+        except TypeError:
+            cache_key = None
+
+        suffix: list[int] = []
+        try:
+            # The two fillers must tokenize differently, so the longest common token suffix of the renders is
+            # purely the template tail (the run after the content), never shared content tokens.
+            first = self._render_message_skeleton(conversation, "0", chat_template_kwargs, tokenizer_kwargs)
+            second = self._render_message_skeleton(conversation, "1 2 3 4", chat_template_kwargs, tokenizer_kwargs)
+            count = 0
+            for left, right in zip(reversed(first), reversed(second)):
+                if left != right:
+                    break
+                count += 1
+            suffix = first[len(first) - count :]  # count == 0 slices at len(first), i.e. []
+        except Exception as exc:  # never let suffix derivation break tokenization
+            logger.debug(f"Could not derive the chat-template suffix: {exc}")
+
+        # Cache the result, including an empty/failed derivation, so it isn't recomputed on every call.
+        if cache_key is not None:
+            self._chat_template_suffix_cache[cache_key] = suffix
+        return suffix
+
+    def _render_message_skeleton(
+        self,
+        conversation: list[MessageInput],
+        filler: str,
+        chat_template_kwargs: dict[str, Any],
+        tokenizer_kwargs: dict[str, Any],
+    ) -> list[int]:
+        """Tokenize one conversation with each text content replaced by ``filler`` (untruncated).
+
+        The short filler keeps the rendered prompt tiny, so this stays cheap regardless of the real input
+        length. ``tokenizer_kwargs`` mirrors the real call's text kwargs so the suffix is tokenized
+        identically (e.g. the same ``add_special_tokens``); ``return_tensors=None`` asks for plain lists.
+        """
+        skeleton = []
+        for message in conversation:
+            if not isinstance(message, dict):
+                skeleton.append(message)
+                continue
+            new_content = [{"type": "text", "text": filler}] if isinstance(message.get("content"), list) else filler
+            skeleton.append({**message, "content": new_content})
+
+        # Mirror the real call's kwarg routing (see _process_chat_messages): a ProcessorMixin wants the text
+        # kwargs nested, a bare tokenizer wants them flat alongside top-level padding/truncation.
+        if isinstance(self.processor, ProcessorMixin):
+            text_kwargs = {**tokenizer_kwargs, "padding": False, "truncation": False}
+            if _TRANSFORMERS_APPLY_CHAT_TEMPLATE_RECOMMENDS_PROCESSOR_KWARGS:
+                call_kwargs = {"processor_kwargs": {"text_kwargs": text_kwargs}}
+            else:
+                call_kwargs = {"text_kwargs": text_kwargs}
+        else:
+            call_kwargs = {"tokenizer_kwargs": tokenizer_kwargs, "padding": False, "truncation": False}
+        output = self.processor.apply_chat_template(
+            [skeleton], tokenize=True, return_dict=True, return_tensors=None, **call_kwargs, **chat_template_kwargs
         )
+        # return_tensors=None should give lists, but some processors return a tensor anyway. The suffix logic
+        # needs a plain list and we render a single conversation, so coerce to a list and unwrap the batch.
+        ids = output["input_ids"]
+        if isinstance(ids, torch.Tensor):
+            ids = ids.tolist()
+        if ids and isinstance(ids[0], list):
+            ids = ids[0]
+        return ids
 
     def _get_prompt_length(self, prompt: str, **kwargs) -> int | None:
         """Return the length of the prompt in tokens, excluding any trailing special token.
 
         Returns None if the processor does not produce ``input_ids``.
         """
+        # TODO: Perhaps mirror the _chat_template_suffix_ids implementation with 2 forwards and then checking the common prefix
         cache_key = (prompt, *sorted(kwargs.items()))
         if cache_key in self._prompt_length_mapping:
             return self._prompt_length_mapping[cache_key]

--- a/sentence_transformers/base/modules/transformer.py
+++ b/sentence_transformers/base/modules/transformer.py
@@ -1333,14 +1333,15 @@ class Transformer(InputModule):
         # `restore_suffix` is a Sentence Transformers flag, not an apply_chat_template arg, so pop it (default on).
         restore_suffix = chat_template_kwargs.pop("restore_suffix", True)
 
-        # Truncation/max_length may ride in any of the three kwarg buckets. Tokenizers also truncate when
-        # max_length is set while truncation was left unset, so only an explicit opt-out disables the restore.
+        # Truncation/max_length may ride in any kwarg bucket (chat-template wins). Tokenizers also truncate
+        # when max_length is set while truncation was left unset, so only an explicit opt-out disables the
+        # restore.
         text_kwargs = modality_kwargs["text"]
-        truncation = text_kwargs.get(
-            "truncation", common_kwargs.get("truncation", chat_template_kwargs.get("truncation"))
+        truncation = chat_template_kwargs.get(
+            "truncation", text_kwargs.get("truncation", common_kwargs.get("truncation"))
         )
-        max_length = text_kwargs.get(
-            "max_length", common_kwargs.get("max_length", chat_template_kwargs.get("max_length"))
+        max_length = chat_template_kwargs.get(
+            "max_length", text_kwargs.get("max_length", common_kwargs.get("max_length"))
         )
         truncation_active = bool(truncation) or (truncation is None and max_length is not None)
         restore_chat_template_suffix = restore_suffix and truncation_active and truncation != "do_not_truncate"
@@ -1366,6 +1367,13 @@ class Transformer(InputModule):
         a ProcessorMixin, flat with the size kwargs hoisted to the top level for a bare tokenizer. Both the
         real batch and the suffix skeleton renders go through this (the given dicts are never mutated).
         """
+        # Fold size kwargs from the chat-template bucket into the text kwargs (chat wins), else
+        # apply_chat_template gets them twice (bare tokenizer) or misroutes them (ProcessorMixin).
+        if size_keys := _APPLY_CHAT_TEMPLATE_TOP_LEVEL_KWARGS & chat_template_kwargs.keys():
+            chat_template_kwargs = dict(chat_template_kwargs)
+            folded = {key: chat_template_kwargs.pop(key) for key in size_keys}
+            modality_kwargs = {**modality_kwargs, "text": {**modality_kwargs["text"], **folded}}
+
         if isinstance(self.processor, ProcessorMixin):
             # Transformers v5.4.0 prefers us to pass processor_kwargs as a single dict, but there's still some top level
             # kwargs that need to be hoisted out for backwards compatibility.
@@ -1442,7 +1450,7 @@ class Transformer(InputModule):
         if not isinstance(input_ids, (torch.Tensor, list)):
             return
 
-        # An unknown max_length (None) disables the truncation gates below.
+        # An unknown max_length (None) becomes 0, so the gates below never skip a row.
         max_length = max_length or 0
 
         is_tensor = isinstance(input_ids, torch.Tensor)

--- a/sentence_transformers/base/modules/transformer.py
+++ b/sentence_transformers/base/modules/transformer.py
@@ -443,7 +443,7 @@ class ProcessingKwargs(TypedDict, total=False):
 
     Valid keys: ``"common"``, ``"text"``, ``"audio"``, ``"image"``, ``"video"``, ``"chat_template"``.
     Modality and ``"common"`` kwargs override built-in defaults. ``"chat_template"`` kwargs are
-    forwarded to ``apply_chat_template``.
+    forwarded to ``apply_chat_template``, except the Sentence Transformers ``restore_suffix`` flag.
     """
 
     common: dict[str, Any]
@@ -546,10 +546,9 @@ class Transformer(InputModule):
             modalities, or ``"chat_template"`` for kwargs forwarded to ``apply_chat_template`` (e.g.
             ``{"add_generation_prompt": True}``). Modality and common kwargs override the built-in defaults.
             The ``"chat_template"`` dict also accepts ``"restore_suffix"`` (default ``True``), a Sentence
-            Transformers flag: when truncation would drop the fixed tokens a chat template appends after the
-            content (e.g. an assistant prefill or a trailing EOS), they are restored onto the truncated tail
-            so models that read the final token position keep working. Set ``False`` to disable. Saved to and
-            loaded from the model configuration file. Defaults to None.
+            Transformers flag: fixed tokens a chat template appends after the content (e.g. an assistant
+            prefill) are restored when truncation drops them, so models that read the final token position
+            keep working. Saved to and loaded from the model configuration file. Defaults to None.
         backend (str, optional): Backend used for model inference. Can be ``"torch"`` (default), ``"onnx"``,
             or ``"openvino"``. Defaults to ``"torch"``.
         modality_config (dict, optional): Custom modality configuration mapping modality names to method and
@@ -1320,7 +1319,8 @@ class Transformer(InputModule):
     ) -> dict[str, Any]:
         """Process chat messages using the processor's chat template.
 
-        ``chat_template_kwargs`` is forwarded to ``apply_chat_template``.
+        ``chat_template_kwargs`` is forwarded to ``apply_chat_template``, except the Sentence Transformers
+        ``restore_suffix`` flag, which only toggles the truncation suffix restore.
         """
         if "message" not in self.modality_config:
             raise ValueError(
@@ -1328,28 +1328,49 @@ class Transformer(InputModule):
                 f"Supported modalities: {list(self.modality_config.keys())}"
             )
 
-        # ProcessorMixin and bare tokenizers need different kwarg routing (nested vs top-level text kwargs).
         chat_template_kwargs = dict(chat_template_kwargs or {})
 
         # `restore_suffix` is a Sentence Transformers flag, not an apply_chat_template arg, so pop it (default on).
         restore_suffix = chat_template_kwargs.pop("restore_suffix", True)
 
-        # Read truncation/max_length before the hoist below pops them (text kwargs take priority over common).
-        # max_length lets the restore skip work entirely when nothing reached the limit (no truncation).
-        text_kwargs = modality_kwargs.get("text", {})
-        truncation = text_kwargs.get("truncation", common_kwargs.get("truncation"))
-        restore_chat_template_suffix = restore_suffix and bool(truncation) and truncation != "do_not_truncate"
-        max_length = None
-        if restore_chat_template_suffix:
-            max_length = text_kwargs.get("max_length", common_kwargs.get("max_length"))
-            if max_length is None and self.tokenizer is not None:
-                max_length = self.tokenizer.model_max_length
+        # Truncation/max_length may ride in any of the three kwarg buckets. Tokenizers also truncate when
+        # max_length is set while truncation was left unset, so only an explicit opt-out disables the restore.
+        text_kwargs = modality_kwargs["text"]
+        truncation = text_kwargs.get(
+            "truncation", common_kwargs.get("truncation", chat_template_kwargs.get("truncation"))
+        )
+        max_length = text_kwargs.get(
+            "max_length", common_kwargs.get("max_length", chat_template_kwargs.get("max_length"))
+        )
+        truncation_active = bool(truncation) or (truncation is None and max_length is not None)
+        restore_chat_template_suffix = restore_suffix and truncation_active and truncation != "do_not_truncate"
 
+        features = self._apply_chat_template(messages, modality_kwargs, common_kwargs, chat_template_kwargs)
+
+        if restore_chat_template_suffix:
+            if max_length is None:
+                max_length = self.max_seq_length
+            self._restore_chat_template_suffix(
+                features, messages, chat_template_kwargs, text_kwargs, common_kwargs, max_length
+            )
+        return features
+
+    def _apply_chat_template(
+        self,
+        messages: list[list[MessageInput]],
+        modality_kwargs: dict[str, dict[str, Any]],
+        common_kwargs: dict[str, Any],
+        chat_template_kwargs: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Call ``apply_chat_template`` with the kwarg routing the processor type expects: nested kwargs for
+        a ProcessorMixin, flat with the size kwargs hoisted to the top level for a bare tokenizer. Both the
+        real batch and the suffix skeleton renders go through this (the given dicts are never mutated).
+        """
         if isinstance(self.processor, ProcessorMixin):
             # Transformers v5.4.0 prefers us to pass processor_kwargs as a single dict, but there's still some top level
             # kwargs that need to be hoisted out for backwards compatibility.
             if _TRANSFORMERS_APPLY_CHAT_TEMPLATE_RECOMMENDS_PROCESSOR_KWARGS:
-                features = self.processor.apply_chat_template(
+                return self.processor.apply_chat_template(
                     messages,
                     tokenize=True,
                     return_dict=True,
@@ -1364,48 +1385,37 @@ class Transformer(InputModule):
                     },
                     **chat_template_kwargs,
                 )
-            else:
-                features = self.processor.apply_chat_template(
-                    messages,
-                    tokenize=True,
-                    return_dict=True,
-                    text_kwargs=modality_kwargs["text"],
-                    images_kwargs=modality_kwargs["image"],
-                    audio_kwargs=modality_kwargs["audio"],
-                    videos_kwargs=modality_kwargs["video"],
-                    common_kwargs=common_kwargs,
-                    **chat_template_kwargs,
-                )
-        else:
-            # apply_chat_template expects padding/truncation/max_length/return_tensors as top-level kwargs,
-            # not nested inside tokenizer_kwargs or common_kwargs, so we hoist them out.
-            top_level_kwargs = {
-                key: common_kwargs.pop(key) for key in _APPLY_CHAT_TEMPLATE_TOP_LEVEL_KWARGS & common_kwargs.keys()
-            }
-            top_level_kwargs |= {
-                key: modality_kwargs["text"].pop(key)
-                for key in _APPLY_CHAT_TEMPLATE_TOP_LEVEL_KWARGS & modality_kwargs["text"].keys()
-            }
-            features = self.processor.apply_chat_template(
+            return self.processor.apply_chat_template(
                 messages,
                 tokenize=True,
                 return_dict=True,
-                tokenizer_kwargs=modality_kwargs["text"],
+                text_kwargs=modality_kwargs["text"],
+                images_kwargs=modality_kwargs["image"],
+                audio_kwargs=modality_kwargs["audio"],
+                videos_kwargs=modality_kwargs["video"],
                 common_kwargs=common_kwargs,
-                **top_level_kwargs,
                 **chat_template_kwargs,
             )
 
-        if restore_chat_template_suffix:
-            # Forward the text kwargs (minus the size/truncation ones) so the derived suffix is tokenized
-            # like the real call.
-            suffix_tokenizer_kwargs = {
-                key: value for key, value in text_kwargs.items() if key not in _APPLY_CHAT_TEMPLATE_TOP_LEVEL_KWARGS
-            }
-            self._restore_chat_template_suffix(
-                features, messages, chat_template_kwargs, suffix_tokenizer_kwargs, max_length
-            )
-        return features
+        # apply_chat_template expects padding/truncation/max_length/return_tensors as top-level kwargs, not
+        # nested inside tokenizer_kwargs or common_kwargs, so we hoist them out of copies.
+        text_kwargs = dict(modality_kwargs["text"])
+        common_kwargs = dict(common_kwargs)
+        top_level_kwargs = {
+            key: common_kwargs.pop(key) for key in _APPLY_CHAT_TEMPLATE_TOP_LEVEL_KWARGS & common_kwargs.keys()
+        }
+        top_level_kwargs |= {
+            key: text_kwargs.pop(key) for key in _APPLY_CHAT_TEMPLATE_TOP_LEVEL_KWARGS & text_kwargs.keys()
+        }
+        return self.processor.apply_chat_template(
+            messages,
+            tokenize=True,
+            return_dict=True,
+            tokenizer_kwargs=text_kwargs,
+            common_kwargs=common_kwargs,
+            **top_level_kwargs,
+            **chat_template_kwargs,
+        )
 
     def _restore_chat_template_suffix(
         self,
@@ -1413,137 +1423,151 @@ class Transformer(InputModule):
         messages: list[list[MessageInput]],
         chat_template_kwargs: dict[str, Any],
         tokenizer_kwargs: dict[str, Any],
+        common_kwargs: dict[str, Any] | None = None,
         max_length: int | None = None,
     ) -> None:
         """Restore the trailing chat-template suffix that truncation may have removed (in place).
 
-        Chat templates append a fixed suffix after the user content (e.g. the ``<|im_end|> ... assistant``
-        prefill or a trailing EOS). Right-truncation cuts that suffix off first, which is harmless for
-        mean/CLS pooling but breaks any model that reads from the final position: causal-LM rerankers
-        (last-token logits) and last-token-pooling embedders. ``apply_chat_template`` is allowed to truncate
-        as usual, then this overwrites the final tokens of any row whose tail was cut with the suffix.
+        Chat templates append fixed tokens after the content (e.g. an assistant prefill or EOS) that
+        right-truncation cuts off first. That is harmless for mean/CLS pooling but breaks models that read
+        the final position (causal-LM rerankers, last-token pooling), so the suffix is written back over the
+        final real tokens of every truncated row. This must happen post-hoc: the tokenizer truncates the
+        rendered string blind to template structure, with no upstream option to trim only the content.
 
-        This runs post-hoc (after truncation) because ``apply_chat_template`` renders to a flat string and
-        the tokenizer truncates it blind to template structure: there is no upstream option to trim only the
-        content while keeping the suffix.
-
-        The suffix is derived per row (cached per structure), so a batch mixing different role layouts is
-        handled correctly. If the longest real row is shorter than ``max_length`` nothing was truncated, so
-        the whole pass is skipped. Otherwise every row is checked and a row that already ends with the suffix
-        is left untouched, as is ``truncation=False``.
+        Only rows whose real length reached ``max_length`` can have been truncated, so shorter rows are
+        skipped. The suffix is derived (and cached) per row, handling batches that mix role layouts.
         """
         input_ids = features.get("input_ids")
-        if input_ids is None:
+        # Anything but torch tensors and the flattening path's token lists (e.g. numpy) is left untouched.
+        if not isinstance(input_ids, (torch.Tensor, list)):
             return
+
+        # An unknown max_length (None) disables the truncation gates below.
+        max_length = max_length or 0
 
         is_tensor = isinstance(input_ids, torch.Tensor)
         if is_tensor:
-            if input_ids.numel() == 0:
-                return
             # unsqueeze returns a view, so the in-place writes below propagate to features["input_ids"]
             ids = input_ids if input_ids.dim() == 2 else input_ids.unsqueeze(0)
             width = ids.shape[-1]
-            # Each row's real-token count and padding side, from the mask, so the suffix lands on real tokens
-            # even under padding: the tail ends at `width` for left padding, else at the real length.
+            # No row can have reached max_length when even the padded width is below it.
+            if width < max_length:
+                return
+            # The mask gives each row's real length and padding side, so the suffix lands on real tokens.
+            # Without one, real tokens can't be told apart from padding and nothing can be restored safely.
             attention_mask = features.get("attention_mask")
-            if isinstance(attention_mask, torch.Tensor) and attention_mask.numel():
-                am = attention_mask if attention_mask.dim() == 2 else attention_mask.unsqueeze(0)
-                real_lengths = am.sum(dim=1).tolist()
-                left_padded = (am[:, 0] == 0).tolist()
-            else:
-                real_lengths = [width] * ids.shape[0]
-                left_padded = [False] * ids.shape[0]
+            if not isinstance(attention_mask, torch.Tensor) or attention_mask.numel() == 0:
+                return
+            am = attention_mask if attention_mask.dim() == 2 else attention_mask.unsqueeze(0)
+            real_lengths = am.long().sum(dim=1).tolist()
+            left_padded = (am[:, 0] == 0).tolist()
             n_rows = ids.shape[0]
         else:
-            # Flattening path (feature-extraction + can_flatten_inputs, see preprocess): return_tensors is
-            # dropped, so apply_chat_template returns ragged, unpadded token lists. Each row's tail is real.
-            rows = input_ids if input_ids and isinstance(input_ids[0], list) else [input_ids]
+            # The flattening path (see preprocess) drops return_tensors, giving ragged unpadded token lists.
+            rows = input_ids
             real_lengths = [len(row) for row in rows]
             n_rows = len(rows)
 
-        # If the longest real row is below max_length, nothing was truncated. Real lengths (not padded
-        # width) stay correct when pad_to_multiple_of pads a truncated row past max_length.
-        if max_length is not None and max(real_lengths, default=0) < max_length:
-            return
-
         for index in range(min(n_rows, len(messages))):
-            suffix = self._chat_template_suffix_ids(messages[index], chat_template_kwargs, tokenizer_kwargs)
-            if not suffix:
+            # Truncation cuts to exactly max_length, so shorter rows kept their tail. Real lengths stay
+            # correct when pad_to_multiple_of pads a truncated row past max_length.
+            if real_lengths[index] < max_length:
+                continue
+            suffix = self._chat_template_suffix_ids(
+                messages[index], chat_template_kwargs, tokenizer_kwargs, common_kwargs
+            )
+            keep = min(len(suffix), real_lengths[index])
+            if keep == 0:
                 continue
             if is_tensor:
-                keep = min(len(suffix), real_lengths[index])
-                if keep == 0:
-                    continue
                 end = width if left_padded[index] else real_lengths[index]
-                suffix_tensor = torch.as_tensor(suffix[-keep:], dtype=ids.dtype, device=ids.device)
-                if (ids[index, end - keep : end] != suffix_tensor).any():
-                    ids[index, end - keep : end] = suffix_tensor
+                ids[index, end - keep : end] = torch.as_tensor(suffix[-keep:], dtype=ids.dtype, device=ids.device)
             else:
-                row = rows[index]
-                keep = min(len(suffix), real_lengths[index])
-                if keep and row[-keep:] != suffix[-keep:]:
-                    row[-keep:] = suffix[-keep:]
+                rows[index][-keep:] = suffix[-keep:]
 
     def _chat_template_suffix_ids(
         self,
         conversation: list[MessageInput],
         chat_template_kwargs: dict[str, Any],
         tokenizer_kwargs: dict[str, Any],
+        common_kwargs: dict[str, Any] | None = None,
     ) -> list[int]:
-        """Pre-tokenize one conversation's trailing chat-template suffix, cached per structure.
+        """Derive one conversation's trailing chat-template suffix (cached).
 
-        The suffix is the run of tokens the template appends after the user content (e.g. the assistant
-        prefill). It is found by rendering the conversation's role layout with two different fillers and
-        taking the longest common token suffix, so no per-model count is hard-coded. ``system`` messages (the
-        prompt/instruction) are kept fixed rather than fillered, so a prompt the template renders in the tail
-        is captured too. The cache keys on their content so different prompts get their own suffix.
+        The conversation is rendered twice with different fillers: the longest common token suffix of the
+        renders is the template tail, so no per-model token count is hard-coded. ``system`` messages are
+        kept verbatim so a prompt the template renders in the tail is captured too.
         """
-        # Skip rows with actual media: image/audio/video placeholder tokens can't be cut without desyncing
-        # them from their media features (the model would then error), so there's nothing safe to restore.
-        # Text-only inputs to a multimodal model still qualify.
-        if not conversation or not self.input_formatter.is_text_only_messages([conversation]):
+        # Media rows are skipped: cutting placeholder tokens would desync them from their media features.
+        # Message shapes the check can't inspect are skipped too rather than failing tokenization.
+        try:
+            if not conversation or not self.input_formatter.is_text_only_messages([conversation]):
+                return []
+        except Exception as exc:
+            logger.debug(f"Could not derive the chat-template suffix: {exc}")
             return []
-        # Cache per template-kwargs + tokenizer-kwargs + role layout + prompt. Kept (system) prompts can land
-        # in the suffix, so their content is part of the key. repr() keeps the key hashable even when a value
-        # is a list (e.g. a ``tools`` arg), and is how the prompt content is keyed anyway.
-        roles = tuple(m.get("role") if isinstance(m, dict) else None for m in conversation)
-        prompts = tuple(
-            repr(m.get("content")) for m in conversation if isinstance(m, dict) and m.get("role") == "system"
+        # Size/output kwargs in any bucket must not reach the untruncated skeleton renders or the cache key.
+        chat_template_kwargs, tokenizer_kwargs, common_kwargs = (
+            {key: value for key, value in kwargs.items() if key not in _APPLY_CHAT_TEMPLATE_TOP_LEVEL_KWARGS}
+            for kwargs in (chat_template_kwargs, tokenizer_kwargs, common_kwargs or {})
         )
+        # The skeleton key covers everything the renders see except the fillered content (roles, system
+        # prompts, fields like ``name``), so conversations that render differently can't share an entry.
+        # repr() keeps the key hashable even when a value is a list (e.g. a ``tools`` arg).
         cache = self._chat_template_suffix_cache
         cache_key = (
             repr(sorted(chat_template_kwargs.items())),
             repr(sorted(tokenizer_kwargs.items())),
-            roles,
-            prompts,
+            repr(sorted(common_kwargs.items())),
+            repr(self._message_skeleton(conversation, "")),
         )
         if cache_key in cache:
             return cache[cache_key]
 
         suffix: list[int] = []
         try:
-            # The two fillers must tokenize differently, so the longest common token suffix of the renders is
-            # purely the template tail (the run after the content), never shared content tokens.
-            first = self._render_message_skeleton(conversation, "0", chat_template_kwargs, tokenizer_kwargs)
-            second = self._render_message_skeleton(conversation, "1 2 3 4", chat_template_kwargs, tokenizer_kwargs)
+            # The fillers tokenize differently, so the common token suffix is template tail, never content.
+            first = self._render_message_skeleton(
+                conversation, "0", chat_template_kwargs, tokenizer_kwargs, common_kwargs
+            )
+            second = self._render_message_skeleton(
+                conversation, "1 2 3 4", chat_template_kwargs, tokenizer_kwargs, common_kwargs
+            )
             count = 0
             for left, right in zip(reversed(first), reversed(second)):
                 if left != right:
                     break
                 count += 1
-            # count == min(len) means the renders never diverged (e.g. a conversation with no variable
-            # content), so the common run would include filler/content. Only trust a strictly bounded tail.
+            # count == min(len) means the renders never diverged (no variable content): don't trust the run.
             if 0 < count < min(len(first), len(second)):
                 suffix = first[len(first) - count :]
         except Exception as exc:  # never let suffix derivation break tokenization
             logger.debug(f"Could not derive the chat-template suffix: {exc}")
 
-        # Cache the result (including an empty/failed derivation), evicting the oldest entry past the cap so a
-        # workload with many distinct prompts can't grow it without bound.
+        # Cache the result (even an empty one) and evict the oldest entry past the cap. Concurrent encode()
+        # calls can race on the shared dict, so the eviction is best effort.
         cache[cache_key] = suffix
         if len(cache) > _CHAT_TEMPLATE_SUFFIX_CACHE_SIZE:
-            cache.pop(next(iter(cache)))
+            try:
+                cache.pop(next(iter(cache)))
+            except (KeyError, RuntimeError):
+                pass
         return suffix
+
+    def _message_skeleton(self, conversation: list[MessageInput], filler: str) -> list[MessageInput]:
+        """Replace each non-system message content with ``filler``, keeping everything else verbatim.
+
+        Keeping system messages whole lets the derivation capture a prompt rendered in the tail. Fillering
+        the rest keeps the renders tiny regardless of input length.
+        """
+        skeleton = []
+        for message in conversation:
+            if not isinstance(message, dict) or message.get("role") == "system":
+                skeleton.append(message)
+                continue
+            new_content = [{"type": "text", "text": filler}] if isinstance(message.get("content"), list) else filler
+            skeleton.append({**message, "content": new_content})
+        return skeleton
 
     def _render_message_skeleton(
         self,
@@ -1551,39 +1575,26 @@ class Transformer(InputModule):
         filler: str,
         chat_template_kwargs: dict[str, Any],
         tokenizer_kwargs: dict[str, Any],
+        common_kwargs: dict[str, Any],
     ) -> list[int]:
-        """Tokenize one conversation with each non-system content replaced by ``filler`` (untruncated).
+        """Tokenize one conversation's skeleton (non-system content replaced by ``filler``), untruncated.
 
-        ``system`` messages (the prompt/instruction) are kept verbatim so the diff can capture a prompt the
-        template renders in the tail. Everything else is per-row content and gets fillered, which keeps the
-        rendered prompt tiny and cheap regardless of input length (a long kept system prompt is the one
-        exception). ``tokenizer_kwargs`` mirrors the real call's text kwargs so the suffix is tokenized
-        identically (e.g. the same ``add_special_tokens``). ``return_tensors=None`` asks for plain lists.
+        The render shares ``_apply_chat_template`` with the real batch, so the suffix tokenizes exactly like
+        the rows it is restored onto, just without padding, truncation, or tensors.
         """
-        skeleton = []
-        for message in conversation:
-            # Keep system messages (the prompt) fixed so the diff captures them if rendered in the tail.
-            if not isinstance(message, dict) or message.get("role") == "system":
-                skeleton.append(message)
-                continue
-            new_content = [{"type": "text", "text": filler}] if isinstance(message.get("content"), list) else filler
-            skeleton.append({**message, "content": new_content})
-
-        # Mirror the real call's kwarg routing (see _process_chat_messages): a ProcessorMixin wants the text
-        # kwargs nested, a bare tokenizer wants them flat alongside top-level padding/truncation.
-        if isinstance(self.processor, ProcessorMixin):
-            text_kwargs = {**tokenizer_kwargs, "padding": False, "truncation": False}
-            if _TRANSFORMERS_APPLY_CHAT_TEMPLATE_RECOMMENDS_PROCESSOR_KWARGS:
-                call_kwargs = {"processor_kwargs": {"text_kwargs": text_kwargs}}
-            else:
-                call_kwargs = {"text_kwargs": text_kwargs}
-        else:
-            call_kwargs = {"tokenizer_kwargs": tokenizer_kwargs, "padding": False, "truncation": False}
-        output = self.processor.apply_chat_template(
-            [skeleton], tokenize=True, return_dict=True, return_tensors=None, **call_kwargs, **chat_template_kwargs
+        skeleton = self._message_skeleton(conversation, filler)
+        output = self._apply_chat_template(
+            [skeleton],
+            modality_kwargs={
+                "text": {**tokenizer_kwargs, "padding": False, "truncation": False},
+                "audio": {},
+                "image": {},
+                "video": {},
+            },
+            common_kwargs=common_kwargs,
+            chat_template_kwargs=chat_template_kwargs,
         )
-        # return_tensors=None should give lists, but some processors return a tensor anyway. The suffix logic
-        # needs a plain list and we render a single conversation, so coerce to a list and unwrap the batch.
+        # Coerce to a plain list and unwrap the single-conversation batch (some processors return tensors).
         ids = output["input_ids"]
         if isinstance(ids, torch.Tensor):
             ids = ids.tolist()

--- a/sentence_transformers/base/modules/transformer.py
+++ b/sentence_transformers/base/modules/transformer.py
@@ -1443,16 +1443,17 @@ class Transformer(InputModule):
 
         if is_tensor:
             width = ids.shape[-1]
-            # Final real-token index per row from the attention mask, so this is correct for either padding
-            # side (left padding is only enforced for the causal-LM tasks, not e.g. embedders).
+            # Find each row's real tail from the mask so the suffix lands on real tokens even when padding
+            # extends a truncated row (pad_to_multiple_of): the real tokens end at `width` for left padding
+            # (first token is pad), else at their count.
             attention_mask = features.get("attention_mask")
             if isinstance(attention_mask, torch.Tensor) and attention_mask.numel():
                 am = attention_mask if attention_mask.dim() == 2 else attention_mask.unsqueeze(0)
-                last_idx = (am * torch.arange(width, device=ids.device)).argmax(dim=1).tolist()
                 real_lengths = am.sum(dim=1).tolist()
+                left_padded = (am[:, 0] == 0).tolist()
             else:
-                last_idx = [width - 1] * n_rows
                 real_lengths = [width] * n_rows
+                left_padded = [False] * n_rows
 
         for index, suffix in enumerate(suffixes):
             if not suffix:
@@ -1461,7 +1462,7 @@ class Transformer(InputModule):
                 keep = min(len(suffix), real_lengths[index])
                 if keep == 0:
                     continue
-                end = last_idx[index] + 1
+                end = width if left_padded[index] else real_lengths[index]
                 suffix_tensor = torch.as_tensor(suffix[-keep:], dtype=ids.dtype, device=ids.device)
                 if (ids[index, end - keep : end] != suffix_tensor).any():
                     ids[index, end - keep : end] = suffix_tensor

--- a/sentence_transformers/base/modules/transformer.py
+++ b/sentence_transformers/base/modules/transformer.py
@@ -116,6 +116,7 @@ _TRANSFORMERS_APPLY_CHAT_TEMPLATE_RECOMMENDS_PROCESSOR_KWARGS = parse_version(tr
 )
 _TRANSFORMERS_SUPPORTS_USE_BIDIRECTIONAL_ATTENTION = parse_version(transformers_version) >= parse_version("4.56.2")
 _TRANSFORMERS_SUPPORTS_IS_CAUSAL_FALSE = parse_version(transformers_version) >= parse_version("5.2.0")
+DEFAULT_CHAT_TEMPLATE_PRESERVE_FINAL_TOKENS = 16
 
 TransformerTask = Literal[
     "feature-extraction", "sequence-classification", "text-generation", "any-to-any", "fill-mask"
@@ -1360,7 +1361,9 @@ class Transformer(InputModule):
         top_level_kwargs |= {
             key: modality_kwargs["text"].pop(key) for key in top_level_kwarg_names & modality_kwargs["text"].keys()
         }
-        preserve_final_tokens = chat_template_kwargs.pop("preserve_final_tokens", 16)
+        preserve_final_tokens = chat_template_kwargs.pop(
+            "preserve_final_tokens", DEFAULT_CHAT_TEMPLATE_PRESERVE_FINAL_TOKENS
+        )
         truncation = top_level_kwargs.get("truncation", False)
         max_length = top_level_kwargs.get("max_length")
         if max_length is None and truncation and self.tokenizer is not None:

--- a/sentence_transformers/base/modules/transformer.py
+++ b/sentence_transformers/base/modules/transformer.py
@@ -1320,7 +1320,7 @@ class Transformer(InputModule):
 
         # Ideally we'd use the same code path for both ProcessorMixin and Tokenizers, but the latter expects
         # the text kwargs to be passed at the top level instead of in a nested "text_kwargs" dict.
-        chat_template_kwargs = chat_template_kwargs or {}
+        chat_template_kwargs = dict(chat_template_kwargs or {})
         if isinstance(self.processor, ProcessorMixin):
             # Transformers v5.4.0 prefers us to pass processor_kwargs as a single dict, but there's still some top level
             # kwargs that need to be hoisted out for backwards compatibility.
@@ -1360,6 +1360,28 @@ class Transformer(InputModule):
         top_level_kwargs |= {
             key: modality_kwargs["text"].pop(key) for key in top_level_kwarg_names & modality_kwargs["text"].keys()
         }
+        preserve_final_tokens = chat_template_kwargs.pop("preserve_final_tokens", 16)
+        truncation = top_level_kwargs.get("truncation", False)
+        max_length = top_level_kwargs.get("max_length")
+        if max_length is None and truncation and self.tokenizer is not None:
+            max_length = self.tokenizer.model_max_length
+
+        if (
+            preserve_final_tokens
+            and self.transformer_task in ("text-generation", "any-to-any")
+            and self.input_formatter.is_text_only_messages(messages)
+            and truncation
+            and max_length is not None
+        ):
+            return self._apply_chat_template_preserving_tail(
+                messages=messages,
+                modality_kwargs=modality_kwargs,
+                common_kwargs=common_kwargs,
+                chat_template_kwargs=chat_template_kwargs,
+                top_level_kwargs=top_level_kwargs,
+                max_length=max_length,
+                preserve_final_tokens=preserve_final_tokens,
+            )
 
         return self.processor.apply_chat_template(
             messages,
@@ -1369,6 +1391,48 @@ class Transformer(InputModule):
             common_kwargs=common_kwargs,
             **top_level_kwargs,
             **chat_template_kwargs,
+        )
+
+    def _apply_chat_template_preserving_tail(
+        self,
+        messages: list[list[MessageInput]],
+        modality_kwargs: dict[str, dict[str, Any]],
+        common_kwargs: dict[str, Any],
+        chat_template_kwargs: dict[str, Any],
+        top_level_kwargs: dict[str, Any],
+        max_length: int,
+        preserve_final_tokens: int,
+    ) -> dict[str, Any]:
+        tokenizer_kwargs = {**modality_kwargs["text"], "verbose": False}
+        full = self.processor.apply_chat_template(
+            messages,
+            tokenize=True,
+            return_dict=True,
+            tokenizer_kwargs=tokenizer_kwargs,
+            common_kwargs=common_kwargs,
+            padding=False,
+            truncation=False,
+            return_tensors=None,
+            **chat_template_kwargs,
+        )
+        input_ids = full["input_ids"]
+        if isinstance(input_ids, torch.Tensor):
+            input_ids = input_ids.tolist()
+        if input_ids and isinstance(input_ids[0], int):
+            input_ids = [input_ids]
+
+        preserve_final_tokens = min(preserve_final_tokens, max_length)
+        head_length = max_length - preserve_final_tokens
+        input_ids = [
+            ids[:head_length] + ids[-preserve_final_tokens:] if len(ids) > max_length else ids
+            for ids in input_ids
+        ]
+        return self.processor.pad(
+            {"input_ids": input_ids},
+            padding=top_level_kwargs.get("padding", False),
+            max_length=max_length if top_level_kwargs.get("padding") == "max_length" else None,
+            return_tensors=top_level_kwargs.get("return_tensors"),
+            verbose=False,
         )
 
     def _get_prompt_length(self, prompt: str, **kwargs) -> int | None:

--- a/tests/base/modules/test_transformer.py
+++ b/tests/base/modules/test_transformer.py
@@ -860,8 +860,8 @@ class TestProcessChatMessages:
         assert features["input_ids"].tolist() == [[0, 0, 0, 10, 11, 101, 102, 103]]
 
     def test_chat_template_suffix_ids_tolerates_unhashable_kwargs(self, bert_tiny_transformer, monkeypatch):
-        # chat_template_kwargs may carry unhashable values (e.g. a ``tools`` list). The cache lookup must not
-        # raise TypeError, so derivation falls back to running uncached.
+        # chat_template_kwargs may carry unhashable values (e.g. a ``tools`` list). repr() in the cache key
+        # keeps the lookup from raising TypeError, so derivation still runs (and caches).
         model = bert_tiny_transformer
 
         def mock_apply_chat_template(messages, **kwargs):
@@ -883,7 +883,7 @@ class TestProcessChatMessages:
         monkeypatch.setattr(model.processor, "apply_chat_template", mock_apply_chat_template)
         assert model._chat_template_suffix_ids([{"role": "system", "content": "only a prompt"}], {}, {}) == []
 
-    def test_chat_template_suffix_cache_is_lru_bounded(self, bert_tiny_transformer, monkeypatch):
+    def test_chat_template_suffix_cache_is_bounded(self, bert_tiny_transformer, monkeypatch):
         # The cache key includes the prompt, so a workload with many distinct prompts must stay bounded.
         model = bert_tiny_transformer
         monkeypatch.setattr("sentence_transformers.base.modules.transformer._CHAT_TEMPLATE_SUFFIX_CACHE_SIZE", 3)

--- a/tests/base/modules/test_transformer.py
+++ b/tests/base/modules/test_transformer.py
@@ -659,6 +659,32 @@ class TestCallProcessor:
         assert "input_ids" in result
 
 
+def make_char_chat_template_mock(suffix, captured_kwargs=None):
+    """Chat-template mock: one token per content character plus ``suffix``, honoring truncation/max_length
+    and return_tensors ("pt", "np", or ragged lists)."""
+
+    def mock_apply_chat_template(messages, **kwargs):
+        if captured_kwargs is not None:
+            captured_kwargs.append(kwargs)
+        text = "".join(str(message["content"]) for message in messages[0])
+        ids = [ord(char) for char in text] + suffix
+        # Like real tokenizers, max_length truncates unless truncation is explicitly disabled.
+        if kwargs.get("max_length") and kwargs.get("truncation") is not False:
+            ids = ids[: kwargs["max_length"]]
+        if kwargs.get("return_tensors") == "pt":
+            return {"input_ids": torch.tensor([ids]), "attention_mask": torch.ones(1, len(ids), dtype=torch.long)}
+        if kwargs.get("return_tensors") == "np":
+            return {"input_ids": np.array([ids]), "attention_mask": np.ones((1, len(ids)), dtype=np.int64)}
+        return {"input_ids": [ids]}
+
+    return mock_apply_chat_template
+
+
+def make_modality_kwargs(**text_kwargs):
+    """Modality kwargs for _process_chat_messages with only the text bucket populated."""
+    return {"text": text_kwargs, "audio": {}, "image": {}, "video": {}}
+
+
 class TestProcessChatMessages:
     def test_unsupported_message_modality(self, bert_tiny_transformer):
         """Should raise ValueError when 'message' modality is not in modality_config."""
@@ -708,38 +734,19 @@ class TestProcessChatMessages:
 
     def test_chat_truncation_restores_chat_template_suffix(self, bert_tiny_transformer, monkeypatch):
         model = bert_tiny_transformer
-        # Suffix preservation is task-independent: use the default feature-extraction task to confirm it
-        # benefits embedders (e.g. last-token pooling), not just causal-LM rerankers.
-        model.transformer_task = "feature-extraction"
+        # Suffix preservation is task-independent: the default feature-extraction task confirms it benefits
+        # embedders (e.g. last-token pooling), not just causal-LM rerankers.
         model.modality_config["message"] = {"method": "forward", "method_output_name": "logits"}
 
         # A chat template appends a fixed scoring suffix (e.g. the assistant prefill) that right-truncation
         # cuts off first. The mock mimics this: one token per content character, then ``suffix``.
         suffix = [101, 102, 103]
-
-        def mock_apply_chat_template(messages, **kwargs):
-            text = "".join(str(message["content"]) for message in messages[0])
-            ids = [ord(char) for char in text] + suffix
-            if kwargs.get("truncation") and kwargs.get("max_length"):
-                ids = ids[: kwargs["max_length"]]
-            if kwargs.get("return_tensors") == "pt":
-                return {
-                    "input_ids": torch.tensor([ids]),
-                    "attention_mask": torch.ones(1, len(ids), dtype=torch.long),
-                }
-            return {"input_ids": [ids]}
-
-        monkeypatch.setattr(model.processor, "apply_chat_template", mock_apply_chat_template)
+        monkeypatch.setattr(model.processor, "apply_chat_template", make_char_chat_template_mock(suffix))
 
         def run(content, max_length, truncation=True):
             return model._process_chat_messages(
                 messages=[[{"role": "user", "content": content}]],
-                modality_kwargs={
-                    "text": {"padding": True, "truncation": truncation, "max_length": max_length},
-                    "audio": {},
-                    "image": {},
-                    "video": {},
-                },
+                modality_kwargs=make_modality_kwargs(padding=True, truncation=truncation, max_length=max_length),
                 common_kwargs={"return_tensors": "pt"},
             )
 
@@ -764,7 +771,7 @@ class TestProcessChatMessages:
         # processor returns ragged unpadded lists. The list branch restores the suffix the same way.
         list_ids = model._process_chat_messages(
             messages=[[{"role": "user", "content": long_content}]],
-            modality_kwargs={"text": {"truncation": True, "max_length": 8}, "audio": {}, "image": {}, "video": {}},
+            modality_kwargs=make_modality_kwargs(truncation=True, max_length=8),
             common_kwargs={},
         )["input_ids"][0]
         assert len(list_ids) == 8 and list_ids[-3:] == suffix and list_ids[:5] == [ord(c) for c in long_content[:5]]
@@ -777,28 +784,14 @@ class TestProcessChatMessages:
         model.modality_config["message"] = {"method": "forward", "method_output_name": "logits"}
         suffix = [201, 202, 203]
         forwarded_kwargs = []
-
-        def mock_apply_chat_template(messages, **kwargs):
-            forwarded_kwargs.append(kwargs)
-            text = "".join(str(message["content"]) for message in messages[0])
-            ids = [ord(char) for char in text] + suffix
-            if kwargs.get("truncation") and kwargs.get("max_length"):
-                ids = ids[: kwargs["max_length"]]
-            if kwargs.get("return_tensors") == "pt":
-                return {"input_ids": torch.tensor([ids]), "attention_mask": torch.ones(1, len(ids), dtype=torch.long)}
-            return {"input_ids": [ids]}
-
-        monkeypatch.setattr(model.processor, "apply_chat_template", mock_apply_chat_template)
+        monkeypatch.setattr(
+            model.processor, "apply_chat_template", make_char_chat_template_mock(suffix, forwarded_kwargs)
+        )
 
         def run(restore_suffix):
             return model._process_chat_messages(
                 messages=[[{"role": "user", "content": "abcdefghij"}]],
-                modality_kwargs={
-                    "text": {"padding": True, "truncation": True, "max_length": 8},
-                    "audio": {},
-                    "image": {},
-                    "video": {},
-                },
+                modality_kwargs=make_modality_kwargs(padding=True, truncation=True, max_length=8),
                 common_kwargs={"return_tensors": "pt"},
                 chat_template_kwargs={"restore_suffix": restore_suffix},
             )["input_ids"].tolist()[0]
@@ -809,6 +802,50 @@ class TestProcessChatMessages:
         assert run(False) == [ord(char) for char in "abcdefghij"][:8]
         # restore_suffix is a ST-only flag, so it is never leaked into the apply_chat_template call(s).
         assert forwarded_kwargs and all("restore_suffix" not in kwargs for kwargs in forwarded_kwargs)
+
+    def test_chat_truncation_restore_leaves_non_torch_tensors_untouched(self, bert_tiny_transformer, monkeypatch):
+        # The restore only supports torch tensors and token lists. Other containers (e.g. numpy arrays from
+        # ``return_tensors="np"``) must be returned untouched, not crash on ndarray truthiness.
+        model = bert_tiny_transformer
+        model.modality_config["message"] = {"method": "forward", "method_output_name": "logits"}
+
+        monkeypatch.setattr(model.processor, "apply_chat_template", make_char_chat_template_mock([101, 102, 103]))
+        features = model._process_chat_messages(
+            messages=[[{"role": "user", "content": "abcdefghijklm"}]],
+            modality_kwargs=make_modality_kwargs(padding=True, truncation=True, max_length=8),
+            common_kwargs={"return_tensors": "np"},
+        )
+        # The truncated numpy row keeps its raw tail (content tokens, no suffix): numpy is not restored.
+        assert features["input_ids"].tolist() == [[ord(char) for char in "abcdefghijklm"][:8]]
+
+    def test_chat_truncation_restore_reads_chat_template_bucket_kwargs(self, bert_tiny_transformer, monkeypatch):
+        # truncation/max_length can also ride in the chat_template bucket (apply_chat_template accepts them
+        # top level). The restore gate must see them there, and the skeleton renders must not inherit them.
+        model = bert_tiny_transformer
+        model.modality_config["message"] = {"method": "forward", "method_output_name": "logits"}
+        suffix = [101, 102, 103]
+        monkeypatch.setattr(model.processor, "apply_chat_template", make_char_chat_template_mock(suffix))
+        ids = model._process_chat_messages(
+            messages=[[{"role": "user", "content": "abcdefghijklm"}]],
+            modality_kwargs=make_modality_kwargs(padding=True),
+            common_kwargs={"return_tensors": "pt"},
+            chat_template_kwargs={"truncation": True, "max_length": 8},
+        )["input_ids"].tolist()[0]
+        assert len(ids) == 8 and ids[-3:] == suffix
+
+    def test_chat_truncation_restore_handles_implicit_truncation(self, bert_tiny_transformer, monkeypatch):
+        # Tokenizers truncate when max_length is set even if truncation was merely left unset (None), so the
+        # restore gate must treat that as truncation-on.
+        model = bert_tiny_transformer
+        model.modality_config["message"] = {"method": "forward", "method_output_name": "logits"}
+        suffix = [101, 102, 103]
+        monkeypatch.setattr(model.processor, "apply_chat_template", make_char_chat_template_mock(suffix))
+        ids = model._process_chat_messages(
+            messages=[[{"role": "user", "content": "abcdefghijklm"}]],
+            modality_kwargs=make_modality_kwargs(padding=False, truncation=None, max_length=8),
+            common_kwargs={"return_tensors": "pt"},
+        )["input_ids"].tolist()[0]
+        assert len(ids) == 8 and ids[-3:] == suffix
 
     def test_restore_chat_template_suffix_handles_both_padding_sides(self, bert_tiny_transformer, monkeypatch):
         # The restore must locate the real tail via the attention mask (not a fixed [-keep:] slice), so it is
@@ -860,8 +897,7 @@ class TestProcessChatMessages:
         assert features["input_ids"].tolist() == [[0, 0, 0, 10, 11, 101, 102, 103]]
 
     def test_restore_skipped_when_nothing_reached_max_length(self, bert_tiny_transformer, monkeypatch):
-        # If the longest row is shorter than max_length, nothing was truncated, so the restore returns
-        # immediately without deriving any suffix.
+        # Rows shorter than max_length were not truncated, so they are skipped without deriving any suffix.
         model = bert_tiny_transformer
         derived = []
         monkeypatch.setattr(model, "_chat_template_suffix_ids", lambda *a, **k: derived.append(True) or [1, 2, 3])
@@ -870,35 +906,72 @@ class TestProcessChatMessages:
             "input_ids": torch.tensor([[10, 11, 12, 0, 0, 0]]),
             "attention_mask": torch.tensor([[1, 1, 1, 0, 0, 0]]),  # real length 3
         }
-        # longest real length (3) < max_length (8): nothing truncated -> skipped, no derivation, untouched.
+        # real length (3) < max_length (8): not truncated -> skipped, no derivation, untouched.
         model._restore_chat_template_suffix(features, messages, {}, {}, max_length=8)
         assert derived == [] and features["input_ids"].tolist() == [[10, 11, 12, 0, 0, 0]]
-        # longest (3) == max_length (3): a row reached the limit, so derivation runs.
-        model._restore_chat_template_suffix(features, messages, {}, {}, max_length=3)
-        assert derived == [True]
+
+    def test_restore_only_touches_rows_that_reached_max_length(self, bert_tiny_transformer, monkeypatch):
+        # The truncation check is per row: in a batch where one row was truncated (real length equals
+        # max_length), shorter rows kept their tail and must be skipped entirely (no derivation, no write).
+        model = bert_tiny_transformer
+        derived = []
+        monkeypatch.setattr(
+            model, "_chat_template_suffix_ids", lambda *a, **k: derived.append(True) or [101, 102, 103]
+        )
+        messages = [[{"role": "user", "content": "a"}], [{"role": "user", "content": "b"}]]
+        features = {
+            "input_ids": torch.tensor([[10, 11, 12, 13, 14, 15], [20, 21, 22, 0, 0, 0]]),
+            "attention_mask": torch.tensor([[1, 1, 1, 1, 1, 1], [1, 1, 1, 0, 0, 0]]),
+        }
+        model._restore_chat_template_suffix(features, messages, {}, {}, max_length=6)
+        # Row 0 (length 6 == max_length) is restored, row 1 (length 3) is left untouched and underived.
+        assert features["input_ids"].tolist() == [[10, 11, 12, 101, 102, 103], [20, 21, 22, 0, 0, 0]]
+        assert len(derived) == 1
+
+    def test_restore_skips_tensor_batches_without_attention_mask(self, bert_tiny_transformer, monkeypatch):
+        # Without a mask, real tokens can't be told apart from padding, so the restore must leave the batch
+        # untouched rather than stamp the suffix over what may be padding.
+        model = bert_tiny_transformer
+        derived = []
+        monkeypatch.setattr(model, "_chat_template_suffix_ids", lambda *a, **k: derived.append(True) or [101, 102])
+        features = {"input_ids": torch.tensor([[10, 11, 12, 13]])}
+        model._restore_chat_template_suffix(features, [[{"role": "user", "content": "x"}]], {}, {})
+        assert derived == [] and features["input_ids"].tolist() == [[10, 11, 12, 13]]
+
+    def test_restore_handles_float_attention_mask(self, bert_tiny_transformer, monkeypatch):
+        # Some processors emit float masks: the real lengths must still be ints for the tensor slicing.
+        model = bert_tiny_transformer
+        monkeypatch.setattr(model, "_chat_template_suffix_ids", lambda *a, **k: [101, 102, 103])
+        features = {
+            "input_ids": torch.tensor([[10, 11, 12, 13, 14, 15]]),
+            "attention_mask": torch.ones(1, 6),  # float32
+        }
+        model._restore_chat_template_suffix(features, [[{"role": "user", "content": "a"}]], {}, {})
+        assert features["input_ids"].tolist() == [[10, 11, 12, 101, 102, 103]]
 
     def test_chat_template_suffix_ids_tolerates_unhashable_kwargs(self, bert_tiny_transformer, monkeypatch):
         # chat_template_kwargs may carry unhashable values (e.g. a ``tools`` list). repr() in the cache key
         # keeps the lookup from raising TypeError, so derivation still runs (and caches).
         model = bert_tiny_transformer
-
-        def mock_apply_chat_template(messages, **kwargs):
-            body = "".join(str(m["content"]) for m in messages[0])
-            return {"input_ids": [[ord(c) for c in body] + [99]]}  # 99 = fixed content-independent tail
-
-        monkeypatch.setattr(model.processor, "apply_chat_template", mock_apply_chat_template)
+        monkeypatch.setattr(model.processor, "apply_chat_template", make_char_chat_template_mock([99]))
         suffix = model._chat_template_suffix_ids([{"role": "user", "content": "x"}], {"tools": [{"name": "f"}]}, {})
         assert suffix == [99]  # no crash from the unhashable kwarg; the fixed marker is the derived suffix
+
+    def test_chat_template_suffix_ids_skips_uninspectable_messages(self, bert_tiny_transformer, monkeypatch):
+        # Some templates accept shapes the text-only check can't inspect (a non-dict message, or a content
+        # list of plain strings). The restore must skip them (no suffix), not raise AttributeError.
+        model = bert_tiny_transformer
+        monkeypatch.setattr(
+            model.processor, "apply_chat_template", lambda messages, **kwargs: {"input_ids": [[1, 2, 3]]}
+        )
+        assert model._chat_template_suffix_ids([{"role": "user", "content": "x"}, "not a message"], {}, {}) == []
+        assert model._chat_template_suffix_ids([{"role": "user", "content": ["chunk a", "chunk b"]}], {}, {}) == []
 
     def test_chat_template_suffix_ids_returns_empty_without_variable_content(self, bert_tiny_transformer, monkeypatch):
         # With only kept (system) content there's nothing to vary, so the two renders are identical and there
         # is no reliable suffix boundary -> return [] rather than treating the whole render as the suffix.
         model = bert_tiny_transformer
-
-        def mock_apply_chat_template(messages, **kwargs):
-            return {"input_ids": [[ord(c) for c in "".join(str(m["content"]) for m in messages[0])]]}
-
-        monkeypatch.setattr(model.processor, "apply_chat_template", mock_apply_chat_template)
+        monkeypatch.setattr(model.processor, "apply_chat_template", make_char_chat_template_mock([]))
         assert model._chat_template_suffix_ids([{"role": "system", "content": "only a prompt"}], {}, {}) == []
 
     def test_chat_template_suffix_cache_is_bounded(self, bert_tiny_transformer, monkeypatch):
@@ -932,7 +1005,40 @@ class TestProcessChatMessages:
         assert model._chat_template_suffix_ids(
             [{"role": "system", "content": "RS"}, {"role": "user", "content": "x"}], {}, {}
         ) == [82, 83, 99]
-        assert len(model._chat_template_suffix_cache) == 2
+
+    def test_chat_template_suffix_ids_keys_on_non_content_fields(self, bert_tiny_transformer, monkeypatch):
+        # The skeleton keeps non-content message fields (e.g. ``name``, ``tool_calls``) verbatim and a
+        # template may render them, so they are part of the cache key: the same role layout with different
+        # fields must not share a cached suffix.
+        model = bert_tiny_transformer
+
+        def mock_apply_chat_template(messages, **kwargs):
+            # Render the (fillered) content, then the kept ``name`` field, then a fixed marker (99).
+            body = "".join(str(m["content"]) for m in messages[0])
+            name = "".join(str(m.get("name", "")) for m in messages[0])
+            return {"input_ids": [[ord(c) for c in body] + [ord(c) for c in name] + [99]]}
+
+        monkeypatch.setattr(model.processor, "apply_chat_template", mock_apply_chat_template)
+        conv_a = [{"role": "user", "content": "x", "name": "AB"}]
+        conv_b = [{"role": "user", "content": "x", "name": "CD"}]
+        assert model._chat_template_suffix_ids(conv_a, {}, {}) == [65, 66, 99]  # "AB" + marker
+        assert model._chat_template_suffix_ids(conv_b, {}, {}) == [67, 68, 99]  # "CD", not A's cached suffix
+
+    def test_chat_template_suffix_ids_mirrors_common_kwargs(self, bert_tiny_transformer, monkeypatch):
+        # Common kwargs can change tokenization (a ProcessorMixin spreads them into the text kwargs), so the
+        # skeleton renders must receive them and the cache must key on them.
+        model = bert_tiny_transformer
+
+        def mock_apply_chat_template(messages, **kwargs):
+            # Emit a different fixed tail depending on a tokenization-affecting common kwarg.
+            marker = 98 if kwargs.get("common_kwargs", {}).get("add_special_tokens") is False else 99
+            body = "".join(str(m["content"]) for m in messages[0])
+            return {"input_ids": [[ord(c) for c in body] + [marker]]}
+
+        monkeypatch.setattr(model.processor, "apply_chat_template", mock_apply_chat_template)
+        conversation = [{"role": "user", "content": "x"}]
+        assert model._chat_template_suffix_ids(conversation, {}, {}, {"add_special_tokens": False}) == [98]
+        assert model._chat_template_suffix_ids(conversation, {}, {}, {}) == [99]
 
     def test_restore_chat_template_suffix_is_per_row_and_skips_multimodal(self, bert_tiny_transformer, monkeypatch):
         # A heterogeneous batch: the text-only row is restored per-row, while the multimodal row is left
@@ -958,24 +1064,19 @@ class TestProcessChatMessages:
         assert features["input_ids"][0].tolist() == [10, 11, 12, 101, 102, 103]  # text row restored
         assert features["input_ids"][1].tolist() == [20, 21, 22, 23, 24, 25]  # multimodal row untouched
 
-    def test_chat_truncation_restores_suffix_with_real_chat_template(self, monkeypatch):
+    def test_chat_truncation_restores_suffix_with_real_chat_template(self):
         # Integration check against a real chat-template model (the other suffix tests mock the tokenizer), so
         # it exercises the real apply_chat_template dispatch and two-filler derivation. The Llama-2 template
         # ends the user turn with `[/INST]`, which truncation drops and the restore must put back.
         model = Transformer(TINY_LLAMA, transformer_task="feature-extraction")
         tokenizer = model.tokenizer
 
-        def process(max_length):
+        def process(max_length, restore_suffix=True):
             return model._process_chat_messages(
                 messages=[[{"role": "user", "content": "word " * 50}]],
-                modality_kwargs={
-                    "text": {"padding": True, "truncation": "longest_first", "max_length": max_length},
-                    "audio": {},
-                    "image": {},
-                    "video": {},
-                },
+                modality_kwargs=make_modality_kwargs(padding=True, truncation="longest_first", max_length=max_length),
                 common_kwargs={"return_tensors": "pt"},
-                chat_template_kwargs={"add_generation_prompt": True},
+                chat_template_kwargs={"add_generation_prompt": True, "restore_suffix": restore_suffix},
             )["input_ids"][0].tolist()
 
         # The conversation overflows max_length=16, so `[/INST]` is truncated off and then restored.
@@ -986,8 +1087,7 @@ class TestProcessChatMessages:
         assert "word" in decoded  # real content is kept at the head, not overwritten wholesale
 
         # With the restore disabled the same input ends on a content token: the bug this feature fixes.
-        monkeypatch.setattr(model, "_restore_chat_template_suffix", lambda *args, **kwargs: None)
-        assert not tokenizer.decode(process(16)).rstrip().endswith("[/INST]")
+        assert not tokenizer.decode(process(16, restore_suffix=False)).rstrip().endswith("[/INST]")
 
 
 class TestModelLoading:

--- a/tests/base/modules/test_transformer.py
+++ b/tests/base/modules/test_transformer.py
@@ -822,11 +822,58 @@ class TestProcessChatMessages:
         # chat_template_kwargs may carry unhashable values (e.g. a ``tools`` list). The cache lookup must not
         # raise TypeError, so derivation falls back to running uncached.
         model = bert_tiny_transformer
+
+        def mock_apply_chat_template(messages, **kwargs):
+            body = "".join(str(m["content"]) for m in messages[0])
+            return {"input_ids": [[ord(c) for c in body] + [99]]}  # 99 = fixed content-independent tail
+
+        monkeypatch.setattr(model.processor, "apply_chat_template", mock_apply_chat_template)
+        suffix = model._chat_template_suffix_ids([{"role": "user", "content": "x"}], {"tools": [{"name": "f"}]}, {})
+        assert suffix == [99]  # no crash from the unhashable kwarg; the fixed marker is the derived suffix
+
+    def test_chat_template_suffix_ids_returns_empty_without_variable_content(self, bert_tiny_transformer, monkeypatch):
+        # With only kept (system) content there's nothing to vary, so the two renders are identical and there
+        # is no reliable suffix boundary -> return [] rather than treating the whole render as the suffix.
+        model = bert_tiny_transformer
+
+        def mock_apply_chat_template(messages, **kwargs):
+            return {"input_ids": [[ord(c) for c in "".join(str(m["content"]) for m in messages[0])]]}
+
+        monkeypatch.setattr(model.processor, "apply_chat_template", mock_apply_chat_template)
+        assert model._chat_template_suffix_ids([{"role": "system", "content": "only a prompt"}], {}, {}) == []
+
+    def test_chat_template_suffix_cache_is_lru_bounded(self, bert_tiny_transformer, monkeypatch):
+        # The cache key includes the prompt, so a workload with many distinct prompts must stay bounded.
+        model = bert_tiny_transformer
+        monkeypatch.setattr("sentence_transformers.base.modules.transformer._CHAT_TEMPLATE_SUFFIX_CACHE_SIZE", 3)
         monkeypatch.setattr(
             model.processor, "apply_chat_template", lambda messages, **kwargs: {"input_ids": [[1, 2, 3]]}
         )
-        suffix = model._chat_template_suffix_ids([{"role": "user", "content": "x"}], {"tools": [{"name": "f"}]}, {})
-        assert suffix == [1, 2, 3]  # no crash: identical renders make the entire output the suffix
+        for index in range(10):
+            model._chat_template_suffix_ids([{"role": "system", "content": f"prompt {index}"}], {}, {})
+        assert len(model._chat_template_suffix_cache) == 3
+
+    def test_chat_template_suffix_ids_captures_prompt_rendered_in_tail(self, bert_tiny_transformer, monkeypatch):
+        # When the template renders the system prompt in the tail, keeping it fixed (not fillered) lets the
+        # diff capture it, so a truncated trailing prompt can be restored. Different prompts -> different keys.
+        model = bert_tiny_transformer
+
+        def mock_apply_chat_template(messages, **kwargs):
+            # Render the (fillered) non-system content, then the kept system prompt, then a fixed marker (99).
+            body = "".join(str(m["content"]) for m in messages[0] if m.get("role") != "system")
+            prompt = "".join(str(m["content"]) for m in messages[0] if m.get("role") == "system")
+            return {"input_ids": [[ord(c) for c in body] + [ord(c) for c in prompt] + [99]]}
+
+        monkeypatch.setattr(model.processor, "apply_chat_template", mock_apply_chat_template)
+        # "PQ" (80, 81) is kept fixed and lands in the tail, so it plus the marker (99) form the suffix.
+        assert model._chat_template_suffix_ids(
+            [{"role": "system", "content": "PQ"}, {"role": "user", "content": "x"}], {}, {}
+        ) == [80, 81, 99]
+        # A different prompt gets its own cache entry and its own suffix.
+        assert model._chat_template_suffix_ids(
+            [{"role": "system", "content": "RS"}, {"role": "user", "content": "x"}], {}, {}
+        ) == [82, 83, 99]
+        assert len(model._chat_template_suffix_cache) == 2
 
     def test_restore_chat_template_suffix_is_per_row_and_skips_multimodal(self, bert_tiny_transformer, monkeypatch):
         # A heterogeneous batch: the text-only row is restored per-row, while the multimodal row is left

--- a/tests/base/modules/test_transformer.py
+++ b/tests/base/modules/test_transformer.py
@@ -859,6 +859,24 @@ class TestProcessChatMessages:
         model._restore_chat_template_suffix(features, messages, {}, {})
         assert features["input_ids"].tolist() == [[0, 0, 0, 10, 11, 101, 102, 103]]
 
+    def test_restore_skipped_when_nothing_reached_max_length(self, bert_tiny_transformer, monkeypatch):
+        # If the longest row is shorter than max_length, nothing was truncated, so the restore returns
+        # immediately without deriving any suffix.
+        model = bert_tiny_transformer
+        derived = []
+        monkeypatch.setattr(model, "_chat_template_suffix_ids", lambda *a, **k: derived.append(True) or [1, 2, 3])
+        messages = [[{"role": "user", "content": "x"}]]
+        features = {
+            "input_ids": torch.tensor([[10, 11, 12, 0, 0, 0]]),
+            "attention_mask": torch.tensor([[1, 1, 1, 0, 0, 0]]),  # real length 3
+        }
+        # longest real length (3) < max_length (8): nothing truncated -> skipped, no derivation, untouched.
+        model._restore_chat_template_suffix(features, messages, {}, {}, max_length=8)
+        assert derived == [] and features["input_ids"].tolist() == [[10, 11, 12, 0, 0, 0]]
+        # longest (3) == max_length (3): a row reached the limit, so derivation runs.
+        model._restore_chat_template_suffix(features, messages, {}, {}, max_length=3)
+        assert derived == [True]
+
     def test_chat_template_suffix_ids_tolerates_unhashable_kwargs(self, bert_tiny_transformer, monkeypatch):
         # chat_template_kwargs may carry unhashable values (e.g. a ``tools`` list). repr() in the cache key
         # keeps the lookup from raising TypeError, so derivation still runs (and caches).

--- a/tests/base/modules/test_transformer.py
+++ b/tests/base/modules/test_transformer.py
@@ -769,6 +769,47 @@ class TestProcessChatMessages:
         )["input_ids"][0]
         assert len(list_ids) == 8 and list_ids[-3:] == suffix and list_ids[:5] == [ord(c) for c in long_content[:5]]
 
+    def test_chat_truncation_restore_can_be_disabled(self, bert_tiny_transformer, monkeypatch):
+        # The restore is on by default, but ``chat_template_kwargs["restore_suffix"]=False`` (set via
+        # ``processing_kwargs["chat_template"]``) turns it off. The flag is a Sentence Transformers concept,
+        # so it must be popped and never forwarded to apply_chat_template.
+        model = bert_tiny_transformer
+        model.modality_config["message"] = {"method": "forward", "method_output_name": "logits"}
+        suffix = [201, 202, 203]
+        forwarded_kwargs = []
+
+        def mock_apply_chat_template(messages, **kwargs):
+            forwarded_kwargs.append(kwargs)
+            text = "".join(str(message["content"]) for message in messages[0])
+            ids = [ord(char) for char in text] + suffix
+            if kwargs.get("truncation") and kwargs.get("max_length"):
+                ids = ids[: kwargs["max_length"]]
+            if kwargs.get("return_tensors") == "pt":
+                return {"input_ids": torch.tensor([ids]), "attention_mask": torch.ones(1, len(ids), dtype=torch.long)}
+            return {"input_ids": [ids]}
+
+        monkeypatch.setattr(model.processor, "apply_chat_template", mock_apply_chat_template)
+
+        def run(restore_suffix):
+            return model._process_chat_messages(
+                messages=[[{"role": "user", "content": "abcdefghij"}]],
+                modality_kwargs={
+                    "text": {"padding": True, "truncation": True, "max_length": 8},
+                    "audio": {},
+                    "image": {},
+                    "video": {},
+                },
+                common_kwargs={"return_tensors": "pt"},
+                chat_template_kwargs={"restore_suffix": restore_suffix},
+            )["input_ids"].tolist()[0]
+
+        # Default behaviour (restore on): the template suffix is put back at the tail.
+        assert run(True)[-3:] == suffix
+        # Disabled: the raw truncated tail (content tokens, no suffix) is left untouched.
+        assert run(False) == [ord(char) for char in "abcdefghij"][:8]
+        # restore_suffix is a ST-only flag, so it is never leaked into the apply_chat_template call(s).
+        assert forwarded_kwargs and all("restore_suffix" not in kwargs for kwargs in forwarded_kwargs)
+
     def test_restore_chat_template_suffix_handles_both_padding_sides(self, bert_tiny_transformer, monkeypatch):
         # The restore must locate the real tail via the attention mask (not a fixed [-keep:] slice), so it is
         # correct whether the batch is left- or right-padded. In each batch row 0 was truncated (full width,

--- a/tests/base/modules/test_transformer.py
+++ b/tests/base/modules/test_transformer.py
@@ -743,9 +743,9 @@ class TestProcessChatMessages:
                 common_kwargs={"return_tensors": "pt"},
             )
 
-        # Long content (13 tokens) crosses max_length=8: the suffix is restored onto the tail while the
-        # head is kept, and the auto-derived suffix length (3) means nothing is hard-coded.
-        long_content = "abcdefghij"
+        # The mock tokenizes one token per character, so this 13-token content is truncated at max_length=8,
+        # dropping the suffix. The restore puts it back on the tail (head kept), with an auto-derived length.
+        long_content = "abcdefghijklm"
         ids = run(long_content, max_length=8)["input_ids"].tolist()[0]
         assert len(ids) == 8  # max_length is respected
         assert ids[-3:] == suffix  # the scoring suffix is back at the tail

--- a/tests/base/modules/test_transformer.py
+++ b/tests/base/modules/test_transformer.py
@@ -669,7 +669,7 @@ def make_char_chat_template_mock(suffix, captured_kwargs=None):
         text = "".join(str(message["content"]) for message in messages[0])
         ids = [ord(char) for char in text] + suffix
         # Like real tokenizers, max_length truncates unless truncation is explicitly disabled.
-        if kwargs.get("max_length") and kwargs.get("truncation") is not False:
+        if kwargs.get("max_length") and kwargs.get("truncation") not in (False, "do_not_truncate"):
             ids = ids[: kwargs["max_length"]]
         if kwargs.get("return_tensors") == "pt":
             return {"input_ids": torch.tensor([ids]), "attention_mask": torch.ones(1, len(ids), dtype=torch.long)}
@@ -762,10 +762,11 @@ class TestProcessChatMessages:
         assert run("ab", max_length=8)["input_ids"].tolist()[0] == [ord("a"), ord("b")] + suffix
 
         # Escape hatch: with truncation disabled the full sequence (suffix intact) is returned as-is.
-        assert (
-            run(long_content, max_length=8, truncation=False)["input_ids"].tolist()[0]
-            == [ord(char) for char in long_content] + suffix
-        )
+        for truncation in (False, "do_not_truncate"):
+            assert (
+                run(long_content, max_length=8, truncation=truncation)["input_ids"].tolist()[0]
+                == [ord(char) for char in long_content] + suffix
+            )
 
         # Flattening path (feature-extraction + can_flatten_inputs): return_tensors is dropped, so the
         # processor returns ragged unpadded lists. The list branch restores the suffix the same way.

--- a/tests/base/modules/test_transformer.py
+++ b/tests/base/modules/test_transformer.py
@@ -705,16 +705,21 @@ class TestProcessChatMessages:
         )
         assert captured_kwargs["add_generation_prompt"] is True
 
-    def test_text_generation_chat_truncation_preserves_tail(self, bert_tiny_transformer, monkeypatch):
+    def test_chat_truncation_restores_chat_template_suffix(self, bert_tiny_transformer, monkeypatch):
         model = bert_tiny_transformer
-        model.transformer_task = "text-generation"
+        # Suffix preservation is task-independent: use the default feature-extraction task to confirm it
+        # benefits embedders (e.g. last-token pooling), not just causal-LM rerankers.
+        model.transformer_task = "feature-extraction"
         model.modality_config["message"] = {"method": "forward", "method_output_name": "logits"}
 
-        full_ids = list(range(20))
+        # A chat template appends a fixed scoring suffix (e.g. the assistant prefill) that right-truncation
+        # cuts off first. The mock mimics this: one token per content character, then ``suffix``.
+        suffix = [101, 102, 103]
 
         def mock_apply_chat_template(messages, **kwargs):
-            ids = full_ids
-            if kwargs.get("truncation"):
+            text = "".join(str(message["content"]) for message in messages[0])
+            ids = [ord(char) for char in text] + suffix
+            if kwargs.get("truncation") and kwargs.get("max_length"):
                 ids = ids[: kwargs["max_length"]]
             if kwargs.get("return_tensors") == "pt":
                 return {
@@ -724,32 +729,103 @@ class TestProcessChatMessages:
             return {"input_ids": [ids]}
 
         monkeypatch.setattr(model.processor, "apply_chat_template", mock_apply_chat_template)
-        output = model._process_chat_messages(
-            messages=[[{"role": "user", "content": "test"}]],
-            modality_kwargs={
-                "text": {"padding": True, "truncation": True, "max_length": 8},
-                "audio": {},
-                "image": {},
-                "video": {},
-            },
-            common_kwargs={"return_tensors": "pt"},
+
+        def run(content, max_length, truncation=True):
+            return model._process_chat_messages(
+                messages=[[{"role": "user", "content": content}]],
+                modality_kwargs={
+                    "text": {"padding": True, "truncation": truncation, "max_length": max_length},
+                    "audio": {},
+                    "image": {},
+                    "video": {},
+                },
+                common_kwargs={"return_tensors": "pt"},
+            )
+
+        # Long content (13 tokens) crosses max_length=8: the suffix is restored onto the tail while the
+        # head is kept, and the auto-derived suffix length (3) means nothing is hard-coded.
+        long_content = "abcdefghij"
+        ids = run(long_content, max_length=8)["input_ids"].tolist()[0]
+        assert len(ids) == 8  # max_length is respected
+        assert ids[-3:] == suffix  # the scoring suffix is back at the tail
+        assert ids[:5] == [ord(char) for char in long_content[:5]]  # the head is preserved
+
+        # Short content fits, so no truncation happened and the row is returned untouched (no-op restore).
+        assert run("ab", max_length=8)["input_ids"].tolist()[0] == [ord("a"), ord("b")] + suffix
+
+        # Escape hatch: with truncation disabled the full sequence (suffix intact) is returned as-is.
+        assert (
+            run(long_content, max_length=8, truncation=False)["input_ids"].tolist()[0]
+            == [ord(char) for char in long_content] + suffix
         )
 
-        assert output["input_ids"].tolist() == [full_ids[-8:]]
+        # Flattening path (feature-extraction + can_flatten_inputs): return_tensors is dropped, so the
+        # processor returns ragged unpadded lists. The list branch restores the suffix the same way.
+        list_ids = model._process_chat_messages(
+            messages=[[{"role": "user", "content": long_content}]],
+            modality_kwargs={"text": {"truncation": True, "max_length": 8}, "audio": {}, "image": {}, "video": {}},
+            common_kwargs={},
+        )["input_ids"][0]
+        assert len(list_ids) == 8 and list_ids[-3:] == suffix and list_ids[:5] == [ord(c) for c in long_content[:5]]
 
-        output = model._process_chat_messages(
-            messages=[[{"role": "user", "content": "test"}]],
-            modality_kwargs={
-                "text": {"padding": True, "truncation": True, "max_length": 8},
-                "audio": {},
-                "image": {},
-                "video": {},
-            },
-            common_kwargs={"return_tensors": "pt"},
-            chat_template_kwargs={"preserve_final_tokens": 4},
+    def test_restore_chat_template_suffix_handles_both_padding_sides(self, bert_tiny_transformer, monkeypatch):
+        # The restore must locate the real tail via the attention mask (not a fixed [-keep:] slice), so it is
+        # correct whether the batch is left- or right-padded. In each batch row 0 was truncated (full width,
+        # suffix cut) and row 1 fits (real tokens end with the suffix, the remainder is padding).
+        model = bert_tiny_transformer
+        suffix = [101, 102, 103]
+        monkeypatch.setattr(model, "_chat_template_suffix_ids", lambda *args, **kwargs: suffix)
+        messages = [[{"role": "user", "content": "a"}], [{"role": "user", "content": "b"}]]
+
+        # Right padding: real tokens left-aligned, pad on the right. The fit row's pad must stay untouched.
+        features = {
+            "input_ids": torch.tensor([[10, 11, 12, 13, 14, 15], [20, 21, 101, 102, 103, 0]]),
+            "attention_mask": torch.tensor([[1, 1, 1, 1, 1, 1], [1, 1, 1, 1, 1, 0]]),
+        }
+        model._restore_chat_template_suffix(features, messages, {}, {})
+        assert features["input_ids"].tolist() == [[10, 11, 12, 101, 102, 103], [20, 21, 101, 102, 103, 0]]
+
+        # Left padding: pad on the left, real tokens right-aligned.
+        features = {
+            "input_ids": torch.tensor([[10, 11, 12, 13, 14, 15], [0, 20, 21, 101, 102, 103]]),
+            "attention_mask": torch.tensor([[1, 1, 1, 1, 1, 1], [0, 1, 1, 1, 1, 1]]),
+        }
+        model._restore_chat_template_suffix(features, messages, {}, {})
+        assert features["input_ids"].tolist() == [[10, 11, 12, 101, 102, 103], [0, 20, 21, 101, 102, 103]]
+
+    def test_chat_template_suffix_ids_tolerates_unhashable_kwargs(self, bert_tiny_transformer, monkeypatch):
+        # chat_template_kwargs may carry unhashable values (e.g. a ``tools`` list). The cache lookup must not
+        # raise TypeError, so derivation falls back to running uncached.
+        model = bert_tiny_transformer
+        monkeypatch.setattr(
+            model.processor, "apply_chat_template", lambda messages, **kwargs: {"input_ids": [[1, 2, 3]]}
         )
+        suffix = model._chat_template_suffix_ids([{"role": "user", "content": "x"}], {"tools": [{"name": "f"}]}, {})
+        assert suffix == [1, 2, 3]  # no crash: identical renders make the entire output the suffix
 
-        assert output["input_ids"].tolist() == [full_ids[:4] + full_ids[-4:]]
+    def test_restore_chat_template_suffix_is_per_row_and_skips_multimodal(self, bert_tiny_transformer, monkeypatch):
+        # A heterogeneous batch: the text-only row is restored per-row, while the multimodal row is left
+        # untouched (its trailing suffix can't be isolated from a text skeleton, so it returns []).
+        model = bert_tiny_transformer
+        suffix = [101, 102, 103]
+
+        def mock_apply_chat_template(messages, **kwargs):
+            # Skeleton content is the filler string, so emit one content token plus the fixed suffix.
+            text = "".join(str(message["content"]) for message in messages[0])
+            return {"input_ids": [[ord(text[0])] + suffix]}
+
+        monkeypatch.setattr(model.processor, "apply_chat_template", mock_apply_chat_template)
+        messages = [
+            [{"role": "user", "content": "text"}],
+            [{"role": "user", "content": [{"type": "text", "text": "t"}, {"type": "image", "image": "img"}]}],
+        ]
+        features = {
+            "input_ids": torch.tensor([[10, 11, 12, 13, 14, 15], [20, 21, 22, 23, 24, 25]]),
+            "attention_mask": torch.ones(2, 6, dtype=torch.long),
+        }
+        model._restore_chat_template_suffix(features, messages, {}, {})
+        assert features["input_ids"][0].tolist() == [10, 11, 12, 101, 102, 103]  # text row restored
+        assert features["input_ids"][1].tolist() == [20, 21, 22, 23, 24, 25]  # multimodal row untouched
 
 
 class TestModelLoading:

--- a/tests/base/modules/test_transformer.py
+++ b/tests/base/modules/test_transformer.py
@@ -27,6 +27,7 @@ from sentence_transformers.util import batch_to_device
 transformer_module = sys.modules[Transformer.__module__]
 
 TINY_BERT = "sentence-transformers-testing/stsb-bert-tiny-safetensors"
+TINY_LLAMA = "hf-internal-testing/tiny-random-LlamaForCausalLM"
 
 
 @pytest.fixture()
@@ -793,6 +794,30 @@ class TestProcessChatMessages:
         model._restore_chat_template_suffix(features, messages, {}, {})
         assert features["input_ids"].tolist() == [[10, 11, 12, 101, 102, 103], [0, 20, 21, 101, 102, 103]]
 
+    def test_restore_chat_template_suffix_when_truncated_row_is_padded(self, bert_tiny_transformer, monkeypatch):
+        # pad_to_multiple_of can pad a truncated row past max_length, so a truncated row may itself carry
+        # padding. The real tail is read from the mask, so the suffix still lands on real tokens (pad intact).
+        model = bert_tiny_transformer
+        suffix = [101, 102, 103]
+        monkeypatch.setattr(model, "_chat_template_suffix_ids", lambda *args, **kwargs: suffix)
+        messages = [[{"role": "user", "content": "x"}]]
+
+        # Right padding: 5 real tokens (suffix cut by truncation) then 3 trailing pads.
+        features = {
+            "input_ids": torch.tensor([[10, 11, 12, 13, 14, 0, 0, 0]]),
+            "attention_mask": torch.tensor([[1, 1, 1, 1, 1, 0, 0, 0]]),
+        }
+        model._restore_chat_template_suffix(features, messages, {}, {})
+        assert features["input_ids"].tolist() == [[10, 11, 101, 102, 103, 0, 0, 0]]
+
+        # Left padding: 3 leading pads then the 5 real tokens.
+        features = {
+            "input_ids": torch.tensor([[0, 0, 0, 10, 11, 12, 13, 14]]),
+            "attention_mask": torch.tensor([[0, 0, 0, 1, 1, 1, 1, 1]]),
+        }
+        model._restore_chat_template_suffix(features, messages, {}, {})
+        assert features["input_ids"].tolist() == [[0, 0, 0, 10, 11, 101, 102, 103]]
+
     def test_chat_template_suffix_ids_tolerates_unhashable_kwargs(self, bert_tiny_transformer, monkeypatch):
         # chat_template_kwargs may carry unhashable values (e.g. a ``tools`` list). The cache lookup must not
         # raise TypeError, so derivation falls back to running uncached.
@@ -826,6 +851,37 @@ class TestProcessChatMessages:
         model._restore_chat_template_suffix(features, messages, {}, {})
         assert features["input_ids"][0].tolist() == [10, 11, 12, 101, 102, 103]  # text row restored
         assert features["input_ids"][1].tolist() == [20, 21, 22, 23, 24, 25]  # multimodal row untouched
+
+    def test_chat_truncation_restores_suffix_with_real_chat_template(self, monkeypatch):
+        # Integration check against a real chat-template model (the other suffix tests mock the tokenizer), so
+        # it exercises the real apply_chat_template dispatch and two-filler derivation. The Llama-2 template
+        # ends the user turn with `[/INST]`, which truncation drops and the restore must put back.
+        model = Transformer(TINY_LLAMA, transformer_task="feature-extraction")
+        tokenizer = model.tokenizer
+
+        def process(max_length):
+            return model._process_chat_messages(
+                messages=[[{"role": "user", "content": "word " * 50}]],
+                modality_kwargs={
+                    "text": {"padding": True, "truncation": "longest_first", "max_length": max_length},
+                    "audio": {},
+                    "image": {},
+                    "video": {},
+                },
+                common_kwargs={"return_tensors": "pt"},
+                chat_template_kwargs={"add_generation_prompt": True},
+            )["input_ids"][0].tolist()
+
+        # The conversation overflows max_length=16, so `[/INST]` is truncated off and then restored.
+        restored = process(16)
+        decoded = tokenizer.decode(restored)
+        assert len(restored) == 16  # truncation is still respected
+        assert decoded.rstrip().endswith("[/INST]")  # the template suffix is back at the tail
+        assert "word" in decoded  # real content is kept at the head, not overwritten wholesale
+
+        # With the restore disabled the same input ends on a content token: the bug this feature fixes.
+        monkeypatch.setattr(model, "_restore_chat_template_suffix", lambda *args, **kwargs: None)
+        assert not tokenizer.decode(process(16)).rstrip().endswith("[/INST]")
 
 
 class TestModelLoading:

--- a/tests/base/modules/test_transformer.py
+++ b/tests/base/modules/test_transformer.py
@@ -833,6 +833,16 @@ class TestProcessChatMessages:
         )["input_ids"].tolist()[0]
         assert len(ids) == 8 and ids[-3:] == suffix
 
+        # The chat bucket also wins over an existing text value (preprocess always sets a default text
+        # truncation, which previously collided with an explicit chat-bucket one as a duplicate kwarg).
+        ids = model._process_chat_messages(
+            messages=[[{"role": "user", "content": "abcdefghijklm"}]],
+            modality_kwargs=make_modality_kwargs(padding=True, truncation="longest_first"),
+            common_kwargs={"return_tensors": "pt"},
+            chat_template_kwargs={"truncation": True, "max_length": 8},
+        )["input_ids"].tolist()[0]
+        assert len(ids) == 8 and ids[-3:] == suffix
+
     def test_chat_truncation_restore_handles_implicit_truncation(self, bert_tiny_transformer, monkeypatch):
         # Tokenizers truncate when max_length is set even if truncation was merely left unset (None), so the
         # restore gate must treat that as truncation-on.
@@ -1064,6 +1074,7 @@ class TestProcessChatMessages:
         assert features["input_ids"][0].tolist() == [10, 11, 12, 101, 102, 103]  # text row restored
         assert features["input_ids"][1].tolist() == [20, 21, 22, 23, 24, 25]  # multimodal row untouched
 
+    @pytest.mark.slow
     def test_chat_truncation_restores_suffix_with_real_chat_template(self):
         # Integration check against a real chat-template model (the other suffix tests mock the tokenizer), so
         # it exercises the real apply_chat_template dispatch and two-filler derivation. The Llama-2 template

--- a/tests/base/modules/test_transformer.py
+++ b/tests/base/modules/test_transformer.py
@@ -705,6 +705,52 @@ class TestProcessChatMessages:
         )
         assert captured_kwargs["add_generation_prompt"] is True
 
+    def test_text_generation_chat_truncation_preserves_tail(self, bert_tiny_transformer, monkeypatch):
+        model = bert_tiny_transformer
+        model.transformer_task = "text-generation"
+        model.modality_config["message"] = {"method": "forward", "method_output_name": "logits"}
+
+        full_ids = list(range(20))
+
+        def mock_apply_chat_template(messages, **kwargs):
+            ids = full_ids
+            if kwargs.get("truncation"):
+                ids = ids[: kwargs["max_length"]]
+            if kwargs.get("return_tensors") == "pt":
+                return {
+                    "input_ids": torch.tensor([ids]),
+                    "attention_mask": torch.ones(1, len(ids), dtype=torch.long),
+                }
+            return {"input_ids": [ids]}
+
+        monkeypatch.setattr(model.processor, "apply_chat_template", mock_apply_chat_template)
+        output = model._process_chat_messages(
+            messages=[[{"role": "user", "content": "test"}]],
+            modality_kwargs={
+                "text": {"padding": True, "truncation": True, "max_length": 8},
+                "audio": {},
+                "image": {},
+                "video": {},
+            },
+            common_kwargs={"return_tensors": "pt"},
+        )
+
+        assert output["input_ids"].tolist() == [full_ids[-8:]]
+
+        output = model._process_chat_messages(
+            messages=[[{"role": "user", "content": "test"}]],
+            modality_kwargs={
+                "text": {"padding": True, "truncation": True, "max_length": 8},
+                "audio": {},
+                "image": {},
+                "video": {},
+            },
+            common_kwargs={"return_tensors": "pt"},
+            chat_template_kwargs={"preserve_final_tokens": 4},
+        )
+
+        assert output["input_ids"].tolist() == [full_ids[:4] + full_ids[-4:]]
+
 
 class TestModelLoading:
     def test_invalid_backend_error(self):


### PR DESCRIPTION
Hello!

## Pull Request overview

* This PR fixes an issue where, for causal LM rerankers, setting `max_length` can truncate the tail of the chat template, remove tokens required for scoring, and make reranking scores suddenly unreliable.
* Causal LM rerankers such as Qwen3 Reranker compute scores from the logits at the final input token position, rather than from a CLS token or mean pooling. This makes it important to preserve the assistant prefill / scoring suffix at the end of the chat template.
* For text-only causal LM inputs, this PR preserves important final tokens when truncating chat-template inputs.
* It also adds a focused unit test for the text-generation chat-template truncation path.

## Details

Causal LM rerankers such as `Qwen/Qwen3-Reranker-0.6B` do not score query-document pairs like typical sequence-classification rerankers that use a CLS token or mean pooling. Instead, they compute the score from the logits at the final input token position.

For Qwen3 Reranker, the chat template ends with an assistant prefill, and the model compares the next-token logits for `"yes"` and `"no"` immediately after that. As a result, the formatted input must still end with the assistant prefill.

However, when `max_length` is set and the query/document pair is long, `apply_chat_template(..., truncation=True, max_length=...)` may truncate the tail. The resulting input can still look like a valid truncated prompt, but the assistant/scoring context immediately before the last-token logits is gone.

As a result, even a highly relevant query-document pair can suddenly receive a very low reranking score once the formatted input crosses `max_length`, making the score difficult to use for ranking. I reproduced this locally with a highly relevant pair of roughly 200 tokens and `max_length=128`: without truncation, the score was high, but with truncation the assistant prefill was removed and the score dropped sharply.

This PR adds a small fallback for the tokenizer-only chat-template path:

* only for `text-generation` / `any-to-any`
* only for text-only messages
* only when truncation and `max_length` are active
* first tokenize the full chat template without truncation
* if the sequence exceeds `max_length`, keep the head while reserving a fixed number of final tokens from the tail
* then pad with the regular processor padding path

The default number of reserved final tokens is `16`. Qwen3 Reranker currently needs 9 tokens for the assistant prefill, but that value is not obvious from the Sentence Transformers interface, so this PR keeps a small buffer. Users can override it with `processing_kwargs["chat_template"]["preserve_final_tokens"]`.

This PR uses `processing_kwargs["chat_template"]` because the existing Sentence Transformers implementation already routes kwargs for `apply_chat_template` through that path. That said, this may not be the best user-facing API for this setting.

I kept the change intentionally narrow. It does not touch the multimodal `ProcessorMixin` path, and it does not change truncation behavior for encoder or sequence-classification models.

## Example

The issue this PR is intended to prevent looks like this:

```python
import torch
from sentence_transformers import CrossEncoder

query = (
    "Find a passage that explains why the Qwen3 Reranker needs the final "
    "assistant prefill before checking the yes/no next-token logits."
)
doc = (
    "Qwen3 Reranker is implemented as a causal language model reranker. "
    "After the query and document are formatted with the chat template, the "
    "model does not use a CLS token or mean pooling for scoring. Instead, it "
    "reads the logits at the final input position and compares the logits for "
    "the yes and no tokens. This means the end of the chat template, including "
    "the assistant prefill, must still be present after truncation. If max_length "
    "cuts off that suffix, the reranking score is computed from the wrong final "
    "position and can become very low even for a clearly relevant query-document "
    "pair. In production systems the max_length may often be 1024 or 2048, but "
    "the same issue appears whenever long query/document inputs cross that limit. "
    "The document is directly relevant because it explains the scoring mechanism, "
    "the role of the assistant prefill, and why tail truncation breaks the final "
    "logit comparison for a causal language model reranker."
)

model_without_max_length = CrossEncoder(
    "Qwen/Qwen3-Reranker-0.6B",
    activation_fn=torch.nn.Identity(),
    model_kwargs={"torch_dtype": torch.float32},
)
score_without_max_length = model_without_max_length.predict([[query, doc]])[0]

model_with_max_length = CrossEncoder(
    "Qwen/Qwen3-Reranker-0.6B",
    max_length=128,
    activation_fn=torch.nn.Identity(),
    model_kwargs={"torch_dtype": torch.float32},
)
score_with_max_length = model_with_max_length.predict([[query, doc]])[0]

# In my local check with this PR:
# - no max_length: raw score = 8.789059, sigmoid(score) = 0.999848
# - max_length=128: raw score = 5.351816, sigmoid(score) = 0.995283
#
# Before this PR, once the formatted input exceeded max_length, the tail of the
# chat template could be removed. For last-token causal LM rerankers, that meant
# the score was computed at the wrong final token. In my earlier reproduction,
# a relevant pair with max_length=128 dropped to raw score = -3.046875
# (sigmoid(score) = 0.045410).
print(score_without_max_length, score_with_max_length)
```

This example uses `max_length=128` to make the issue easy to reproduce. In production, `1024` or `2048` are also commonly used, and the same issue can occur when long query/document inputs cross those limits.

In my local check before this change, the decoded input ended in the middle of the document and the assistant prefill was missing. With this PR, the chat-template suffix is still preserved with `max_length=128`, and the score no longer suddenly breaks.

## Configuration

The default number of final reserved tokens is 16. It can be overridden per call:

```python
score = model.predict(
    [[query, doc]],
    processing_kwargs={
        "chat_template": {"preserve_final_tokens": 9},
    },
)
```

This uses `processing_kwargs["chat_template"]` so the setting goes through the same path as kwargs passed to Transformers' `apply_chat_template`.

It can also be stored in a saved model config. In the current Sentence Transformers save format, this belongs to the Transformer module config (`sentence_bert_config.json`), not the root `config_sentence_transformers.json`:

```json
{
  "transformer_task": "text-generation",
  "processing_kwargs": {
    "chat_template": {
      "preserve_final_tokens": 9
    }
  }
}
```

However, `preserve_final_tokens` is not actually a standard Transformers `apply_chat_template` argument; it controls a Sentence Transformers fallback. Because of that, putting it under `processing_kwargs["chat_template"]` may be confusing. For example, it might be better as a `CrossEncoder` initialization argument for causal LM reranker truncation/suffix behavior.

## Testing

```bash
pytest tests/base/modules/test_transformer.py::TestProcessChatMessages -q
ruff check sentence_transformers/base/modules/transformer.py tests/base/modules/test_transformer.py
```

I also manually checked Qwen3 Reranker with `max_length=128`. After this change, the formatted input keeps the assistant prefill at the end, and the score no longer drops sharply when the formatted input exceeds `max_length`.

---

This PR is a fairly narrow fix for the causal LM reranker + `max_length` scoring issue.

There may be a better Sentence Transformers abstraction for this, such as detecting last-token scoring models, reading the required suffix token count explicitly from the model/config, exposing this as a `CrossEncoder` initialization argument, or aligning the behavior with a Transformers-side API. I would be happy to adjust this PR or move toward a different implementation if that fits the project better.

Please let me know what you think, or if you have suggestions for a better direction.
