### PR TITLE
fix(modality): improve error message for mixed modality batches

### DIFF
--- a/sentence_transformers/base/modality.py
+++ b/sentence_transformers/base/modality.py
@@ -733,6 +733,15 @@ def raise_unsupported_modality_error(
                 f"This batch mixes multiple modalities ({present_str}), which this {source} cannot "
                 f"encode in a single batch. Encode each modality separately (one call per modality)."
             )
+        # If we couldn't re-infer individual sample modalities but the batch modality is "message",
+        # it's likely because the batch contains mixed modalities. Provide a helpful error message.
+        raise ValueError(
+            f"This batch contains inputs that cannot be encoded together by this {source}. "
+            f"When a model does not support the 'message' modality, all inputs in a batch must be "
+            f"of the same type. This error typically occurs when mixing different modalities "
+            f"(e.g., images and text) in a single batch. Encode each modality separately "
+            f"(one call per modality). Supported modalities: {supported_str}."
+        )
 
     # A single combined input (e.g. a {"text": ..., "image": ...} dict) with parts the source
     # supports individually but cannot fuse without "message" support: encode each separately.

--- a/tests/base/test_modality.py
+++ b/tests/base/test_modality.py
@@ -13,6 +13,7 @@ from sentence_transformers.base.modality import (
     is_audio_url_or_path,
     is_image_url_or_path,
     is_video_url_or_path,
+    raise_unsupported_modality_error,
 )
 from sentence_transformers.base.modality_types import MODALITY_TO_PROCESSOR_ARG
 
@@ -1146,3 +1147,28 @@ class TestIsTextOnlyMessages:
             ]
         ]
         assert InputFormatter.is_text_only_messages(batch) is True
+
+
+class TestRaiseUnsupportedModalityError:
+    def test_mixed_modality_batch_clear_error(self):
+        """Mixed-modality batches should produce a clear error message when 'message' is not supported."""
+        # Simulate a batch with images and texts, like in issue #3722
+        img = Image.new("RGB", (100, 100))
+        text = "hello world"
+        inputs = [img, img, text, text]
+
+        # The batch modality is inferred as 'message' because of mixed modalities
+        modality = infer_batch_modality(inputs, supported_modalities=["text", "image"])
+        assert modality == "message"
+
+        # When the model doesn't support 'message', it should provide a helpful error
+        with pytest.raises(ValueError) as exc_info:
+            raise_unsupported_modality_error(inputs, modality, ["text", "image"], "SentenceTransformer model")
+
+        error_message = str(exc_info.value)
+        # The error should mention mixing modalities or encoding separately
+        assert any(phrase in error_message.lower() for phrase in [
+            "mixes multiple modalities",
+            "mixing different modalities",
+            "encode each modality separately"
+        ]), f"Error message should explain the mixed modality issue. Got: {error_message}"


### PR DESCRIPTION
The `raise_unsupported_modality_error` function in `sentence_transformers/base/modality.py` previously raised an unhelpful error when users attempted to encode mixed modality batches (e.g., images and text together) with a model that doesn't support the 'message' modality. The error occurred because the function couldn't re-infer individual sample modalities from a batch that had already been classified as requiring 'message' support. This fix adds a fallback error path that explicitly explains the problem: when a batch contains mixed modalities and the model doesn't support 'message', each modality must be encoded separately. The new error message clearly states that the batch contains inputs that cannot be encoded together and provides actionable guidance to encode each modality in separate calls. A test was added to verify that mixed modality batches (images and text) now produce a clear, helpful error message.

Fixes #3722
