### PR TITLE
[`fix`] Clarify unsupported-modality error messages

### DIFF
--- a/sentence_transformers/base/modality.py
+++ b/sentence_transformers/base/modality.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 import os
 from collections import defaultdict
-from typing import Any, Literal
+from typing import Any, Literal, NoReturn
 from urllib.parse import urlparse
 
 import numpy as np
@@ -667,3 +667,82 @@ def format_modality(modality: Modality) -> str:
     if isinstance(modality, tuple):
         return "+".join(modality)
     return modality
+
+
+def raise_unsupported_modality_error(
+    inputs: list[SingleInput | PairInput],
+    modality: Modality,
+    supported_modalities: list[Modality],
+    source: str,
+) -> NoReturn:
+    """Raise a clear ``ValueError`` explaining why ``modality`` is not supported.
+
+    Shared by :meth:`BaseModel.preprocess` and :meth:`Transformer.preprocess` so both raise the
+    same, accurate guidance. ``source`` is a human-readable description of what rejected the input,
+    e.g. ``"SentenceTransformer model"`` or ``"Transformer module"``.
+
+    Args:
+        inputs: The original batch of inputs, re-inspected per sample to distinguish explicit
+            chat-style ``"message"`` inputs from inferred mixed-modality batches (both collapse to
+            the ``"message"`` modality at the batch level).
+        modality: The inferred (and unsupported) batch modality.
+        supported_modalities: The modalities the source actually supports.
+        source: Human-readable name of the rejecting component, used verbatim in the message.
+
+    Raises:
+        ValueError: Always, with a message tailored to the specific unsupported-modality scenario.
+    """
+    supported_str = ", ".join(format_modality(m) for m in supported_modalities)
+
+    if modality == "message":
+        # "message" is returned both for explicit chat-style inputs and for inferred mixed-modality
+        # batches. Re-inspect each sample to tell them apart. If a sample cannot be classified on its
+        # own (e.g. a non-text pair), fall back to the generic message below.
+        try:
+            sample_modalities: set[Modality] = {
+                infer_modality(sample, supported_modalities=supported_modalities) for sample in inputs
+            }
+        except (ValueError, TypeError):
+            sample_modalities = set()
+
+        if sample_modalities == {"message"}:
+            raise ValueError(
+                f"This {source} does not support chat-style 'message' inputs (dicts with "
+                f"'role' and 'content'). Supported modalities: {supported_str}."
+            )
+        if "message" in sample_modalities:
+            # Chat-style inputs are mixed with other inputs. Since this source does not support the
+            # message format, the chat-style inputs are the blocking issue; report that rather than
+            # listing "message" as if it were a content modality alongside text/image/audio.
+            raise ValueError(
+                f"This {source} does not support chat-style 'message' inputs (dicts with 'role' and "
+                f"'content'), which this batch mixes with other modalities. Supported modalities: {supported_str}."
+            )
+        if sample_modalities:
+            present_str = ", ".join(format_modality(m) for m in sorted(sample_modalities, key=format_modality))
+            # Decompose into base parts: a part the source cannot handle at all is a genuine error.
+            # If every part is supported, the modalities just cannot be combined (handled below).
+            base_modalities = {part for m in sample_modalities for part in (m if isinstance(m, tuple) else (m,))}
+            unsupported = sorted(part for part in base_modalities if part not in supported_modalities)
+            if unsupported:
+                raise ValueError(
+                    f"This batch mixes multiple modalities ({present_str}), but this {source} does "
+                    f"not support {', '.join(unsupported)}. Supported modalities: {supported_str}."
+                )
+            raise ValueError(
+                f"This batch mixes multiple modalities ({present_str}), which this {source} cannot "
+                f"encode in a single batch. Encode each modality separately (one call per modality)."
+            )
+
+    # A single combined input (e.g. a {"text": ..., "image": ...} dict) with parts the source
+    # supports individually but cannot fuse without "message" support: encode each separately.
+    if isinstance(modality, tuple) and all(part in supported_modalities for part in modality):
+        raise ValueError(
+            f"This {source} supports {' and '.join(modality)} individually, but cannot "
+            f"combine them in a single input. Encode each modality separately (one call per modality)."
+        )
+
+    raise ValueError(
+        f"Modality '{format_modality(modality)}' is not supported by this {source}. "
+        f"Supported modalities: {supported_str}."
+    )

--- a/sentence_transformers/base/modality.py
+++ b/sentence_transformers/base/modality.py
@@ -707,7 +707,7 @@ def raise_unsupported_modality_error(
 
         if sample_modalities == {"message"}:
             raise ValueError(
-                f"This {source} does not support chat-style 'message' inputs (dicts with "
+                f"This {source} does not support chat-style 'message' inputs (dicts or lists of dicts with "
                 f"'role' and 'content'). Supported modalities: {supported_str}."
             )
         if "message" in sample_modalities:
@@ -715,7 +715,7 @@ def raise_unsupported_modality_error(
             # message format, the chat-style inputs are the blocking issue; report that rather than
             # listing "message" as if it were a content modality alongside text/image/audio.
             raise ValueError(
-                f"This {source} does not support chat-style 'message' inputs (dicts with 'role' and "
+                f"This {source} does not support chat-style 'message' inputs (dicts or lists of dicts with 'role' and "
                 f"'content'), which this batch mixes with other modalities. Supported modalities: {supported_str}."
             )
         if sample_modalities:

--- a/sentence_transformers/base/model.py
+++ b/sentence_transformers/base/model.py
@@ -27,7 +27,7 @@ from transformers.utils import logging as transformers_logging
 
 from sentence_transformers import __version__
 from sentence_transformers.base.evaluation import BaseEvaluator
-from sentence_transformers.base.modality import format_modality, infer_batch_modality
+from sentence_transformers.base.modality import infer_batch_modality, raise_unsupported_modality_error
 from sentence_transformers.base.modality_types import Modality, PairInput, SingleInput
 from sentence_transformers.base.model_card import BaseModelCardData, generate_model_card
 from sentence_transformers.base.modules import Module, Router, Transformer
@@ -529,17 +529,7 @@ class BaseModel(nn.Sequential, PeftAdapterMixin, ABC):
             pass
 
         if modality is not None and not self.supports(modality):
-            supported = ", ".join(format_modality(m) for m in self.modalities)
-            message = (
-                f"Modality '{format_modality(modality)}' is not supported by this {type(self).__name__} model. "
-                f"Supported modalities: {supported}"
-            )
-            if isinstance(modality, tuple) and all(part in self.modalities for part in modality):
-                message += (
-                    f"\nThis model supports {' and '.join(modality)} individually, "
-                    "but not in the same input. Please process each modality separately."
-                )
-            raise ValueError(message)
+            raise_unsupported_modality_error(inputs, modality, self.modalities, f"{type(self).__name__} model")
 
         # Backwards compatibility: fall back to preprocess/tokenize without prompt if the
         # input module doesn't accept it. Only the main path (preprocess with prompt) will

--- a/sentence_transformers/base/modules/transformer.py
+++ b/sentence_transformers/base/modules/transformer.py
@@ -45,7 +45,7 @@ from transformers.utils.import_utils import is_peft_available
 from transformers.utils.peft_utils import find_adapter_config_file
 
 from sentence_transformers.backend import load_onnx_model, load_openvino_model
-from sentence_transformers.base.modality import InputFormatter, format_modality
+from sentence_transformers.base.modality import InputFormatter, format_modality, raise_unsupported_modality_error
 from sentence_transformers.base.modality_types import (
     MODALITY_TO_PROCESSOR_ARG,
     MessageInput,
@@ -953,10 +953,7 @@ class Transformer(InputModule):
         if "message" in self.modality_config and modality != "message":
             modality, processor_inputs = self.input_formatter.batch_to_message(modality, processor_inputs)
         elif modality not in self.modality_config:
-            raise ValueError(
-                f"Modality '{format_modality(modality)}' is not supported by this model. "
-                f"Supported modalities: {', '.join(format_modality(m) for m in sorted(self.modality_config.keys(), key=str))}"
-            )
+            raise_unsupported_modality_error(inputs, modality, list(self.modality_config.keys()), "Transformer module")
 
         # Incorporate prompt into inputs if applicable
         prompt_length = None

--- a/tests/base/modules/test_transformer.py
+++ b/tests/base/modules/test_transformer.py
@@ -35,6 +35,24 @@ def bert_tiny_transformer(stsb_bert_tiny_model) -> Transformer:
     return stsb_bert_tiny_model[0]
 
 
+def test_preprocess_unsupported_modality_uses_shared_error(bert_tiny_transformer):
+    """A text-only Transformer module rejects unsupported modalities with the same module-scoped
+    guidance that BaseModel.preprocess produces (both via ``raise_unsupported_modality_error``)."""
+    image = np.zeros((8, 8, 3), dtype=np.uint8)
+
+    with pytest.raises(
+        ValueError,
+        match=r"Modality 'image' is not supported by this Transformer module\. Supported modalities: text",
+    ):
+        bert_tiny_transformer.preprocess([image])
+
+    with pytest.raises(
+        ValueError,
+        match=r"mixes multiple modalities \(image, text\), but this Transformer module does not support image",
+    ):
+        bert_tiny_transformer.preprocess(["a sentence", image])
+
+
 class TestSetTemporaryClassAttrs:
     def test_sets_and_restores(self):
         class Dummy:

--- a/tests/base/test_model.py
+++ b/tests/base/test_model.py
@@ -94,38 +94,137 @@ class TestSparseEncoderPreprocess(BaseModelPreprocessTest):
         return ["This is a test.", "Another test sentence."]
 
 
-def test_preprocess_rejects_unsupported_modality(
-    stsb_bert_tiny_model: SentenceTransformer, monkeypatch: pytest.MonkeyPatch
+# A 3D array is inferred as the "image" modality, a 1D array as "audio"; values are never read
+# because preprocess() raises before processing, so reusing these constants across cases is safe.
+_IMAGE = np.zeros((8, 8, 3), dtype=np.uint8)
+_AUDIO = np.zeros((16000,), dtype=np.float32)
+
+
+@pytest.mark.parametrize(
+    ("modalities", "inputs", "expected", "forbidden"),
+    [
+        # Genuinely unsupported modality -> "Modality 'X' is not supported".
+        pytest.param(
+            ["text"],
+            [_IMAGE],
+            ["Modality 'image' is not supported", "Supported modalities: text"],
+            ["mixes", "individually", "chat-style"],
+            id="unsupported-image-on-text-only",
+        ),
+        pytest.param(
+            ["text"],
+            [{"text": "a cat", "image": _IMAGE}],
+            ["Modality 'image+text' is not supported", "Supported modalities: text"],
+            ["individually", "mixes", "chat-style"],
+            id="unsupported-combined-dict-on-text-only",
+        ),
+        # Combinable but not combined: every part is supported, the model just cannot fuse them
+        # without 'message' support, so the guidance is to encode each modality separately.
+        pytest.param(
+            ["text", "image"],
+            [{"text": "a cat", "image": _IMAGE}],
+            [
+                "supports image and text individually",
+                "cannot combine them in a single input",
+                "Encode each modality separately",
+            ],
+            ["is not supported", "mixes", "does not support"],
+            id="combinable-single-dict-on-text-image",
+        ),
+        pytest.param(
+            ["text", "image"],
+            ["a sentence", _IMAGE],
+            ["mixes multiple modalities (image, text)", "Encode each modality separately"],
+            ["does not support", "is not supported", "chat-style"],
+            id="combinable-mixed-batch-on-text-image",
+        ),
+        pytest.param(
+            ["text", "image"],
+            ["a sentence", {"text": "a cat", "image": _IMAGE}],
+            ["mixes multiple modalities (image+text, text)", "Encode each modality separately"],
+            ["does not support", "is not supported"],
+            id="combinable-mixed-batch-with-dict-on-text-image",
+        ),
+        # Mixed batch where a base modality is genuinely unsupported -> name the unsupported part(s).
+        pytest.param(
+            ["text"],
+            ["a sentence", _IMAGE],
+            ["mixes multiple modalities (image, text)", "does not support image", "Supported modalities: text"],
+            ["Encode each modality separately", "chat-style"],
+            id="mixed-batch-unsupported-image-on-text-only",
+        ),
+        pytest.param(
+            ["text"],
+            [{"text": "a cat", "image": _IMAGE}, {"text": "a dog"}],
+            ["mixes multiple modalities (image+text, text)", "does not support image"],
+            ["Encode each modality separately"],
+            id="mixed-batch-dict-and-text-on-text-only",
+        ),
+        pytest.param(
+            ["text"],
+            ["a sentence", _AUDIO, _IMAGE],
+            ["mixes multiple modalities (audio, image, text)", "does not support audio, image"],
+            ["Encode each modality separately"],
+            id="mixed-batch-multiple-unsupported-on-text-only",
+        ),
+        # Explicit chat-style message inputs on a model without 'message' support.
+        pytest.param(
+            ["text"],
+            [{"role": "user", "content": "hi"}],
+            ["does not support chat-style 'message' inputs", "Supported modalities: text"],
+            ["mixes", "Modality '"],
+            id="explicit-messages-on-text-only",
+        ),
+        pytest.param(
+            ["text", "image"],
+            [{"role": "user", "content": "hi"}, {"role": "assistant", "content": "yo"}],
+            ["does not support chat-style 'message' inputs", "Supported modalities: text, image"],
+            ["mixes", "does not support image"],
+            id="explicit-messages-on-text-image",
+        ),
+        # Chat-style messages mixed with other inputs: the model lacks 'message' support, so the
+        # chat-style inputs are the blocking issue. "message" must not be listed as a content modality.
+        pytest.param(
+            ["text"],
+            [{"role": "user", "content": "hi"}, _IMAGE],
+            ["does not support chat-style 'message' inputs", "mixes with other modalities"],
+            ["multiple modalities", ", message", "does not support image"],
+            id="messages-mixed-with-image-on-text-only",
+        ),
+        pytest.param(
+            ["text"],
+            [{"role": "user", "content": "hi"}, "a plain sentence"],
+            ["does not support chat-style 'message' inputs", "mixes with other modalities"],
+            ["multiple modalities", ", message", "does not support text"],
+            id="messages-mixed-with-text-on-text-only",
+        ),
+    ],
+)
+def test_preprocess_modality_error_messages(
+    stsb_bert_tiny_model: SentenceTransformer,
+    monkeypatch: pytest.MonkeyPatch,
+    modalities: list[str],
+    inputs: list,
+    expected: list[str],
+    forbidden: list[str],
 ) -> None:
-    """preprocess() should raise ValueError when the inferred modality is not supported."""
-    monkeypatch.setattr(
-        "sentence_transformers.base.model.infer_batch_modality",
-        lambda inputs, supported_modalities=None: "image",
-    )
-    with pytest.raises(ValueError, match="Modality 'image' is not supported"):
-        stsb_bert_tiny_model.preprocess(["dummy text"])
+    """preprocess() should raise a clear, accurate ValueError for each unsupported-modality scenario.
 
-
-def test_preprocess_rejects_multimodal_without_message_support(
-    stsb_bert_tiny_model: SentenceTransformer, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """preprocess() should raise ValueError for combined modalities when the model supports
-    individual modalities (e.g. text and image) but not 'message' format.
-
-    This mirrors the behavior of architectures like blip-2, sam3, and flava that handle
-    text and image separately but cannot combine them in a single forward pass.
+    The model's supported modalities are simulated via ``modalities``; inputs use real inference
+    (numpy arrays for image/audio, dicts for combined/chat inputs) so the full path is exercised.
+    ``forbidden`` guards against misleading wording, e.g. claiming a modality is unsupported when
+    every part is actually supported.
     """
-    # Pretend the model supports text and image individually, but not message format
-    monkeypatch.setattr(type(stsb_bert_tiny_model), "modalities", property(lambda self: ["text", "image"]))
-    # Pretend the inferred modality is a combined tuple
-    monkeypatch.setattr(
-        "sentence_transformers.base.model.infer_batch_modality",
-        lambda inputs, supported_modalities=None: ("text", "image"),
-    )
-    with pytest.raises(
-        ValueError, match=r"This model supports text and image individually, but not in the same input"
-    ):
-        stsb_bert_tiny_model.preprocess(["dummy text"])
+    monkeypatch.setattr(type(stsb_bert_tiny_model), "modalities", property(lambda self: modalities))
+
+    with pytest.raises(ValueError) as exc_info:
+        stsb_bert_tiny_model.preprocess(inputs)
+
+    message = str(exc_info.value)
+    for substring in expected:
+        assert substring in message, f"expected {substring!r} in error message, got: {message!r}"
+    for substring in forbidden:
+        assert substring not in message, f"did not expect {substring!r} in error message, got: {message!r}"
 
 
 def test_preprocess_passes_supported_modality(stsb_bert_tiny_model: SentenceTransformer) -> None:

--- a/tests/sentence_transformer/modules/test_static_embedding.py
+++ b/tests/sentence_transformer/modules/test_static_embedding.py
@@ -91,10 +91,14 @@ def test_unsupported_modality(static_embedding: StaticEmbedding) -> None:
     ):
         model.encode([{"text": "a cat", "image": dummy_image}])
 
-    # Mixed text+image input via multimodal dict
+    # Mixed-modality batch (a multimodal dict alongside a text-only dict) is inferred as 'message'.
+    # The model genuinely cannot handle image, so it is named as the unsupported modality.
     with pytest.raises(
         ValueError,
-        match="Modality 'message' is not supported by this SentenceTransformer model. Supported modalities: text",
+        match=(
+            r"This batch mixes multiple modalities \(image\+text, text\), but this SentenceTransformer "
+            r"model does not support image\. Supported modalities: text"
+        ),
     ):
         model.encode([{"text": "a cat", "image": dummy_image}, {"text": "a dog"}])
 


### PR DESCRIPTION
Supersedes #3789

Hello!

## Pull Request overview
* Clarify the errors raised for unsupported, mixed, and combined-modality inputs
* Share a single `raise_unsupported_modality_error` helper across `BaseModel` and `Transformer`

## Details
When inputs don't match what a model supports, the errors were confusing. Because a batch that mixes modalities collapses to the internal `"message"` modality (the format we use to combine modalities into one input), passing e.g. a list of images and texts to CLIP raised `Modality 'message' is not supported`, even though the user never passed a message. That's the confusion reported in #3722. A single combined `{"text": ..., "image": ...}` input was worse: on a model that supports both modalities individually it raised `Modality 'image+text' is not supported. Supported modalities: text, image`, contradicting itself.

I've reworked the validation to re-inspect the per-sample modalities on the error path and emit guidance tailored to the actual situation: explicit chat-style `message` inputs, a mixed batch containing a genuinely unsupported modality (now named explicitly), a mixed batch the model could encode one modality at a time (so the message says to do exactly that), and a single combined input whose parts are each supported but can't be fused without `message` support. All of this now lives in one `raise_unsupported_modality_error` helper in `modality.py`, shared by `BaseModel.preprocess` and `Transformer.preprocess` so both raise the same accurate message.

This supersedes #3789, which clarified only the mixed-modality batch case. This version should cover every unsupported-modality scenario and unifies the two code paths. I also expanded the tests into a parametrized matrix that exercises the real inference path for each case, with guards against misleading wording (e.g. never claiming a modality is unsupported when every part is actually supported).

- Tom Aarsen
