### PR TITLE
[fix] Cast learning-to-rank loss logits to float32 for bf16/fp16 CrossEncoder training

### DIFF
--- a/sentence_transformers/cross_encoder/losses/adr_mse.py
+++ b/sentence_transformers/cross_encoder/losses/adr_mse.py
@@ -178,7 +178,7 @@ class ADRMSELoss(nn.Module):
             logits_list.append(logits)
 
         logits = torch.cat(logits_list, dim=0)
-        logits = self.activation_fn(logits)
+        logits = self.activation_fn(logits).float()
 
         # Place logits into a padded matrix
         logits_matrix = torch.full((batch_size, max_docs), -1e16, device=self.model.device)

--- a/sentence_transformers/cross_encoder/losses/adr_mse.py
+++ b/sentence_transformers/cross_encoder/losses/adr_mse.py
@@ -177,8 +177,8 @@ class ADRMSELoss(nn.Module):
             logits = self.model(tokens)["scores"].view(-1)
             logits_list.append(logits)
 
-        logits = torch.cat(logits_list, dim=0)
-        logits = self.activation_fn(logits).float()
+        logits = torch.cat(logits_list, dim=0).float()
+        logits = self.activation_fn(logits)
 
         # Place logits into a padded matrix
         logits_matrix = torch.full((batch_size, max_docs), -1e16, device=self.model.device)

--- a/sentence_transformers/cross_encoder/losses/lambda_loss.py
+++ b/sentence_transformers/cross_encoder/losses/lambda_loss.py
@@ -266,8 +266,8 @@ class LambdaLoss(nn.Module):
             logits = self.model(tokens)["scores"].view(-1)
             logits_list.append(logits)
 
-        logits = torch.cat(logits_list, dim=0)
-        logits = self.activation_fn(logits).float()
+        logits = torch.cat(logits_list, dim=0).float()
+        logits = self.activation_fn(logits)
 
         # Create output tensor filled with 0 (padded logits will be ignored via labels)
         logits_matrix = torch.full((batch_size, max_docs), -1e16, device=self.model.device)

--- a/sentence_transformers/cross_encoder/losses/lambda_loss.py
+++ b/sentence_transformers/cross_encoder/losses/lambda_loss.py
@@ -267,7 +267,7 @@ class LambdaLoss(nn.Module):
             logits_list.append(logits)
 
         logits = torch.cat(logits_list, dim=0)
-        logits = self.activation_fn(logits)
+        logits = self.activation_fn(logits).float()
 
         # Create output tensor filled with 0 (padded logits will be ignored via labels)
         logits_matrix = torch.full((batch_size, max_docs), -1e16, device=self.model.device)

--- a/sentence_transformers/cross_encoder/losses/list_net.py
+++ b/sentence_transformers/cross_encoder/losses/list_net.py
@@ -152,7 +152,7 @@ class ListNetLoss(nn.Module):
             logits_list.append(logits)
 
         logits = torch.cat(logits_list, dim=0)
-        logits = self.activation_fn(logits)
+        logits = self.activation_fn(logits).float()
 
         # Create output tensor filled with 0 (padded logits will be ignored via labels)
         logits_matrix = torch.full((batch_size, max_docs), -1e16, device=self.model.device)

--- a/sentence_transformers/cross_encoder/losses/list_net.py
+++ b/sentence_transformers/cross_encoder/losses/list_net.py
@@ -151,8 +151,8 @@ class ListNetLoss(nn.Module):
             logits = self.model(tokens)["scores"].view(-1)
             logits_list.append(logits)
 
-        logits = torch.cat(logits_list, dim=0)
-        logits = self.activation_fn(logits).float()
+        logits = torch.cat(logits_list, dim=0).float()
+        logits = self.activation_fn(logits)
 
         # Create output tensor filled with 0 (padded logits will be ignored via labels)
         logits_matrix = torch.full((batch_size, max_docs), -1e16, device=self.model.device)

--- a/sentence_transformers/cross_encoder/losses/plist_mle.py
+++ b/sentence_transformers/cross_encoder/losses/plist_mle.py
@@ -211,7 +211,7 @@ class PListMLELoss(nn.Module):
             logits_list.append(logits)
 
         logits = torch.cat(logits_list, dim=0)
-        logits = self.activation_fn(logits)
+        logits = self.activation_fn(logits).float()
 
         # Create output tensor filled with a very small value for padded logits
         logits_matrix = torch.full((batch_size, max_docs), 1e-16, device=self.model.device)

--- a/sentence_transformers/cross_encoder/losses/plist_mle.py
+++ b/sentence_transformers/cross_encoder/losses/plist_mle.py
@@ -210,8 +210,8 @@ class PListMLELoss(nn.Module):
             logits = self.model(tokens)["scores"].view(-1)
             logits_list.append(logits)
 
-        logits = torch.cat(logits_list, dim=0)
-        logits = self.activation_fn(logits).float()
+        logits = torch.cat(logits_list, dim=0).float()
+        logits = self.activation_fn(logits)
 
         # Create output tensor filled with a very small value for padded logits
         logits_matrix = torch.full((batch_size, max_docs), 1e-16, device=self.model.device)

--- a/tests/cross_encoder/losses/test_rerank_losses_dtype.py
+++ b/tests/cross_encoder/losses/test_rerank_losses_dtype.py
@@ -27,10 +27,13 @@ LISTWISE_LOSSES = [
 ]
 
 
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16], ids=["bf16", "fp16"])
 @pytest.mark.parametrize("loss_cls", LISTWISE_LOSSES)
-def test_listwise_loss_supports_bfloat16(reranker_bert_tiny_model_v6: CrossEncoder, loss_cls) -> None:
+def test_listwise_loss_supports_low_precision(
+    reranker_bert_tiny_model_v6: CrossEncoder, loss_cls, dtype: torch.dtype
+) -> None:
     model = reranker_bert_tiny_model_v6
-    model.model.to(torch.bfloat16)
+    model.model.to(dtype)
     loss_fn = loss_cls(model)
 
     queries = ["What is Python?", "What is PyTorch?"]
@@ -45,3 +48,9 @@ def test_listwise_loss_supports_bfloat16(reranker_bert_tiny_model_v6: CrossEncod
     loss_value = loss_fn((queries, docs_list), labels)
     assert loss_value.dtype == torch.float32
     assert torch.isfinite(loss_value)
+
+    # Gradients must flow back into the low-precision model without dtype errors.
+    loss_value.backward()
+    grads = [p.grad for p in model.parameters() if p.grad is not None]
+    assert grads, "Expected at least one parameter to receive a gradient."
+    assert all(torch.isfinite(grad).all() for grad in grads)

--- a/tests/cross_encoder/losses/test_rerank_losses_dtype.py
+++ b/tests/cross_encoder/losses/test_rerank_losses_dtype.py
@@ -31,6 +31,9 @@ def test_listwise_loss_supports_low_precision(
     reranker_bert_tiny_model_v6: CrossEncoder, loss_cls, dtype: torch.dtype
 ) -> None:
     model = reranker_bert_tiny_model_v6
+    if dtype == torch.float16 and not torch.cuda.is_available():
+        pytest.skip("float16 CrossEncoder forward is only supported when CUDA is available.")
+
     model.model.to(dtype)
     loss_fn = loss_cls(model)
 

--- a/tests/cross_encoder/losses/test_rerank_losses_dtype.py
+++ b/tests/cross_encoder/losses/test_rerank_losses_dtype.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import pytest
+import torch
+
+from sentence_transformers.cross_encoder import CrossEncoder
+from sentence_transformers.cross_encoder.losses import (
+    ADRMSELoss,
+    LambdaLoss,
+    ListMLELoss,
+    ListNetLoss,
+    PListMLELoss,
+    RankNetLoss,
+)
+
+# Learning-to-rank losses that build an internal logits matrix from the model's
+# logits. Regression test for #3793: training in low precision (bf16/fp16) used to
+# crash with "Index put requires the source and destination dtypes match" because
+# the matrix defaulted to float32 while the model emitted bf16/fp16 logits.
+LISTWISE_LOSSES = [
+    PListMLELoss,
+    LambdaLoss,
+    ListNetLoss,
+    ListMLELoss,  # subclass of PListMLELoss
+    RankNetLoss,  # subclass of LambdaLoss
+    ADRMSELoss,
+]
+
+
+@pytest.mark.parametrize("loss_cls", LISTWISE_LOSSES)
+def test_listwise_loss_supports_bfloat16(reranker_bert_tiny_model_v6: CrossEncoder, loss_cls) -> None:
+    model = reranker_bert_tiny_model_v6
+    model.model.to(torch.bfloat16)
+    loss_fn = loss_cls(model)
+
+    queries = ["What is Python?", "What is PyTorch?"]
+    docs_list = [
+        ["A programming language.", "A snake."],
+        ["A deep learning framework.", "A lunch box.", "A board game."],
+    ]
+    labels = [torch.tensor([1.0, 0.0], device=model.device), torch.tensor([2.0, 1.0, 0.0], device=model.device)]
+
+    # Must not raise a dtype-mismatch RuntimeError, and the loss should be computed
+    # in float32 for numerical stability of exp/log/cumsum/softmax.
+    loss_value = loss_fn((queries, docs_list), labels)
+    assert loss_value.dtype == torch.float32
+    assert torch.isfinite(loss_value)

--- a/tests/cross_encoder/losses/test_rerank_losses_dtype.py
+++ b/tests/cross_encoder/losses/test_rerank_losses_dtype.py
@@ -13,10 +13,8 @@ from sentence_transformers.cross_encoder.losses import (
     RankNetLoss,
 )
 
-# Learning-to-rank losses that build an internal logits matrix from the model's
-# logits. Regression test for #3793: training in low precision (bf16/fp16) used to
-# crash with "Index put requires the source and destination dtypes match" because
-# the matrix defaulted to float32 while the model emitted bf16/fp16 logits.
+# Learning-to-rank losses that scatter the model's logits into an internal matrix.
+# Regression test for #3793: bf16/fp16 training crashed on a float32 dtype mismatch.
 LISTWISE_LOSSES = [
     PListMLELoss,
     LambdaLoss,


### PR DESCRIPTION
Fixes #3793.

Training a CrossEncoder reranker in bf16/fp16 crashes in the learning-to-rank losses. The logits matrix is built with `torch.full(...)`, which is float32 by default, and then the model's logits get scattered into it — so as soon as the model's in bf16 you get:

```
RuntimeError: Index put requires the source and destination dtypes match, got Float for the destination and BFloat16 for the source.
```

I just cast the logits to float32 (`.float()` after the activation) rather than the `dtype=logits.dtype` from the issue. Matching the matrix to the logits dtype doesn't fully fix it — the next line that writes the labels (`labels_matrix[...] = torch.cat(labels).float()`) crashes the same way in reverse. On top of that these losses do `exp`/`cumsum`/`log`/`softmax` with no max-shift, so bf16 is shaky and fp16 overflows. Running the loss in fp32 avoids both, and it's a no-op when you're already in float32.

Same pattern was in `PListMLELoss`, `LambdaLoss`, `ListNetLoss` and `ADRMSELoss`. `ListMLELoss` and `RankNetLoss` subclass those two, so they're covered too.

Added a test that runs all six on a bf16 model — fails on main, passes here.
