### PR TITLE
🚨 Clip out-of-range values in int8/uint8 quantization

### DIFF
--- a/sentence_transformers/util/quantization.py
+++ b/sentence_transformers/util/quantization.py
@@ -429,12 +429,10 @@ def quantize_embeddings(
         steps = (ranges[1, :] - ranges[0, :]) / 255
         steps = np.where(steps == 0, 1, steps)
 
+        q_vals = np.clip(np.floor((embeddings - starts) / steps), 0, 255)
         if precision == "uint8":
-            q_vals = np.floor((embeddings - starts) / steps)
-            return np.clip(q_vals, 0, 255).astype(np.uint8)
+            return q_vals.astype(np.uint8)
         elif precision == "int8":
-            q_vals = np.floor((embeddings - starts) / steps)
-            q_vals = np.clip(q_vals, 0, 255)
             return (q_vals - 128).astype(np.int8)
 
     if precision == "binary":

--- a/sentence_transformers/util/quantization.py
+++ b/sentence_transformers/util/quantization.py
@@ -430,9 +430,12 @@ def quantize_embeddings(
         steps = np.where(steps == 0, 1, steps)
 
         if precision == "uint8":
-            return ((embeddings - starts) / steps).astype(np.uint8)
+            q_vals = np.floor((embeddings - starts) / steps)
+            return np.clip(q_vals, 0, 255).astype(np.uint8)
         elif precision == "int8":
-            return ((embeddings - starts) / steps - 128).astype(np.int8)
+            q_vals = np.floor((embeddings - starts) / steps)
+            q_vals = np.clip(q_vals, 0, 255)
+            return (q_vals - 128).astype(np.int8)
 
     if precision == "binary":
         return (np.packbits(embeddings > 0, axis=-1).reshape(embeddings.shape[0], -1) - 128).astype(np.int8)

--- a/tests/util/test_quantization.py
+++ b/tests/util/test_quantization.py
@@ -82,3 +82,24 @@ def test_binary_quantize_row_independence(precision: str) -> None:
     else:  # ubinary
         assert result[0, 0] == 0xFF, f"All-positive row: expected 255, got {result[0, 0]}"
         assert result[1, 0] == 0x00, f"All-negative row: expected 0, got {result[1, 0]}"
+
+
+@pytest.mark.parametrize("precision", ["int8", "uint8"])
+def test_quantize_clips_out_of_range_values(precision: str) -> None:
+    """Values outside the calibration range must saturate, not wrap around, on cast.
+
+    Without clipping, a value that should quantize above 255 silently wraps
+    (e.g. 300 -> 44 in uint8) instead of saturating at the dtype's min/max.
+    See issue #3159 / PR #2865.
+    """
+    calibration_embeddings = np.array([[1, 20, -3], [4, 5, -60]], dtype=np.float32)
+    dataset = np.array([[-1, 15, 1]], dtype=np.float32)  # -1 and 1 fall outside calibration range
+
+    result = quantize_embeddings(dataset, precision, calibration_embeddings=calibration_embeddings)
+
+    if precision == "int8":
+        expected = np.array([[-128, 42, 127]], dtype=np.int8)
+    else:
+        expected = np.array([[0, 170, 255]], dtype=np.uint8)
+
+    np.testing.assert_array_equal(result, expected)


### PR DESCRIPTION
Hello!

## Pull Request overview
* Clip quantized values to the valid range before casting to int8/uint8 in `quantize_embeddings`

## Details
`quantize_embeddings` computes `(embeddings - starts) / steps` and then casts straight to `np.uint8`/`np.int8`. When an embedding value falls outside the range used to compute `starts`/`steps` (either the provided `ranges`, a `calibration_embeddings` set, or the embeddings themselves), the intermediate value lands outside `[0, 255]` before the cast. NumPy doesn't clip on an out-of-range float-to-int cast, it wraps. So a value that should saturate at 255 can silently come out as e.g. 44 instead.

This is easiest to see with a calibration set that doesn't cover the data being quantized:

```python
calibration_embeddings = np.array([[1, 20, -3], [4, 5, -60]], dtype=np.float32)
dataset = np.array([[-1, 15, 1]], dtype=np.float32)

quantize_embeddings(dataset, precision="int8", calibration_embeddings=calibration_embeddings)
# Before: [[ -42   42 -112]]
# After:  [[-128   42  127]]
```

The fix adds np.clip(q_vals, 0, 255) before the final cast for both uint8 and int8, so out-of-range values saturate at the dtype bounds instead of wrapping.

Originally reported in #3159, with a fix proposed in #2865 by @meiravgri in 2024. That PR was never merged, and quantize_embeddings has since moved from sentence_transformers/quantization.py to sentence_transformers/util/quantization.py. I've applied the fix to the current location and added a regression test (test_quantize_clips_out_of_range_values) covering both precisions.

Fixes #3159

Anjali Yadav

---

## Maintainer note

I pushed a small simplification on top, hoisting the shared `np.clip(np.floor(...), 0, 255)` out of the two branches. No behavior change.

Worth calling out for users: beyond the out-of-range clipping, this PR also introduces `np.floor` before the cast, which changes `int8` output for **in-range** values too. The old `int8` path cast `x - 128` with truncation-toward-zero, so it rounded *toward* bucket 128 (up below it, down above it). Flooring first makes `int8` a consistent uniform quantizer, matching what `uint8` already did.

In practice, `int8` values in the lower half of the range now shift down by one level (one bucket out of 256). This is a small fidelity improvement (measured against the original float32, it cuts reconstruction error by roughly 2.5x under center-of-bucket dequantization, and is a wash for the raw `int8` scoring used in retrieval today), but it does mean `int8` embeddings are no longer bit-identical to those produced by older versions. If you need exact reproducibility against an already-quantized corpus, re-quantize it with this version. `uint8` is unaffected, as `floor` and truncation agree for positive values.

- Tom Aarsen
