### PR TITLE
[`feat`] Add token-level sparse autoencoder modules

### DIFF
--- a/docs/package_reference/sparse_encoder/modules.md
+++ b/docs/package_reference/sparse_encoder/modules.md
@@ -14,7 +14,17 @@ See also the modules from `sentence_transformers.base.modules` in [Base > Module
 .. autoclass:: sentence_transformers.sparse_encoder.modules.SparseAutoEncoder
 ```
 
+## SparseAutoEncoderTokenEncoder
+```{eval-rst}
+.. autoclass:: sentence_transformers.sparse_encoder.modules.SparseAutoEncoderTokenEncoder
+```
+
+## SparseTokenPooling
+```{eval-rst}
+.. autoclass:: sentence_transformers.sparse_encoder.modules.SparseTokenPooling
+```
+
 ## SparseStaticEmbedding
 ```{eval-rst}
 .. autoclass:: sentence_transformers.sparse_encoder.modules.SparseStaticEmbedding
-``` 
+```

--- a/sentence_transformers/sparse_encoder/model.py
+++ b/sentence_transformers/sparse_encoder/model.py
@@ -23,7 +23,12 @@ from sentence_transformers.base.modality_types import TextInput
 from sentence_transformers.base.modules import Transformer
 from sentence_transformers.sentence_transformer.modules import Pooling
 from sentence_transformers.sparse_encoder.model_card import SparseEncoderModelCardData
-from sentence_transformers.sparse_encoder.modules import SparseAutoEncoder, SpladePooling
+from sentence_transformers.sparse_encoder.modules import (
+    SparseAutoEncoder,
+    SparseAutoEncoderTokenEncoder,
+    SparseTokenPooling,
+    SpladePooling,
+)
 from sentence_transformers.util import batch_to_device, select_max_active_dims
 from sentence_transformers.util.decorators import deprecated_kwargs
 from sentence_transformers.util.similarity import SimilarityFunction
@@ -187,7 +192,7 @@ class SparseEncoder(BaseModel):
         self.max_active_dims = max_active_dims
         if max_active_dims is None:
             for module in self._modules.values():
-                if isinstance(module, SparseAutoEncoder):
+                if isinstance(module, (SparseAutoEncoder, SparseAutoEncoderTokenEncoder)):
                     self.max_active_dims = module.k
                     break
 
@@ -602,7 +607,7 @@ class SparseEncoder(BaseModel):
         e.g. CSR models with a :class:`~sentence_transformers.sentence_transformer.modules.Pooling` layer.
         """
         for module in self:
-            if isinstance(module, Pooling):
+            if isinstance(module, (Pooling, SparseTokenPooling)):
                 module.include_prompt = include_prompt
                 break
 

--- a/sentence_transformers/sparse_encoder/model_card.py
+++ b/sentence_transformers/sparse_encoder/model_card.py
@@ -9,7 +9,12 @@ import torch
 
 from sentence_transformers.base.model_card import BaseModelCardCallback, BaseModelCardData
 from sentence_transformers.base.modules import Module, Router
-from sentence_transformers.sparse_encoder.modules import SparseAutoEncoder, SparseStaticEmbedding, SpladePooling
+from sentence_transformers.sparse_encoder.modules import (
+    SparseAutoEncoder,
+    SparseAutoEncoderTokenEncoder,
+    SparseStaticEmbedding,
+    SpladePooling,
+)
 
 if TYPE_CHECKING:
     from sentence_transformers.sparse_encoder.model import SparseEncoder
@@ -107,6 +112,9 @@ class SparseEncoderModelCardData(BaseModelCardData):
 
         if SpladePooling in all_modules:
             model_type += ["SPLADE"]
+
+        if SparseAutoEncoderTokenEncoder in all_modules:
+            model_type += ["Token SAE"]
 
         if SparseAutoEncoder in all_modules:
             model_type += ["CSR"]

--- a/sentence_transformers/sparse_encoder/modules/__init__.py
+++ b/sentence_transformers/sparse_encoder/modules/__init__.py
@@ -9,7 +9,9 @@ from ...base.modules.router import Asym, Router
 from ...base.modules.transformer import Transformer
 from .mlm_transformer import MLMTransformer
 from .sparse_auto_encoder import SparseAutoEncoder
+from .sparse_auto_encoder_token_encoder import SparseAutoEncoderTokenEncoder
 from .sparse_static_embedding import SparseStaticEmbedding
+from .sparse_token_pooling import SparseTokenPooling
 from .splade_pooling import SpladePooling
 
 __all__ = [
@@ -21,6 +23,8 @@ __all__ = [
     "Transformer",
     "MLMTransformer",
     "SparseAutoEncoder",
+    "SparseAutoEncoderTokenEncoder",
     "SparseStaticEmbedding",
+    "SparseTokenPooling",
     "SpladePooling",
 ]

--- a/sentence_transformers/sparse_encoder/modules/sparse_auto_encoder.py
+++ b/sentence_transformers/sparse_encoder/modules/sparse_auto_encoder.py
@@ -10,6 +10,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 from sentence_transformers.base.modules.module import Module
+from sentence_transformers.sparse_encoder.modules.sparse_auto_encoder_projection import _SparseAutoEncoderProjection
 
 
 class TiedTranspose(nn.Module):
@@ -65,6 +66,7 @@ class SparseAutoEncoder(Module):
         dead_threshold: int = 30,
     ) -> None:
         super().__init__()
+        _SparseAutoEncoderProjection.validate_dimensions(input_dim, hidden_dim, k)
         self.input_dim = input_dim
         self.hidden_dim = hidden_dim
         self.dead_threshold = dead_threshold
@@ -93,9 +95,12 @@ class SparseAutoEncoder(Module):
             Example: latent_slice = slice(0, 10) to compute only the first 10 latents.
         :return: autoencoder latents before activation (shape: [batch, hidden_dim])
         """
-        x = x - self.pre_bias
-        latents_pre_act = F.linear(x, self.encoder.weight, self.latent_bias)
-        return latents_pre_act
+        return _SparseAutoEncoderProjection.encode_pre_act(
+            x,
+            self.encoder.weight.t(),
+            self.latent_bias,
+            self.pre_bias,
+        )
 
     def LN(self, x: torch.Tensor, eps: float = 1e-5):
         mu = x.mean(dim=-1, keepdim=True)
@@ -119,31 +124,16 @@ class SparseAutoEncoder(Module):
         """
         if k is None:
             k = self.k
-        topk = torch.topk(x, k=k, dim=-1)
-        z_topk = torch.zeros_like(x)
-        z_topk.scatter_(-1, topk.indices, topk.values)
-        latents_k = F.relu(z_topk)
-        ## set num nonzero stat ##
-        tmp = torch.zeros_like(self.stats_last_nonzero)
-        tmp.scatter_add_(
-            0,
-            topk.indices.reshape(-1),
-            (topk.values > 1e-5).to(tmp.dtype).reshape(-1),
+        _SparseAutoEncoderProjection.validate_k(k, self.hidden_dim)
+        return _SparseAutoEncoderProjection.top_k_dense(
+            x,
+            k=k,
+            hidden_dim=self.hidden_dim,
+            stats_last_nonzero=self.stats_last_nonzero,
+            compute_aux=compute_aux,
+            k_aux=self.k_aux,
+            auxk_mask_fn=self.auxk_mask_fn,
         )
-        self.stats_last_nonzero *= 1 - tmp.clamp(max=1)
-        self.stats_last_nonzero += 1
-        ## end stats ##
-
-        latents_auxk = None
-        if self.k_aux and compute_aux:
-            aux_topk = torch.topk(
-                input=self.auxk_mask_fn(x),
-                k=self.k_aux,
-            )
-            z_auxk = torch.zeros_like(x)
-            z_auxk.scatter_(-1, aux_topk.indices, aux_topk.values)
-            latents_auxk = F.relu(z_auxk)
-        return latents_k, latents_auxk
 
     def decode(self, latents: torch.Tensor, info=None) -> torch.Tensor:
         """

--- a/sentence_transformers/sparse_encoder/modules/sparse_auto_encoder_projection.py
+++ b/sentence_transformers/sparse_encoder/modules/sparse_auto_encoder_projection.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from typing import Literal
+
+import torch
+import torch.nn.functional as F
+
+
+class _SparseAutoEncoderProjection:
+    """Shared sparse-autoencoder projection math.
+
+    This helper intentionally does not own parameters. The sentence-level
+    ``SparseAutoEncoder`` keeps its historical state-dict names, while the
+    token-level adapter can store checkpoint-compatible frozen weights.
+    """
+
+    VARIANTS = {"standard", "jumprelu"}
+
+    @classmethod
+    def validate_dimensions(cls, input_dim: int, hidden_dim: int, k: int) -> None:
+        if input_dim <= 0:
+            raise ValueError(f"input_dim must be a positive integer, got {input_dim}.")
+        if hidden_dim <= 0:
+            raise ValueError(f"hidden_dim must be a positive integer, got {hidden_dim}.")
+        cls.validate_k(k, hidden_dim)
+
+    @staticmethod
+    def validate_k(k: int, hidden_dim: int) -> None:
+        if k <= 0:
+            raise ValueError(f"k must be a positive integer, got {k}.")
+        if k > hidden_dim:
+            raise ValueError(f"k must be <= hidden_dim, got k={k}, hidden_dim={hidden_dim}.")
+
+    @classmethod
+    def validate_variant(cls, variant: str) -> None:
+        if variant not in cls.VARIANTS:
+            raise ValueError("variant must be either 'standard' or 'jumprelu'.")
+
+    @staticmethod
+    def encode_pre_act(
+        x: torch.Tensor,
+        weight: torch.Tensor,
+        bias: torch.Tensor,
+        pre_bias: torch.Tensor,
+    ) -> torch.Tensor:
+        return (x - pre_bias) @ weight + bias
+
+    @staticmethod
+    def apply_variant(
+        logits: torch.Tensor,
+        variant: Literal["standard", "jumprelu"],
+        theta: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        if variant == "jumprelu" and theta is not None:
+            return logits * (logits > theta).to(logits.dtype)
+        return logits
+
+    @staticmethod
+    def top_k_sparse(
+        logits: torch.Tensor,
+        k: int,
+        variant: Literal["standard", "jumprelu"] = "standard",
+        theta: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        logits = _SparseAutoEncoderProjection.apply_variant(logits, variant, theta)
+        top_values, top_indices = logits.topk(k, dim=-1)
+        return F.relu(top_values), top_indices
+
+    @staticmethod
+    def sparse_to_dense(values: torch.Tensor, indices: torch.Tensor, hidden_dim: int) -> torch.Tensor:
+        dense = torch.zeros(*values.shape[:-1], hidden_dim, dtype=values.dtype, device=values.device)
+        dense.scatter_(-1, indices, values)
+        return dense
+
+    @classmethod
+    def top_k_dense(
+        cls,
+        logits: torch.Tensor,
+        k: int,
+        hidden_dim: int,
+        stats_last_nonzero: torch.Tensor | None = None,
+        compute_aux: bool = True,
+        k_aux: int | None = None,
+        auxk_mask_fn=None,
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        values, indices = cls.top_k_sparse(logits, k)
+        latents_k = cls.sparse_to_dense(values, indices, hidden_dim)
+
+        if stats_last_nonzero is not None:
+            tmp = torch.zeros_like(stats_last_nonzero)
+            tmp.scatter_add_(0, indices.reshape(-1), (values > 1e-5).to(tmp.dtype).reshape(-1))
+            stats_last_nonzero *= 1 - tmp.clamp(max=1)
+            stats_last_nonzero += 1
+
+        latents_auxk = None
+        if k_aux and compute_aux:
+            aux_logits = auxk_mask_fn(logits) if auxk_mask_fn is not None else logits
+            aux_values, aux_indices = cls.top_k_sparse(aux_logits, k_aux)
+            latents_auxk = cls.sparse_to_dense(aux_values, aux_indices, hidden_dim)
+        return latents_k, latents_auxk

--- a/sentence_transformers/sparse_encoder/modules/sparse_auto_encoder_token_encoder.py
+++ b/sentence_transformers/sparse_encoder/modules/sparse_auto_encoder_token_encoder.py
@@ -61,11 +61,41 @@ def _restore_token_topk(
 
 
 class SparseAutoEncoderTokenEncoder(Module):
-    """Apply a trained sparse autoencoder projection to token embeddings.
+    """Applies a sparse autoencoder projection to token embeddings.
 
-    The module stores the sparse autoencoder encoder weights, normalization state,
-    activation variant, and per-token top-k projection used at inference time. It
-    emits sparse per-token values and indices for :class:`SparseTokenPooling`.
+    This module consumes token embeddings and produces sparse per-token activations
+    represented by values and feature indices. It can be followed by
+    :class:`~sentence_transformers.sparse_encoder.modules.SparseTokenPooling` to produce a
+    sparse sentence embedding. The sparse activations are stored in the features dictionary
+    under ``"token_sparse_values"`` and ``"token_sparse_indices"``.
+
+    In training mode, if a decoder is available, the module additionally emits
+    ``"token_embedding_backbone"`` and ``"decoded_token_embeddings"``. These tensors can be
+    used by a loss function to train the sparse autoencoder. In evaluation mode, or when no
+    decoder is available, only the sparse token activations are produced.
+
+    The module accepts token embeddings in padded form (``[batch_size, seq_length, input_dim]``),
+    flattened form (``[num_tokens, input_dim]``), or packed form with ``"cu_seq_lens_q"`` in the
+    features dictionary.
+
+    Args:
+        input_dim: Dimension of the input token embeddings.
+        hidden_dim: Number of sparse autoencoder features.
+        k: Number of active features to keep per token.
+        variant: Sparse activation variant. ``"standard"`` applies top-k followed by ReLU,
+            while ``"jumprelu"`` applies learned thresholds before top-k.
+        output_format: Controls optional dense sparse-token output. ``"topk"`` emits only
+            values and indices, ``"dense"`` also emits ``"token_sparse_embeddings"``, and
+            ``"both"`` behaves the same as ``"dense"`` while preserving the top-k outputs.
+        replace_token_embeddings: If ``True``, replaces ``"token_embeddings"`` with dense
+            sparse-token embeddings.
+        checkpoint_format_version: Version number saved in the module configuration.
+        has_decoder: Whether to create a decoder for reconstruction during training.
+        k_aux: Number of auxiliary features available for external sparse-autoencoder losses.
+        frozen: Whether sparse autoencoder parameters should be frozen.
+        rms_scale: Optional scalar applied before L2 normalization when no ``data_mean`` is set.
+        token_batch_size: Optional number of tokens to project at once. Smaller values reduce
+            peak memory use for the sparse projection.
     """
 
     config_keys = [

--- a/sentence_transformers/sparse_encoder/modules/sparse_auto_encoder_token_encoder.py
+++ b/sentence_transformers/sparse_encoder/modules/sparse_auto_encoder_token_encoder.py
@@ -89,7 +89,6 @@ class SparseAutoEncoderTokenEncoder(Module):
             ``"both"`` behaves the same as ``"dense"`` while preserving the top-k outputs.
         replace_token_embeddings: If ``True``, replaces ``"token_embeddings"`` with dense
             sparse-token embeddings.
-        checkpoint_format_version: Version number saved in the module configuration.
         has_decoder: Whether to create a decoder for reconstruction during training.
         k_aux: Number of auxiliary features available for external sparse-autoencoder losses.
         frozen: Whether sparse autoencoder parameters should be frozen.
@@ -105,7 +104,6 @@ class SparseAutoEncoderTokenEncoder(Module):
         "variant",
         "output_format",
         "replace_token_embeddings",
-        "checkpoint_format_version",
         "has_decoder",
         "k_aux",
         "frozen",
@@ -122,7 +120,6 @@ class SparseAutoEncoderTokenEncoder(Module):
         variant: Literal["standard", "jumprelu"] = "standard",
         output_format: Literal["topk", "dense", "both"] = "topk",
         replace_token_embeddings: bool = False,
-        checkpoint_format_version: int = 1,
         has_decoder: bool = True,
         k_aux: int = 512,
         frozen: bool = False,
@@ -143,7 +140,6 @@ class SparseAutoEncoderTokenEncoder(Module):
         self.variant = variant
         self.output_format = output_format
         self.replace_token_embeddings = replace_token_embeddings
-        self.checkpoint_format_version = checkpoint_format_version
         self.has_decoder = has_decoder
         self.k_aux = k_aux
         self.frozen = frozen

--- a/sentence_transformers/sparse_encoder/modules/sparse_auto_encoder_token_encoder.py
+++ b/sentence_transformers/sparse_encoder/modules/sparse_auto_encoder_token_encoder.py
@@ -37,6 +37,8 @@ def _flatten_token_embeddings(
             raise ValueError(f"Expected flattened token_embeddings to be rank 2; got {tuple(token_embeddings.shape)}")
         return flat, None, bounds
 
+    if token_embeddings.ndim == 2:
+        return token_embeddings, None, None
     if token_embeddings.ndim != 3:
         raise ValueError(f"Expected padded token_embeddings to be [B, T, D]; got {tuple(token_embeddings.shape)}")
     mask = features.get("attention_mask")

--- a/sentence_transformers/sparse_encoder/modules/sparse_auto_encoder_token_encoder.py
+++ b/sentence_transformers/sparse_encoder/modules/sparse_auto_encoder_token_encoder.py
@@ -78,7 +78,7 @@ class SparseAutoEncoderTokenEncoder(Module):
     flattened form (``[num_tokens, input_dim]``), or packed form with ``"cu_seq_lens_q"`` in the
     features dictionary.
 
-    Args:
+    General Args:
         input_dim: Dimension of the input token embeddings.
         hidden_dim: Number of sparse autoencoder features.
         k: Number of active features to keep per token.
@@ -89,12 +89,14 @@ class SparseAutoEncoderTokenEncoder(Module):
             ``"both"`` behaves the same as ``"dense"`` while preserving the top-k outputs.
         replace_token_embeddings: If ``True``, replaces ``"token_embeddings"`` with dense
             sparse-token embeddings.
-        has_decoder: Whether to create a decoder for reconstruction during training.
-        k_aux: Number of auxiliary features available for external sparse-autoencoder losses.
         frozen: Whether sparse autoencoder parameters should be frozen.
         rms_scale: Optional scalar applied before L2 normalization when no ``data_mean`` is set.
         token_batch_size: Optional number of tokens to project at once. Smaller values reduce
             peak memory use for the sparse projection.
+
+    Training Args:
+        has_decoder: Whether to create a decoder for reconstruction during training.
+        k_aux: Number of auxiliary features available for external sparse-autoencoder losses.
     """
 
     config_keys = [

--- a/sentence_transformers/sparse_encoder/modules/sparse_auto_encoder_token_encoder.py
+++ b/sentence_transformers/sparse_encoder/modules/sparse_auto_encoder_token_encoder.py
@@ -1,0 +1,270 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Literal
+
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from sentence_transformers.base.modules.module import Module
+
+
+def _split_flattened_sequence_bounds(features: dict[str, Any]) -> list[tuple[int, int]] | None:
+    if "cu_seq_lens_q" not in features:
+        return None
+    cu_seq_lens_q = features["cu_seq_lens_q"].detach().cpu().tolist()
+    return [(int(start), int(end)) for start, end in zip(cu_seq_lens_q, cu_seq_lens_q[1:])]
+
+
+def _flatten_token_embeddings(
+    features: dict[str, Any],
+) -> tuple[torch.Tensor, torch.Tensor | None, list[tuple[int, int]] | None]:
+    token_embeddings = features["token_embeddings"]
+    bounds = _split_flattened_sequence_bounds(features)
+    if bounds is not None:
+        flat = (
+            token_embeddings.squeeze(0)
+            if token_embeddings.ndim == 3 and token_embeddings.shape[0] == 1
+            else token_embeddings
+        )
+        if flat.ndim != 2:
+            raise ValueError(f"Expected flattened token_embeddings to be rank 2; got {tuple(token_embeddings.shape)}")
+        return flat, None, bounds
+
+    if token_embeddings.ndim != 3:
+        raise ValueError(f"Expected padded token_embeddings to be [B, T, D]; got {tuple(token_embeddings.shape)}")
+    mask = features.get("attention_mask")
+    if mask is not None and mask.shape != token_embeddings.shape[:2]:
+        mask = None
+    return token_embeddings.reshape(-1, token_embeddings.shape[-1]), mask, None
+
+
+def _restore_token_topk(
+    flat_values: torch.Tensor,
+    flat_indices: torch.Tensor,
+    token_embeddings: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if token_embeddings.ndim == 3 and token_embeddings.shape[0] != 1:
+        shape = (*token_embeddings.shape[:2], flat_values.shape[-1])
+        return flat_values.reshape(shape), flat_indices.reshape(shape)
+    if token_embeddings.ndim == 3 and token_embeddings.shape[0] == 1:
+        return flat_values.unsqueeze(0), flat_indices.unsqueeze(0)
+    return flat_values, flat_indices
+
+
+class SparseAutoEncoderTokenEncoder(Module):
+    """Apply a trained sparse autoencoder projection to token embeddings.
+
+    The module stores the sparse autoencoder encoder weights, normalization state,
+    activation variant, and per-token top-k projection used at inference time. It
+    emits sparse per-token values and indices for :class:`SparseTokenPooling`.
+    """
+
+    config_keys = [
+        "input_dim",
+        "hidden_dim",
+        "k",
+        "variant",
+        "output_format",
+        "replace_token_embeddings",
+        "checkpoint_format_version",
+        "has_decoder",
+        "rms_scale",
+        "token_batch_size",
+    ]
+    config_key_renames = {"sae_width": "hidden_dim", "topk": "k"}
+
+    def __init__(
+        self,
+        input_dim: int,
+        hidden_dim: int,
+        k: int,
+        variant: Literal["standard", "jumprelu"] = "standard",
+        output_format: Literal["topk", "dense", "both"] = "topk",
+        replace_token_embeddings: bool = False,
+        checkpoint_format_version: int = 1,
+        has_decoder: bool = False,
+        rms_scale: float | None = None,
+        token_batch_size: int | None = None,
+    ) -> None:
+        super().__init__()
+        if hidden_dim <= 0:
+            raise ValueError(f"hidden_dim must be a positive integer, got {hidden_dim}.")
+        if k <= 0:
+            raise ValueError(f"k must be a positive integer, got {k}.")
+        if k > hidden_dim:
+            raise ValueError(f"k must be <= hidden_dim, got k={k}, hidden_dim={hidden_dim}.")
+        if variant not in {"standard", "jumprelu"}:
+            raise ValueError("variant must be either 'standard' or 'jumprelu'.")
+        if output_format not in {"topk", "dense", "both"}:
+            raise ValueError("output_format must be one of: 'topk', 'dense', 'both'.")
+
+        self.input_dim = input_dim
+        self.hidden_dim = hidden_dim
+        self.k = k
+        self.variant = variant
+        self.output_format = output_format
+        self.replace_token_embeddings = replace_token_embeddings
+        self.checkpoint_format_version = checkpoint_format_version
+        self.has_decoder = has_decoder
+        self.target_norm = input_dim**0.5
+        self.rms_scale = rms_scale
+        self.token_batch_size = token_batch_size
+
+        self.W_enc = nn.Parameter(torch.empty(input_dim, hidden_dim), requires_grad=False)
+        self.b_enc = nn.Parameter(torch.zeros(hidden_dim), requires_grad=False)
+        self.b_pre = nn.Parameter(torch.zeros(input_dim), requires_grad=False)
+        if variant == "jumprelu":
+            self.theta = nn.Parameter(torch.empty(hidden_dim), requires_grad=False)
+        else:
+            self.register_parameter("theta", None)
+        self.register_buffer("data_mean", None)
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        nn.init.kaiming_uniform_(self.W_enc, a=5**0.5)
+        self.b_enc.data.zero_()
+        self.b_pre.data.zero_()
+        if self.theta is not None:
+            self.theta.data.zero_()
+
+    @classmethod
+    def from_checkpoint(cls, path: str | Path, device: str = "cpu", **kwargs) -> Self:
+        checkpoint = torch.load(path, map_location="cpu", weights_only=False)
+        config = checkpoint.get("config", {})
+        module = cls(
+            input_dim=int(config.get("input_dim", checkpoint["W_enc"].shape[0])),
+            hidden_dim=int(config.get("hidden_dim", config.get("sae_width", checkpoint["W_enc"].shape[1]))),
+            k=kwargs.pop("k", kwargs.pop("topk", int(config.get("k", config.get("topk", 16))))),
+            variant=config.get("variant", "standard"),
+            **kwargs,
+        )
+        with torch.no_grad():
+            module.W_enc.copy_(checkpoint["W_enc"])
+            module.b_enc.copy_(checkpoint["b_enc"])
+            module.b_pre.copy_(checkpoint["b_pre"])
+            if module.theta is not None and "theta" in checkpoint:
+                module.theta.copy_(checkpoint["theta"])
+        if "data_mean" in checkpoint:
+            module.data_mean = checkpoint["data_mean"].detach().clone()
+        if "rms_scale" in checkpoint:
+            module.rms_scale = float(checkpoint["rms_scale"])
+        return module.to(device)
+
+    def normalize(self, tokens: torch.Tensor) -> torch.Tensor:
+        x = tokens.float()
+        if self.data_mean is not None:
+            x = x - self.data_mean
+        elif self.rms_scale is not None:
+            x = x * self.rms_scale
+        return x * (self.target_norm / x.norm(dim=-1, keepdim=True).clamp(min=1e-8))
+
+    def encode_pre_act(self, tokens: torch.Tensor) -> torch.Tensor:
+        return (tokens - self.b_pre) @ self.W_enc + self.b_enc
+
+    @torch.no_grad()
+    def encode_tokens(self, tokens: torch.Tensor, k: int | None = None) -> tuple[torch.Tensor, torch.Tensor]:
+        k = k if k is not None else self.k
+        if k <= 0:
+            raise ValueError(f"k must be a positive integer, got {k}.")
+        if k > self.hidden_dim:
+            raise ValueError(f"k must be <= hidden_dim, got k={k}, hidden_dim={self.hidden_dim}.")
+
+        token_batch_size = self.token_batch_size
+        if token_batch_size is None or token_batch_size <= 0 or tokens.shape[0] <= token_batch_size:
+            logits = self.encode_pre_act(self.normalize(tokens))
+            if self.variant == "jumprelu" and self.theta is not None:
+                logits = logits * (logits > self.theta).to(logits.dtype)
+            top_values, top_indices = logits.topk(k, dim=-1)
+            return F.relu(top_values), top_indices
+
+        values = []
+        indices = []
+        for start in range(0, tokens.shape[0], token_batch_size):
+            chunk = tokens[start : start + token_batch_size]
+            logits = self.encode_pre_act(self.normalize(chunk))
+            if self.variant == "jumprelu" and self.theta is not None:
+                logits = logits * (logits > self.theta).to(logits.dtype)
+            top_values, top_indices = logits.topk(k, dim=-1)
+            values.append(F.relu(top_values))
+            indices.append(top_indices)
+            del logits, top_values, top_indices
+        return torch.cat(values, dim=0), torch.cat(indices, dim=0)
+
+    def forward(self, features: dict[str, torch.Tensor | Any], **kwargs) -> dict[str, torch.Tensor | Any]:
+        token_embeddings = features["token_embeddings"]
+        flat_tokens, _, _ = _flatten_token_embeddings(features)
+        flat_values, flat_indices = self.encode_tokens(flat_tokens, k=self.k)
+        token_values, token_indices = _restore_token_topk(flat_values, flat_indices, token_embeddings)
+
+        features["backbone_token_embeddings"] = token_embeddings
+        features["token_sparse_values"] = token_values
+        features["token_sparse_indices"] = token_indices
+
+        if self.output_format in {"dense", "both"} or self.replace_token_embeddings:
+            dense = torch.zeros(
+                flat_values.shape[0],
+                self.hidden_dim,
+                dtype=flat_values.dtype,
+                device=flat_values.device,
+            )
+            dense.scatter_(1, flat_indices, flat_values)
+            dense_tokens = dense.reshape(*token_embeddings.shape[:-1], self.hidden_dim)
+            features["token_sparse_embeddings"] = dense_tokens
+            if self.replace_token_embeddings:
+                features["token_embeddings"] = dense_tokens
+
+        return features
+
+    def save(self, output_path: str, *args, safe_serialization: bool = True, **kwargs) -> None:
+        Path(output_path).mkdir(parents=True, exist_ok=True)
+        self.save_config(output_path)
+        self.save_torch_weights(output_path, safe_serialization=safe_serialization)
+
+    @classmethod
+    def load(
+        cls,
+        model_name_or_path: str,
+        subfolder: str = "",
+        token: bool | str | None = None,
+        cache_folder: str | None = None,
+        revision: str | None = None,
+        local_files_only: bool = False,
+        **kwargs,
+    ) -> Self:
+        config = cls.load_config(
+            model_name_or_path,
+            subfolder=subfolder,
+            token=token,
+            cache_folder=cache_folder,
+            revision=revision,
+            local_files_only=local_files_only,
+        )
+        model = cls(**config)
+        state_dict = cls.load_torch_weights(
+            model_name_or_path,
+            subfolder=subfolder,
+            token=token,
+            cache_folder=cache_folder,
+            revision=revision,
+            local_files_only=local_files_only,
+        )
+        legacy_prefix = "sae."
+        if any(key.startswith(legacy_prefix) for key in state_dict):
+            state_dict = {
+                key.removeprefix(legacy_prefix) if key.startswith(legacy_prefix) else key: value
+                for key, value in state_dict.items()
+            }
+        if "data_mean" in state_dict:
+            model.data_mean = state_dict["data_mean"].detach().clone()
+        model.load_state_dict(state_dict)
+        return model
+
+    def get_embedding_dimension(self) -> int:
+        return self.hidden_dim

--- a/sentence_transformers/sparse_encoder/modules/sparse_auto_encoder_token_encoder.py
+++ b/sentence_transformers/sparse_encoder/modules/sparse_auto_encoder_token_encoder.py
@@ -180,6 +180,9 @@ class SparseAutoEncoderTokenEncoder(Module):
             x = x * self.rms_scale
         return x * (self.target_norm / x.norm(dim=-1, keepdim=True).clamp(min=1e-8))
 
+    def _normalize_for_projection(self, tokens: torch.Tensor) -> torch.Tensor:
+        return self.normalize(tokens).to(dtype=self.W_enc.dtype)
+
     def encode_pre_act(self, tokens: torch.Tensor) -> torch.Tensor:
         return _SparseAutoEncoderProjection.encode_pre_act(tokens, self.W_enc, self.b_enc, self.b_pre)
 
@@ -189,14 +192,14 @@ class SparseAutoEncoderTokenEncoder(Module):
 
         token_batch_size = self.token_batch_size
         if token_batch_size is None or token_batch_size <= 0 or tokens.shape[0] <= token_batch_size:
-            logits = self.encode_pre_act(self.normalize(tokens))
+            logits = self.encode_pre_act(self._normalize_for_projection(tokens))
             return _SparseAutoEncoderProjection.top_k_sparse(logits, k, self.variant, self.theta)
 
         values = []
         indices = []
         for start in range(0, tokens.shape[0], token_batch_size):
             chunk = tokens[start : start + token_batch_size]
-            logits = self.encode_pre_act(self.normalize(chunk))
+            logits = self.encode_pre_act(self._normalize_for_projection(chunk))
             top_values, top_indices = _SparseAutoEncoderProjection.top_k_sparse(logits, k, self.variant, self.theta)
             values.append(top_values)
             indices.append(top_indices)
@@ -213,7 +216,7 @@ class SparseAutoEncoderTokenEncoder(Module):
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
         token_batch_size = self.token_batch_size
         if token_batch_size is None or token_batch_size <= 0 or tokens.shape[0] <= token_batch_size:
-            normalized = self.normalize(tokens)
+            normalized = self._normalize_for_projection(tokens)
             logits = self.encode_pre_act(normalized)
             values, indices = _SparseAutoEncoderProjection.top_k_sparse(logits, k, self.variant, self.theta)
             latents = _SparseAutoEncoderProjection.sparse_to_dense(values, indices, self.hidden_dim)
@@ -226,7 +229,7 @@ class SparseAutoEncoderTokenEncoder(Module):
         decoded_tokens = []
         for start in range(0, tokens.shape[0], token_batch_size):
             chunk = tokens[start : start + token_batch_size]
-            normalized = self.normalize(chunk)
+            normalized = self._normalize_for_projection(chunk)
             logits = self.encode_pre_act(normalized)
             top_values, top_indices = _SparseAutoEncoderProjection.top_k_sparse(logits, k, self.variant, self.theta)
             latents = _SparseAutoEncoderProjection.sparse_to_dense(top_values, top_indices, self.hidden_dim)

--- a/sentence_transformers/sparse_encoder/modules/sparse_auto_encoder_token_encoder.py
+++ b/sentence_transformers/sparse_encoder/modules/sparse_auto_encoder_token_encoder.py
@@ -10,9 +10,9 @@ except ImportError:
 
 import torch
 import torch.nn as nn
-import torch.nn.functional as F
 
 from sentence_transformers.base.modules.module import Module
+from sentence_transformers.sparse_encoder.modules.sparse_auto_encoder_projection import _SparseAutoEncoderProjection
 
 
 def _split_flattened_sequence_bounds(features: dict[str, Any]) -> list[tuple[int, int]] | None:
@@ -75,10 +75,12 @@ class SparseAutoEncoderTokenEncoder(Module):
         "replace_token_embeddings",
         "checkpoint_format_version",
         "has_decoder",
+        "k_aux",
+        "frozen",
         "rms_scale",
         "token_batch_size",
     ]
-    config_key_renames = {"sae_width": "hidden_dim", "topk": "k"}
+    forward_kwargs = {"max_active_dims"}
 
     def __init__(
         self,
@@ -89,19 +91,17 @@ class SparseAutoEncoderTokenEncoder(Module):
         output_format: Literal["topk", "dense", "both"] = "topk",
         replace_token_embeddings: bool = False,
         checkpoint_format_version: int = 1,
-        has_decoder: bool = False,
+        has_decoder: bool = True,
+        k_aux: int = 512,
+        frozen: bool = False,
         rms_scale: float | None = None,
         token_batch_size: int | None = None,
     ) -> None:
         super().__init__()
-        if hidden_dim <= 0:
-            raise ValueError(f"hidden_dim must be a positive integer, got {hidden_dim}.")
-        if k <= 0:
-            raise ValueError(f"k must be a positive integer, got {k}.")
-        if k > hidden_dim:
-            raise ValueError(f"k must be <= hidden_dim, got k={k}, hidden_dim={hidden_dim}.")
-        if variant not in {"standard", "jumprelu"}:
-            raise ValueError("variant must be either 'standard' or 'jumprelu'.")
+        _SparseAutoEncoderProjection.validate_dimensions(input_dim, hidden_dim, k)
+        _SparseAutoEncoderProjection.validate_variant(variant)
+        if k_aux < 0:
+            raise ValueError(f"k_aux must be a non-negative integer, got {k_aux}.")
         if output_format not in {"topk", "dense", "both"}:
             raise ValueError("output_format must be one of: 'topk', 'dense', 'both'.")
 
@@ -113,15 +113,22 @@ class SparseAutoEncoderTokenEncoder(Module):
         self.replace_token_embeddings = replace_token_embeddings
         self.checkpoint_format_version = checkpoint_format_version
         self.has_decoder = has_decoder
+        self.k_aux = k_aux
+        self.frozen = frozen
         self.target_norm = input_dim**0.5
         self.rms_scale = rms_scale
         self.token_batch_size = token_batch_size
 
-        self.W_enc = nn.Parameter(torch.empty(input_dim, hidden_dim), requires_grad=False)
-        self.b_enc = nn.Parameter(torch.zeros(hidden_dim), requires_grad=False)
-        self.b_pre = nn.Parameter(torch.zeros(input_dim), requires_grad=False)
+        requires_grad = not frozen
+        self.W_enc = nn.Parameter(torch.empty(input_dim, hidden_dim), requires_grad=requires_grad)
+        self.b_enc = nn.Parameter(torch.zeros(hidden_dim), requires_grad=requires_grad)
+        self.b_pre = nn.Parameter(torch.zeros(input_dim), requires_grad=requires_grad)
+        if has_decoder:
+            self.W_dec = nn.Parameter(torch.empty(hidden_dim, input_dim), requires_grad=requires_grad)
+        else:
+            self.register_parameter("W_dec", None)
         if variant == "jumprelu":
-            self.theta = nn.Parameter(torch.empty(hidden_dim), requires_grad=False)
+            self.theta = nn.Parameter(torch.empty(hidden_dim), requires_grad=requires_grad)
         else:
             self.register_parameter("theta", None)
         self.register_buffer("data_mean", None)
@@ -131,6 +138,8 @@ class SparseAutoEncoderTokenEncoder(Module):
         nn.init.kaiming_uniform_(self.W_enc, a=5**0.5)
         self.b_enc.data.zero_()
         self.b_pre.data.zero_()
+        if self.W_dec is not None:
+            nn.init.kaiming_uniform_(self.W_dec, a=5**0.5)
         if self.theta is not None:
             self.theta.data.zero_()
 
@@ -140,15 +149,19 @@ class SparseAutoEncoderTokenEncoder(Module):
         config = checkpoint.get("config", {})
         module = cls(
             input_dim=int(config.get("input_dim", checkpoint["W_enc"].shape[0])),
-            hidden_dim=int(config.get("hidden_dim", config.get("sae_width", checkpoint["W_enc"].shape[1]))),
-            k=kwargs.pop("k", kwargs.pop("topk", int(config.get("k", config.get("topk", 16))))),
+            hidden_dim=int(config.get("hidden_dim", checkpoint["W_enc"].shape[1])),
+            k=kwargs.pop("k", int(config.get("k", 16))),
             variant=config.get("variant", "standard"),
+            has_decoder=kwargs.pop("has_decoder", bool(config.get("has_decoder", "W_dec" in checkpoint))),
+            frozen=kwargs.pop("frozen", True),
             **kwargs,
         )
         with torch.no_grad():
             module.W_enc.copy_(checkpoint["W_enc"])
             module.b_enc.copy_(checkpoint["b_enc"])
             module.b_pre.copy_(checkpoint["b_pre"])
+            if module.W_dec is not None and "W_dec" in checkpoint:
+                module.W_dec.copy_(checkpoint["W_dec"])
             if module.theta is not None and "theta" in checkpoint:
                 module.theta.copy_(checkpoint["theta"])
         if "data_mean" in checkpoint:
@@ -166,41 +179,78 @@ class SparseAutoEncoderTokenEncoder(Module):
         return x * (self.target_norm / x.norm(dim=-1, keepdim=True).clamp(min=1e-8))
 
     def encode_pre_act(self, tokens: torch.Tensor) -> torch.Tensor:
-        return (tokens - self.b_pre) @ self.W_enc + self.b_enc
+        return _SparseAutoEncoderProjection.encode_pre_act(tokens, self.W_enc, self.b_enc, self.b_pre)
 
-    @torch.no_grad()
     def encode_tokens(self, tokens: torch.Tensor, k: int | None = None) -> tuple[torch.Tensor, torch.Tensor]:
         k = k if k is not None else self.k
-        if k <= 0:
-            raise ValueError(f"k must be a positive integer, got {k}.")
-        if k > self.hidden_dim:
-            raise ValueError(f"k must be <= hidden_dim, got k={k}, hidden_dim={self.hidden_dim}.")
+        _SparseAutoEncoderProjection.validate_k(k, self.hidden_dim)
 
         token_batch_size = self.token_batch_size
         if token_batch_size is None or token_batch_size <= 0 or tokens.shape[0] <= token_batch_size:
             logits = self.encode_pre_act(self.normalize(tokens))
-            if self.variant == "jumprelu" and self.theta is not None:
-                logits = logits * (logits > self.theta).to(logits.dtype)
-            top_values, top_indices = logits.topk(k, dim=-1)
-            return F.relu(top_values), top_indices
+            return _SparseAutoEncoderProjection.top_k_sparse(logits, k, self.variant, self.theta)
 
         values = []
         indices = []
         for start in range(0, tokens.shape[0], token_batch_size):
             chunk = tokens[start : start + token_batch_size]
             logits = self.encode_pre_act(self.normalize(chunk))
-            if self.variant == "jumprelu" and self.theta is not None:
-                logits = logits * (logits > self.theta).to(logits.dtype)
-            top_values, top_indices = logits.topk(k, dim=-1)
-            values.append(F.relu(top_values))
+            top_values, top_indices = _SparseAutoEncoderProjection.top_k_sparse(logits, k, self.variant, self.theta)
+            values.append(top_values)
             indices.append(top_indices)
             del logits, top_values, top_indices
         return torch.cat(values, dim=0), torch.cat(indices, dim=0)
 
-    def forward(self, features: dict[str, torch.Tensor | Any], **kwargs) -> dict[str, torch.Tensor | Any]:
+    def decode(self, latents: torch.Tensor) -> torch.Tensor:
+        if self.W_dec is None:
+            raise ValueError("SparseAutoEncoderTokenEncoder was initialized without a decoder.")
+        return latents @ self.W_dec + self.b_pre
+
+    def _encode_training_chunks(
+        self, tokens: torch.Tensor, k: int
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        token_batch_size = self.token_batch_size
+        if token_batch_size is None or token_batch_size <= 0 or tokens.shape[0] <= token_batch_size:
+            normalized = self.normalize(tokens)
+            logits = self.encode_pre_act(normalized)
+            values, indices = _SparseAutoEncoderProjection.top_k_sparse(logits, k, self.variant, self.theta)
+            latents = _SparseAutoEncoderProjection.sparse_to_dense(values, indices, self.hidden_dim)
+            decoded = self.decode(latents)
+            return values, indices, normalized, decoded
+
+        values = []
+        indices = []
+        normalized_tokens = []
+        decoded_tokens = []
+        for start in range(0, tokens.shape[0], token_batch_size):
+            chunk = tokens[start : start + token_batch_size]
+            normalized = self.normalize(chunk)
+            logits = self.encode_pre_act(normalized)
+            top_values, top_indices = _SparseAutoEncoderProjection.top_k_sparse(logits, k, self.variant, self.theta)
+            latents = _SparseAutoEncoderProjection.sparse_to_dense(top_values, top_indices, self.hidden_dim)
+            values.append(top_values)
+            indices.append(top_indices)
+            normalized_tokens.append(normalized)
+            decoded_tokens.append(self.decode(latents))
+        return (
+            torch.cat(values, dim=0),
+            torch.cat(indices, dim=0),
+            torch.cat(normalized_tokens, dim=0),
+            torch.cat(decoded_tokens, dim=0),
+        )
+
+    def forward(
+        self, features: dict[str, torch.Tensor | Any], max_active_dims: int | None = None, **kwargs
+    ) -> dict[str, torch.Tensor | Any]:
         token_embeddings = features["token_embeddings"]
         flat_tokens, _, _ = _flatten_token_embeddings(features)
-        flat_values, flat_indices = self.encode_tokens(flat_tokens, k=self.k)
+        k = max_active_dims if max_active_dims is not None else self.k
+        if self.training and self.W_dec is not None:
+            flat_values, flat_indices, flat_backbone, flat_decoded = self._encode_training_chunks(flat_tokens, k=k)
+            features["token_embedding_backbone"] = flat_backbone
+            features["decoded_token_embeddings"] = flat_decoded
+        else:
+            flat_values, flat_indices = self.encode_tokens(flat_tokens, k=k)
         token_values, token_indices = _restore_token_topk(flat_values, flat_indices, token_embeddings)
 
         features["backbone_token_embeddings"] = token_embeddings
@@ -208,13 +258,7 @@ class SparseAutoEncoderTokenEncoder(Module):
         features["token_sparse_indices"] = token_indices
 
         if self.output_format in {"dense", "both"} or self.replace_token_embeddings:
-            dense = torch.zeros(
-                flat_values.shape[0],
-                self.hidden_dim,
-                dtype=flat_values.dtype,
-                device=flat_values.device,
-            )
-            dense.scatter_(1, flat_indices, flat_values)
+            dense = _SparseAutoEncoderProjection.sparse_to_dense(flat_values, flat_indices, self.hidden_dim)
             dense_tokens = dense.reshape(*token_embeddings.shape[:-1], self.hidden_dim)
             features["token_sparse_embeddings"] = dense_tokens
             if self.replace_token_embeddings:
@@ -255,12 +299,6 @@ class SparseAutoEncoderTokenEncoder(Module):
             revision=revision,
             local_files_only=local_files_only,
         )
-        legacy_prefix = "sae."
-        if any(key.startswith(legacy_prefix) for key in state_dict):
-            state_dict = {
-                key.removeprefix(legacy_prefix) if key.startswith(legacy_prefix) else key: value
-                for key, value in state_dict.items()
-            }
         if "data_mean" in state_dict:
             model.data_mean = state_dict["data_mean"].detach().clone()
         model.load_state_dict(state_dict)

--- a/sentence_transformers/sparse_encoder/modules/sparse_auto_encoder_token_encoder.py
+++ b/sentence_transformers/sparse_encoder/modules/sparse_auto_encoder_token_encoder.py
@@ -70,7 +70,7 @@ class SparseAutoEncoderTokenEncoder(Module):
     under ``"token_sparse_values"`` and ``"token_sparse_indices"``.
 
     In training mode, if a decoder is available, the module additionally emits
-    ``"token_embedding_backbone"`` and ``"decoded_token_embeddings"``. These tensors can be
+    ``"sae_input_normalized"`` and ``"sae_output_decoded"``. These tensors can be
     used by a loss function to train the sparse autoencoder. In evaluation mode, or when no
     decoder is available, only the sparse token activations are produced.
 
@@ -282,8 +282,8 @@ class SparseAutoEncoderTokenEncoder(Module):
         k = max_active_dims if max_active_dims is not None else self.k
         if self.training and self.W_dec is not None:
             flat_values, flat_indices, flat_backbone, flat_decoded = self._encode_training_chunks(flat_tokens, k=k)
-            features["token_embedding_backbone"] = flat_backbone
-            features["decoded_token_embeddings"] = flat_decoded
+            features["sae_input_normalized"] = flat_backbone
+            features["sae_output_decoded"] = flat_decoded
         else:
             flat_values, flat_indices = self.encode_tokens(flat_tokens, k=k)
         token_values, token_indices = _restore_token_topk(flat_values, flat_indices, token_embeddings)

--- a/sentence_transformers/sparse_encoder/modules/sparse_token_pooling.py
+++ b/sentence_transformers/sparse_encoder/modules/sparse_token_pooling.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Literal
+
+import torch
+
+from sentence_transformers.base.modules.module import Module
+
+
+def _split_flattened_sequence_bounds(features: dict[str, Any]) -> list[tuple[int, int]] | None:
+    if "cu_seq_lens_q" not in features:
+        return None
+    cu_seq_lens_q = features["cu_seq_lens_q"].detach().cpu().tolist()
+    return [(int(start), int(end)) for start, end in zip(cu_seq_lens_q, cu_seq_lens_q[1:])]
+
+
+class SparseTokenPooling(Module):
+    """Pool sparse per-token activations into one sparse feature vector per input."""
+
+    config_keys = ["embedding_dimension", "pooling_strategy", "include_prompt", "values_key", "indices_key"]
+    config_key_renames = {"sae_width": "embedding_dimension", "pooling": "pooling_strategy"}
+    POOLING_STRATEGIES = ("sum", "max", "max_log1p")
+
+    def __init__(
+        self,
+        embedding_dimension: int,
+        pooling_strategy: Literal["sum", "max", "max_log1p"] = "sum",
+        include_prompt: bool = True,
+        values_key: str = "token_sparse_values",
+        indices_key: str = "token_sparse_indices",
+    ) -> None:
+        super().__init__()
+        if pooling_strategy not in self.POOLING_STRATEGIES:
+            raise ValueError("pooling_strategy must be one of: 'sum', 'max', 'max_log1p'.")
+        self.embedding_dimension = embedding_dimension
+        self.pooling_strategy = pooling_strategy
+        self.include_prompt = include_prompt
+        self.values_key = values_key
+        self.indices_key = indices_key
+
+    @staticmethod
+    def _prompt_length(features: dict[str, torch.Tensor | Any]) -> int | None:
+        if "prompt_length" not in features:
+            return None
+        prompt_length = features["prompt_length"]
+        if isinstance(prompt_length, torch.Tensor):
+            return int(prompt_length.flatten()[0].item())
+        return int(prompt_length)
+
+    def _pool_one(
+        self,
+        values: torch.Tensor,
+        indices: torch.Tensor,
+        active: torch.Tensor | None = None,
+        prompt_length: int | None = None,
+    ) -> torch.Tensor:
+        if prompt_length is not None and prompt_length > 0:
+            values = values[prompt_length:]
+            indices = indices[prompt_length:]
+            if active is not None:
+                active = active[prompt_length:]
+
+        flat_values = values.reshape(-1)
+        flat_indices = indices.reshape(-1)
+        keep = flat_values > 0
+        if active is not None:
+            keep = keep & active.reshape(-1, 1).expand_as(values).reshape(-1).to(torch.bool)
+
+        pooled = torch.zeros(self.embedding_dimension, dtype=flat_values.dtype, device=flat_values.device)
+        if not keep.any():
+            return pooled
+        if self.pooling_strategy == "max_log1p":
+            pooled.scatter_reduce_(
+                0,
+                flat_indices[keep],
+                torch.log1p(flat_values[keep]),
+                reduce="amax",
+                include_self=False,
+            )
+        elif self.pooling_strategy == "max":
+            pooled.scatter_reduce_(0, flat_indices[keep], flat_values[keep], reduce="amax", include_self=False)
+        else:
+            pooled.scatter_add_(0, flat_indices[keep], flat_values[keep])
+        return pooled
+
+    def forward(self, features: dict[str, torch.Tensor | Any], **kwargs) -> dict[str, torch.Tensor | Any]:
+        token_values = features[self.values_key]
+        token_indices = features[self.indices_key]
+        bounds = _split_flattened_sequence_bounds(features)
+        prompt_length = None if self.include_prompt else self._prompt_length(features)
+
+        pooled_rows: list[torch.Tensor] = []
+        if bounds is not None:
+            values = token_values.squeeze(0) if token_values.ndim == 3 and token_values.shape[0] == 1 else token_values
+            indices = (
+                token_indices.squeeze(0) if token_indices.ndim == 3 and token_indices.shape[0] == 1 else token_indices
+            )
+            for start, end in bounds:
+                pooled_rows.append(self._pool_one(values[start:end], indices[start:end], prompt_length=prompt_length))
+        else:
+            if token_values.ndim != 3:
+                raise ValueError(
+                    f"Expected padded sparse token values to be [B, T, K]; got {tuple(token_values.shape)}"
+                )
+            mask = features.get("attention_mask")
+            for row in range(token_values.shape[0]):
+                active = mask[row] if mask is not None and mask.shape == token_values.shape[:2] else None
+                pooled_rows.append(
+                    self._pool_one(
+                        token_values[row],
+                        token_indices[row],
+                        active=active,
+                        prompt_length=prompt_length,
+                    )
+                )
+
+        features["sentence_embedding"] = torch.stack(pooled_rows, dim=0)
+        return features
+
+    def save(self, output_path: str, *args, safe_serialization: bool = True, **kwargs) -> None:
+        Path(output_path).mkdir(parents=True, exist_ok=True)
+        self.save_config(output_path)
+
+    def get_embedding_dimension(self) -> int:
+        return self.embedding_dimension

--- a/sentence_transformers/sparse_encoder/modules/sparse_token_pooling.py
+++ b/sentence_transformers/sparse_encoder/modules/sparse_token_pooling.py
@@ -19,7 +19,6 @@ class SparseTokenPooling(Module):
     """Pool sparse per-token activations into one sparse feature vector per input."""
 
     config_keys = ["embedding_dimension", "pooling_strategy", "include_prompt", "values_key", "indices_key"]
-    config_key_renames = {"sae_width": "embedding_dimension", "pooling": "pooling_strategy"}
     POOLING_STRATEGIES = ("sum", "max", "max_log1p")
 
     def __init__(
@@ -47,6 +46,17 @@ class SparseTokenPooling(Module):
         if isinstance(prompt_length, torch.Tensor):
             return int(prompt_length.flatten()[0].item())
         return int(prompt_length)
+
+    @staticmethod
+    def _exclude_prompt_from_mask(attention_mask: torch.Tensor, prompt_length: int) -> torch.Tensor:
+        attention_mask = attention_mask.clone()
+        pad_lengths = attention_mask.to(torch.int32).argmax(dim=1)
+        if pad_lengths.sum() == 0:
+            attention_mask[:, :prompt_length] = 0
+        else:
+            positions = torch.arange(attention_mask.size(1), device=attention_mask.device).unsqueeze(0)
+            attention_mask[positions < (pad_lengths + prompt_length).unsqueeze(1)] = 0
+        return attention_mask
 
     def _pool_one(
         self,
@@ -104,14 +114,18 @@ class SparseTokenPooling(Module):
                     f"Expected padded sparse token values to be [B, T, K]; got {tuple(token_values.shape)}"
                 )
             mask = features.get("attention_mask")
+            if mask is not None and mask.shape != token_values.shape[:2]:
+                mask = None
+            if mask is None:
+                mask = torch.ones(token_values.shape[:2], dtype=torch.bool, device=token_values.device)
+            if prompt_length is not None and prompt_length > 0:
+                mask = self._exclude_prompt_from_mask(mask, prompt_length)
             for row in range(token_values.shape[0]):
-                active = mask[row] if mask is not None and mask.shape == token_values.shape[:2] else None
                 pooled_rows.append(
                     self._pool_one(
                         token_values[row],
                         token_indices[row],
-                        active=active,
-                        prompt_length=prompt_length,
+                        active=mask[row],
                     )
                 )
 

--- a/sentence_transformers/sparse_encoder/modules/sparse_token_pooling.py
+++ b/sentence_transformers/sparse_encoder/modules/sparse_token_pooling.py
@@ -16,7 +16,30 @@ def _split_flattened_sequence_bounds(features: dict[str, Any]) -> list[tuple[int
 
 
 class SparseTokenPooling(Module):
-    """Pool sparse per-token activations into one sparse feature vector per input."""
+    """Pools sparse per-token activations into sparse sentence embeddings.
+
+    This module consumes sparse token activations represented by values and feature indices,
+    such as the outputs of
+    :class:`~sentence_transformers.sparse_encoder.modules.SparseAutoEncoderTokenEncoder`.
+    It pools all active token features into one vector per input and stores the result in
+    ``"sentence_embedding"``.
+
+    The input activations may be padded (``[batch_size, seq_length, k]``) or packed with
+    ``"cu_seq_lens_q"`` in the features dictionary. If an ``"attention_mask"`` is present, padded
+    tokens are excluded from pooling. If ``include_prompt`` is ``False`` and ``"prompt_length"`` is
+    present, prompt tokens are excluded in the same style as
+    :class:`sentence_transformers.sentence_transformer.modules.Pooling`.
+
+    Args:
+        embedding_dimension: Dimension of the output sparse sentence embeddings.
+        pooling_strategy: Pooling strategy over token activations. ``"sum"`` adds all active
+            token features, ``"max"`` keeps the largest activation per feature, and
+            ``"max_log1p"`` keeps the largest ``log1p`` activation per feature.
+        include_prompt: If ``False``, prompt tokens are excluded from pooling when
+            ``"prompt_length"`` is present in the features dictionary.
+        values_key: Key in the features dictionary containing sparse token values.
+        indices_key: Key in the features dictionary containing sparse token feature indices.
+    """
 
     config_keys = ["embedding_dimension", "pooling_strategy", "include_prompt", "values_key", "indices_key"]
     POOLING_STRATEGIES = ("sum", "max", "max_log1p")

--- a/sentence_transformers/util/deprecated_import.py
+++ b/sentence_transformers/util/deprecated_import.py
@@ -102,7 +102,9 @@ DEPRECATED_MODULE_PATHS = {
     "sentence_transformers.sparse_encoder.models": "sentence_transformers.sparse_encoder.modules",
     "sentence_transformers.sparse_encoder.models.MLMTransformer": "sentence_transformers.sparse_encoder.modules.mlm_transformer",
     "sentence_transformers.sparse_encoder.models.SparseAutoEncoder": "sentence_transformers.sparse_encoder.modules.sparse_auto_encoder",
+    "sentence_transformers.sparse_encoder.models.SparseAutoEncoderTokenEncoder": "sentence_transformers.sparse_encoder.modules.sparse_auto_encoder_token_encoder",
     "sentence_transformers.sparse_encoder.models.SparseStaticEmbedding": "sentence_transformers.sparse_encoder.modules.sparse_static_embedding",
+    "sentence_transformers.sparse_encoder.models.SparseTokenPooling": "sentence_transformers.sparse_encoder.modules.sparse_token_pooling",
     "sentence_transformers.sparse_encoder.models.SpladePooling": "sentence_transformers.sparse_encoder.modules.splade_pooling",
     # Renamed in Sentence Transformers v5.4.0 (approximately TitleCase -> snake_case)
     "sentence_transformers.cross_encoder.losses.BinaryCrossEntropyLoss": "sentence_transformers.cross_encoder.losses.binary_cross_entropy",

--- a/tests/sparse_encoder/modules/test_sparse_auto_encoder_token_encoder.py
+++ b/tests/sparse_encoder/modules/test_sparse_auto_encoder_token_encoder.py
@@ -291,6 +291,25 @@ def test_sparse_auto_encoder_token_encoder_training_outputs_and_gradients() -> N
         assert encoder.b_pre.grad is not None
 
 
+def test_sparse_auto_encoder_token_encoder_training_supports_bfloat16() -> None:
+    encoder = _make_token_encoder().to(torch.bfloat16)
+    encoder.train()
+    hidden = torch.randn(8, 4, requires_grad=True)
+
+    out = encoder({"token_embeddings": hidden})
+
+    assert out["token_embedding_backbone"].dtype == torch.bfloat16
+    assert out["decoded_token_embeddings"].dtype == torch.bfloat16
+    loss = torch.nn.functional.mse_loss(
+        out["decoded_token_embeddings"].float(), out["token_embedding_backbone"].float()
+    )
+    loss.backward()
+
+    assert encoder.W_enc.grad is not None
+    assert encoder.W_dec is not None
+    assert encoder.W_dec.grad is not None
+
+
 def test_sparse_auto_encoder_token_encoder_from_checkpoint_is_frozen_by_default(tmp_path) -> None:
     module = _make_token_encoder()
     module.save(str(tmp_path))

--- a/tests/sparse_encoder/modules/test_sparse_auto_encoder_token_encoder.py
+++ b/tests/sparse_encoder/modules/test_sparse_auto_encoder_token_encoder.py
@@ -80,7 +80,7 @@ def _run_modules(
     pooler = SparseTokenPooling(
         embedding_dimension=encoder.hidden_dim, pooling_strategy=pooling_strategy, include_prompt=include_prompt
     )
-    out = encoder(_clone_features(features))
+    out = encoder(features)
     out = pooler(out)
     return out["sentence_embedding"]
 
@@ -141,6 +141,36 @@ def test_sparse_auto_encoder_token_pooling_matches_dense_contract_padded_without
             _pool_expected(encoder, hidden[1], pooling_strategy="sum", token_mask=mask[1], prompt_length=1),
         ]
     ).to(actual.dtype)
+    torch.testing.assert_close(actual, expected)
+
+
+def test_sparse_token_pooling_excludes_prompt_after_left_padding() -> None:
+    token_values = torch.tensor(
+        [
+            [[1.0], [2.0], [3.0], [4.0], [5.0]],
+            [[6.0], [7.0], [8.0], [9.0], [10.0]],
+        ]
+    )
+    token_indices = torch.tensor(
+        [
+            [[0], [1], [2], [3], [4]],
+            [[0], [1], [2], [3], [4]],
+        ]
+    )
+    features = {
+        "token_sparse_values": token_values,
+        "token_sparse_indices": token_indices,
+        "attention_mask": torch.tensor([[0, 0, 1, 1, 1], [0, 1, 1, 1, 1]]),
+        "prompt_length": 1,
+    }
+
+    actual = SparseTokenPooling(embedding_dimension=5, include_prompt=False)(features)["sentence_embedding"]
+    expected = torch.tensor(
+        [
+            [0.0, 0.0, 0.0, 4.0, 5.0],
+            [0.0, 0.0, 8.0, 9.0, 10.0],
+        ]
+    )
     torch.testing.assert_close(actual, expected)
 
 
@@ -211,6 +241,78 @@ def test_sparse_auto_encoder_token_pooling_matches_dense_contract_flattened_with
         ]
     ).to(actual.dtype)
     torch.testing.assert_close(actual, expected)
+
+
+def test_sparse_auto_encoder_token_encoder_respects_max_active_dims() -> None:
+    encoder = _make_token_encoder()
+    hidden = torch.randn(2, 4, 4)
+    features = {
+        "token_embeddings": hidden.clone(),
+        "attention_mask": torch.ones(2, 4, dtype=torch.long),
+    }
+
+    out = encoder(_clone_features(features), max_active_dims=1)
+    assert out["token_sparse_values"].shape == (2, 4, 1)
+    assert out["token_sparse_indices"].shape == (2, 4, 1)
+
+
+def test_sparse_auto_encoder_token_encoder_training_outputs_and_gradients() -> None:
+    encoder = _make_token_encoder()
+    encoder.train()
+    hidden = torch.randn(2, 4, 4, requires_grad=True)
+    features = {
+        "token_embeddings": hidden,
+        "attention_mask": torch.ones(2, 4, dtype=torch.long),
+    }
+
+    out = encoder(features)
+    assert out["token_embedding_backbone"].shape == (8, 4)
+    assert out["decoded_token_embeddings"].shape == (8, 4)
+    assert "token_reconstruction_loss" not in out
+
+    loss = torch.nn.functional.mse_loss(out["decoded_token_embeddings"], out["token_embedding_backbone"])
+    loss = loss + out["token_sparse_values"].sum()
+    loss.backward()
+
+    assert hidden.grad is not None
+    assert encoder.W_enc.grad is not None
+    assert encoder.W_dec is not None
+    assert encoder.W_dec.grad is not None
+    assert encoder.b_enc.grad is not None
+    assert encoder.b_pre.grad is not None
+
+
+def test_sparse_auto_encoder_token_encoder_from_checkpoint_is_frozen_by_default(tmp_path) -> None:
+    module = _make_token_encoder()
+    module.save(str(tmp_path))
+    checkpoint_path = tmp_path / "sae.pt"
+    torch.save(
+        {
+            "W_enc": module.W_enc.detach(),
+            "b_enc": module.b_enc.detach(),
+            "b_pre": module.b_pre.detach(),
+            "W_dec": module.W_dec.detach(),
+            "config": {
+                "input_dim": module.input_dim,
+                "hidden_dim": module.hidden_dim,
+                "k": module.k,
+                "has_decoder": True,
+            },
+        },
+        checkpoint_path,
+    )
+
+    frozen = SparseAutoEncoderTokenEncoder.from_checkpoint(checkpoint_path)
+    assert not frozen.W_enc.requires_grad
+    assert not frozen.b_enc.requires_grad
+    assert not frozen.b_pre.requires_grad
+    assert frozen.W_dec is not None
+    assert not frozen.W_dec.requires_grad
+
+    trainable = SparseAutoEncoderTokenEncoder.from_checkpoint(checkpoint_path, frozen=False)
+    assert trainable.W_enc.requires_grad
+    assert trainable.W_dec is not None
+    assert trainable.W_dec.requires_grad
 
 
 def test_sparse_auto_encoder_token_batching_matches_unchunked_padded_and_flattened() -> None:

--- a/tests/sparse_encoder/modules/test_sparse_auto_encoder_token_encoder.py
+++ b/tests/sparse_encoder/modules/test_sparse_auto_encoder_token_encoder.py
@@ -259,27 +259,36 @@ def test_sparse_auto_encoder_token_encoder_respects_max_active_dims() -> None:
 def test_sparse_auto_encoder_token_encoder_training_outputs_and_gradients() -> None:
     encoder = _make_token_encoder()
     encoder.train()
-    hidden = torch.randn(2, 4, 4, requires_grad=True)
-    features = {
-        "token_embeddings": hidden,
-        "attention_mask": torch.ones(2, 4, dtype=torch.long),
-    }
+    for hidden, features in [
+        (
+            torch.randn(2, 4, 4, requires_grad=True),
+            {
+                "token_embeddings": torch.randn(2, 4, 4, requires_grad=True),
+                "attention_mask": torch.ones(2, 4, dtype=torch.long),
+            },
+        ),
+        (
+            torch.randn(8, 4, requires_grad=True),
+            {"token_embeddings": torch.randn(8, 4, requires_grad=True)},
+        ),
+    ]:
+        features["token_embeddings"] = hidden
+        out = encoder(features)
+        assert out["token_embedding_backbone"].shape == (8, 4)
+        assert out["decoded_token_embeddings"].shape == (8, 4)
+        assert "token_reconstruction_loss" not in out
 
-    out = encoder(features)
-    assert out["token_embedding_backbone"].shape == (8, 4)
-    assert out["decoded_token_embeddings"].shape == (8, 4)
-    assert "token_reconstruction_loss" not in out
+        loss = torch.nn.functional.mse_loss(out["decoded_token_embeddings"], out["token_embedding_backbone"])
+        loss = loss + out["token_sparse_values"].sum()
+        encoder.zero_grad()
+        loss.backward()
 
-    loss = torch.nn.functional.mse_loss(out["decoded_token_embeddings"], out["token_embedding_backbone"])
-    loss = loss + out["token_sparse_values"].sum()
-    loss.backward()
-
-    assert hidden.grad is not None
-    assert encoder.W_enc.grad is not None
-    assert encoder.W_dec is not None
-    assert encoder.W_dec.grad is not None
-    assert encoder.b_enc.grad is not None
-    assert encoder.b_pre.grad is not None
+        assert hidden.grad is not None
+        assert encoder.W_enc.grad is not None
+        assert encoder.W_dec is not None
+        assert encoder.W_dec.grad is not None
+        assert encoder.b_enc.grad is not None
+        assert encoder.b_pre.grad is not None
 
 
 def test_sparse_auto_encoder_token_encoder_from_checkpoint_is_frozen_by_default(tmp_path) -> None:

--- a/tests/sparse_encoder/modules/test_sparse_auto_encoder_token_encoder.py
+++ b/tests/sparse_encoder/modules/test_sparse_auto_encoder_token_encoder.py
@@ -274,11 +274,11 @@ def test_sparse_auto_encoder_token_encoder_training_outputs_and_gradients() -> N
     ]:
         features["token_embeddings"] = hidden
         out = encoder(features)
-        assert out["token_embedding_backbone"].shape == (8, 4)
-        assert out["decoded_token_embeddings"].shape == (8, 4)
+        assert out["sae_input_normalized"].shape == (8, 4)
+        assert out["sae_output_decoded"].shape == (8, 4)
         assert "token_reconstruction_loss" not in out
 
-        loss = torch.nn.functional.mse_loss(out["decoded_token_embeddings"], out["token_embedding_backbone"])
+        loss = torch.nn.functional.mse_loss(out["sae_output_decoded"], out["sae_input_normalized"])
         loss = loss + out["token_sparse_values"].sum()
         encoder.zero_grad()
         loss.backward()
@@ -298,11 +298,9 @@ def test_sparse_auto_encoder_token_encoder_training_supports_bfloat16() -> None:
 
     out = encoder({"token_embeddings": hidden})
 
-    assert out["token_embedding_backbone"].dtype == torch.bfloat16
-    assert out["decoded_token_embeddings"].dtype == torch.bfloat16
-    loss = torch.nn.functional.mse_loss(
-        out["decoded_token_embeddings"].float(), out["token_embedding_backbone"].float()
-    )
+    assert out["sae_input_normalized"].dtype == torch.bfloat16
+    assert out["sae_output_decoded"].dtype == torch.bfloat16
+    loss = torch.nn.functional.mse_loss(out["sae_output_decoded"].float(), out["sae_input_normalized"].float())
     loss.backward()
 
     assert encoder.W_enc.grad is not None

--- a/tests/sparse_encoder/modules/test_sparse_auto_encoder_token_encoder.py
+++ b/tests/sparse_encoder/modules/test_sparse_auto_encoder_token_encoder.py
@@ -1,0 +1,265 @@
+from __future__ import annotations
+
+import torch
+
+from sentence_transformers.sentence_transformer.modules import Pooling
+from sentence_transformers.sparse_encoder.modules import SparseAutoEncoderTokenEncoder, SparseTokenPooling
+
+
+def _make_token_encoder() -> SparseAutoEncoderTokenEncoder:
+    torch.manual_seed(0)
+    encoder = SparseAutoEncoderTokenEncoder(input_dim=4, hidden_dim=8, k=2)
+    with torch.no_grad():
+        encoder.W_enc.normal_()
+        encoder.b_enc.normal_()
+        encoder.b_pre.normal_()
+        encoder.data_mean = torch.randn(4)
+    return encoder
+
+
+def _copy_encoder(
+    encoder: SparseAutoEncoderTokenEncoder, *, token_batch_size: int | None = None
+) -> SparseAutoEncoderTokenEncoder:
+    copied = SparseAutoEncoderTokenEncoder(
+        input_dim=encoder.input_dim,
+        hidden_dim=encoder.hidden_dim,
+        k=encoder.k,
+        variant=encoder.variant,
+        token_batch_size=token_batch_size,
+    )
+    if encoder.data_mean is not None:
+        copied.data_mean = encoder.data_mean.detach().clone()
+    copied.load_state_dict(encoder.state_dict())
+    copied.rms_scale = encoder.rms_scale
+    return copied
+
+
+def _clone_features(features):
+    return {key: value.clone() if torch.is_tensor(value) else value for key, value in features.items()}
+
+
+def _dense_pool_rows(features) -> int:
+    pooler = Pooling(4, pooling_mode="mean")
+    out = pooler(_clone_features(features))
+    return out["sentence_embedding"].shape[0]
+
+
+def _pool_expected(
+    encoder: SparseAutoEncoderTokenEncoder,
+    hidden: torch.Tensor,
+    pooling_strategy: str,
+    token_mask: torch.Tensor | None = None,
+    prompt_length: int = 0,
+) -> torch.Tensor:
+    if prompt_length:
+        hidden = hidden[prompt_length:]
+        if token_mask is not None:
+            token_mask = token_mask[prompt_length:]
+    values, indices = encoder.encode_tokens(hidden)
+    flat_values = values.reshape(-1)
+    flat_indices = indices.reshape(-1)
+    active = flat_values > 0
+    if token_mask is not None:
+        token_active = token_mask.reshape(-1, 1).expand_as(values).reshape(-1).to(torch.bool)
+        active = active & token_active
+    pooled = torch.zeros(encoder.hidden_dim, dtype=flat_values.dtype, device=flat_values.device)
+    if not active.any():
+        return pooled
+    if pooling_strategy == "max_log1p":
+        pooled.scatter_reduce_(0, flat_indices[active], torch.log1p(flat_values[active]), reduce="amax")
+    elif pooling_strategy == "max":
+        pooled.scatter_reduce_(0, flat_indices[active], flat_values[active], reduce="amax")
+    else:
+        pooled.scatter_add_(0, flat_indices[active], flat_values[active])
+    return pooled
+
+
+def _run_modules(
+    features, encoder: SparseAutoEncoderTokenEncoder, pooling_strategy: str, include_prompt: bool = True
+) -> torch.Tensor:
+    pooler = SparseTokenPooling(
+        embedding_dimension=encoder.hidden_dim, pooling_strategy=pooling_strategy, include_prompt=include_prompt
+    )
+    out = encoder(_clone_features(features))
+    out = pooler(out)
+    return out["sentence_embedding"]
+
+
+def test_sparse_auto_encoder_token_pooling_matches_direct_pooling_padded() -> None:
+    encoder = _make_token_encoder()
+    hidden = torch.randn(2, 4, 4)
+    mask = torch.tensor([[1, 1, 1, 0], [1, 1, 0, 0]])
+    features = {
+        "token_embeddings": hidden.clone(),
+        "attention_mask": mask,
+    }
+    assert _dense_pool_rows(features) == 2
+
+    for pooling_strategy in ("sum", "max", "max_log1p"):
+        actual = _run_modules(features.copy(), encoder, pooling_strategy)
+        expected = torch.stack(
+            [
+                _pool_expected(encoder, hidden[0], pooling_strategy=pooling_strategy, token_mask=mask[0]),
+                _pool_expected(encoder, hidden[1], pooling_strategy=pooling_strategy, token_mask=mask[1]),
+            ]
+        ).to(actual.dtype)
+        torch.testing.assert_close(actual, expected)
+
+
+def test_sparse_auto_encoder_token_pooling_matches_dense_contract_padded_without_attention_mask() -> None:
+    encoder = _make_token_encoder()
+    hidden = torch.randn(2, 4, 4)
+    features = {"token_embeddings": hidden.clone()}
+    assert _dense_pool_rows(features) == 2
+
+    actual = _run_modules(features, encoder, "sum")
+    expected = torch.stack(
+        [
+            _pool_expected(encoder, hidden[0], pooling_strategy="sum"),
+            _pool_expected(encoder, hidden[1], pooling_strategy="sum"),
+        ]
+    ).to(actual.dtype)
+    torch.testing.assert_close(actual, expected)
+
+
+def test_sparse_auto_encoder_token_pooling_matches_dense_contract_padded_without_prompt() -> None:
+    encoder = _make_token_encoder()
+    hidden = torch.randn(2, 5, 4)
+    mask = torch.tensor([[1, 1, 1, 1, 0], [1, 1, 1, 0, 0]])
+    features = {
+        "token_embeddings": hidden.clone(),
+        "attention_mask": mask,
+        "prompt_length": 1,
+    }
+    dense_pooler = Pooling(4, pooling_mode="mean", include_prompt=False)
+    assert dense_pooler(_clone_features(features))["sentence_embedding"].shape[0] == 2
+
+    actual = _run_modules(features, encoder, "sum", include_prompt=False)
+    expected = torch.stack(
+        [
+            _pool_expected(encoder, hidden[0], pooling_strategy="sum", token_mask=mask[0], prompt_length=1),
+            _pool_expected(encoder, hidden[1], pooling_strategy="sum", token_mask=mask[1], prompt_length=1),
+        ]
+    ).to(actual.dtype)
+    torch.testing.assert_close(actual, expected)
+
+
+def test_sparse_auto_encoder_token_pooling_matches_direct_pooling_flattened_rank3() -> None:
+    encoder = _make_token_encoder()
+    doc_a = torch.randn(3, 4)
+    doc_b = torch.randn(2, 4)
+    packed = torch.cat([doc_a, doc_b], dim=0).unsqueeze(0)
+    features = {
+        "token_embeddings": packed,
+        "cu_seq_lens_q": torch.tensor([0, 3, 5], dtype=torch.int32),
+        "seq_idx": torch.tensor([[0, 0, 0, 1, 1]], dtype=torch.int32),
+    }
+    assert _dense_pool_rows(features) == 2
+
+    for pooling_strategy in ("sum", "max", "max_log1p"):
+        actual = _run_modules(features, encoder, pooling_strategy)
+        expected = torch.stack(
+            [
+                _pool_expected(encoder, doc_a, pooling_strategy=pooling_strategy),
+                _pool_expected(encoder, doc_b, pooling_strategy=pooling_strategy),
+            ]
+        ).to(actual.dtype)
+        torch.testing.assert_close(actual, expected)
+
+
+def test_sparse_auto_encoder_token_pooling_matches_dense_contract_flattened_rank2() -> None:
+    encoder = _make_token_encoder()
+    doc_a = torch.randn(3, 4)
+    doc_b = torch.randn(2, 4)
+    packed = torch.cat([doc_a, doc_b], dim=0)
+    features = {
+        "token_embeddings": packed,
+        "cu_seq_lens_q": torch.tensor([0, 3, 5], dtype=torch.int32),
+        "seq_idx": torch.tensor([0, 0, 0, 1, 1], dtype=torch.int32),
+    }
+    assert _dense_pool_rows(features) == 2
+
+    actual = _run_modules(features, encoder, "sum")
+    expected = torch.stack(
+        [
+            _pool_expected(encoder, doc_a, pooling_strategy="sum"),
+            _pool_expected(encoder, doc_b, pooling_strategy="sum"),
+        ]
+    ).to(actual.dtype)
+    torch.testing.assert_close(actual, expected)
+
+
+def test_sparse_auto_encoder_token_pooling_matches_dense_contract_flattened_without_prompt() -> None:
+    encoder = _make_token_encoder()
+    doc_a = torch.randn(4, 4)
+    doc_b = torch.randn(3, 4)
+    packed = torch.cat([doc_a, doc_b], dim=0).unsqueeze(0)
+    features = {
+        "token_embeddings": packed,
+        "cu_seq_lens_q": torch.tensor([0, 4, 7], dtype=torch.int32),
+        "seq_idx": torch.tensor([[0, 0, 0, 0, 1, 1, 1]], dtype=torch.int32),
+        "prompt_length": 1,
+    }
+    dense_pooler = Pooling(4, pooling_mode="mean", include_prompt=False)
+    assert dense_pooler(_clone_features(features))["sentence_embedding"].shape[0] == 2
+
+    actual = _run_modules(features, encoder, "sum", include_prompt=False)
+    expected = torch.stack(
+        [
+            _pool_expected(encoder, doc_a, pooling_strategy="sum", prompt_length=1),
+            _pool_expected(encoder, doc_b, pooling_strategy="sum", prompt_length=1),
+        ]
+    ).to(actual.dtype)
+    torch.testing.assert_close(actual, expected)
+
+
+def test_sparse_auto_encoder_token_batching_matches_unchunked_padded_and_flattened() -> None:
+    encoder = _make_token_encoder()
+    chunked = _copy_encoder(encoder, token_batch_size=2)
+    hidden = torch.randn(2, 5, 4)
+    mask = torch.tensor([[1, 1, 1, 1, 0], [1, 1, 1, 0, 0]])
+    padded = {
+        "token_embeddings": hidden.clone(),
+        "attention_mask": mask,
+    }
+
+    actual = chunked(_clone_features(padded))
+    expected = encoder(_clone_features(padded))
+    torch.testing.assert_close(actual["token_sparse_values"], expected["token_sparse_values"])
+    torch.testing.assert_close(actual["token_sparse_indices"], expected["token_sparse_indices"])
+    torch.testing.assert_close(
+        SparseTokenPooling(chunked.hidden_dim)(actual)["sentence_embedding"],
+        SparseTokenPooling(encoder.hidden_dim)(expected)["sentence_embedding"],
+    )
+
+    doc_a = torch.randn(4, 4)
+    doc_b = torch.randn(3, 4)
+    flattened = {
+        "token_embeddings": torch.cat([doc_a, doc_b], dim=0).unsqueeze(0),
+        "cu_seq_lens_q": torch.tensor([0, 4, 7], dtype=torch.int32),
+        "seq_idx": torch.tensor([[0, 0, 0, 0, 1, 1, 1]], dtype=torch.int32),
+    }
+    actual = chunked(_clone_features(flattened))
+    expected = encoder(_clone_features(flattened))
+    torch.testing.assert_close(actual["token_sparse_values"], expected["token_sparse_values"])
+    torch.testing.assert_close(actual["token_sparse_indices"], expected["token_sparse_indices"])
+    torch.testing.assert_close(
+        SparseTokenPooling(chunked.hidden_dim)(actual)["sentence_embedding"],
+        SparseTokenPooling(encoder.hidden_dim)(expected)["sentence_embedding"],
+    )
+
+
+def test_sparse_auto_encoder_token_encoder_save_load_roundtrip(tmp_path) -> None:
+    module = _make_token_encoder()
+    module.save(str(tmp_path))
+
+    loaded = SparseAutoEncoderTokenEncoder.load(str(tmp_path))
+    hidden = torch.randn(1, 3, 4)
+    features = {
+        "token_embeddings": hidden,
+        "attention_mask": torch.ones(1, 3, dtype=torch.long),
+    }
+    actual = loaded(features.copy())
+    expected = module(features.copy())
+    torch.testing.assert_close(actual["token_sparse_values"], expected["token_sparse_values"])
+    torch.testing.assert_close(actual["token_sparse_indices"], expected["token_sparse_indices"])

--- a/tests/sparse_encoder/test_model.py
+++ b/tests/sparse_encoder/test_model.py
@@ -13,7 +13,13 @@ import torch
 
 from sentence_transformers.sentence_transformer.modules import Pooling
 from sentence_transformers.sparse_encoder.model import SparseEncoder
-from sentence_transformers.sparse_encoder.modules import Router, SparseAutoEncoder, SpladePooling, Transformer
+from sentence_transformers.sparse_encoder.modules import (
+    Router,
+    SparseAutoEncoder,
+    SparseTokenPooling,
+    SpladePooling,
+    Transformer,
+)
 from sentence_transformers.util.similarity import SimilarityFunction
 
 
@@ -70,6 +76,15 @@ def test_decode_token_types(splade_bert_tiny_model: SparseEncoder, text: str, ex
     for token, weight in decoded:
         assert isinstance(token, expected_token_types)
         assert isinstance(weight, float)
+
+
+def test_set_pooling_include_prompt_updates_sparse_token_pooling() -> None:
+    pooler = SparseTokenPooling(embedding_dimension=8)
+    model = SparseEncoder(modules=[pooler])
+
+    model.set_pooling_include_prompt(False)
+
+    assert pooler.include_prompt is False
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

This PR adds token-level sparse autoencoder support for `SparseEncoder` models.
It implements the method described in [Latent Terms: Dense Retrievers Contain Trivially Extractable BM25-ready Zipfian Vocabularies](https://arxiv.org/abs/2605.29384)

It introduces:

- `SparseAutoEncoderTokenEncoder`, which projects token embeddings into sparse _per-token_ SAE activations
- `SparseTokenPooling`, which pools sparse token activations into `sentence_embedding`
- shared stateless SAE projection helpers used by both sentence-level `SparseAutoEncoder` and the token-level encoder
- `SparseEncoder` integration for `max_active_dims` and `set_pooling_include_prompt`
- model card tagging for token SAE models
- package reference docs for the new modules

The token encoder supports padded, flattened, and packed token inputs. In training mode, when a decoder is available, it emits:

- `sae_input_normalized`
- `sae_output_decoded`

so external losses can train the SAE without baking loss logic into the module.

## Motivation

`SparseAutoEncoder` currently operates on sentence embeddings. This PR adds the corresponding token-level path:

```text
token_embeddings
-> SparseAutoEncoderTokenEncoder
-> token_sparse_values / token_sparse_indices
-> SparseTokenPooling
-> sentence_embedding
```

This makes token-level SAE projection compatible with the existing `SparseEncoder` feature-dict interface and final sparse embedding contract.

## Tests
(python 3.12 due to an unresolved and seemingly unrelated issue with kenlm when using python 3.14)
```bash
uv run --python 3.12 --no-sync pytest tests/sparse_encoder/modules/test_sparse_auto_encoder_token_encoder.py
uv run --python 3.12 --no-sync pytest tests/sparse_encoder/modules/test_csr.py
uv run --python 3.12 --no-sync pytest tests/sparse_encoder/test_model.py -k 'csr_max_active_dims_passed_to_forward or max_active_dims_set_init or default_to_csr or set_pooling_include_prompt_updates_sparse_token_pooling'
git diff --check
```

Results:

- `13 passed` for token SAE module tests
- `2 passed` for CSR module regression tests
- `4 passed` for selected SparseEncoder integration tests
- `git diff --check` clean
