### PR TITLE
Warn when ContrastiveLoss gets non-binary labels

### DIFF
--- a/sentence_transformers/sentence_transformer/losses/contrastive.py
+++ b/sentence_transformers/sentence_transformer/losses/contrastive.py
@@ -84,7 +84,7 @@ class ContrastiveLoss(nn.Module):
         self.margin = margin
         self.model = model
         self.size_average = size_average
-        self._warned_non_binary_labels = False
+        self._checked_labels = False
 
     def get_config_dict(self) -> dict[str, Any]:
         distance_metric_name = getattr(self.distance_metric, "__name__", str(self.distance_metric))
@@ -96,14 +96,15 @@ class ContrastiveLoss(nn.Module):
         return {"distance_metric": distance_metric_name, "margin": self.margin, "size_average": self.size_average}
 
     def forward(self, sentence_features: Iterable[dict[str, Tensor]], labels: Tensor) -> Tensor:
-        if not self._warned_non_binary_labels and labels.ne(0).logical_and(labels.ne(1)).any().item():
-            warnings.warn(
-                "ContrastiveLoss expects binary labels (0 or 1). Non-binary labels are allowed, "
-                "but they change the loss behaviour; check that this is intended.",
-                UserWarning,
-                stacklevel=4,
-            )
-            self._warned_non_binary_labels = True
+        if not self._checked_labels:
+            self._checked_labels = True
+            if labels.ne(0).logical_and(labels.ne(1)).any().item():
+                warnings.warn(
+                    "ContrastiveLoss expects binary labels (0 or 1). Non-binary labels are accepted but are "
+                    "treated as if binarized at a 0.5 threshold.",
+                    UserWarning,
+                    stacklevel=4,
+                )
 
         reps = [self.model(sentence_feature)["sentence_embedding"] for sentence_feature in sentence_features]
         assert len(reps) == 2

--- a/sentence_transformers/sentence_transformer/losses/contrastive.py
+++ b/sentence_transformers/sentence_transformer/losses/contrastive.py
@@ -101,7 +101,7 @@ class ContrastiveLoss(nn.Module):
             if labels.ne(0).logical_and(labels.ne(1)).any().item():
                 warnings.warn(
                     "ContrastiveLoss expects binary labels (0 or 1). Non-binary labels are accepted but are "
-                    "treated as if binarized at a 0.5 threshold.",
+                    "used directly to weight the positive term, with 1 - label weighting the negative term.",
                     UserWarning,
                     stacklevel=4,
                 )

--- a/sentence_transformers/sentence_transformer/losses/contrastive.py
+++ b/sentence_transformers/sentence_transformer/losses/contrastive.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from collections.abc import Iterable
 from enum import Enum
 from typing import Any
@@ -83,6 +84,7 @@ class ContrastiveLoss(nn.Module):
         self.margin = margin
         self.model = model
         self.size_average = size_average
+        self._warned_non_binary_labels = False
 
     def get_config_dict(self) -> dict[str, Any]:
         distance_metric_name = getattr(self.distance_metric, "__name__", str(self.distance_metric))
@@ -94,6 +96,15 @@ class ContrastiveLoss(nn.Module):
         return {"distance_metric": distance_metric_name, "margin": self.margin, "size_average": self.size_average}
 
     def forward(self, sentence_features: Iterable[dict[str, Tensor]], labels: Tensor) -> Tensor:
+        if not self._warned_non_binary_labels and labels.ne(0).logical_and(labels.ne(1)).any().item():
+            warnings.warn(
+                "ContrastiveLoss expects binary labels (0 or 1). Non-binary labels are allowed, "
+                "but they change the loss behaviour; check that this is intended.",
+                UserWarning,
+                stacklevel=4,
+            )
+            self._warned_non_binary_labels = True
+
         reps = [self.model(sentence_feature)["sentence_embedding"] for sentence_feature in sentence_features]
         assert len(reps) == 2
         rep_anchor, rep_other = reps

--- a/sentence_transformers/sentence_transformer/losses/online_contrastive.py
+++ b/sentence_transformers/sentence_transformer/losses/online_contrastive.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from collections.abc import Iterable
 from typing import Any
 
@@ -71,8 +72,19 @@ class OnlineContrastiveLoss(nn.Module):
         self.model = model
         self.margin = margin
         self.distance_metric = distance_metric
+        self._checked_labels = False
 
     def forward(self, sentence_features: Iterable[dict[str, Tensor]], labels: Tensor, size_average=False) -> Tensor:
+        if not self._checked_labels:
+            self._checked_labels = True
+            if labels.ne(0).logical_and(labels.ne(1)).any().item():
+                warnings.warn(
+                    "OnlineContrastiveLoss expects binary labels (0 or 1). Pairs with any other label are ignored, "
+                    "since they match neither the positive nor the negative set.",
+                    UserWarning,
+                    stacklevel=4,
+                )
+
         embeddings = [self.model(sentence_feature)["sentence_embedding"] for sentence_feature in sentence_features]
 
         distance_matrix = self.distance_metric(embeddings[0], embeddings[1])

--- a/tests/sentence_transformer/losses/test_contrastive.py
+++ b/tests/sentence_transformer/losses/test_contrastive.py
@@ -6,8 +6,10 @@ import pytest
 import torch
 
 from sentence_transformers.sentence_transformer.losses.contrastive import ContrastiveLoss
+from sentence_transformers.sentence_transformer.losses.online_contrastive import OnlineContrastiveLoss
 
-LABEL_WARNING = "ContrastiveLoss expects binary labels.*"
+CONTRASTIVE_WARNING = "ContrastiveLoss expects binary labels.*"
+ONLINE_WARNING = "OnlineContrastiveLoss expects binary labels.*"
 
 
 class _EchoModel:
@@ -26,12 +28,12 @@ def test_contrastive_loss_warns_once_for_non_binary_labels() -> None:
     loss = ContrastiveLoss(_EchoModel())
     labels = torch.tensor([1.0, 0.25])
 
-    with pytest.warns(UserWarning, match="expects binary labels"):
+    with pytest.warns(UserWarning, match="ContrastiveLoss expects binary labels"):
         first_value = loss(_features(), labels)
 
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("ignore")
-        warnings.filterwarnings("always", message=LABEL_WARNING, category=UserWarning)
+        warnings.filterwarnings("always", message=CONTRASTIVE_WARNING, category=UserWarning)
         second_value = loss(_features(), labels)
 
     assert not caught
@@ -44,7 +46,50 @@ def test_contrastive_loss_does_not_warn_for_binary_labels() -> None:
 
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("ignore")
-        warnings.filterwarnings("always", message=LABEL_WARNING, category=UserWarning)
+        warnings.filterwarnings("always", message=CONTRASTIVE_WARNING, category=UserWarning)
+        value = loss(_features(), torch.tensor([1.0, 0.0]))
+
+    assert not caught
+    assert torch.isfinite(value)
+
+
+def test_contrastive_loss_only_checks_the_first_batch() -> None:
+    # The label check runs once, on the first forward, to avoid a per-step device sync. Non-binary
+    # labels that first appear in a later batch are therefore not flagged (labels are fixed per run).
+    loss = ContrastiveLoss(_EchoModel())
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("ignore")
+        warnings.filterwarnings("always", message=CONTRASTIVE_WARNING, category=UserWarning)
+        loss(_features(), torch.tensor([1.0, 0.0]))
+        loss(_features(), torch.tensor([1.0, 0.25]))
+
+    assert not caught
+
+
+def test_online_contrastive_loss_warns_once_for_non_binary_labels() -> None:
+    loss = OnlineContrastiveLoss(_EchoModel())
+    labels = torch.tensor([1.0, 0.25])
+
+    with pytest.warns(UserWarning, match="OnlineContrastiveLoss expects binary labels"):
+        first_value = loss(_features(), labels)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("ignore")
+        warnings.filterwarnings("always", message=ONLINE_WARNING, category=UserWarning)
+        second_value = loss(_features(), labels)
+
+    assert not caught
+    assert torch.isfinite(first_value)
+    assert torch.isfinite(second_value)
+
+
+def test_online_contrastive_loss_does_not_warn_for_binary_labels() -> None:
+    loss = OnlineContrastiveLoss(_EchoModel())
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("ignore")
+        warnings.filterwarnings("always", message=ONLINE_WARNING, category=UserWarning)
         value = loss(_features(), torch.tensor([1.0, 0.0]))
 
     assert not caught

--- a/tests/sentence_transformer/losses/test_contrastive.py
+++ b/tests/sentence_transformer/losses/test_contrastive.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import warnings
+
+import pytest
+import torch
+
+from sentence_transformers.sentence_transformer.losses.contrastive import ContrastiveLoss
+
+LABEL_WARNING = "ContrastiveLoss expects binary labels.*"
+
+
+class _EchoModel:
+    def __call__(self, sentence_feature: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
+        return {"sentence_embedding": sentence_feature["sentence_embedding"]}
+
+
+def _features() -> list[dict[str, torch.Tensor]]:
+    return [
+        {"sentence_embedding": torch.tensor([[1.0, 0.0], [0.0, 1.0]])},
+        {"sentence_embedding": torch.tensor([[0.9, 0.1], [1.0, 0.0]])},
+    ]
+
+
+def test_contrastive_loss_warns_once_for_non_binary_labels() -> None:
+    loss = ContrastiveLoss(_EchoModel())
+    labels = torch.tensor([1.0, 0.25])
+
+    with pytest.warns(UserWarning, match="expects binary labels"):
+        first_value = loss(_features(), labels)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("ignore")
+        warnings.filterwarnings("always", message=LABEL_WARNING, category=UserWarning)
+        second_value = loss(_features(), labels)
+
+    assert not caught
+    assert torch.isfinite(first_value)
+    assert torch.isfinite(second_value)
+
+
+def test_contrastive_loss_does_not_warn_for_binary_labels() -> None:
+    loss = ContrastiveLoss(_EchoModel())
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("ignore")
+        warnings.filterwarnings("always", message=LABEL_WARNING, category=UserWarning)
+        value = loss(_features(), torch.tensor([1.0, 0.0]))
+
+    assert not caught
+    assert torch.isfinite(value)


### PR DESCRIPTION
## What changed

- Added a one-time warning when `ContrastiveLoss` receives labels outside `0` or `1`.
- Added focused tests for non-binary labels and ordinary binary labels using a tiny fake model.

## Why

`ContrastiveLoss` documents binary labels, but the current implementation still produces a finite loss for dense similarity-style labels. The maintainer discussion on #3382 suggested that this should not necessarily become a hard error, because some existing training workflows may be relying on that behaviour.

This uses a one-time warning instead of an assertion so accidental non-binary labels are visible, while existing runs are not broken or flooded with repeated warnings.

## Testing

- `PYTHONPATH=/private/tmp/st-pytest:$PYTHONPATH /opt/homebrew/bin/python3.11 -m pytest tests/sentence_transformer/losses/test_contrastive.py -q`
- `/opt/homebrew/bin/python3.11 -m py_compile sentence_transformers/sentence_transformer/losses/contrastive.py tests/sentence_transformer/losses/test_contrastive.py`

Fixes #3382