### PR TITLE
[`ci`] Pass HF read token for `main` CI

### DIFF
--- a/.github/workflows/min-versions.yml
+++ b/.github/workflows/min-versions.yml
@@ -18,6 +18,7 @@ on:
 env:
   TRANSFORMERS_IS_CI: 1
   HF_HUB_DISABLE_PROGRESS_BARS: 1
+  HF_TOKEN: ${{ secrets.HF_TOKEN }}  # Read token to avoid rate limits / gated-repo failures when downloading from the Hub
 
 jobs:
   test_min_versions:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,6 +14,7 @@ on:
 env:
   TRANSFORMERS_IS_CI: 1
   HF_HUB_DISABLE_PROGRESS_BARS: 1  # The Transformers v5 weight loading progress bars heavily expand the logs
+  HF_TOKEN: ${{ secrets.HF_TOKEN }}  # Read token to avoid rate limits / gated-repo failures when downloading from the Hub
 
 jobs:
   test_sampling:


### PR DESCRIPTION
Hello!

## Pull Request overview
* Pass HF read token for `main` CI

## Details
This should only run on branches in this repository, so not on PRs sadly, and the token has no permissions at all.

- Tom Aarsen