### PR TITLE
Update GitHub Actions to resolve Node 20 deprecation warnings

### DIFF
--- a/.github/workflows/min-versions.yml
+++ b/.github/workflows/min-versions.yml
@@ -45,12 +45,12 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Setup Python environment
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: "3.10"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@d0d8abe699bfb85fec6de9f7adb5ae17292296ff  # v6
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
 
       - name: Install FFmpeg libraries (needed to build av)
         run: sudo apt-get update && sudo apt-get install -y libavformat-dev libavcodec-dev libavdevice-dev libavutil-dev libavfilter-dev libswscale-dev libswresample-dev

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -22,11 +22,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Setup Python environment
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: "3.10"
       - name: Install uv
-        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e  # v6
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
       - name: Install pre-commit
         run: uv pip install pre-commit --system
       - name: Code quality

--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -31,7 +31,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout sentence-transformers
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Determine PR title
         id: pr_title
@@ -44,21 +44,21 @@ jobs:
 
       - name: Create GitHub App token
         id: app_token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.APP_ID_HUB_SKILLS_REPO }}
           private-key: ${{ secrets.APP_SECRET_PREM_HUB_SKILLS_REPO }}
           repositories: skills
 
       - name: Checkout huggingface/skills
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: huggingface/skills
           token: ${{ steps.app_token.outputs.token }}
           path: skills-repo
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
       - name: Copy skill
         run: |
@@ -84,7 +84,7 @@ jobs:
 
       - name: Create Pull Request
         if: steps.check_changes.outputs.changed == 'true'
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ steps.app_token.outputs.token }}
           path: skills-repo

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,12 +51,12 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Setup Python environment
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@d0d8abe699bfb85fec6de9f7adb5ae17292296ff  # v6
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
 
       # kenlm doesn't compile on Python 3.13, and pyctcdecode pins numpy<2.0.0
       # which conflicts with the rest of the stack. Exclude both on Python 3.13.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,6 +57,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
+        with:
+          cache-suffix: "transformers-5-${{ (matrix.transformers-version == '<5.0.0') && 'minus' || 'plus' }}"
 
       # kenlm doesn't compile on Python 3.13, and pyctcdecode pins numpy<2.0.0
       # which conflicts with the rest of the stack. Exclude both on Python 3.13.


### PR DESCRIPTION
This PR introduces the following changes:

* Update GitHub Actions versions and comments.
* Update all workflows to use pinned actions.
* In commit 2, a uv cache key suffix is added to resolve "Warning: Failed to save: Unable to reserve cache with key $KEY, another job may be creating this cache" errors. [[recent example](https://github.com/huggingface/sentence-transformers/actions/runs/27152257734/job/80148988079#step:18:10)] Details are in the message body of commit 30051f5.

It resolves Node 20 deprecation warnings [[recent example](https://github.com/huggingface/sentence-transformers/actions/runs/27139810510)]:

> <img width="638" height="187" alt="image" src="https://github.com/user-attachments/assets/4d3dbc1f-24f0-47cc-94ab-980418be77d0" />

[pinact](https://github.com/suzuki-shunsuke/pinact) was used to make the changes, and this was the command (note that a 20 day cooldown was used):

```
pinact run --verify-comment --verify-min-age --update --min-age 20
```
