### PR TITLE
[fix] Fix positive masking in GIST losses with gather_across_devices

### DIFF
--- a/sentence_transformers/sentence_transformer/losses/cached_gist_embed.py
+++ b/sentence_transformers/sentence_transformer/losses/cached_gist_embed.py
@@ -348,9 +348,11 @@ class CachedGISTEmbedLoss(nn.Module):
                 sim_mat[mask] = -torch.inf
                 return sim_mat
 
-            # Create a mask to protect true positive pairs in the anchor-positive matrix (i.e., diagonal elements)
-            positive_mask = torch.eye(*guided_ap_sim.shape, dtype=torch.bool, device=guided_ap_sim.device)
-            positive_mask = positive_mask.roll(begin)
+            # Protect each anchor's true positive from false-negative suppression using the same
+            # gathered column index as the CE target.
+            positive_mask = torch.zeros_like(guided_ap_sim, dtype=torch.bool)
+            rows = torch.arange(guided_ap_sim.size(0), device=guided_ap_sim.device)
+            positive_mask[rows, offset + begin + rows] = True
 
             # Apply false negative suppression to each similarity matrix using guided similarity as anchor
             ap_sim = mask_false_negatives(guided_ap_sim, ap_sim, positive_mask=positive_mask)  # anchor-positive

--- a/sentence_transformers/sentence_transformer/losses/gist_embed.py
+++ b/sentence_transformers/sentence_transformer/losses/gist_embed.py
@@ -208,8 +208,11 @@ class GISTEmbedLoss(nn.Module):
             sim_mat[mask] = -torch.inf
             return sim_mat
 
-        # Create a mask to protect true positive pairs in the anchor-positive matrix (i.e., diagonal elements)
-        positive_mask = torch.eye(*guided_ap_sim.shape, dtype=torch.bool, device=guided_ap_sim.device)
+        # Protect each anchor's true positive from false-negative suppression using the same
+        # gathered column index as the CE target.
+        positive_mask = torch.zeros_like(guided_ap_sim, dtype=torch.bool)
+        rows = torch.arange(guided_ap_sim.size(0), device=guided_ap_sim.device)
+        positive_mask[rows, offset + rows] = True
 
         # Apply false negative suppression to each similarity matrix using guided similarity as anchor
         ap_sim = mask_false_negatives(guided_ap_sim, ap_sim, positive_mask=positive_mask)  # anchor-positive

--- a/tests/sentence_transformer/losses/test_cached_gist_embed.py
+++ b/tests/sentence_transformer/losses/test_cached_gist_embed.py
@@ -44,7 +44,8 @@ def simulate_rank1_world2(monkeypatch):
 
     monkeypatch.setattr(cge, "all_gather_with_grad", fake_gather)
     monkeypatch.setattr(cge, "is_dist_initialized", lambda: True)
-    monkeypatch.setattr(torch.distributed, "get_rank", lambda: 1)
+    # get_rank may be absent on CPU-only/ROCm builds (torch.distributed.is_available() is False).
+    monkeypatch.setattr(torch.distributed, "get_rank", lambda: 1, raising=False)
     return per
 
 
@@ -89,34 +90,34 @@ def test_gather_rank1_margin_zero_baseline(simulate_rank1_world2):
 
 @pytest.mark.parametrize("mini_batch_size", [32, 2])
 def test_positive_mask_protects_ce_target_column(simulate_rank1_world2, mini_batch_size):
-    """Structural invariant: across every minibatch chunk, the column protected by
-    ``positive_mask`` for local row r equals the CE target column
-    ``range_labels[begin + r] = offset + begin + r``.
+    """Drive the real loss and assert it protects exactly the CE-target column in every minibatch.
 
-    We reconstruct the mask exactly as the loss does, for each ``begin`` chunk, and compare
-    against the targets. ``mini_batch_size=2`` exercises a ``begin > 0`` chunk.
+    We capture each minibatch's (masked) score matrix and labels as passed to cross-entropy and
+    check that every anchor's CE-target logit survived suppression (is finite). With the old
+    offset-unaware ``roll(begin)`` mask, on rank 1 that column is set to -inf, so this fails on the
+    pre-fix code. ``mini_batch_size=2`` exercises a ``begin > 0`` chunk.
     """
     per = simulate_rank1_world2
-    dim = 16
-    reps, reps_guided = _local_reps(per, dim=dim)
+    reps, reps_guided = _local_reps(per)
     loss_fn = _make_loss(margin=0.1, mini_batch_size=mini_batch_size)
 
-    anchors = torch.cat(reps[0])
-    candidates = [cge.all_gather_with_grad(torch.cat(r)) for r in reps[1:]]
-    batch_size = anchors.size(0)
-    offset = torch.distributed.get_rank() * batch_size  # = per (rank 1)
+    captured = []
+    real_ce = loss_fn.cross_entropy_loss
 
-    range_labels = torch.arange(offset, offset + batch_size)
+    def capturing_ce(scores, labels):
+        captured.append((scores, labels))
+        return real_ce(scores, labels)
 
-    for begin in range(0, batch_size, mini_batch_size):
-        end = begin + mini_batch_size
-        guided_ap_sim = loss_fn.sim_matrix(anchors[begin:end], candidates[0])
-        positive_mask = torch.zeros_like(guided_ap_sim, dtype=torch.bool)
-        rows = torch.arange(guided_ap_sim.size(0))
-        positive_mask[rows, offset + begin + rows] = True
+    # cross_entropy_loss is registered as an nn.Module child, so drop it before assigning a plain callable.
+    del loss_fn.cross_entropy_loss
+    loss_fn.cross_entropy_loss = capturing_ce
 
-        protected_cols = positive_mask.float().argmax(dim=1)
-        assert torch.equal(protected_cols, range_labels[begin : begin + rows.size(0)]), (
-            f"begin={begin}: protected columns {protected_cols.tolist()} must equal CE targets "
-            f"{range_labels[begin : begin + rows.size(0)].tolist()}"
+    loss = loss_fn.calculate_loss(reps, reps_guided)
+
+    assert captured, "cross-entropy was never called"
+    for scores, labels in captured:
+        target_logits = scores[torch.arange(scores.size(0)), labels]
+        assert torch.isfinite(target_logits).all(), (
+            f"each anchor's CE-target logit must survive masking, got {target_logits.tolist()}"
         )
+    assert torch.isfinite(loss)

--- a/tests/sentence_transformer/losses/test_cached_gist_embed.py
+++ b/tests/sentence_transformer/losses/test_cached_gist_embed.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import pytest
+import torch
+
+import sentence_transformers.sentence_transformer.losses.cached_gist_embed as cge
+from sentence_transformers.sentence_transformer.losses import CachedGISTEmbedLoss
+
+
+def _make_loss(margin: float, mini_batch_size: int = 32) -> CachedGISTEmbedLoss:
+    """Build a CachedGISTEmbedLoss without loading real models.
+
+    ``calculate_loss`` only needs the configuration attributes and operates on
+    precomputed reps, so we bypass ``__init__`` (which requires SentenceTransformers).
+    """
+    obj = CachedGISTEmbedLoss.__new__(CachedGISTEmbedLoss)
+    torch.nn.Module.__init__(obj)
+    obj.temperature = 0.01
+    obj.similarity_fct = torch.nn.CosineSimilarity(dim=-1)
+    obj.mini_batch_size = mini_batch_size
+    obj.show_progress_bar = False
+    obj.margin_strategy = "absolute"
+    obj.margin = margin
+    obj.contrast_anchors = True
+    obj.contrast_positives = True
+    obj.gather_across_devices = True
+    obj.cross_entropy_loss = torch.nn.CrossEntropyLoss()
+    return obj
+
+
+@pytest.fixture
+def simulate_rank1_world2(monkeypatch):
+    """Monkeypatch the distributed helpers so ``calculate_loss`` runs the rank=1/world=2
+    gather path in a single process: ``all_gather_with_grad`` prepends a rank-0 block to
+    the local (rank-1) block, and the rank is reported as 1 so ``offset = batch_size``.
+    """
+    per = 3
+
+    def fake_gather(tensor: torch.Tensor) -> torch.Tensor:
+        # rank 0's block is deterministic and distinct from the local (rank 1) block.
+        g = torch.Generator().manual_seed(1234)
+        rank0_block = torch.randn(per, tensor.size(1), generator=g)
+        return torch.cat([rank0_block, tensor], dim=0)
+
+    monkeypatch.setattr(cge, "all_gather_with_grad", fake_gather)
+    monkeypatch.setattr(cge, "is_dist_initialized", lambda: True)
+    monkeypatch.setattr(torch.distributed, "get_rank", lambda: 1)
+    return per
+
+
+def _local_reps(per: int, dim: int = 16, seed: int = 7):
+    g = torch.Generator().manual_seed(seed)
+    anchors = torch.randn(per, dim, generator=g)
+    positives = torch.randn(per, dim, generator=g)
+    # reps[0] = anchors, reps[1] = positives; each a list of minibatch tensors.
+    reps = [[anchors.clone()], [positives.clone()]]
+    reps_guided = [[anchors.clone()], [positives.clone()]]
+    return reps, reps_guided
+
+
+@pytest.mark.parametrize("mini_batch_size", [32, 2])
+def test_gather_rank1_positive_not_masked_with_margin(simulate_rank1_world2, mini_batch_size):
+    """Regression for the rank>0 positive-mask offset bug (gather_across_devices).
+
+    On rank 1, each anchor's true positive lives at gathered column ``offset + row``.
+    With ``margin > 0`` the positive itself exceeds ``positive_sim - margin``, so it is
+    only spared by ``positive_mask``. If the mask is offset-unaware (the old
+    ``roll(begin)``), it protects the wrong columns, the CE-target logit becomes -inf,
+    and the loss is +inf. With the offset-aware mask the loss stays finite.
+
+    ``mini_batch_size=2`` splits the local batch so the inner loop runs with ``begin > 0``,
+    covering the minibatch-boundary case (where the old flatten-roll could also wrap).
+    """
+    per = simulate_rank1_world2
+    reps, reps_guided = _local_reps(per)
+    loss = _make_loss(margin=0.1, mini_batch_size=mini_batch_size).calculate_loss(reps, reps_guided)
+    assert torch.isfinite(loss), f"rank>0 loss must be finite, got {loss.item()}"
+
+
+def test_gather_rank1_margin_zero_baseline(simulate_rank1_world2):
+    """Sanity baseline: with margin=0 the positive equals its own threshold and is not
+    suppressed regardless of the mask, so the loss is finite both before and after the fix.
+    """
+    per = simulate_rank1_world2
+    reps, reps_guided = _local_reps(per)
+    loss = _make_loss(margin=0.0).calculate_loss(reps, reps_guided)
+    assert torch.isfinite(loss)
+
+
+@pytest.mark.parametrize("mini_batch_size", [32, 2])
+def test_positive_mask_protects_ce_target_column(simulate_rank1_world2, mini_batch_size):
+    """Structural invariant: across every minibatch chunk, the column protected by
+    ``positive_mask`` for local row r equals the CE target column
+    ``range_labels[begin + r] = offset + begin + r``.
+
+    We reconstruct the mask exactly as the loss does, for each ``begin`` chunk, and compare
+    against the targets. ``mini_batch_size=2`` exercises a ``begin > 0`` chunk.
+    """
+    per = simulate_rank1_world2
+    dim = 16
+    reps, reps_guided = _local_reps(per, dim=dim)
+    loss_fn = _make_loss(margin=0.1, mini_batch_size=mini_batch_size)
+
+    anchors = torch.cat(reps[0])
+    candidates = [cge.all_gather_with_grad(torch.cat(r)) for r in reps[1:]]
+    batch_size = anchors.size(0)
+    offset = torch.distributed.get_rank() * batch_size  # = per (rank 1)
+
+    range_labels = torch.arange(offset, offset + batch_size)
+
+    for begin in range(0, batch_size, mini_batch_size):
+        end = begin + mini_batch_size
+        guided_ap_sim = loss_fn.sim_matrix(anchors[begin:end], candidates[0])
+        positive_mask = torch.zeros_like(guided_ap_sim, dtype=torch.bool)
+        rows = torch.arange(guided_ap_sim.size(0))
+        positive_mask[rows, offset + begin + rows] = True
+
+        protected_cols = positive_mask.float().argmax(dim=1)
+        assert torch.equal(protected_cols, range_labels[begin : begin + rows.size(0)]), (
+            f"begin={begin}: protected columns {protected_cols.tolist()} must equal CE targets "
+            f"{range_labels[begin : begin + rows.size(0)].tolist()}"
+        )

--- a/tests/sentence_transformer/losses/test_gist_embed.py
+++ b/tests/sentence_transformer/losses/test_gist_embed.py
@@ -45,7 +45,8 @@ def simulate_rank1_world2(monkeypatch):
 
     monkeypatch.setattr(ge, "all_gather_with_grad", fake_gather)
     monkeypatch.setattr(ge, "is_dist_initialized", lambda: True)
-    monkeypatch.setattr(torch.distributed, "get_rank", lambda: 1)
+    # get_rank may be absent on CPU-only/ROCm builds (torch.distributed.is_available() is False).
+    monkeypatch.setattr(torch.distributed, "get_rank", lambda: 1, raising=False)
     return per
 
 
@@ -79,26 +80,32 @@ def test_gather_rank1_margin_zero_baseline(simulate_rank1_world2):
 
 
 def test_positive_mask_protects_ce_target_column(simulate_rank1_world2):
-    """Structural invariant: the column protected by ``positive_mask`` for anchor row r equals
-    the CE target column ``range_labels[r] = offset + r``.
+    """Drive the real loss and assert it protects exactly the CE-target column.
+
+    We capture the (masked) score matrix the loss feeds to cross-entropy and check that every
+    anchor's CE-target logit survived suppression (is finite). With the old offset-unaware
+    ``torch.eye`` mask, on rank 1 that column is set to -inf, so this fails on the pre-fix code.
     """
     per = simulate_rank1_world2
-    dim = 16
-    feats = _features(per, dim=dim)
     loss_fn = _make_loss(margin=0.1)
 
-    anchor = feats[0]["sentence_embedding"]
-    positive = ge.all_gather_with_grad(feats[1]["sentence_embedding"])
-    batch_size = anchor.size(0)
-    offset = torch.distributed.get_rank() * batch_size  # = per (rank 1)
+    captured = []
+    real_ce = loss_fn.cross_entropy_loss
 
-    range_labels = torch.arange(offset, offset + batch_size)
-    guided_ap_sim = loss_fn.sim_matrix(anchor, positive)
-    positive_mask = torch.zeros_like(guided_ap_sim, dtype=torch.bool)
-    rows = torch.arange(guided_ap_sim.size(0))
-    positive_mask[rows, offset + rows] = True
+    def capturing_ce(scores, labels):
+        captured.append((scores, labels))
+        return real_ce(scores, labels)
 
-    protected_cols = positive_mask.float().argmax(dim=1)
-    assert torch.equal(protected_cols, range_labels), (
-        f"protected columns {protected_cols.tolist()} must equal CE targets {range_labels.tolist()}"
-    )
+    # cross_entropy_loss is registered as an nn.Module child, so drop it before assigning a plain callable.
+    del loss_fn.cross_entropy_loss
+    loss_fn.cross_entropy_loss = capturing_ce
+
+    loss = loss_fn(_features(per), labels=None)
+
+    assert captured, "cross-entropy was never called"
+    for scores, labels in captured:
+        target_logits = scores[torch.arange(scores.size(0)), labels]
+        assert torch.isfinite(target_logits).all(), (
+            f"each anchor's CE-target logit must survive masking, got {target_logits.tolist()}"
+        )
+    assert torch.isfinite(loss)

--- a/tests/sentence_transformer/losses/test_gist_embed.py
+++ b/tests/sentence_transformer/losses/test_gist_embed.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import pytest
+import torch
+
+import sentence_transformers.sentence_transformer.losses.gist_embed as ge
+from sentence_transformers.sentence_transformer.losses import GISTEmbedLoss
+
+
+def _make_loss(margin: float) -> GISTEmbedLoss:
+    """Build a GISTEmbedLoss without loading real models.
+
+    ``forward`` encodes via ``self.model`` / ``self.guide``; we replace both with a fake
+    that returns precomputed embeddings carried on the feature dict, so no model is needed.
+    """
+    obj = GISTEmbedLoss.__new__(GISTEmbedLoss)
+    torch.nn.Module.__init__(obj)
+    obj.temperature = 0.01
+    obj.similarity_fct = torch.nn.CosineSimilarity(dim=-1)
+    obj.margin_strategy = "absolute"
+    obj.margin = margin
+    obj.contrast_anchors = True
+    obj.contrast_positives = True
+    obj.gather_across_devices = True
+    obj.must_retokenize = False
+    obj.cross_entropy_loss = torch.nn.CrossEntropyLoss()
+
+    fake = lambda sentence_feature: {"sentence_embedding": sentence_feature["sentence_embedding"]}
+    obj.model = fake
+    obj.guide = fake
+    return obj
+
+
+@pytest.fixture
+def simulate_rank1_world2(monkeypatch):
+    """Run the rank=1/world=2 gather path in a single process: ``all_gather_with_grad``
+    prepends a deterministic rank-0 block, and the rank is reported as 1 (offset = batch_size).
+    """
+    per = 3
+
+    def fake_gather(tensor: torch.Tensor) -> torch.Tensor:
+        g = torch.Generator().manual_seed(1234)
+        rank0_block = torch.randn(per, tensor.size(1), generator=g)
+        return torch.cat([rank0_block, tensor], dim=0)
+
+    monkeypatch.setattr(ge, "all_gather_with_grad", fake_gather)
+    monkeypatch.setattr(ge, "is_dist_initialized", lambda: True)
+    monkeypatch.setattr(torch.distributed, "get_rank", lambda: 1)
+    return per
+
+
+def _features(per: int, dim: int = 16, seed: int = 7):
+    g = torch.Generator().manual_seed(seed)
+    anchors = torch.randn(per, dim, generator=g)
+    positives = torch.randn(per, dim, generator=g)
+    return [{"sentence_embedding": anchors}, {"sentence_embedding": positives}]
+
+
+def test_gather_rank1_positive_not_masked_with_margin(simulate_rank1_world2):
+    """Regression for the rank>0 positive-mask offset bug in the non-cached GISTEmbedLoss.
+
+    The old ``torch.eye(*shape)`` mask protects columns [0..batch-1], but on rank 1 each
+    anchor's positive is at gathered column ``offset + row``. With ``margin > 0`` the unprotected
+    positive is masked to -inf, the CE-target logit becomes -inf, and the loss is +inf. The
+    offset-aware mask keeps it finite.
+    """
+    per = simulate_rank1_world2
+    loss = _make_loss(margin=0.1)(_features(per), labels=None)
+    assert torch.isfinite(loss), f"rank>0 loss must be finite, got {loss.item()}"
+
+
+def test_gather_rank1_margin_zero_baseline(simulate_rank1_world2):
+    """Sanity baseline: with margin=0 the positive equals its own threshold and is not
+    suppressed regardless of the mask, so the loss is finite both before and after the fix.
+    """
+    per = simulate_rank1_world2
+    loss = _make_loss(margin=0.0)(_features(per), labels=None)
+    assert torch.isfinite(loss)
+
+
+def test_positive_mask_protects_ce_target_column(simulate_rank1_world2):
+    """Structural invariant: the column protected by ``positive_mask`` for anchor row r equals
+    the CE target column ``range_labels[r] = offset + r``.
+    """
+    per = simulate_rank1_world2
+    dim = 16
+    feats = _features(per, dim=dim)
+    loss_fn = _make_loss(margin=0.1)
+
+    anchor = feats[0]["sentence_embedding"]
+    positive = ge.all_gather_with_grad(feats[1]["sentence_embedding"])
+    batch_size = anchor.size(0)
+    offset = torch.distributed.get_rank() * batch_size  # = per (rank 1)
+
+    range_labels = torch.arange(offset, offset + batch_size)
+    guided_ap_sim = loss_fn.sim_matrix(anchor, positive)
+    positive_mask = torch.zeros_like(guided_ap_sim, dtype=torch.bool)
+    rows = torch.arange(guided_ap_sim.size(0))
+    positive_mask[rows, offset + rows] = True
+
+    protected_cols = positive_mask.float().argmax(dim=1)
+    assert torch.equal(protected_cols, range_labels), (
+        f"protected columns {protected_cols.tolist()} must equal CE targets {range_labels.tolist()}"
+    )


### PR DESCRIPTION
## Summary

When `gather_across_devices=True`, `GISTEmbedLoss` and `CachedGISTEmbedLoss` build the
positive-protection mask without the cross-device `offset`, so on rank > 0 the wrong columns are
protected and true positives can be suppressed.

In both losses the CE targets and the guided-similarity diagonal already use the rank offset (the
cached loss adds `begin` for its minibatch loop):

```python
range_labels = torch.arange(offset, offset + batch_size, ...)        # CE targets
guided_sim = guided_ap_sim.diagonal(offset=offset).view(-1, 1)       # positive threshold (GISTEmbedLoss)
guided_sim = guided_ap_sim.diagonal(offset=offset + begin).view(-1, 1)  # CachedGISTEmbedLoss
```

but the positive mask did not:

```python
# GISTEmbedLoss
positive_mask = torch.eye(*guided_ap_sim.shape, ...)                 # protects columns [0 .. batch-1]
# CachedGISTEmbedLoss
positive_mask = torch.eye(*guided_ap_sim.shape, ...).roll(begin)
```

On rank 1 with `world_size=2` and `batch_size=3`, the CE target for local row `r` is column
`offset + r` (i.e. `[3, 4, 5]`), but the mask protects `[0, 1, 2]`. With `margin > 0` the true
positive itself exceeds `positive_sim - margin`, so the absolute-margin false-negative suppression
sets the target logit to `-inf` and cross-entropy then returns `+inf`. This can be hidden in rank-0
or single-process runs because `offset = 0`.

`gather_across_devices` was added to these losses in #3442, and #3453 patched the offset alignment
for the in-batch-negative losses (`MultipleNegativesRankingLoss` and the cached / symmetric
variants), which select their identity mask by global index (`identity[local_batch]` with
`local_indices = arange(offset, ...)`). The two GIST losses were not part of that patch and kept the
offset-unaware mask.

This builds the mask with the same global index as the CE targets:

```python
positive_mask = torch.zeros_like(guided_ap_sim, dtype=torch.bool)
rows = torch.arange(guided_ap_sim.size(0), ...)
positive_mask[rows, offset + rows] = True            # + begin in the cached minibatch loop
```

When `offset == 0` this is identical to the previous mask, so rank 0 / single-GPU behavior is
unchanged.

## Tests

Added `tests/sentence_transformer/losses/test_gist_embed.py` and
`tests/sentence_transformer/losses/test_cached_gist_embed.py`. They simulate rank 1 / world 2 in a
single process (monkeypatching the gather and rank helpers; the cached test parametrizes
`mini_batch_size` so `begin = 0` and `begin > 0` are both covered) and assert that with `margin > 0`
the loss stays finite and that the protected column equals the CE target. Both regression tests fail
on the current code and pass with the fix.

```bash
pytest tests/sentence_transformer/losses/test_gist_embed.py tests/sentence_transformer/losses/test_cached_gist_embed.py
```
