### PR TITLE
fix `MPS` errors

### DIFF
--- a/sentence_transformers/cross_encoder/fit_mixin.py
+++ b/sentence_transformers/cross_encoder/fit_mixin.py
@@ -480,10 +480,13 @@ class FitMixin:
         train_dataloader.collate_fn = self.smart_batching_collate
 
         if use_amp:
+            device_type = self.model.device.type
             if is_torch_npu_available():
                 scaler = torch.npu.amp.GradScaler()
-            else:
+            elif device_type == "cuda":
                 scaler = torch.cuda.amp.GradScaler()
+            else:
+                scaler = torch.amp.GradScaler(device_type)
 
         if output_path is not None:
             os.makedirs(output_path, exist_ok=True)

--- a/sentence_transformers/sentence_transformer/fit_mixin.py
+++ b/sentence_transformers/sentence_transformer/fit_mixin.py
@@ -17,7 +17,7 @@ from torch.optim import Optimizer
 from torch.optim.lr_scheduler import LambdaLR
 from torch.utils.data import DataLoader
 from tqdm.autonotebook import trange
-from transformers import TrainerCallback, TrainerControl, TrainerState
+from transformers import TrainerCallback, TrainerControl, TrainerState, is_torch_npu_available
 
 from sentence_transformers.base.evaluation import BaseEvaluator
 from sentence_transformers.base.training_args import BatchSamplers, MultiDatasetBatchSamplers
@@ -563,9 +563,13 @@ class FitMixin:
         ).replace("{FIT_PARAMETERS}", info_fit_parameters)
 
         if use_amp:
-            from torch.cuda.amp import autocast
-
-            scaler = torch.cuda.amp.GradScaler()
+            device_type = self.device.type
+            if is_torch_npu_available():
+                scaler = torch.npu.amp.GradScaler()
+            elif device_type == "cuda":
+                scaler = torch.cuda.amp.GradScaler()
+            else:
+                scaler = torch.amp.GradScaler(device_type)
 
         self.to(self.device)
 
@@ -641,7 +645,7 @@ class FitMixin:
                     features = list(map(lambda batch: batch_to_device(batch, self.device), features))
 
                     if use_amp:
-                        with autocast():
+                        with torch.autocast(device_type=self.device.type):
                             loss_value = loss_model(features, labels)
 
                         scale_before_step = scaler.get_scale()

--- a/sentence_transformers/sparse_encoder/model.py
+++ b/sentence_transformers/sparse_encoder/model.py
@@ -1035,8 +1035,13 @@ class SparseEncoder(BaseModel):
                 "sparsity_ratio": 1.0,
             }
 
-        # CSR gives O(1) per-row non-zero counts via crow_indices
-        embeddings = embeddings.to_sparse_csr()
+        # CSR gives O(1) per-row non-zero counts via crow_indices.
+        # SparseMPS (and some other accelerator backends) lack the to_sparse_csr kernel,
+        # so fall back to CPU when the conversion is not implemented.
+        try:
+            embeddings = embeddings.to_sparse_csr()
+        except NotImplementedError:
+            embeddings = embeddings.cpu().to_sparse_csr()
         crow_indices = embeddings.crow_indices()
         non_zero_per_row = crow_indices[1:] - crow_indices[:-1]
 

--- a/sentence_transformers/sparse_encoder/model.py
+++ b/sentence_transformers/sparse_encoder/model.py
@@ -1035,9 +1035,7 @@ class SparseEncoder(BaseModel):
                 "sparsity_ratio": 1.0,
             }
 
-        # CSR gives O(1) per-row non-zero counts via crow_indices.
-        # SparseMPS (and some other accelerator backends) lack the to_sparse_csr kernel,
-        # so fall back to CPU when the conversion is not implemented.
+        # CSR gives O(1) per-row non-zero counts via crow_indices, and fall back to CPU for MPS.
         try:
             embeddings = embeddings.to_sparse_csr()
         except NotImplementedError:


### PR DESCRIPTION

Three spots in the library still hardcode CUDA, even though MPS is listed as a supported device in `get_device_name()`. This PR fixes them.

## What changes

1. `sparse_encoder/model.py`: `SparseEncoder.sparsity()` calls `to_sparse_csr()`,
which has no kernel on `SparseMPS`. Wrapped in `try/except NotImplementedError` with a CPU fallback. The result is a Python float so it's bit-identical, and the fallback covers any other backend missing the kernel too.

2. `sentence_transformer/fit_mixin.py` and `cross_encoder/fit_mixin.py`: `fit(use_amp=True)` was hardcoded to `torch.cuda.amp.GradScaler()` (and to `from torch.cuda.amp import autocast` in the SentenceTransformer side). Now both files dispatch on `device.type`: cuda and npu keep their existing namespaces, everything else (mps, xpu, cpu) goes through `torch.amp.*`.

## Testing

Ran the small examples on Apple Silicon end to end against this branch, without `PYTORCH_ENABLE_MPS_FALLBACK`. All passed:

* SparseEncoder smoke (encode, sparsity, similarity, intersection on `naver/splade-cocondenser-ensembledistil`)
* `computing_embeddings.py`
* `clustering/agglomerative.py`, `clustering/kmeans.py`
* `semantic-search/semantic_search.py`
* `cross_encoder/applications/cross_encoder_usage.py`

I also tried the heavier retrieval examples (Quora 100k with pytorch top-k, HNSWlib, Annoy). Those work too.