### PR TITLE
fix: declare tokenizers as a direct dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ classifiers = [
 ]
 dependencies = [
     "transformers>=4.41.0,<6.0.0",
+    "tokenizers>=0.19",
     "huggingface-hub>=0.23.0",
     "torch>=1.11.0",
     "numpy>=1.20.0",


### PR DESCRIPTION
Fixes #3519

`sentence_transformers` imports `tokenizers` directly (`Tokenizer`, `normalizers`) in `static_embedding.py`, `base/modules/input_module.py`, and `base/modules/transformer.py`, but `pyproject.toml` only lists `transformers` and relies on it to pull `tokenizers` in transitively.

Added `tokenizers>=0.19` as a direct dependency, matching the same floor that `transformers>=4.41.0` itself requires.