### PR TITLE
Fix formatting in contrastive_tension.py documentation

### DIFF
--- a/sentence_transformers/sentence_transformer/losses/contrastive_tension.py
+++ b/sentence_transformers/sentence_transformer/losses/contrastive_tension.py
@@ -33,11 +33,11 @@ class ContrastiveTensionLoss(nn.Module):
         * `Unsupervised Learning > CT <../../../examples/sentence_transformer/unsupervised_learning/CT/README.html>`_
 
     Inputs:
-        +================================+=========+
+        +------------------------------------------+
         | Inputs                         | Labels  |
         +================================+=========+
         | (input_A, input_B) pairs       | None    |
-        +================================+=========+
+        +------------------------------------------+
 
     Relations:
         * :class:`ContrastiveTensionLossInBatchNegatives` uses in-batch negative sampling, which gives a stronger training signal than this loss.


### PR DESCRIPTION
Updated documentation formatting in contrastive_tension.py

The previous format wasn't rendering as a table (Inputs section).

<img width="1202" height="555" alt="image" src="https://github.com/user-attachments/assets/4316e6a5-6512-4ecd-b836-377f0ad59062" />
