### PR TITLE
docs: add missing docstrings to Dense methods and to_scipy_coo

### DIFF
--- a/sentence_transformers/util/tensor.py
+++ b/sentence_transformers/util/tensor.py
@@ -204,6 +204,24 @@ def batch_to_device(batch: dict[str, Any], target_device: device) -> dict[str, A
 
 
 def to_scipy_coo(x: Tensor) -> coo_matrix:
+    """
+    Converts a sparse PyTorch tensor to a SciPy COO sparse matrix.
+
+    Args:
+        x (torch.Tensor): A 2-dimensional sparse PyTorch tensor in COO layout.
+
+    Example:
+        >>> import torch
+        >>> from sentence_transformers.util import to_scipy_coo
+        >>> x = torch.sparse_coo_tensor([[0, 1], [1, 0]], [1.0, 2.0], (3, 3))
+        >>> to_scipy_coo(x).toarray()
+        array([[0., 1., 0.],
+               [2., 0., 0.],
+               [0., 0., 0.]], dtype=float32)
+
+    Returns:
+        scipy.sparse.coo_matrix: A SciPy COO matrix with the same shape, indices and values as the input tensor.
+    """
     x = x.coalesce()
     indices = x.indices().cpu().numpy()
     values = x.values().cpu().numpy()


### PR DESCRIPTION
## What does this PR do?

Adds missing docstrings to five public methods/functions across two files. Each docstring follows the existing HuggingFace-style documentation patterns used elsewhere in the codebase.

**`sentence_transformers/base/modules/dense.py` — 4 methods:**

| Method | Added |
|---|---|
| `Dense.forward` | Args / Returns |
| `Dense.get_embedding_dimension` | Returns |
| `Dense.get_config_dict` | Returns |
| `Dense.save` | Args |

The `Dense` class had a thorough class-level docstring but its individual methods were undocumented, making it harder to understand what each method expects and returns at a glance.

**`sentence_transformers/util/tensor.py` — 1 function:**

| Function | Added |
|---|---|
| `to_scipy_coo` | Args / Returns / Example |

`to_scipy_coo` sits next to `compute_count_vector` (which already has a full docstring) but had no documentation of its own.

## Tests

No logic changed — documentation only.

`ruff check` and `ruff format --check` both pass. `typos` reports no issues.