### PR TITLE
Fix package build warnings and errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "sentence-transformers"
 version = "5.6.0.dev0"
 description = "Embeddings, Retrieval, and Reranking"
-license = { text = "Apache 2.0" }
+license = "Apache-2.0"
 readme = "README.md"
 authors = [
     { name = "Nils Reimers", email = "info@nils-reimers.de" },
@@ -24,7 +24,6 @@ keywords = [
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -99,7 +98,7 @@ docs = [
 ]
 
 [build-system]
-requires = ["setuptools>=64", "wheel"]
+requires = ["setuptools>=77.0.3"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
## Build problems with MINIMUM build requirements installed

The following commands demonstrate a build warning when using the minimum supported Python version (3.10) and the minimum specified setuptools version (64):

```console
$ python3.10 -m venv venv-build-310
$ source venv-build-310/bin/activate
$ python -m pip install setuptools==64 wheel build
$ python -m build --no-isolation

...

venv-build-310/lib/python3.10/site-packages/setuptools/config/pyprojecttoml.py:108:
_BetaConfiguration: Support for `[tool.setuptools]` in `pyproject.toml` is still *beta*.
  warnings.warn(msg, _BetaConfiguration)

venv-build-310/lib/python3.10/site-packages/wheel/bdist_wheel.py:4:
FutureWarning: The 'wheel' package is no longer the canonical location
of the 'bdist_wheel' command, and will be removed in a future release.
Please update to setuptools v70.1 or later which contains an integrated version
of this command.
  warn(

...

$ deactivate
```

The following commands demonstrate a build error
when using the latest supported Python version (3.14) and the minimum specified setuptools version (64):

```console
$ python3.14 -m venv venv-build-314
$ source venv-build-314/bin/activate
$ python -m pip install setuptools==64 wheel build
$ python -m build --no-isolation

...

  File "venv-build-314/lib/python3.14/site-packages/pkg_resources/__init__.py", line 2191, in <module>
    register_finder(pkgutil.ImpImporter, find_on_path)
                    ^^^^^^^^^^^^^^^^^^^
AttributeError: module 'pkgutil' has no attribute 'ImpImporter'. Did you mean: 'zipimporter'?

ERROR Backend subprocess exited when trying to invoke get_requires_for_build_sdist

...

$ deactivate
```

----

## Build problems with LATEST build requirements installed

The following commands demonstrate build warnings
when using the latest available setuptools version (82.0.1 on 2026-06-09):

```console
$ rm -rf venv-build-310
$ python3.10 -m venv venv-build-310
$ source venv-build-310/bin/activate
$ python -m pip install setuptools==82.0.1 build
$ python -m build --no-isolation

...

venv-build-310/lib/python3.10/site-packages/setuptools/config/_apply_pyprojecttoml.py:82:
SetuptoolsDeprecationWarning: `project.license` as a TOML table is deprecated
!!

        ********************************************************************************
        Please use a simple string containing a SPDX expression for `project.license`.
        You can also use `project.license-files`. (Both options available on setuptools>=77.0.0).

        By 2027-Feb-18, you need to update your project and remove deprecated calls
        or your builds will no longer be supported.

        See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
        ********************************************************************************

!!
  corresp(dist, value, root_dir)
venv-build-310/lib/python3.10/site-packages/setuptools/config/_apply_pyprojecttoml.py:61:
SetuptoolsDeprecationWarning: License classifiers are deprecated.
!!

        ********************************************************************************
        Please consider removing the following classifiers in favor of a SPDX license expression:

        License :: OSI Approved :: Apache Software License

        See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
        ********************************************************************************

!!
  dist._finalize_license_expression()
venv-build-310/lib/python3.10/site-packages/setuptools/dist.py:765:
SetuptoolsDeprecationWarning: License classifiers are deprecated.
!!

        ********************************************************************************
        Please consider removing the following classifiers in favor of a SPDX license expression:

        License :: OSI Approved :: Apache Software License

        See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
        ********************************************************************************

...

$ deactivate
```

----

This commit introduces the following changes to resolve these warnings/errors:

* Remove the "wheel" package from the `build-system.requires` list
* Update the minimum required setuptools version to v77.0.3
* Update `project.license` to use the `Apache-2.0` SPDX identifier
* Remove the Apache license trove classifier

This resolves all of the current build warnings and errors.

```console
$ rm -rf venv-build-310
$ python3.10 -m venv venv-build-310
$ source venv-build-310/bin/activate

$ python -m pip install setuptools==77.0.3 build
$ python -m build --no-isolation

$ python -m pip install --upgrade setuptools
$ python -m build --no-isolation

$ deactivate
```

```console
$ rm -rf venv-build-314
$ python3.14 -m venv venv-build-314
$ source venv-build-314/bin/activate

$ python -m pip install setuptools==77.0.3 build
$ python -m build --no-isolation

$ python -m pip install --upgrade setuptools
$ python -m build --no-isolation

$ deactivate
```