### PR TITLE
Fix BinaryClassificationEvaluator KeyError('cosine') with multiple non-cosine metrics

### DIFF
--- a/sentence_transformers/sentence_transformer/evaluation/binary_classification.py
+++ b/sentence_transformers/sentence_transformer/evaluation/binary_classification.py
@@ -210,7 +210,7 @@ class BinaryClassificationEvaluator(BaseEvaluator):
             metrics.update(
                 {
                     f"max_{metric}": max(scores[short_name][metric] for short_name in scores)
-                    for metric in scores["cosine"]
+                    for metric in next(iter(scores.values()))
                 }
             )
             self.primary_metric = "max_ap"

--- a/tests/sentence_transformer/evaluation/test_binary_classification_evaluator.py
+++ b/tests/sentence_transformer/evaluation/test_binary_classification_evaluator.py
@@ -5,8 +5,10 @@ Tests the correct computation of evaluation scores from BinaryClassificationEval
 from __future__ import annotations
 
 import numpy as np
+import pytest
 from sklearn.metrics import accuracy_score, f1_score
 
+from sentence_transformers import SentenceTransformer
 from sentence_transformers.sentence_transformer import evaluation
 
 
@@ -27,46 +29,6 @@ def test_BinaryClassificationEvaluator_find_best_f1_and_threshold() -> None:
     assert np.abs(best_f1 - sklearn_f1score) < 1e-6
 
 
-def test_BinaryClassificationEvaluator_multiple_non_cosine_metrics() -> None:
-    """The ``max_*`` aggregation must not assume a ``cosine`` key.
-
-    When two or more similarity functions are requested but cosine is not one
-    of them, ``scores`` has no ``cosine`` key, so aggregating the ``max_*``
-    metrics used to raise ``KeyError('cosine')``.
-    """
-    evaluator = evaluation.BinaryClassificationEvaluator(
-        sentences1=["a", "b"],
-        sentences2=["c", "d"],
-        labels=[0, 1],
-        similarity_fn_names=["dot", "euclidean"],
-        write_csv=False,
-    )
-
-    metric_names = [
-        "accuracy",
-        "accuracy_threshold",
-        "f1",
-        "f1_threshold",
-        "precision",
-        "recall",
-        "ap",
-        "mcc",
-    ]
-    # Stub the embedding-dependent computation so the test needs no model.
-    evaluator.compute_metrics = lambda model: {
-        "dot": {name: 0.5 for name in metric_names},
-        "euclidean": {name: 0.25 for name in metric_names},
-    }
-    evaluator.store_metrics_in_model_card_data = lambda *args, **kwargs: None
-
-    metrics = evaluator(model=None)
-
-    assert evaluator.primary_metric == "max_ap"
-    assert metrics["max_ap"] == 0.5
-    assert metrics["max_accuracy"] == 0.5
-    assert "cosine_ap" not in metrics
-
-
 def test_BinaryClassificationEvaluator_find_best_accuracy_and_threshold() -> None:
     """Tests that the Acc score for the computed threshold is correct"""
     y_true = np.random.randint(0, 2, 1000)
@@ -80,3 +42,25 @@ def test_BinaryClassificationEvaluator_find_best_accuracy_and_threshold() -> Non
     y_pred_labels = [1 if pred >= threshold else 0 for pred in y_pred_cosine]
     sklearn_acc = accuracy_score(y_true, y_pred_labels)
     assert np.abs(max_acc - sklearn_acc) < 1e-6
+
+
+@pytest.mark.parametrize(
+    "similarity_fn_names",
+    [["dot", "euclidean"], ["cosine", "dot"], ["cosine", "dot", "euclidean", "manhattan"]],
+)
+def test_BinaryClassificationEvaluator_multiple_similarity_fn_names(
+    stsb_bert_tiny_model: SentenceTransformer, similarity_fn_names: list[str]
+) -> None:
+    """Tests that the max_* aggregation does not assume that cosine was requested"""
+    model = stsb_bert_tiny_model
+    evaluator = evaluation.BinaryClassificationEvaluator(
+        sentences1=["A man is eating food.", "A cat sits outside.", "The girl plays guitar."],
+        sentences2=["A man eats something.", "The sky is blue.", "A woman plays a guitar."],
+        labels=[1, 0, 1],
+        similarity_fn_names=similarity_fn_names,
+    )
+    metrics = evaluator(model)
+
+    assert evaluator.primary_metric == "max_ap"
+    for metric in ["accuracy", "f1", "precision", "recall", "ap", "mcc"]:
+        assert metrics[f"max_{metric}"] == max(metrics[f"{name}_{metric}"] for name in similarity_fn_names)

--- a/tests/sentence_transformer/evaluation/test_binary_classification_evaluator.py
+++ b/tests/sentence_transformer/evaluation/test_binary_classification_evaluator.py
@@ -27,6 +27,46 @@ def test_BinaryClassificationEvaluator_find_best_f1_and_threshold() -> None:
     assert np.abs(best_f1 - sklearn_f1score) < 1e-6
 
 
+def test_BinaryClassificationEvaluator_multiple_non_cosine_metrics() -> None:
+    """The ``max_*`` aggregation must not assume a ``cosine`` key.
+
+    When two or more similarity functions are requested but cosine is not one
+    of them, ``scores`` has no ``cosine`` key, so aggregating the ``max_*``
+    metrics used to raise ``KeyError('cosine')``.
+    """
+    evaluator = evaluation.BinaryClassificationEvaluator(
+        sentences1=["a", "b"],
+        sentences2=["c", "d"],
+        labels=[0, 1],
+        similarity_fn_names=["dot", "euclidean"],
+        write_csv=False,
+    )
+
+    metric_names = [
+        "accuracy",
+        "accuracy_threshold",
+        "f1",
+        "f1_threshold",
+        "precision",
+        "recall",
+        "ap",
+        "mcc",
+    ]
+    # Stub the embedding-dependent computation so the test needs no model.
+    evaluator.compute_metrics = lambda model: {
+        "dot": {name: 0.5 for name in metric_names},
+        "euclidean": {name: 0.25 for name in metric_names},
+    }
+    evaluator.store_metrics_in_model_card_data = lambda *args, **kwargs: None
+
+    metrics = evaluator(model=None)
+
+    assert evaluator.primary_metric == "max_ap"
+    assert metrics["max_ap"] == 0.5
+    assert metrics["max_accuracy"] == 0.5
+    assert "cosine_ap" not in metrics
+
+
 def test_BinaryClassificationEvaluator_find_best_accuracy_and_threshold() -> None:
     """Tests that the Acc score for the computed threshold is correct"""
     y_true = np.random.randint(0, 2, 1000)


### PR DESCRIPTION
When `BinaryClassificationEvaluator` (or `SparseBinaryClassificationEvaluator`) is given two or more similarity functions via `similarity_fn_names` and cosine is not one of them, calling the evaluator raises `KeyError: 'cosine'`:

```python
from sentence_transformers.evaluation import BinaryClassificationEvaluator

evaluator = BinaryClassificationEvaluator(
    sentences1, sentences2, labels,
    similarity_fn_names=["dot", "euclidean"],   # no cosine
)
evaluator(model)   # KeyError: 'cosine'
```

### Root cause

In `__call__`, when more than one similarity function is requested, the `max_*` metrics are aggregated with:

```python
for metric in scores["cosine"]
```

`scores` is keyed by the requested similarity-function names (built in `compute_metrics`), so `"cosine"` is only present when the user actually requested cosine. With two or more non-cosine functions the subscript raises `KeyError("cosine")`. The single-function path takes the `else` branch and is unaffected, and the default single function is usually cosine, which is why this went unnoticed.

### Fix

Iterate the metric names from any requested function's score dict instead of hard-coding `"cosine"`:

```python
for metric in next(iter(scores.values()))
```

Every per-function score dict is built with the same metric keys, so the aggregation is identical when cosine is present (verified: `max_ap` etc. unchanged) and no longer crashes when it is absent. This branch only runs when at least one function is requested, so `next(iter(...))` is always safe. `SparseBinaryClassificationEvaluator` inherits the fix via `super().__call__`.

### Test

Adds `test_BinaryClassificationEvaluator_multiple_non_cosine_metrics`, which constructs the evaluator with `similarity_fn_names=["dot", "euclidean"]`, stubs the embedding-dependent `compute_metrics` (so no model is needed), and asserts the `max_*` metrics are produced. It raises `KeyError("cosine")` before the change and passes after. ruff is clean.