### PR TITLE
Guard distributed APIs in get_device_name

### DIFF
--- a/sentence_transformers/sentence_transformer/losses/cached_gist_embed.py
+++ b/sentence_transformers/sentence_transformer/losses/cached_gist_embed.py
@@ -17,7 +17,7 @@ from sentence_transformers.sentence_transformer.losses.cached_multiple_negatives
 )
 from sentence_transformers.sentence_transformer.model import SentenceTransformer
 from sentence_transformers.sentence_transformer.modules import StaticEmbedding
-from sentence_transformers.util import all_gather_with_grad
+from sentence_transformers.util import all_gather_with_grad, is_dist_initialized
 
 
 class RandContext:
@@ -308,7 +308,7 @@ class CachedGISTEmbedLoss(nn.Module):
             candidates_guide = [all_gather_with_grad(candidate) for candidate in candidates_guide]
             # All have this shape: 1 + nneg items of (batch_size * world_size, embedding_dim)
 
-            if torch.distributed.is_initialized():
+            if is_dist_initialized():
                 rank = torch.distributed.get_rank()
                 offset = rank * batch_size
 

--- a/sentence_transformers/sentence_transformer/losses/cached_multiple_negatives_ranking.py
+++ b/sentence_transformers/sentence_transformer/losses/cached_multiple_negatives_ranking.py
@@ -14,7 +14,7 @@ from torch.utils.checkpoint import get_device_states, set_device_states
 from sentence_transformers import util
 from sentence_transformers.sentence_transformer.model import SentenceTransformer
 from sentence_transformers.sentence_transformer.modules import StaticEmbedding
-from sentence_transformers.util import all_gather_with_grad
+from sentence_transformers.util import all_gather_with_grad, is_dist_initialized
 
 logger = logging.getLogger(__name__)
 
@@ -439,7 +439,7 @@ class CachedMultipleNegativesRankingLoss(nn.Module):
             # (1 + num_negatives) tensors of shape (batch_size * world_size, embedding_dim)
 
             # Adjust the offset to account for the gathered candidates, so that each device computes the correct local indices.
-            if torch.distributed.is_initialized():
+            if is_dist_initialized():
                 rank = torch.distributed.get_rank()
                 offset = rank * batch_size
 

--- a/sentence_transformers/sentence_transformer/losses/gist_embed.py
+++ b/sentence_transformers/sentence_transformer/losses/gist_embed.py
@@ -9,7 +9,7 @@ from transformers import PreTrainedTokenizerBase
 
 from sentence_transformers.sentence_transformer.model import SentenceTransformer
 from sentence_transformers.sentence_transformer.modules import StaticEmbedding
-from sentence_transformers.util import all_gather_with_grad
+from sentence_transformers.util import all_gather_with_grad, is_dist_initialized
 
 
 class GISTEmbedLoss(nn.Module):
@@ -182,7 +182,7 @@ class GISTEmbedLoss(nn.Module):
                 negative_guide = all_gather_with_grad(negative_guide)
             # All have this shape: (batch_size * world_size * (1 + num_negatives), embedding_dim)
 
-            if torch.distributed.is_initialized():
+            if is_dist_initialized():
                 rank = torch.distributed.get_rank()
                 offset = rank * batch_size
 

--- a/sentence_transformers/sentence_transformer/losses/multiple_negatives_ranking.py
+++ b/sentence_transformers/sentence_transformer/losses/multiple_negatives_ranking.py
@@ -9,7 +9,7 @@ from torch import Tensor, nn
 
 from sentence_transformers import util
 from sentence_transformers.sentence_transformer.model import SentenceTransformer
-from sentence_transformers.util import all_gather_with_grad
+from sentence_transformers.util import all_gather_with_grad, is_dist_initialized
 
 logger = logging.getLogger(__name__)
 
@@ -247,7 +247,7 @@ class MultipleNegativesRankingLoss(nn.Module):
             # We do this in such a way that the backward pass on the embeddings can flow back to the original devices.
             queries = all_gather_with_grad(queries)
             docs = [all_gather_with_grad(doc) for doc in docs]
-            if torch.distributed.is_initialized():
+            if is_dist_initialized():
                 rank = torch.distributed.get_rank()
                 offset = rank * batch_size
 

--- a/sentence_transformers/util/__init__.py
+++ b/sentence_transformers/util/__init__.py
@@ -7,6 +7,7 @@ from .environment import (
     get_device_name,
     is_accelerate_available,
     is_datasets_available,
+    is_dist_initialized,
     is_training_available,
 )
 from .file_io import disabled_tqdm, http_get, is_sentence_transformer_model, load_dir_path, load_file_path
@@ -65,6 +66,7 @@ __all__ = [
     "check_package_availability",
     "is_accelerate_available",
     "is_datasets_available",
+    "is_dist_initialized",
     "is_training_available",
     # From file_io.py
     "is_sentence_transformer_model",

--- a/sentence_transformers/util/distributed.py
+++ b/sentence_transformers/util/distributed.py
@@ -4,6 +4,8 @@ import torch
 import torch.distributed as dist
 from transformers.utils import logging
 
+from .environment import is_dist_initialized
+
 # NOTE: transformers wraps the regular logging module for e.g. warning_once
 logger = logging.get_logger(__name__)
 
@@ -22,7 +24,7 @@ def all_gather(tensor: torch.Tensor, with_grad: bool = False) -> torch.Tensor:
         If torch.distributed is not available or not initialized, returns the original tensor.
     """
 
-    if dist.is_available() and dist.is_initialized():
+    if is_dist_initialized():
         if with_grad:
             gathered_tensors = torch.distributed.nn.all_gather(tensor)
         else:

--- a/sentence_transformers/util/environment.py
+++ b/sentence_transformers/util/environment.py
@@ -37,6 +37,17 @@ def suggest_extra_on_exception() -> Generator[None, None, None]:
         raise
 
 
+def is_dist_initialized() -> bool:
+    """
+    Returns whether ``torch.distributed`` is available and has been initialized.
+
+    The availability check must come first: some PyTorch builds (e.g. ROCm or CPU-only) report
+    ``torch.distributed.is_available() == False`` and do not expose APIs like ``is_initialized``, so calling
+    them directly raises ``AttributeError``.
+    """
+    return torch.distributed.is_available() and torch.distributed.is_initialized()
+
+
 def get_device_name() -> str:
     """
     Returns the name of the device where this module is running on.
@@ -50,11 +61,7 @@ def get_device_name() -> str:
     if torch.cuda.is_available():
         if "LOCAL_RANK" in os.environ:
             local_rank = int(os.environ["LOCAL_RANK"])
-        elif (
-            torch.distributed.is_available()
-            and torch.distributed.is_initialized()
-            and torch.cuda.device_count() > torch.distributed.get_rank()
-        ):
+        elif is_dist_initialized() and torch.cuda.device_count() > torch.distributed.get_rank():
             local_rank = torch.distributed.get_rank()
         else:
             local_rank = 0

--- a/sentence_transformers/util/environment.py
+++ b/sentence_transformers/util/environment.py
@@ -50,7 +50,11 @@ def get_device_name() -> str:
     if torch.cuda.is_available():
         if "LOCAL_RANK" in os.environ:
             local_rank = int(os.environ["LOCAL_RANK"])
-        elif torch.distributed.is_initialized() and torch.cuda.device_count() > torch.distributed.get_rank():
+        elif (
+            torch.distributed.is_available()
+            and torch.distributed.is_initialized()
+            and torch.cuda.device_count() > torch.distributed.get_rank()
+        ):
             local_rank = torch.distributed.get_rank()
         else:
             local_rank = 0

--- a/tests/util/test_environment.py
+++ b/tests/util/test_environment.py
@@ -5,7 +5,11 @@ from types import SimpleNamespace
 import pytest
 from transformers import AutoProcessor
 
-from sentence_transformers.util.environment import get_device_name, suggest_extra_on_exception
+from sentence_transformers.util.environment import (
+    get_device_name,
+    is_dist_initialized,
+    suggest_extra_on_exception,
+)
 
 
 def test_get_device_name_cuda_without_distributed_is_initialized(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -17,6 +21,16 @@ def test_get_device_name_cuda_without_distributed_is_initialized(monkeypatch: py
     monkeypatch.setattr("sentence_transformers.util.environment.torch.distributed", fake_distributed)
 
     assert get_device_name() == "cuda:0"
+
+
+def test_is_dist_initialized_returns_false_when_distributed_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
+    # ROCm / CPU-only builds expose is_available() but do not define is_initialized; the helper must short-circuit.
+    monkeypatch.setattr(
+        "sentence_transformers.util.environment.torch.distributed",
+        SimpleNamespace(is_available=lambda: False),
+    )
+
+    assert is_dist_initialized() is False
 
 
 @pytest.mark.parametrize(

--- a/tests/util/test_environment.py
+++ b/tests/util/test_environment.py
@@ -1,9 +1,22 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
 from transformers import AutoProcessor
 
-from sentence_transformers.util.environment import suggest_extra_on_exception
+from sentence_transformers.util.environment import get_device_name, suggest_extra_on_exception
+
+
+def test_get_device_name_cuda_without_distributed_is_initialized(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_cuda = SimpleNamespace(is_available=lambda: True, device_count=lambda: 1)
+    fake_distributed = SimpleNamespace(is_available=lambda: False)
+
+    monkeypatch.delenv("LOCAL_RANK", raising=False)
+    monkeypatch.setattr("sentence_transformers.util.environment.torch.cuda", fake_cuda)
+    monkeypatch.setattr("sentence_transformers.util.environment.torch.distributed", fake_distributed)
+
+    assert get_device_name() == "cuda:0"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Fixes an AttributeError in get_device_name() when using PyTorch builds where 	orch.distributed is present but distributed functionality is unavailable.

The current implementation calls:

`python
torch.distributed.is_initialized()
`

without first checking:

`python
torch.distributed.is_available()
`

In some ROCm-based PyTorch environments, is_available() returns False and is_initialized() is not exposed, causing:

`	ext
AttributeError: module 'torch.distributed' has no attribute 'is_initialized'
`

This PR adds an is_available() guard before accessing distributed APIs and adds a regression test covering the case where distributed functionality is unavailable.

## Changes

* Guard 	orch.distributed.is_initialized() with 	orch.distributed.is_available()
* Add regression test for get_device_name() when distributed APIs are unavailable

## Related

Closes #3795