### PR TITLE
Fix relative_margin sign-dependence in mine_hard_negatives

### DIFF
--- a/sentence_transformers/util/hard_negatives.py
+++ b/sentence_transformers/util/hard_negatives.py
@@ -586,7 +586,13 @@ def mine_hard_negatives(
                 num_candidates -= num_skipped
 
         if relative_margin is not None:
-            removed_indices = scores > max_positive_scores.repeat(scores.size(1), 1).T * (1 - relative_margin)
+            # Use a score-order threshold (positive - |positive| * relative_margin) rather than
+            # positive * (1 - relative_margin). The latter is sign-dependent: for a negative positive-pair
+            # score it raises the threshold (e.g. -0.50 -> -0.475), so negatives that are *more* similar than
+            # the positive can survive. Subtracting the absolute value always keeps the threshold below the
+            # positive while matching the previous behavior for positive scores.
+            relative_thresholds = max_positive_scores - max_positive_scores.abs() * relative_margin
+            removed_indices = scores > relative_thresholds.repeat(scores.size(1), 1).T
             scores[removed_indices] = -float("inf")
 
             num_skipped = removed_indices.sum().item()

--- a/tests/util/test_hard_negatives.py
+++ b/tests/util/test_hard_negatives.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
 import importlib.util
+import math
 import os
 from copy import deepcopy
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
+import torch
 from torch import Tensor
 
 from sentence_transformers import CrossEncoder
@@ -1376,3 +1379,66 @@ def test_missing_negatives(
     assert len(result) < expected_max_count
     captured = capsys.readouterr()
     assert "Could not find enough negatives" in captured.out
+
+
+class _ControlledModel:
+    """Minimal deterministic stand-in for a SentenceTransformer, used to exercise the
+    `relative_margin` threshold logic without downloading a model (see #3819)."""
+
+    device = torch.device("cpu")
+    model_card_data = SimpleNamespace(base_model="controlled-relative-margin")
+
+    def __init__(self, vecs: dict[str, Tensor]) -> None:
+        self.vecs = vecs
+
+    def encode_query(self, texts, **kwargs):
+        return torch.stack([self.vecs[t] for t in texts]).numpy()
+
+    def encode_document(self, texts, **kwargs):
+        return torch.stack([self.vecs[t] for t in texts]).numpy()
+
+    def similarity(self, queries, corpus):
+        return torch.as_tensor(queries, dtype=torch.float32) @ torch.as_tensor(corpus, dtype=torch.float32).T
+
+    def similarity_pairwise(self, queries, positives):
+        return (torch.as_tensor(queries, dtype=torch.float32) * torch.as_tensor(positives, dtype=torch.float32)).sum(
+            dim=1
+        )
+
+
+def test_relative_margin_negative_positive_score() -> None:
+    """Regression test for #3819: `relative_margin` must not keep negatives that are more similar to the
+    anchor than the positive pair when the positive-pair score is negative.
+
+    The positive-pair score here is -0.50. `n_more_similar` (score -0.49) is closer to the anchor than the
+    positive, so any non-zero `relative_margin` must drop it (just like `relative_margin=0.0`), leaving the
+    genuinely farther `n_far` (score -0.80). The previous `positive * (1 - relative_margin)` threshold raised
+    the cutoff to -0.475 for negative scores and wrongly kept `n_more_similar`.
+    """
+    vecs = {
+        "q": torch.tensor([1.0, 0.0]),
+        "p": torch.tensor([-0.50, math.sqrt(1 - 0.50**2)]),
+        "n_more_similar": torch.tensor([-0.49, math.sqrt(1 - 0.49**2)]),
+        "n_far": torch.tensor([-0.80, math.sqrt(1 - 0.80**2)]),
+    }
+    dataset = Dataset.from_dict({"query": ["q"], "positive": ["p"]})
+    corpus = ["p", "n_more_similar", "n_far"]
+
+    for relative_margin in [0.0, 0.05]:
+        mined = mine_hard_negatives(
+            dataset=dataset,
+            model=_ControlledModel(vecs),
+            anchor_column_name="query",
+            positive_column_name="positive",
+            corpus=corpus,
+            range_max=2,
+            num_negatives=1,
+            relative_margin=relative_margin,
+            output_scores=True,
+            verbose=False,
+        )
+        negatives = [row["negative"] for row in mined.to_list()]
+        assert negatives == ["n_far"], (
+            f"relative_margin={relative_margin} should drop the too-similar 'n_more_similar' "
+            f"and keep 'n_far', got {negatives}"
+        )


### PR DESCRIPTION
## Summary

Fixes #3819.

`mine_hard_negatives(relative_margin=...)` used `positive_score * (1 - relative_margin)` as the cutoff for dropping negatives that are too similar to the anchor. That expression is **sign-dependent**:

- For a positive pair score of `0.8` and `relative_margin=0.05`, the threshold becomes `0.76` and correctly drops closer negatives.
- For a **negative** pair score of `-0.50`, it becomes `-0.475`, which is *higher* than the positive. A negative at `-0.49` (more similar to the anchor than the positive) then survives, so enabling the margin filtered **less** than `relative_margin=0.0`.

## Fix

Use a score-order threshold:

```python
relative_thresholds = max_positive_scores - max_positive_scores.abs() * relative_margin
```

This equals `positive * (1 - relative_margin)` for positive scores (existing behavior unchanged) and always stays below the positive for negative scores, removing the sign dependence.

## Test

Added `test_relative_margin_negative_positive_score`, a deterministic regression test using a tiny controlled model (no model download, CPU only). It reproduces the issue's scenario (positive score `-0.50`, a closer negative at `-0.49`, a farther one at `-0.80`) and asserts that any non-zero `relative_margin` drops the too-similar negative. The test **fails on `main`** (mines `n_more_similar`) and **passes** with this change (mines `n_far`).

Verified on macOS / CPU.

---
*Disclosure: this change was prepared with AI assistance; I reviewed it and can explain every line.*