### PR TITLE
[Fix] batch_to_message routes non-text 2-element inputs (e.g. 2-frame video) to pair_to_messages (#3840)

### DIFF
--- a/sentence_transformers/base/modality.py
+++ b/sentence_transformers/base/modality.py
@@ -431,7 +431,12 @@ class InputFormatter:
             # Text pairs (e.g. ("query", "document")) are routed to pair_to_messages instead
             if len(typed_input) == 1:
                 mod, value = next(iter(typed_input.items()))
-                if mod == "text" and isinstance(value, (tuple, list)) and len(value) == 2 and all(isinstance(v, str) for v in value):
+                if (
+                    mod == "text"
+                    and isinstance(value, (tuple, list))
+                    and len(value) == 2
+                    and all(isinstance(v, str) for v in value)
+                ):
                     messages.append(self.pair_to_messages(value))
                     continue
             messages.append(self.to_message(typed_input))  # type: ignore[arg-type]

--- a/sentence_transformers/base/modality.py
+++ b/sentence_transformers/base/modality.py
@@ -430,8 +430,8 @@ class InputFormatter:
             typed_input = {mod: processor_inputs[mod][i] for mod in processor_inputs if mod in modalities}
             # Text pairs (e.g. ("query", "document")) are routed to pair_to_messages instead
             if len(typed_input) == 1:
-                value = next(iter(typed_input.values()))
-                if isinstance(value, (tuple, list)) and len(value) == 2 and all(isinstance(v, str) for v in value):
+                mod, value = next(iter(typed_input.items()))
+                if mod == "text" and isinstance(value, (tuple, list)) and len(value) == 2 and all(isinstance(v, str) for v in value):
                     messages.append(self.pair_to_messages(value))
                     continue
             messages.append(self.to_message(typed_input))  # type: ignore[arg-type]

--- a/tests/base/test_modality.py
+++ b/tests/base/test_modality.py
@@ -795,6 +795,24 @@ class TestBatchToMessage:
         assert new_mod == "message"
         assert len(new_inputs["message"]) == 2
 
+    def test_two_element_video_not_routed_to_pair(self):
+        """A 2-frame video (2 image paths) stays one video message, not a query/document pair (#3840)."""
+        processor_inputs = {"video": [["frame1.png", "frame2.png"]]}
+        modality, result = self.fmt.batch_to_message("video", processor_inputs)
+        assert modality == "message"
+        messages = result["message"][0]
+        # A single "user" message, not a ("query", "document") pair
+        assert [msg["role"] for msg in messages] == ["user"]
+        assert messages[0]["content"] == [{"type": "video", "video": ["frame1.png", "frame2.png"]}]
+
+    def test_two_element_text_still_routed_to_pair(self):
+        """A 2-element text input keeps routing to query/document roles (#3840)."""
+        processor_inputs = {"text": [["a query", "a document"]]}
+        modality, result = self.fmt.batch_to_message("text", processor_inputs)
+        assert modality == "message"
+        messages = result["message"][0]
+        assert [msg["role"] for msg in messages] == ["query", "document"]
+
 
 class TestPrependPromptToMessages:
     def test_structured_format(self):


### PR DESCRIPTION
## Motivation

Passing a 2-frame video as a list of image paths works in `transformers` but breaks in `sentence-transformers`: a 2-element list is silently treated as a text query/document pair (#3840). 1-frame and 3+-frame inputs work, which makes the failure look arbitrary.

## Root cause

In `sentence_transformers/base/modality.py`, `batch_to_message()` routes any single-modality input whose value is a 2-element list/tuple of strings to `pair_to_messages()` — without checking the modality:

```python
if len(typed_input) == 1:
    value = next(iter(typed_input.values()))
    if isinstance(value, (tuple, list)) and len(value) == 2 and all(isinstance(v, str) for v in value):
        messages.append(self.pair_to_messages(value))
        continue
```

So `{"video": [path1, path2]}` (a 2-frame video) is mis-handled as a text pair. The sibling routing elsewhere in this module already guards on `mod == "text"`.

## Modifications

`sentence_transformers/base/modality.py` (`batch_to_message`): capture the modality key and only route to `pair_to_messages` when it is `"text"`, matching the existing text-pair guard.

## Duplicate-check

- Track A — `gh api 'repos/huggingface/sentence-transformers/pulls?state=open&per_page=100' --paginate` grepped for `3840` → no open PR references it or touches `batch_to_message`.
- Track B — issue #3840 has no comments and no in-progress claim.
