### PR TITLE
Make SentenceTransformer.config settable (fixes #3830)

### DIFF
--- a/sentence_transformers/base/model.py
+++ b/sentence_transformers/base/model.py
@@ -1582,7 +1582,25 @@ This pull request has been automatically generated to add {self.__class__.__name
         transformers model can be located (e.g. a pure StaticEmbedding-only setup).
         """
         underlying = self.transformers_model
-        return getattr(underlying, "config", None)
+        if underlying is not None:
+            return getattr(underlying, "config", None)
+        return getattr(self, "_config", None)
+
+    @config.setter
+    def config(self, value: PretrainedConfig | None) -> None:
+        """Allow assigning ``model.config``.
+
+        Before the read-only :attr:`config` property was introduced, ``model.config = ...``
+        simply set an instance attribute. Tools such as ``optimum`` rely on this during
+        ONNX export, and broke with ``property 'config' has no setter`` (#3830). Forward the
+        assignment to the underlying transformers model so reads stay consistent, falling
+        back to local storage when there is no underlying model.
+        """
+        underlying = self.transformers_model
+        if underlying is not None:
+            underlying.config = value
+        else:
+            object.__setattr__(self, "_config", value)
 
     @property
     def _target_device(self) -> torch.device:

--- a/tests/base/test_model.py
+++ b/tests/base/test_model.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 import json
 import logging
 import os
@@ -264,6 +265,28 @@ def test_config_returns_none_when_no_underlying_transformers_model(
     `model.config` returns `None` instead of raising.
     """
     assert static_embedding_model.config is None
+
+
+def test_config_is_settable(stsb_bert_tiny_model: SentenceTransformer) -> None:
+    """`model.config` must be assignable, not just readable (#3830).
+
+    A read-only `config` property broke tools that assign `model.config = ...`
+    (e.g. optimum during ONNX export) with "property 'config' has no setter".
+    The setter forwards to the underlying transformers model, so the value
+    round-trips.
+    """
+    new_config = copy.deepcopy(stsb_bert_tiny_model.config)
+    stsb_bert_tiny_model.config = new_config  # must not raise
+    assert stsb_bert_tiny_model.config is new_config
+    assert stsb_bert_tiny_model.transformers_model.config is new_config
+
+
+def test_config_setter_without_underlying_model(static_embedding_model: SentenceTransformer) -> None:
+    """Assigning `config` on a model with no underlying transformers model stores
+    the value locally instead of raising (mirrors the getter's None handling)."""
+    sentinel = object()
+    static_embedding_model.config = sentinel
+    assert static_embedding_model.config is sentinel
 
 
 def test_sentence_transformer(stsb_bert_tiny_model: SentenceTransformer) -> None:


### PR DESCRIPTION
### Summary

`SentenceTransformer.config` was made a **read-only property** (to delegate `model.config` reads for Deepspeed / `transformers.Trainer`). That broke tools which *assign* `model.config = ...` — most notably `optimum` during ONNX export, which now fails with:

```
AttributeError: property 'config' of 'SentenceTransformer' object has no setter
```

This is a regression: `optimum-cli export onnx ... --model intfloat/multilingual-e5-small` worked on `sentence-transformers==5.4.1` and broke on `5.5.0`. Reported in #3830.

### Fix

Add a `config` setter that forwards the assignment to the underlying transformers model (so reads and writes stay consistent), falling back to local storage when there is no underlying transformers model — mirroring the getter's existing `None` handling.

### Tests

Added to `tests/base/test_model.py`:
- `test_config_is_settable` — assigning `model.config` no longer raises and round-trips through the underlying model.
- `test_config_setter_without_underlying_model` — assignment on a StaticEmbedding-only model stores locally instead of raising.

The existing `config` getter tests still pass (delegation unchanged).

Fixes #3830.
