### PR TITLE
[fix] Memory growth in community_detection with larger datasets

### DIFF
--- a/sentence_transformers/util/retrieval.py
+++ b/sentence_transformers/util/retrieval.py
@@ -333,7 +333,9 @@ def community_detection(
                         sort_max_size = min(2 * sort_max_size, len(embeddings))
                         top_val_large, top_idx_large = cos_scores[i].topk(k=sort_max_size, largest=True)
 
-                    extracted_communities.append(top_idx_large[top_val_large >= threshold].cpu().numpy().astype(np.uint32))
+                    extracted_communities.append(
+                        top_idx_large[top_val_large >= threshold].cpu().numpy().astype(np.uint32)
+                    )
 
     # Largest cluster first
     extracted_communities = sorted(extracted_communities, key=lambda x: len(x), reverse=True)
@@ -353,8 +355,7 @@ def community_detection(
             extracted_ids.update(non_overlapped_community)
 
     unique_communities = [
-        [int(idx) for idx in community]
-        for community in sorted(unique_communities, key=lambda x: len(x), reverse=True)
+        [int(idx) for idx in community] for community in sorted(unique_communities, key=lambda x: len(x), reverse=True)
     ]
 
     return unique_communities

--- a/sentence_transformers/util/retrieval.py
+++ b/sentence_transformers/util/retrieval.py
@@ -352,6 +352,9 @@ def community_detection(
             unique_communities.append(non_overlapped_community)
             extracted_ids.update(non_overlapped_community)
 
-    unique_communities = sorted(unique_communities, key=lambda x: len(x), reverse=True)
+    unique_communities = [
+        [int(idx) for idx in community]
+        for community in sorted(unique_communities, key=lambda x: len(x), reverse=True)
+    ]
 
     return unique_communities

--- a/sentence_transformers/util/retrieval.py
+++ b/sentence_transformers/util/retrieval.py
@@ -317,7 +317,7 @@ def community_detection(
 
             # Use the row-wise count to slice the indices
             for count, indices in zip(row_wise_count, top_k_indices):
-                extracted_communities.append(indices[:count].tolist())
+                extracted_communities.append(indices[:count].cpu().numpy().astype(np.uint32))
         else:
             # Minimum size for a community
             top_k_values, _ = cos_scores.topk(k=min_community_size, largest=True)
@@ -333,7 +333,7 @@ def community_detection(
                         sort_max_size = min(2 * sort_max_size, len(embeddings))
                         top_val_large, top_idx_large = cos_scores[i].topk(k=sort_max_size, largest=True)
 
-                    extracted_communities.append(top_idx_large[top_val_large >= threshold].tolist())
+                    extracted_communities.append(top_idx_large[top_val_large >= threshold].cpu().numpy().astype(np.uint32))
 
     # Largest cluster first
     extracted_communities = sorted(extracted_communities, key=lambda x: len(x), reverse=True)

--- a/sentence_transformers/util/retrieval.py
+++ b/sentence_transformers/util/retrieval.py
@@ -315,9 +315,10 @@ def community_detection(
             k = row_wise_count.max()
             _, top_k_indices = cos_scores.topk(k=k, largest=True)
 
-            # Use the row-wise count to slice the indices
-            for count, indices in zip(row_wise_count, top_k_indices):
-                extracted_communities.append(indices[:count].cpu().numpy().astype(np.uint32))
+            # Move the batch indices to CPU once, then slice per community
+            top_k_indices = top_k_indices.cpu()
+            for count, indices in zip(row_wise_count.tolist(), top_k_indices):
+                extracted_communities.append(indices[:count].numpy().astype(np.uint32))
         else:
             # Minimum size for a community
             top_k_values, _ = cos_scores.topk(k=min_community_size, largest=True)
@@ -340,22 +341,19 @@ def community_detection(
     # Largest cluster first
     extracted_communities = sorted(extracted_communities, key=lambda x: len(x), reverse=True)
 
-    # Step 2) Remove overlapping communities
+    # Step 2) Remove overlapping communities using a dense boolean mask of already claimed indices
     unique_communities = []
-    extracted_ids = set()
+    used = np.zeros(len(embeddings), dtype=bool)
 
-    for cluster_id, community in enumerate(extracted_communities):
-        non_overlapped_community = []
-        for idx in community:
-            if idx not in extracted_ids:
-                non_overlapped_community.append(idx)
-
+    for community in extracted_communities:
+        # community keeps its topk order, so the central point stays first
+        non_overlapped_community = community[~used[community]]
         if len(non_overlapped_community) >= min_community_size:
             unique_communities.append(non_overlapped_community)
-            extracted_ids.update(non_overlapped_community)
+            used[non_overlapped_community] = True
 
     unique_communities = [
-        [int(idx) for idx in community] for community in sorted(unique_communities, key=lambda x: len(x), reverse=True)
+        community.tolist() for community in sorted(unique_communities, key=lambda x: len(x), reverse=True)
     ]
 
     return unique_communities


### PR DESCRIPTION
`community_detection` suffers from increased memory usage on larger datasets because it keeps populating the same python list, i.e., `extracted_communities` with python integers. 

The solution proposed aims to switch the current python list implementation with a numpy implementation, which saves around 5 times the memory usage. Here is the calculation behind the 5 times, along with an example:

In python lists, each element roughly costs roughly 20 bytes per index. On the other hand, numpy stores each item in 4 bytes only. And hence, the memory saved is around 20/4 = 5 times less memory usage.

Using the current implementation
```
Finding clusters:   0%|                              | 0/59 [00:00<?, ?it/s]  extracted_communities: 193.33 MB, 486 communities
Finding clusters:   3%|█▏                            | 2/59 [00:03<01:45,  1.85s/it]  extracted_communities: 591.14 MB, 1461 communities
Finding clusters:   7%|██▎                           | 4/59 [00:10<02:42,  2.96s/it]  extracted_communities: 997.35 MB, 2444 communities
Finding clusters:  10%|███▌                          | 6/59 [00:20<03:50,  4.34s/it]  extracted_communities: 1391.05 MB, 3443 communities
Finding clusters:  14%|████▋                         | 8/59 [00:35<05:03,  5.95s/it]  extracted_communities: 1774.79 MB, 4425 communities
Finding clusters:  17%|█████▊                        | 10/59 [00:52<06:00,  7.36s/it]  extracted_communities: 2153.58 MB, 5413 communities
Finding clusters:  20%|██████▉                       | 12/59 [01:13<07:07,  9.09s/it]  extracted_communities: 2526.29 MB, 6379 communities
Finding clusters:  24%|████████                      | 14/59 [01:38<08:04, 10.77s/it]  extracted_communities: 2904.04 MB, 7356 communities 
```

Using the numpy implementation
```
Finding clusters:   0%|                                           | 0/59 [00:00<?, ?it/s]extracted_communities: 43.01 MB, 486 communities
Finding clusters:   3%|█▏                                 | 2/59 [00:00<00:04, 12.02it/s]extracted_communities: 131.50 MB, 1461 communities
Finding clusters:   7%|██▎                                | 4/59 [00:00<00:04, 12.33it/s]extracted_communities: 221.87 MB, 2444 communities
Finding clusters:  10%|███▌                               | 6/59 [00:00<00:04, 12.46it/s]extracted_communities: 309.45 MB, 3443 communities
Finding clusters:  14%|████▋                              | 8/59 [00:00<00:04, 12.49it/s]extracted_communities: 394.82 MB, 4425 communities
Finding clusters:  17%|█████▊                            | 10/59 [00:00<00:03, 12.59it/s]extracted_communities: 479.09 MB, 5413 communities
Finding clusters:  20%|██████▉                           | 12/59 [00:00<00:03, 11.82it/s]extracted_communities: 562.00 MB, 6379 communities
Finding clusters:  24%|████████                          | 14/59 [00:01<00:03, 11.90it/s]extracted_communities: 646.04 MB, 7356 communities
```