### PR TITLE
[`fix`] Clarify mixed-modality batch errors

### DIFF
--- a/sentence_transformers/base/model.py
+++ b/sentence_transformers/base/model.py
@@ -539,6 +539,12 @@ class BaseModel(nn.Sequential, PeftAdapterMixin, ABC):
                     f"\nThis model supports {' and '.join(modality)} individually, "
                     "but not in the same input. Please process each modality separately."
                 )
+            elif modality == "message" and "message" not in self.modalities:
+                message += (
+                    "\nMixed-modality batches require a model that supports the 'message' modality. "
+                    "This model supports individual modalities only; split the inputs by modality and "
+                    "encode each modality separately."
+                )
             raise ValueError(message)
 
         # Backwards compatibility: fall back to preprocess/tokenize without prompt if the

--- a/tests/base/test_model.py
+++ b/tests/base/test_model.py
@@ -128,6 +128,24 @@ def test_preprocess_rejects_multimodal_without_message_support(
         stsb_bert_tiny_model.preprocess(["dummy text"])
 
 
+def test_preprocess_rejects_mixed_batch_without_message_support(
+    stsb_bert_tiny_model: SentenceTransformer, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """preprocess() should explain that mixed-modality batches need message support."""
+    monkeypatch.setattr(type(stsb_bert_tiny_model), "modalities", property(lambda self: ["text", "image"]))
+    monkeypatch.setattr(
+        "sentence_transformers.base.model.infer_batch_modality",
+        lambda inputs, supported_modalities=None: "message",
+    )
+
+    with pytest.raises(ValueError) as exc_info:
+        stsb_bert_tiny_model.preprocess(["dummy text", "dummy image"])
+
+    message = str(exc_info.value)
+    assert "Mixed-modality batches require a model that supports the 'message' modality" in message
+    assert "encode each modality separately" in message
+
+
 def test_preprocess_passes_supported_modality(stsb_bert_tiny_model: SentenceTransformer) -> None:
     """preprocess() should succeed with text inputs on a text-only model."""
     features = stsb_bert_tiny_model.preprocess(["Hello world"])


### PR DESCRIPTION
## Summary
- Clarify the error raised when a batch is inferred as `message` because it mixes modalities, but the model only supports the individual modalities.
- Add a regression test for mixed-modality batches without `message` support.

Refs #3722.

## Validation
- `/Users/mac/Documents/Github/sentence-transformers/.venv/bin/python -m pytest tests/base/test_model.py::test_preprocess_rejects_unsupported_modality tests/base/test_model.py::test_preprocess_rejects_multimodal_without_message_support tests/base/test_model.py::test_preprocess_rejects_mixed_batch_without_message_support tests/base/test_model.py::test_preprocess_passes_supported_modality -q`
- `/Users/mac/Documents/Github/sentence-transformers/.venv/bin/python -m pytest tests/base/test_modality.py::TestInferBatchModality -q`
- `uvx ruff check sentence_transformers/base/model.py tests/base/test_model.py`