### PR TITLE
[`ci`] Avoid model2vec distill install in CI as it limits the transformers version

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -80,9 +80,15 @@ jobs:
         if: ${{ matrix.transformers-version == '>=5.0.0' }}
         run: uv pip install '.[train]' --group test 'transformers>=5.0.0' 'accelerate>=1.13.0' --excludes excludes.txt --system
 
-      - name: Install model2vec
+      # model2vec[distill] pins transformers<5.4.0, so use the distill extra only on
+      # the <5.0.0 leg (distillation tests skip on v5+ anyway) and base model2vec elsewhere.
+      - name: Install model2vec (with distillation extra)
         run: uv pip install model2vec[distill] --system
-        if: ${{ contains(fromJSON('["3.10", "3.11", "3.12", "3.13"]'), matrix.python-version) }}
+        if: ${{ matrix.transformers-version == '<5.0.0' }}
+
+      - name: Install model2vec
+        run: uv pip install model2vec --system
+        if: ${{ matrix.transformers-version == '>=5.0.0' }}
 
       - name: Run unit tests
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -83,7 +83,7 @@ jobs:
       # model2vec[distill] pins transformers<5.4.0, so use the distill extra only on
       # the <5.0.0 leg (distillation tests skip on v5+ anyway) and base model2vec elsewhere.
       - name: Install model2vec (with distillation extra)
-        run: uv pip install model2vec[distill] --system
+        run: uv pip install 'model2vec[distill]' --system
         if: ${{ matrix.transformers-version == '<5.0.0' }}
 
       - name: Install model2vec

--- a/tests/base/test_trainer.py
+++ b/tests/base/test_trainer.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 import json
 import os
 from pathlib import Path
@@ -7,6 +8,7 @@ from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
+from huggingface_hub import HfApi
 
 from sentence_transformers import (
     SentenceTransformer,
@@ -22,6 +24,18 @@ if not is_training_available():
     )
 
 
+@contextlib.contextmanager
+def _patch_hfapi(method: str, **kwargs):
+    # Older transformers imported create_repo/upload_folder into the trainer module.
+    # Newer transformers resolves HfApi.<method> at call time via hf_api(), so patch
+    # whichever the installed version actually uses.
+    import transformers.trainer as hf_trainer
+
+    target = hf_trainer if hasattr(hf_trainer, method) else HfApi
+    with patch.object(target, method, **kwargs) as mock:
+        yield mock
+
+
 def test_push_from_checkpoint_copies_full_layout(static_embedding_model: SentenceTransformer, tmp_path: Path) -> None:
     output_dir = tmp_path / "out"
     checkpoint_folder = output_dir / "checkpoint-437"
@@ -35,7 +49,7 @@ def test_push_from_checkpoint_copies_full_layout(static_embedding_model: Sentenc
         report_to=[],
     )
 
-    with patch("transformers.trainer.create_repo", return_value=SimpleNamespace(repo_id="dummy/model")):
+    with _patch_hfapi("create_repo", return_value=SimpleNamespace(repo_id="dummy/model")):
         trainer = SentenceTransformerTrainer(model=static_embedding_model, args=args)
 
     trainer._save(output_dir=str(checkpoint_folder))
@@ -58,7 +72,7 @@ def test_push_from_checkpoint_copies_full_layout(static_embedding_model: Sentenc
         (checkpoint_folder / shard).write_text("shard")
 
     with (
-        patch("transformers.trainer.upload_folder") as mock_upload,
+        _patch_hfapi("upload_folder") as mock_upload,
         patch.object(trainer, "is_world_process_zero", return_value=True),
         patch.object(trainer, "callback_handler"),
     ):
@@ -95,13 +109,13 @@ def test_push_from_checkpoint_skips_when_end_strategy(
         report_to=[],
     )
 
-    with patch("transformers.trainer.create_repo", return_value=SimpleNamespace(repo_id="dummy/model")):
+    with _patch_hfapi("create_repo", return_value=SimpleNamespace(repo_id="dummy/model")):
         trainer = SentenceTransformerTrainer(model=static_embedding_model, args=args)
 
     trainer._save(output_dir=str(checkpoint_folder))
 
     with (
-        patch("transformers.trainer.upload_folder") as mock_upload,
+        _patch_hfapi("upload_folder") as mock_upload,
         patch.object(trainer, "is_world_process_zero", return_value=True),
         patch.object(trainer, "callback_handler"),
     ):


### PR DESCRIPTION
Hello!

## Pull Request overview
* Stop installing `model2vec[distill]` on the `transformers>=5.0.0` CI leg so it tests the latest transformers instead of being capped to `<5.4.0`
* Keep `model2vec[distill]` on the `transformers<5.0.0` leg, where the distillation tests actually run

## Details
The `model2vec[distill]` extra pins `transformers<5.4.0`, and the model2vec install step ran on every matrix leg, so the `transformers>=5.0.0` job was silently resolving transformers 5.3.0 rather than the latest release. I caught this from the huggingface_hub release-candidate CI: the downgraded transformers 5.3.0 got paired with the 5.11-era `tokenizers==0.23.0rc0` that the first install had pulled in, and that mismatch broke RoBERTa/CLIP tokenizer construction with `RobertaProcessing.__new__() got an unexpected keyword argument 'cls'`.

Base `model2vec` has no `transformers` (or `torch`) dependency at all; only the `distill` extra constrains it. The distillation tests (`test_from_distillation`) already skip on transformers v5+, so the `>=5.0.0` leg never needed the extra in the first place. I now install `model2vec[distill]` only on the `<5.0.0` leg (where the `<5.4.0` cap is moot and distillation actually runs) and plain `model2vec` elsewhere, so the latest-transformers leg resolves the latest transformers and stays internally consistent. I also dropped the `contains(fromJSON(...))` guard on the install step, which was always true now that the matrix is `3.10`–`3.13`.

- Tom Aarsen
