### PR TITLE
Modernize the data-augmentation STSb scripts

### DIFF
--- a/examples/sentence_transformer/training/data_augmentation/train_sts_indomain_bm25.py
+++ b/examples/sentence_transformer/training/data_augmentation/train_sts_indomain_bm25.py
@@ -126,6 +126,7 @@ CrossEncoderTrainer(
     loss=ce_loss,
     evaluator=evaluator,
 ).train()
+cross_encoder.save_pretrained(f"{cross_encoder_path}/final")
 
 ############################################################################
 #
@@ -175,7 +176,6 @@ progress.close()
 logging.info(f"Number of silver pairs generated for STSbenchmark: {len(silver_data)}")
 logging.info(f"Step 2.2: Label STSbenchmark (silver dataset) with cross-encoder: {model_name}")
 
-cross_encoder = CrossEncoder(cross_encoder_path)
 silver_scores = cross_encoder.predict(silver_data)
 
 # All model predictions should be between [0,1]

--- a/examples/sentence_transformer/training/data_augmentation/train_sts_indomain_bm25.py
+++ b/examples/sentence_transformer/training/data_augmentation/train_sts_indomain_bm25.py
@@ -116,16 +116,18 @@ ce_args = CrossEncoderTrainingArguments(
     num_train_epochs=num_epochs,
     per_device_train_batch_size=batch_size,
     warmup_ratio=0.1,
+    eval_strategy="epoch",
 )
 
 # Train the cross-encoder model
-CrossEncoderTrainer(
+ce_trainer = CrossEncoderTrainer(
     model=cross_encoder,
     args=ce_args,
     train_dataset=gold_dataset,
     loss=ce_loss,
     evaluator=evaluator,
-).train()
+)
+ce_trainer.train()
 cross_encoder.save_pretrained(f"{cross_encoder_path}/final")
 
 ############################################################################
@@ -208,7 +210,7 @@ evaluator = EmbeddingSimilarityEvaluator(
     sentences2=eval_dataset["sentence2"],
     scores=eval_dataset["score"],
     main_similarity=SimilarityFunction.COSINE,
-    name="sts-test",
+    name="sts-dev",
 )
 
 # Define the training arguments
@@ -219,16 +221,16 @@ args = SentenceTransformerTrainingArguments(
     num_train_epochs=num_epochs,
     per_device_train_batch_size=batch_size,
     per_device_eval_batch_size=batch_size,
-    warmup_steps=0.1,
+    warmup_ratio=0.1,
     fp16=True,  # Set to False if you get an error that your GPU can't run on FP16
     bf16=False,  # Set to True if you have a GPU that supports BF16
     # Optional tracking/debugging parameters:
     eval_strategy="steps",
-    eval_steps=100,
+    eval_steps=0.1,
     save_strategy="steps",
-    save_steps=100,
+    save_steps=0.1,
     save_total_limit=2,
-    logging_steps=100,
+    logging_steps=0.05,
     run_name="augmentation-indomain-bm25-sts",  # Will be used in W&B if `wandb` is installed
 )
 

--- a/examples/sentence_transformer/training/data_augmentation/train_sts_indomain_bm25.py
+++ b/examples/sentence_transformer/training/data_augmentation/train_sts_indomain_bm25.py
@@ -195,7 +195,7 @@ silver_samples = Dataset.from_dict(
     {
         "sentence1": [data[0] for data in silver_data],
         "sentence2": [data[1] for data in silver_data],
-        "score": silver_scores,
+        "score": [float(score) for score in silver_scores],
     }
 )
 train_dataset = concatenate_datasets([train_dataset, silver_samples])

--- a/examples/sentence_transformer/training/data_augmentation/train_sts_indomain_bm25.py
+++ b/examples/sentence_transformer/training/data_augmentation/train_sts_indomain_bm25.py
@@ -27,7 +27,6 @@ python train_sts_indomain_bm25.py google-bert/bert-base-uncased 3
 """
 
 import logging
-import math
 import sys
 import traceback
 from datetime import datetime
@@ -35,14 +34,15 @@ from datetime import datetime
 import tqdm
 from datasets import Dataset, concatenate_datasets, load_dataset
 from elasticsearch import Elasticsearch
-from torch.utils.data import DataLoader
 
 from sentence_transformers import SentenceTransformer
 from sentence_transformers.cross_encoder import CrossEncoder
 from sentence_transformers.cross_encoder.evaluation import CrossEncoderCorrelationEvaluator
+from sentence_transformers.cross_encoder.losses import BinaryCrossEntropyLoss
+from sentence_transformers.cross_encoder.trainer import CrossEncoderTrainer
+from sentence_transformers.cross_encoder.training_args import CrossEncoderTrainingArguments
 from sentence_transformers.sentence_transformer.evaluation import EmbeddingSimilarityEvaluator
 from sentence_transformers.sentence_transformer.losses import CosineSimilarityLoss
-from sentence_transformers.sentence_transformer.readers import InputExample
 from sentence_transformers.sentence_transformer.trainer import SentenceTransformerTrainer
 from sentence_transformers.sentence_transformer.training_args import SentenceTransformerTrainingArguments
 from sentence_transformers.util.similarity import SimilarityFunction
@@ -98,14 +98,10 @@ eval_dataset = load_dataset("sentence-transformers/stsb", split="validation")
 test_dataset = load_dataset("sentence-transformers/stsb", split="test")
 logging.info(train_dataset)
 
-gold_samples = [
-    InputExample(texts=[sentence1, sentence2], label=data["score"])
-    for data in train_dataset
-    for sentence1, sentence2 in [(data["sentence1"], data["sentence2"]), (data["sentence2"], data["sentence1"])]
-]
-
-# We wrap gold_samples (which is a List[InputExample]) into a pytorch DataLoader
-train_dataloader = DataLoader(gold_samples, shuffle=True, batch_size=batch_size)
+# Build a symmetric training set so CrossEncoder(A, B) == CrossEncoder(B, A)
+gold_dataset = concatenate_datasets(
+    [train_dataset, train_dataset.rename_columns({"sentence1": "sentence2", "sentence2": "sentence1"})]
+)
 
 # We add an evaluator, which evaluates the performance during training
 evaluator = CrossEncoderCorrelationEvaluator(
@@ -113,19 +109,23 @@ evaluator = CrossEncoderCorrelationEvaluator(
     scores=[data["score"] for data in eval_dataset],
     name="sts-dev",
 )
-
 # Configure the training
-warmup_steps = math.ceil(len(train_dataloader) * num_epochs * 0.1)  # 10% of train data for warm-up
-logging.info(f"Warmup-steps: {warmup_steps}")
+ce_loss = BinaryCrossEntropyLoss(cross_encoder)
+ce_args = CrossEncoderTrainingArguments(
+    output_dir=cross_encoder_path,
+    num_train_epochs=num_epochs,
+    per_device_train_batch_size=batch_size,
+    warmup_ratio=0.1,
+)
 
 # Train the cross-encoder model
-cross_encoder.fit(
-    train_dataloader=train_dataloader,
+CrossEncoderTrainer(
+    model=cross_encoder,
+    args=ce_args,
+    train_dataset=gold_dataset,
+    loss=ce_loss,
     evaluator=evaluator,
-    epochs=num_epochs,
-    warmup_steps=warmup_steps,
-    output_path=cross_encoder_path,
-)
+).train()
 
 ############################################################################
 #
@@ -139,16 +139,12 @@ cross_encoder.fit(
 index_name = "stsb"  # index-name should be in lowercase
 logging.info(f"Step 2.1: Generate STSbenchmark (silver dataset) using top-{top_k} bm25 combinations")
 
-unique_sentences = set()
-
-for sample in gold_samples:
-    unique_sentences.update(sample.texts)
-
-unique_sentences = list(unique_sentences)  # unique sentences
+unique_sentences = list(set(train_dataset["sentence1"]) | set(train_dataset["sentence2"]))
 sent2idx = {sentence: idx for idx, sentence in enumerate(unique_sentences)}  # storing id and sentence in dictionary
-duplicates = set(
-    (sent2idx[data.texts[0]], sent2idx[data.texts[1]]) for data in gold_samples
-)  # not to include gold pairs of sentences again
+duplicates = set()  # not to include gold pairs of sentences again
+for sentence1, sentence2 in zip(train_dataset["sentence1"], train_dataset["sentence2"]):
+    duplicates.add((sent2idx[sentence1], sent2idx[sentence2]))
+    duplicates.add((sent2idx[sentence2], sent2idx[sentence1]))
 
 # Ignore 400 cause by IndexAlreadyExistsException when creating an index
 logging.info(f"Creating elastic-search index - {index_name}")
@@ -193,7 +189,7 @@ assert all(0.0 <= score <= 1.0 for score in silver_scores)
 
 logging.info(f"Step 3: Train bi-encoder: {model_name} with STSbenchmark (gold + silver dataset)")
 
-# Convert the dataset to a DataLoader ready for training
+# Combine the gold and silver pairs for bi-encoder training
 logging.info("Read STSbenchmark gold and silver train dataset")
 silver_samples = Dataset.from_dict(
     {

--- a/examples/sentence_transformer/training/data_augmentation/train_sts_indomain_semantic.py
+++ b/examples/sentence_transformer/training/data_augmentation/train_sts_indomain_semantic.py
@@ -123,16 +123,16 @@ ce_args = CrossEncoderTrainingArguments(
     num_train_epochs=num_epochs,
     per_device_train_batch_size=batch_size,
     warmup_ratio=0.1,
-    eval_strategy="steps",
-    eval_steps=1000,
+    eval_strategy="epoch",
 )
-CrossEncoderTrainer(
+ce_trainer = CrossEncoderTrainer(
     model=cross_encoder,
     args=ce_args,
     train_dataset=gold_dataset,
     loss=ce_loss,
     evaluator=evaluator,
-).train()
+)
+ce_trainer.train()
 cross_encoder.save_pretrained(f"{cross_encoder_path}/final")
 
 ############################################################################
@@ -231,23 +231,24 @@ args = SentenceTransformerTrainingArguments(
     per_device_eval_batch_size=batch_size,
     warmup_ratio=0.1,
     eval_strategy="steps",
-    eval_steps=1000,
+    eval_steps=0.1,
     save_strategy="steps",
-    save_steps=1000,
+    save_steps=0.1,
     save_total_limit=2,
-    logging_steps=100,
+    logging_steps=0.05,
     run_name="augmentation-indomain-semantic-sts",
 )
 
 # Train the bi-encoder model
-SentenceTransformerTrainer(
+trainer = SentenceTransformerTrainer(
     model=bi_encoder,
     args=args,
     train_dataset=bi_encoder_train_dataset,
     eval_dataset=eval_dataset,
     loss=train_loss,
     evaluator=evaluator,
-).train()
+)
+trainer.train()
 bi_encoder.save_pretrained(f"{bi_encoder_path}/final")
 
 #################################################################################

--- a/examples/sentence_transformer/training/data_augmentation/train_sts_indomain_semantic.py
+++ b/examples/sentence_transformer/training/data_augmentation/train_sts_indomain_semantic.py
@@ -133,6 +133,7 @@ CrossEncoderTrainer(
     loss=ce_loss,
     evaluator=evaluator,
 ).train()
+cross_encoder.save_pretrained(f"{cross_encoder_path}/final")
 
 ############################################################################
 #
@@ -188,7 +189,6 @@ progress.close()
 
 logging.info(f"Length of silver_dataset generated: {len(silver_data)}")
 logging.info(f"Step 2.2: Label STSbenchmark (silver dataset) with cross-encoder: {model_name}")
-cross_encoder = CrossEncoder(cross_encoder_path)
 silver_scores = cross_encoder.predict(silver_data)
 
 # All model predictions should be between [0,1]
@@ -248,6 +248,7 @@ SentenceTransformerTrainer(
     loss=train_loss,
     evaluator=evaluator,
 ).train()
+bi_encoder.save_pretrained(f"{bi_encoder_path}/final")
 
 #################################################################################
 #
@@ -255,8 +256,6 @@ SentenceTransformerTrainer(
 #
 #################################################################################
 
-# load the stored augmented-sbert model
-bi_encoder = SentenceTransformer(bi_encoder_path)
 test_evaluator = EmbeddingSimilarityEvaluator(
     sentences1=test_dataset["sentence1"],
     sentences2=test_dataset["sentence2"],

--- a/examples/sentence_transformer/training/data_augmentation/train_sts_indomain_semantic.py
+++ b/examples/sentence_transformer/training/data_augmentation/train_sts_indomain_semantic.py
@@ -20,22 +20,24 @@ python train_sts_indomain_semantic.py google-bert/bert-base-uncased 3
 """
 
 import logging
-import math
 import sys
 from datetime import datetime
 
 import torch
 import tqdm
-from datasets import load_dataset
-from torch.utils.data import DataLoader
+from datasets import Dataset, concatenate_datasets, load_dataset
 
 from sentence_transformers import SentenceTransformer
 from sentence_transformers.cross_encoder import CrossEncoder
 from sentence_transformers.cross_encoder.evaluation import CrossEncoderCorrelationEvaluator
+from sentence_transformers.cross_encoder.losses import BinaryCrossEntropyLoss
+from sentence_transformers.cross_encoder.trainer import CrossEncoderTrainer
+from sentence_transformers.cross_encoder.training_args import CrossEncoderTrainingArguments
 from sentence_transformers.sentence_transformer.evaluation import EmbeddingSimilarityEvaluator
 from sentence_transformers.sentence_transformer.losses import CosineSimilarityLoss
 from sentence_transformers.sentence_transformer.modules import Pooling, Transformer
-from sentence_transformers.sentence_transformer.readers import InputExample
+from sentence_transformers.sentence_transformer.trainer import SentenceTransformerTrainer
+from sentence_transformers.sentence_transformer.training_args import SentenceTransformerTrainingArguments
 from sentence_transformers.util import cos_sim
 
 # Set the log level to INFO to get more information
@@ -53,7 +55,9 @@ max_seq_length = 128
 
 # Read Datasets ######
 
-dataset = load_dataset("sentence-transformers/stsb")
+train_dataset = load_dataset("sentence-transformers/stsb", split="train")
+eval_dataset = load_dataset("sentence-transformers/stsb", split="validation")
+test_dataset = load_dataset("sentence-transformers/stsb", split="test")
 
 
 cross_encoder_path = (
@@ -100,41 +104,35 @@ bi_encoder = SentenceTransformer(modules=[word_embedding_model, pooling_model])
 
 logging.info(f"Step 1: Train cross-encoder: {model_name} with STSbenchmark (gold dataset)")
 
-gold_samples = []
-dev_samples = []
-test_samples = []
-
-for row in dataset["validation"]:
-    dev_samples.append(InputExample(texts=[row["sentence1"], row["sentence2"]], label=row["score"]))
-
-for row in dataset["test"]:
-    test_samples.append(InputExample(texts=[row["sentence1"], row["sentence2"]], label=row["score"]))
-for row in dataset["train"]:
-    # As we want to get symmetric scores, i.e. CrossEncoder(A,B) = CrossEncoder(B,A), we pass both combinations to the train set
-    gold_samples.append(InputExample(texts=[row["sentence1"], row["sentence2"]], label=row["score"]))
-    gold_samples.append(InputExample(texts=[row["sentence2"], row["sentence1"]], label=row["score"]))
-
-
-# We wrap gold_samples (which is a List[InputExample]) into a pytorch DataLoader
-train_dataloader = DataLoader(gold_samples, shuffle=True, batch_size=batch_size)
-
+# As we want to get symmetric scores, i.e. CrossEncoder(A,B) = CrossEncoder(B,A), we pass both combinations to the train set
+gold_dataset = concatenate_datasets(
+    [train_dataset, train_dataset.rename_columns({"sentence1": "sentence2", "sentence2": "sentence1"})]
+)
 
 # We add an evaluator, which evaluates the performance during training
-evaluator = CrossEncoderCorrelationEvaluator.from_input_examples(dev_samples, name="sts-dev")
-
-# Configure the training
-warmup_steps = math.ceil(len(train_dataloader) * num_epochs * 0.1)  # 10% of train data for warm-up
-logging.info(f"Warmup-steps: {warmup_steps}")
+evaluator = CrossEncoderCorrelationEvaluator(
+    sentence_pairs=[[row["sentence1"], row["sentence2"]] for row in eval_dataset],
+    scores=[row["score"] for row in eval_dataset],
+    name="sts-dev",
+)
 
 # Train the cross-encoder model
-cross_encoder.fit(
-    train_dataloader=train_dataloader,
-    evaluator=evaluator,
-    epochs=num_epochs,
-    evaluation_steps=1000,
-    warmup_steps=warmup_steps,
-    output_path=cross_encoder_path,
+ce_loss = BinaryCrossEntropyLoss(cross_encoder)
+ce_args = CrossEncoderTrainingArguments(
+    output_dir=cross_encoder_path,
+    num_train_epochs=num_epochs,
+    per_device_train_batch_size=batch_size,
+    warmup_ratio=0.1,
+    eval_strategy="steps",
+    eval_steps=1000,
 )
+CrossEncoderTrainer(
+    model=cross_encoder,
+    args=ce_args,
+    train_dataset=gold_dataset,
+    loss=ce_loss,
+    evaluator=evaluator,
+).train()
 
 ############################################################################
 #
@@ -151,16 +149,12 @@ logging.info(
 )
 
 silver_data = []
-sentences = set()
-
-for sample in gold_samples:
-    sentences.update(sample.texts)
-
-sentences = list(sentences)  # unique sentences
+sentences = list(set(train_dataset["sentence1"]) | set(train_dataset["sentence2"]))
 sent2idx = {sentence: idx for idx, sentence in enumerate(sentences)}  # storing id and sentence in dictionary
-duplicates = set(
-    (sent2idx[data.texts[0]], sent2idx[data.texts[1]]) for data in gold_samples
-)  # not to include gold pairs of sentences again
+duplicates = set()  # not to include gold pairs of sentences again
+for sentence1, sentence2 in zip(train_dataset["sentence1"], train_dataset["sentence2"]):
+    duplicates.add((sent2idx[sentence1], sent2idx[sentence2]))
+    duplicates.add((sent2idx[sentence2], sent2idx[sentence1]))
 
 
 # For simplicity we use a pretrained model
@@ -208,32 +202,52 @@ assert all(0.0 <= score <= 1.0 for score in silver_scores)
 
 logging.info(f"Step 3: Train bi-encoder: {model_name} with STSbenchmark (gold + silver dataset)")
 
-# Convert the dataset to a DataLoader ready for training
+# Combine the gold and silver pairs for bi-encoder training
 logging.info("Read STSbenchmark gold and silver train dataset")
-silver_samples = list(
-    InputExample(texts=[data[0], data[1]], label=score) for data, score in zip(silver_data, silver_scores)
+silver_samples = Dataset.from_dict(
+    {
+        "sentence1": [data[0] for data in silver_data],
+        "sentence2": [data[1] for data in silver_data],
+        "score": silver_scores,
+    }
 )
+bi_encoder_train_dataset = concatenate_datasets([gold_dataset, silver_samples])
 
-
-train_dataloader = DataLoader(gold_samples + silver_samples, shuffle=True, batch_size=batch_size)
 train_loss = CosineSimilarityLoss(model=bi_encoder)
 
 logging.info("Read STSbenchmark dev dataset")
-evaluator = EmbeddingSimilarityEvaluator.from_input_examples(dev_samples, name="sts-dev")
+evaluator = EmbeddingSimilarityEvaluator(
+    sentences1=eval_dataset["sentence1"],
+    sentences2=eval_dataset["sentence2"],
+    scores=eval_dataset["score"],
+    name="sts-dev",
+)
 
-# Configure the training.
-warmup_steps = math.ceil(len(train_dataloader) * num_epochs * 0.1)  # 10% of train data for warm-up
-logging.info(f"Warmup-steps: {warmup_steps}")
+# Define the training arguments
+args = SentenceTransformerTrainingArguments(
+    output_dir=bi_encoder_path,
+    num_train_epochs=num_epochs,
+    per_device_train_batch_size=batch_size,
+    per_device_eval_batch_size=batch_size,
+    warmup_ratio=0.1,
+    eval_strategy="steps",
+    eval_steps=1000,
+    save_strategy="steps",
+    save_steps=1000,
+    save_total_limit=2,
+    logging_steps=100,
+    run_name="augmentation-indomain-semantic-sts",
+)
 
 # Train the bi-encoder model
-bi_encoder.fit(
-    train_objectives=[(train_dataloader, train_loss)],
+SentenceTransformerTrainer(
+    model=bi_encoder,
+    args=args,
+    train_dataset=bi_encoder_train_dataset,
+    eval_dataset=eval_dataset,
+    loss=train_loss,
     evaluator=evaluator,
-    epochs=num_epochs,
-    evaluation_steps=1000,
-    warmup_steps=warmup_steps,
-    output_path=bi_encoder_path,
-)
+).train()
 
 #################################################################################
 #
@@ -243,5 +257,10 @@ bi_encoder.fit(
 
 # load the stored augmented-sbert model
 bi_encoder = SentenceTransformer(bi_encoder_path)
-test_evaluator = EmbeddingSimilarityEvaluator.from_input_examples(test_samples, name="sts-test")
+test_evaluator = EmbeddingSimilarityEvaluator(
+    sentences1=test_dataset["sentence1"],
+    sentences2=test_dataset["sentence2"],
+    scores=test_dataset["score"],
+    name="sts-test",
+)
 test_evaluator(bi_encoder, output_path=bi_encoder_path)

--- a/examples/sentence_transformer/training/data_augmentation/train_sts_indomain_semantic.py
+++ b/examples/sentence_transformer/training/data_augmentation/train_sts_indomain_semantic.py
@@ -208,7 +208,7 @@ silver_samples = Dataset.from_dict(
     {
         "sentence1": [data[0] for data in silver_data],
         "sentence2": [data[1] for data in silver_data],
-        "score": silver_scores,
+        "score": [float(score) for score in silver_scores],
     }
 )
 bi_encoder_train_dataset = concatenate_datasets([gold_dataset, silver_samples])

--- a/examples/sentence_transformer/training/data_augmentation/train_sts_qqp_crossdomain.py
+++ b/examples/sentence_transformer/training/data_augmentation/train_sts_qqp_crossdomain.py
@@ -142,6 +142,7 @@ CrossEncoderTrainer(
     loss=ce_loss,
     evaluator=evaluator,
 ).train()
+cross_encoder.save_pretrained(f"{cross_encoder_path}/final")
 
 ##################################################################
 #
@@ -150,8 +151,6 @@ CrossEncoderTrainer(
 ##################################################################
 
 logging.info(f"Step 2: Label QQP (target dataset) with cross-encoder: {model_name}")
-
-cross_encoder = CrossEncoder(cross_encoder_path)
 
 silver_data = []
 
@@ -230,15 +229,13 @@ SentenceTransformerTrainer(
     loss=train_loss,
     evaluator=evaluator,
 ).train()
+bi_encoder.save_pretrained(f"{bi_encoder_path}/final")
 
 ###############################################################
 #
 # Evaluate Augmented SBERT performance on QQP benchmark dataset
 #
 ###############################################################
-
-# Loading the augmented sbert model
-bi_encoder = SentenceTransformer(bi_encoder_path)
 
 logging.info("Read QQP test dataset")
 test_sentences1 = []

--- a/examples/sentence_transformer/training/data_augmentation/train_sts_qqp_crossdomain.py
+++ b/examples/sentence_transformer/training/data_augmentation/train_sts_qqp_crossdomain.py
@@ -19,23 +19,25 @@ python train_sts_qqp_crossdomain.py pretrained_transformer_model_name
 
 import csv
 import logging
-import math
 import os
 import sys
 from datetime import datetime
 from zipfile import ZipFile
 
 import torch
-from datasets import load_dataset
-from torch.utils.data import DataLoader
+from datasets import Dataset, concatenate_datasets, load_dataset
 
 from sentence_transformers import SentenceTransformer
 from sentence_transformers.cross_encoder import CrossEncoder
 from sentence_transformers.cross_encoder.evaluation import CrossEncoderCorrelationEvaluator
+from sentence_transformers.cross_encoder.losses import BinaryCrossEntropyLoss
+from sentence_transformers.cross_encoder.trainer import CrossEncoderTrainer
+from sentence_transformers.cross_encoder.training_args import CrossEncoderTrainingArguments
 from sentence_transformers.sentence_transformer.evaluation import BinaryClassificationEvaluator
 from sentence_transformers.sentence_transformer.losses import MultipleNegativesRankingLoss
 from sentence_transformers.sentence_transformer.modules import Pooling, Transformer
-from sentence_transformers.sentence_transformer.readers import InputExample
+from sentence_transformers.sentence_transformer.trainer import SentenceTransformerTrainer
+from sentence_transformers.sentence_transformer.training_args import SentenceTransformerTrainingArguments
 from sentence_transformers.util import http_get
 
 # Set the log level to INFO to get more information
@@ -52,7 +54,8 @@ use_cuda = torch.cuda.is_available()
 # Read Datasets ######
 qqp_dataset_path = "quora-IR-dataset"
 
-dataset = load_dataset("sentence-transformers/stsb")
+train_dataset = load_dataset("sentence-transformers/stsb", split="train")
+eval_dataset = load_dataset("sentence-transformers/stsb", split="validation")
 
 
 # Check if the QQP dataset exists. If not, download and extract
@@ -110,42 +113,35 @@ bi_encoder = SentenceTransformer(modules=[word_embedding_model, pooling_model])
 
 logging.info(f"Step 1: Train cross-encoder: {model_name} with STSbenchmark (source dataset)")
 
-gold_samples = []
-dev_samples = []
-test_samples = []
-
-for row in dataset["validation"]:
-    dev_samples.append(InputExample(texts=[row["sentence1"], row["sentence2"]], label=row["score"]))
-
-for row in dataset["test"]:
-    test_samples.append(InputExample(texts=[row["sentence1"], row["sentence2"]], label=row["score"]))
-
-for row in dataset["train"]:
-    # As we want to get symmetric scores, i.e. CrossEncoder(A,B) = CrossEncoder(B,A), we pass both combinations to the train set
-    gold_samples.append(InputExample(texts=[row["sentence1"], row["sentence2"]], label=row["score"]))
-    gold_samples.append(InputExample(texts=[row["sentence2"], row["sentence1"]], label=row["score"]))
-
-
-# We wrap gold_samples (which is a List[InputExample]) into a pytorch DataLoader
-train_dataloader = DataLoader(gold_samples, shuffle=True, batch_size=batch_size)
-
+# As we want to get symmetric scores, i.e. CrossEncoder(A,B) = CrossEncoder(B,A), we pass both combinations to the train set
+gold_dataset = concatenate_datasets(
+    [train_dataset, train_dataset.rename_columns({"sentence1": "sentence2", "sentence2": "sentence1"})]
+)
 
 # We add an evaluator, which evaluates the performance during training
-evaluator = CrossEncoderCorrelationEvaluator.from_input_examples(dev_samples, name="sts-dev")
-
-# Configure the training
-warmup_steps = math.ceil(len(train_dataloader) * num_epochs * 0.1)  # 10% of train data for warm-up
-logging.info(f"Warmup-steps: {warmup_steps}")
+evaluator = CrossEncoderCorrelationEvaluator(
+    sentence_pairs=[[row["sentence1"], row["sentence2"]] for row in eval_dataset],
+    scores=[row["score"] for row in eval_dataset],
+    name="sts-dev",
+)
 
 # Train the cross-encoder model
-cross_encoder.fit(
-    train_dataloader=train_dataloader,
-    evaluator=evaluator,
-    epochs=num_epochs,
-    evaluation_steps=1000,
-    warmup_steps=warmup_steps,
-    output_path=cross_encoder_path,
+ce_loss = BinaryCrossEntropyLoss(cross_encoder)
+ce_args = CrossEncoderTrainingArguments(
+    output_dir=cross_encoder_path,
+    num_train_epochs=num_epochs,
+    per_device_train_batch_size=batch_size,
+    warmup_ratio=0.1,
+    eval_strategy="steps",
+    eval_steps=1000,
 )
+CrossEncoderTrainer(
+    model=cross_encoder,
+    args=ce_args,
+    train_dataset=gold_dataset,
+    loss=ce_loss,
+    evaluator=evaluator,
+).train()
 
 ##################################################################
 #
@@ -180,14 +176,15 @@ binary_silver_scores = [1 if score >= 0.5 else 0 for score in silver_scores]
 
 logging.info(f"Step 3: Train bi-encoder: {model_name} over labeled QQP (target dataset)")
 
-# Convert the dataset to a DataLoader ready for training
 logging.info("Loading BERT labeled QQP dataset")
-qqp_train_data = list(
-    InputExample(texts=[data[0], data[1]], label=score) for (data, score) in zip(silver_data, binary_silver_scores)
+qqp_train_dataset = Dataset.from_dict(
+    {
+        "anchor": [data[0] for data in silver_data],
+        "positive": [data[1] for data in silver_data],
+        "label": binary_silver_scores,
+    }
 )
 
-
-train_dataloader = DataLoader(qqp_train_data, shuffle=True, batch_size=batch_size)
 train_loss = MultipleNegativesRankingLoss(bi_encoder)
 
 # Classification ######
@@ -209,19 +206,30 @@ with open(os.path.join(qqp_dataset_path, "classification/dev_pairs.tsv"), encodi
 
 evaluator = BinaryClassificationEvaluator(dev_sentences1, dev_sentences2, dev_labels)
 
-# Configure the training.
-warmup_steps = math.ceil(len(train_dataloader) * num_epochs * 0.1)  # 10% of train data for warm-up
-logging.info(f"Warmup-steps: {warmup_steps}")
+# Define the training arguments
+args = SentenceTransformerTrainingArguments(
+    output_dir=bi_encoder_path,
+    num_train_epochs=num_epochs,
+    per_device_train_batch_size=batch_size,
+    per_device_eval_batch_size=batch_size,
+    warmup_ratio=0.1,
+    eval_strategy="steps",
+    eval_steps=1000,
+    save_strategy="steps",
+    save_steps=1000,
+    save_total_limit=2,
+    logging_steps=100,
+    run_name="augmentation-qqp-crossdomain",
+)
 
 # Train the bi-encoder model
-bi_encoder.fit(
-    train_objectives=[(train_dataloader, train_loss)],
+SentenceTransformerTrainer(
+    model=bi_encoder,
+    args=args,
+    train_dataset=qqp_train_dataset,
+    loss=train_loss,
     evaluator=evaluator,
-    epochs=num_epochs,
-    evaluation_steps=1000,
-    warmup_steps=warmup_steps,
-    output_path=bi_encoder_path,
-)
+).train()
 
 ###############################################################
 #

--- a/examples/sentence_transformer/training/data_augmentation/train_sts_qqp_crossdomain.py
+++ b/examples/sentence_transformer/training/data_augmentation/train_sts_qqp_crossdomain.py
@@ -17,14 +17,10 @@ OR
 python train_sts_qqp_crossdomain.py pretrained_transformer_model_name
 """
 
-import csv
 import logging
-import os
 import sys
 from datetime import datetime
-from zipfile import ZipFile
 
-import torch
 from datasets import Dataset, concatenate_datasets, load_dataset
 
 from sentence_transformers import SentenceTransformer
@@ -34,11 +30,10 @@ from sentence_transformers.cross_encoder.losses import BinaryCrossEntropyLoss
 from sentence_transformers.cross_encoder.trainer import CrossEncoderTrainer
 from sentence_transformers.cross_encoder.training_args import CrossEncoderTrainingArguments
 from sentence_transformers.sentence_transformer.evaluation import BinaryClassificationEvaluator
-from sentence_transformers.sentence_transformer.losses import MultipleNegativesRankingLoss
+from sentence_transformers.sentence_transformer.losses import CosineSimilarityLoss
 from sentence_transformers.sentence_transformer.modules import Pooling, Transformer
 from sentence_transformers.sentence_transformer.trainer import SentenceTransformerTrainer
 from sentence_transformers.sentence_transformer.training_args import SentenceTransformerTrainingArguments
-from sentence_transformers.util import http_get
 
 # Set the log level to INFO to get more information
 logging.basicConfig(format="%(asctime)s - %(message)s", datefmt="%Y-%m-%d %H:%M:%S", level=logging.INFO)
@@ -49,22 +44,19 @@ model_name = sys.argv[1] if len(sys.argv) > 1 else "google-bert/bert-base-uncase
 batch_size = 16
 num_epochs = 1
 max_seq_length = 128
-use_cuda = torch.cuda.is_available()
 
 # Read Datasets ######
-qqp_dataset_path = "quora-IR-dataset"
-
 train_dataset = load_dataset("sentence-transformers/stsb", split="train")
 eval_dataset = load_dataset("sentence-transformers/stsb", split="validation")
 
-
-# Check if the QQP dataset exists. If not, download and extract
-if not os.path.exists(qqp_dataset_path):
-    logging.info("Dataset not found. Download")
-    zip_save_path = "quora-IR-dataset.zip"
-    http_get(url="https://sbert.net/datasets/quora-IR-dataset.zip", path=zip_save_path)
-    with ZipFile(zip_save_path, "r") as zipIn:
-        zipIn.extractall(qqp_dataset_path)
+# QQP (target dataset): https://huggingface.co/datasets/sentence-transformers/quora-duplicates
+# The pair-class subset has (sentence1, sentence2, label), where label is 0 (different) or 1 (duplicate).
+# It only has a "train" split, so we hold out small dev and test sets for evaluation.
+qqp_dataset = load_dataset("sentence-transformers/quora-duplicates", "pair-class", split="train")
+qqp_dataset = qqp_dataset.train_test_split(test_size=10_000, seed=12)
+qqp_train = qqp_dataset["train"]
+qqp_dev = qqp_dataset["test"].select(range(5_000))
+qqp_test = qqp_dataset["test"].select(range(5_000, 10_000))
 
 
 cross_encoder_path = (
@@ -132,16 +124,16 @@ ce_args = CrossEncoderTrainingArguments(
     num_train_epochs=num_epochs,
     per_device_train_batch_size=batch_size,
     warmup_ratio=0.1,
-    eval_strategy="steps",
-    eval_steps=1000,
+    eval_strategy="epoch",
 )
-CrossEncoderTrainer(
+ce_trainer = CrossEncoderTrainer(
     model=cross_encoder,
     args=ce_args,
     train_dataset=gold_dataset,
     loss=ce_loss,
     evaluator=evaluator,
-).train()
+)
+ce_trainer.train()
 cross_encoder.save_pretrained(f"{cross_encoder_path}/final")
 
 ##################################################################
@@ -152,20 +144,14 @@ cross_encoder.save_pretrained(f"{cross_encoder_path}/final")
 
 logging.info(f"Step 2: Label QQP (target dataset) with cross-encoder: {model_name}")
 
-silver_data = []
-
-with open(os.path.join(qqp_dataset_path, "classification/train_pairs.tsv"), encoding="utf8") as fIn:
-    reader = csv.DictReader(fIn, delimiter="\t", quoting=csv.QUOTE_NONE)
-    for row in reader:
-        if row["is_duplicate"] == "1":
-            silver_data.append([row["question1"], row["question2"]])
-
+# Following AugSBERT, we treat the QQP pairs as unlabeled: we ignore the gold labels and let the
+# STSb-trained cross-encoder assign each pair a soft similarity score in [0, 1]. These silver scores
+# are what the bi-encoder trains on, transferring the cross-encoder's knowledge to the target domain.
+silver_data = list(zip(qqp_train["sentence1"], qqp_train["sentence2"]))
 silver_scores = cross_encoder.predict(silver_data)
 
-# All model predictions should be between [0,1]
+# All model predictions should be between [0, 1]
 assert all(0.0 <= score <= 1.0 for score in silver_scores)
-
-binary_silver_scores = [1 if score >= 0.5 else 0 for score in silver_scores]
 
 ###########################################################################
 #
@@ -175,35 +161,23 @@ binary_silver_scores = [1 if score >= 0.5 else 0 for score in silver_scores]
 
 logging.info(f"Step 3: Train bi-encoder: {model_name} over labeled QQP (target dataset)")
 
-logging.info("Loading BERT labeled QQP dataset")
+logging.info("Loading the cross-encoder labeled QQP dataset")
 qqp_train_dataset = Dataset.from_dict(
     {
-        "anchor": [data[0] for data in silver_data],
-        "positive": [data[1] for data in silver_data],
-        "label": binary_silver_scores,
+        "sentence1": [pair[0] for pair in silver_data],
+        "sentence2": [pair[1] for pair in silver_data],
+        "score": [float(score) for score in silver_scores],
     }
 )
 
-train_loss = MultipleNegativesRankingLoss(bi_encoder)
+train_loss = CosineSimilarityLoss(model=bi_encoder)
 
 # Classification ######
 # Given (question1, question2), is this a duplicate or not?
 # The evaluator will compute the embeddings for both questions and then compute
 # a cosine similarity. If the similarity is above a threshold, we have a duplicate.
 logging.info("Read QQP dev dataset")
-
-dev_sentences1 = []
-dev_sentences2 = []
-dev_labels = []
-
-with open(os.path.join(qqp_dataset_path, "classification/dev_pairs.tsv"), encoding="utf8") as fIn:
-    reader = csv.DictReader(fIn, delimiter="\t", quoting=csv.QUOTE_NONE)
-    for row in reader:
-        dev_sentences1.append(row["question1"])
-        dev_sentences2.append(row["question2"])
-        dev_labels.append(int(row["is_duplicate"]))
-
-evaluator = BinaryClassificationEvaluator(dev_sentences1, dev_sentences2, dev_labels)
+evaluator = BinaryClassificationEvaluator(qqp_dev["sentence1"], qqp_dev["sentence2"], qqp_dev["label"])
 
 # Define the training arguments
 args = SentenceTransformerTrainingArguments(
@@ -213,22 +187,23 @@ args = SentenceTransformerTrainingArguments(
     per_device_eval_batch_size=batch_size,
     warmup_ratio=0.1,
     eval_strategy="steps",
-    eval_steps=1000,
+    eval_steps=0.1,
     save_strategy="steps",
-    save_steps=1000,
+    save_steps=0.1,
     save_total_limit=2,
-    logging_steps=100,
+    logging_steps=0.05,
     run_name="augmentation-qqp-crossdomain",
 )
 
 # Train the bi-encoder model
-SentenceTransformerTrainer(
+trainer = SentenceTransformerTrainer(
     model=bi_encoder,
     args=args,
     train_dataset=qqp_train_dataset,
     loss=train_loss,
     evaluator=evaluator,
-).train()
+)
+trainer.train()
 bi_encoder.save_pretrained(f"{bi_encoder_path}/final")
 
 ###############################################################
@@ -238,16 +213,5 @@ bi_encoder.save_pretrained(f"{bi_encoder_path}/final")
 ###############################################################
 
 logging.info("Read QQP test dataset")
-test_sentences1 = []
-test_sentences2 = []
-test_labels = []
-
-with open(os.path.join(qqp_dataset_path, "classification/test_pairs.tsv"), encoding="utf8") as fIn:
-    reader = csv.DictReader(fIn, delimiter="\t", quoting=csv.QUOTE_NONE)
-    for row in reader:
-        test_sentences1.append(row["question1"])
-        test_sentences2.append(row["question2"])
-        test_labels.append(int(row["is_duplicate"]))
-
-evaluator = BinaryClassificationEvaluator(test_sentences1, test_sentences2, test_labels)
+evaluator = BinaryClassificationEvaluator(qqp_test["sentence1"], qqp_test["sentence2"], qqp_test["label"])
 bi_encoder.evaluate(evaluator)


### PR DESCRIPTION
Three scripts under `examples/sentence_transformer/training/data_augmentation/` still used `cross_encoder.fit` / `model.fit` with `InputExample` + `DataLoader`.   
This pr ports them to `CrossEncoderTrainer` / `SentenceTransformerTrainer` + `datasets.Dataset` so they match the rest of the examples.