### PR TITLE
[fix] Support MPS in the cached losses' RandContext

### DIFF
--- a/sentence_transformers/sentence_transformer/losses/cached_gist_embed.py
+++ b/sentence_transformers/sentence_transformer/losses/cached_gist_embed.py
@@ -30,15 +30,33 @@ class RandContext:
 
     def __init__(self, *tensors) -> None:
         self.fwd_cpu_state = torch.get_rng_state()
-        self.fwd_gpu_devices, self.fwd_gpu_states = get_device_states(*tensors)
+        # torch.utils.checkpoint.get_device_states() fails when it sees MPS tensors (it
+        # calls the non-existent torch.mps.device()), so capture the MPS RNG state for
+        # top-level MPS tensor arguments and filter them out before calling it. The MPS
+        # state is restored in __enter__ so the cached second forward replays the same
+        # randomness (e.g. dropout).
+        self.fwd_mps_state = (
+            torch.mps.get_rng_state()
+            if any(isinstance(t, torch.Tensor) and t.device.type == "mps" for t in tensors)
+            else None
+        )
+        non_mps_tensors = tuple(t for t in tensors if not (isinstance(t, torch.Tensor) and t.device.type == "mps"))
+        self.fwd_gpu_devices, self.fwd_gpu_states = get_device_states(*non_mps_tensors)
 
     def __enter__(self) -> None:
         self._fork = torch.random.fork_rng(devices=self.fwd_gpu_devices, enabled=True)
         self._fork.__enter__()
         torch.set_rng_state(self.fwd_cpu_state)
+        if self.fwd_mps_state is not None:
+            # This fork_rng call uses the default device_type="cuda", so save the outer
+            # MPS state here and restore it in __exit__ (mirroring fork_rng for CPU/CUDA).
+            self._mps_state_outside = torch.mps.get_rng_state()
+            torch.mps.set_rng_state(self.fwd_mps_state)
         set_device_states(self.fwd_gpu_devices, self.fwd_gpu_states)
 
     def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        if self.fwd_mps_state is not None:
+            torch.mps.set_rng_state(self._mps_state_outside)
         self._fork.__exit__(exc_type, exc_val, exc_tb)
         self._fork = None
 

--- a/sentence_transformers/sentence_transformer/losses/cached_multiple_negatives_ranking.py
+++ b/sentence_transformers/sentence_transformer/losses/cached_multiple_negatives_ranking.py
@@ -29,15 +29,33 @@ class RandContext:
 
     def __init__(self, *tensors) -> None:
         self.fwd_cpu_state = torch.get_rng_state()
-        self.fwd_gpu_devices, self.fwd_gpu_states = get_device_states(*tensors)
+        # torch.utils.checkpoint.get_device_states() fails when it sees MPS tensors (it
+        # calls the non-existent torch.mps.device()), so capture the MPS RNG state for
+        # top-level MPS tensor arguments and filter them out before calling it. The MPS
+        # state is restored in __enter__ so the cached second forward replays the same
+        # randomness (e.g. dropout).
+        self.fwd_mps_state = (
+            torch.mps.get_rng_state()
+            if any(isinstance(t, torch.Tensor) and t.device.type == "mps" for t in tensors)
+            else None
+        )
+        non_mps_tensors = tuple(t for t in tensors if not (isinstance(t, torch.Tensor) and t.device.type == "mps"))
+        self.fwd_gpu_devices, self.fwd_gpu_states = get_device_states(*non_mps_tensors)
 
     def __enter__(self) -> None:
         self._fork = torch.random.fork_rng(devices=self.fwd_gpu_devices, enabled=True)
         self._fork.__enter__()
         torch.set_rng_state(self.fwd_cpu_state)
+        if self.fwd_mps_state is not None:
+            # This fork_rng call uses the default device_type="cuda", so save the outer
+            # MPS state here and restore it in __exit__ (mirroring fork_rng for CPU/CUDA).
+            self._mps_state_outside = torch.mps.get_rng_state()
+            torch.mps.set_rng_state(self.fwd_mps_state)
         set_device_states(self.fwd_gpu_devices, self.fwd_gpu_states)
 
     def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        if self.fwd_mps_state is not None:
+            torch.mps.set_rng_state(self._mps_state_outside)
         self._fork.__exit__(exc_type, exc_val, exc_tb)
         self._fork = None
 

--- a/tests/sentence_transformer/losses/test_cmnrl.py
+++ b/tests/sentence_transformer/losses/test_cmnrl.py
@@ -157,6 +157,49 @@ def test_rand_context_working(use_rand_context: bool):
             assert not torch.allclose(torch.rand(1000), expected, precision, precision)
 
 
+@pytest.mark.parametrize(
+    "rand_context_path",
+    [
+        pytest.param(
+            "sentence_transformers.sentence_transformer.losses.cached_multiple_negatives_ranking.RandContext",
+            id="cmnrl",
+        ),
+        pytest.param(
+            "sentence_transformers.sentence_transformer.losses.cached_gist_embed.RandContext",
+            id="gist",
+        ),
+    ],
+)
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="MPS must be available to test the MPS RandContext path."
+)
+def test_rand_context_mps(rand_context_path: str):
+    # Regression test for #3564: RandContext raised
+    # "AttributeError: module 'torch.mps' has no attribute 'device'" for MPS tensors,
+    # because torch.utils.checkpoint.get_device_states() does not support MPS.
+    import importlib
+
+    module_name, class_name = rand_context_path.rsplit(".", 1)
+    RandContext = getattr(importlib.import_module(module_name), class_name)
+
+    # Given:
+    a = torch.randn(4, device="mps")
+    b = torch.randn(4, device="mps")
+    random_state = RandContext(a, b)  # must not raise on MPS
+    expected = torch.rand(1000, device="mps")
+
+    # When / Then: re-entering must replay the same MPS randomness (the cached second forward).
+    with random_state:
+        assert torch.equal(torch.rand(1000, device="mps"), expected)
+
+    # __exit__ must restore the outer MPS RNG state, so the context does not leak the
+    # replayed state to surrounding code.
+    outer_before = torch.mps.get_rng_state()
+    with random_state:
+        torch.rand(500, device="mps")
+    assert torch.equal(torch.mps.get_rng_state(), outer_before)
+
+
 class TestCreateMinibatchMixedModality:
     """Test _create_minibatch with mixed-modality batches (some samples have images, some don't).
 


### PR DESCRIPTION
Fixes #3564.

`CachedMultipleNegativesRankingLoss` and `CachedGISTEmbedLoss` crash on MPS (Apple Silicon):

```
AttributeError: module 'torch.mps' has no attribute 'device'
```

`RandContext` backs up the device RNG state with `torch.utils.checkpoint.get_device_states(*tensors)`, which calls the non-existent `torch.mps.device()` as soon as it sees an MPS tensor.

`RandContext` is there so GradCache's second (cached) forward replays the same randomness, so just skipping the device state on MPS would stop the crash but break that replay — dropout would differ between the two forwards. Instead I capture the MPS RNG state with `torch.mps.get_rng_state()` when an input is on MPS, pass only the non-MPS tensors to `get_device_states()`, restore the snapshot in `__enter__`, and restore the surrounding MPS state in `__exit__` (the existing `fork_rng()` call defaults to `device_type="cuda"`, so it does not cover MPS).

Both SentenceTransformer `RandContext` copies get the fix, so this also covers sparse `CachedSpladeLoss`, which imports the `CachedMultipleNegativesRankingLoss` one. The CrossEncoder cached loss calls `RandContext(pairs)` with raw text rather than tensors, so it never hit this and is left alone.

Added an MPS regression test (skipped without MPS) over both copies — it raises the `AttributeError` on main and passes here, and checks both the replay and that the outer RNG state is not leaked.
