### PR TITLE
[`feat`] Add `mini_batch_num_tokens`: token-budget mini-batching for cached losses

### DIFF
--- a/docs/sentence_transformer/usage/efficiency.rst
+++ b/docs/sentence_transformer/usage/efficiency.rst
@@ -124,6 +124,24 @@ If you're using a GPU, then you can use the following options to speed up your i
 
    Flash Attention 2 with input flattening always outperforms standard Flash Attention 2, while using considerably less VRAM. The gains grow with the variance in input length, with the mixed dataset with wildly varying lengths (10-500 tokens) benefitting the most.
 
+   Input flattening also speeds up training. When training with a cached loss such as
+   :class:`~sentence_transformers.losses.CachedMultipleNegativesRankingLoss`, you can additionally set
+   ``mini_batch_num_tokens`` instead of ``mini_batch_size``. Mini-batches are then packed by total token count
+   rather than by sequence count, so every mini-batch performs a similar amount of work regardless of how
+   sequence lengths are distributed within the batch. This keeps memory usage roughly constant, letting you pick
+   a token budget close to your GPU's limit without risking out-of-memory errors on batches full of long texts,
+   and it can substantially increase training throughput on datasets with varying text lengths:
+
+   .. code-block:: python
+
+      from sentence_transformers import SentenceTransformer, losses
+
+      model = SentenceTransformer(
+          "answerdotai/ModernBERT-base",
+          model_kwargs={"attn_implementation": "flash_attention_2", "torch_dtype": "bfloat16"},
+      )
+      loss = losses.CachedMultipleNegativesRankingLoss(model, mini_batch_num_tokens=32768)
+
    .. seealso::
 
       The `Transformers Attention Interface <https://huggingface.co/docs/transformers/en/attention_interface>`_ documentation

--- a/sentence_transformers/sentence_transformer/losses/cached_gist_embed.py
+++ b/sentence_transformers/sentence_transformer/losses/cached_gist_embed.py
@@ -13,7 +13,7 @@ from transformers import PreTrainedTokenizerBase
 
 from sentence_transformers.sentence_transformer.losses.cached_multiple_negatives_ranking import (
     _create_minibatch,
-    _get_batch_size,
+    _minibatch_ranges,
 )
 from sentence_transformers.sentence_transformer.model import SentenceTransformer
 from sentence_transformers.sentence_transformer.modules import StaticEmbedding
@@ -67,14 +67,18 @@ def _backward_hook(
     """A backward hook to backpropagate the cached gradients mini-batch by mini-batch."""
     assert loss_obj.cache is not None
     assert loss_obj.random_states is not None
+    assert loss_obj.minibatch_ranges is not None
     with torch.enable_grad():
-        for sentence_feature, grad, random_states in zip(sentence_features, loss_obj.cache, loss_obj.random_states):
+        for sentence_feature, grad, random_states, ranges in zip(
+            sentence_features, loss_obj.cache, loss_obj.random_states, loss_obj.minibatch_ranges
+        ):
             for (reps_mb, _, _), grad_mb in zip(
                 loss_obj.embed_minibatch_iter(
                     sentence_feature=sentence_feature,
                     with_grad=True,
                     copy_random_state=False,
                     random_states=random_states,
+                    ranges=ranges,
                 ),
                 grad,
             ):
@@ -101,6 +105,7 @@ class CachedGISTEmbedLoss(nn.Module):
         contrast_anchors: bool = True,
         contrast_positives: bool = True,
         gather_across_devices: bool = False,
+        mini_batch_num_tokens: int | None = None,
     ) -> None:
         """
         This loss is a combination of :class:`GISTEmbedLoss` and :class:`CachedMultipleNegativesRankingLoss`.
@@ -140,6 +145,9 @@ class CachedGISTEmbedLoss(nn.Module):
             gather_across_devices: If True, gather the embeddings across all devices before computing the loss.
                 Recommended when training on multiple GPUs, as it allows for larger batch sizes, but it may slow down
                 training due to communication overhead, and can potentially lead to out-of-memory errors.
+            mini_batch_num_tokens: If set, mini-batches are packed by total (non-padding) token count instead of by
+                sequence count, overriding ``mini_batch_size`` for the embedding forward passes. See
+                :class:`CachedMultipleNegativesRankingLoss` for details. The default is None.
 
         References:
             - Efficient Natural Language Response Suggestion for Smart Reply, Section 4.4: https://huggingface.co/papers/1705.00652
@@ -214,8 +222,12 @@ class CachedGISTEmbedLoss(nn.Module):
                 "Both the training model and the guiding model must use a PreTrainedTokenizer from transformers."
             )
         self.mini_batch_size = mini_batch_size
+        if mini_batch_num_tokens is not None and mini_batch_num_tokens <= 0:
+            raise ValueError("mini_batch_num_tokens must be a positive integer or None.")
+        self.mini_batch_num_tokens = mini_batch_num_tokens
         self.cache: list[list[Tensor]] | None = None
         self.random_states: list[list[RandContext]] | None = None
+        self.minibatch_ranges: list[list[tuple[int, int]]] | None = None
         self.show_progress_bar = show_progress_bar
         self.must_retokenize = (
             model.tokenizer.vocab != guide.tokenizer.vocab or guide.max_seq_length < model.max_seq_length
@@ -270,19 +282,18 @@ class CachedGISTEmbedLoss(nn.Module):
         with_grad: bool,
         copy_random_state: bool,
         random_states: list[RandContext] | None = None,
+        ranges: list[tuple[int, int]] | None = None,
     ) -> Iterator[tuple[Tensor, Tensor, RandContext | None]]:
         """Do forward pass on all the minibatches of the input features and yield corresponding embeddings."""
-        batch_size = _get_batch_size(sentence_feature)
-        for i, begin in enumerate(
-            tqdm.trange(
-                0,
-                batch_size,
-                self.mini_batch_size,
+        if ranges is None:
+            ranges = _minibatch_ranges(sentence_feature, self.mini_batch_size, self.mini_batch_num_tokens)
+        for i, (begin, end) in enumerate(
+            tqdm.tqdm(
+                ranges,
                 desc="Embed mini-batches",
                 disable=not self.show_progress_bar,
             )
         ):
-            end = begin + self.mini_batch_size
             reps, guide_reps, random_state = self.embed_minibatch(
                 sentence_feature=sentence_feature,
                 begin=begin,
@@ -418,10 +429,19 @@ class CachedGISTEmbedLoss(nn.Module):
 
     def forward(self, sentence_features: Iterable[dict[str, Tensor]], labels: Tensor) -> Tensor:
         # Step (1): A quick embedding step without gradients/computation graphs to get all the embeddings
+        sentence_features = list(sentence_features)
         reps = []
         reps_guided = []
         self.random_states = []  # Copy random states to guarantee exact reproduction of the embeddings during the second forward pass, i.e. step (3)
-        for sentence_feature in sentence_features:
+        # Compute the mini-batch boundaries once and replay them in the backward hook: modules may
+        # modify the features in-place (e.g. Pooling zeroes prompt tokens in the attention mask when
+        # include_prompt=False), so recomputing boundaries in the second pass could misalign them
+        # with the cached gradients and random states.
+        self.minibatch_ranges = [
+            _minibatch_ranges(sentence_feature, self.mini_batch_size, self.mini_batch_num_tokens)
+            for sentence_feature in sentence_features
+        ]
+        for sentence_feature, ranges in zip(sentence_features, self.minibatch_ranges):
             reps_mbs = []
             reps_guided_mbs = []
             random_state_mbs = []
@@ -429,6 +449,7 @@ class CachedGISTEmbedLoss(nn.Module):
                 sentence_feature=sentence_feature,
                 with_grad=False,
                 copy_random_state=True,
+                ranges=ranges,
             ):
                 reps_mbs.append(reps_mb.detach().requires_grad_())
                 reps_guided_mbs.append(reps_guided_mb.detach())  # does not requires gradient
@@ -453,6 +474,7 @@ class CachedGISTEmbedLoss(nn.Module):
             "guide": self.guide,
             "temperature": self.temperature,
             "mini_batch_size": self.mini_batch_size,
+            "mini_batch_num_tokens": self.mini_batch_num_tokens,
             "margin_strategy": self.margin_strategy,
             "margin": self.margin,
             "contrast_anchors": self.contrast_anchors,

--- a/sentence_transformers/sentence_transformer/losses/cached_multiple_negatives_ranking.py
+++ b/sentence_transformers/sentence_transformer/losses/cached_multiple_negatives_ranking.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import bisect
 import logging
 from collections.abc import Callable, Iterable, Iterator
 from contextlib import nullcontext
@@ -168,20 +169,65 @@ def _create_minibatch(sentence_feature: dict[str, Any], begin: int, end: int) ->
     return result
 
 
+def _minibatch_ranges(
+    sentence_feature: dict[str, Any],
+    mini_batch_size: int,
+    mini_batch_num_tokens: int | None = None,
+) -> list[tuple[int, int]]:
+    """Compute the ``(begin, end)`` sequence ranges that split a batch into mini-batches.
+
+    If ``mini_batch_num_tokens`` is None, every range spans ``mini_batch_size`` sequences.
+    Otherwise, each range greedily packs as many sequences as possible while keeping the total
+    number of non-padding tokens at or below ``mini_batch_num_tokens``; a single sequence whose
+    length exceeds the budget forms its own mini-batch. Per-sequence token counts are read from
+    ``cu_seq_lens_q`` for flattened inputs, or from the attention mask for padded inputs.
+    """
+    batch_size = _get_batch_size(sentence_feature)
+    if mini_batch_num_tokens is None:
+        return [(begin, min(begin + mini_batch_size, batch_size)) for begin in range(0, batch_size, mini_batch_size)]
+
+    if "cu_seq_lens_q" in sentence_feature:
+        # cu_seq_lens_q already holds the cumulative token counts [0, len_0, len_0 + len_1, ...]
+        cumulative_num_tokens = sentence_feature["cu_seq_lens_q"][1:].tolist()
+    elif "attention_mask" in sentence_feature:
+        cumulative_num_tokens = sentence_feature["attention_mask"].sum(dim=1).cumsum(dim=0).tolist()
+    else:
+        raise ValueError(
+            "mini_batch_num_tokens requires per-sequence token counts, but the tokenized inputs contain "
+            "neither 'cu_seq_lens_q' (flattened inputs) nor 'attention_mask' (padded inputs). "
+            "Use mini_batch_size instead."
+        )
+
+    ranges: list[tuple[int, int]] = []
+    begin = 0
+    while begin < batch_size:
+        previous_num_tokens = cumulative_num_tokens[begin - 1] if begin > 0 else 0
+        end = bisect.bisect_right(cumulative_num_tokens, previous_num_tokens + mini_batch_num_tokens)
+        # Always make progress, even if a single sequence exceeds the token budget
+        end = max(end, begin + 1)
+        ranges.append((begin, end))
+        begin = end
+    return ranges
+
+
 def _backward_hook(
     grad_output: Tensor, sentence_features: Iterable[dict[str, Tensor]], loss_obj: CachedMultipleNegativesRankingLoss
 ) -> None:
     """A backward hook to backpropagate the cached gradients mini-batch by mini-batch."""
     assert loss_obj.cache is not None
     assert loss_obj.random_states is not None
+    assert loss_obj.minibatch_ranges is not None
     with torch.enable_grad():
-        for sentence_feature, grad, random_states in zip(sentence_features, loss_obj.cache, loss_obj.random_states):
+        for sentence_feature, grad, random_states, ranges in zip(
+            sentence_features, loss_obj.cache, loss_obj.random_states, loss_obj.minibatch_ranges
+        ):
             for (reps_mb, _), grad_mb in zip(
                 loss_obj.embed_minibatch_iter(
                     sentence_feature=sentence_feature,
                     with_grad=True,
                     copy_random_state=False,
                     random_states=random_states,
+                    ranges=ranges,
                 ),
                 grad,
             ):
@@ -211,6 +257,7 @@ class CachedMultipleNegativesRankingLoss(nn.Module):
         show_progress_bar: bool = False,
         hardness_mode: Literal["in_batch_negatives", "hard_negatives", "all_negatives"] | None = None,
         hardness_strength: float = 0.0,
+        mini_batch_num_tokens: int | None = None,
     ) -> None:
         """
         Boosted version of :class:`MultipleNegativesRankingLoss` (https://huggingface.co/papers/1705.00652) by GradCache (https://huggingface.co/papers/2101.06983).
@@ -283,6 +330,14 @@ class CachedMultipleNegativesRankingLoss(nn.Module):
                 - For ``"hard_negatives"``: acts as ``alpha`` in the hardness penalty, `Schechter Vera et al. 2025 <https://huggingface.co/papers/2509.20354>`_ uses 5.
 
                 Must be non-negative. Ignored when ``hardness_mode`` is ``None``.
+            mini_batch_num_tokens: If set, mini-batches are packed by total (non-padding) token count instead of by
+                sequence count, overriding ``mini_batch_size`` for the embedding forward passes. Each mini-batch
+                contains as many sequences as fit within this token budget, so memory usage stays roughly constant
+                even when input lengths vary widely, instead of being dictated by the longest inputs. This is most
+                effective when the model processes inputs without padding, e.g. with flash attention input flattening
+                (see :attr:`~sentence_transformers.base.modules.transformer.Transformer.unpad_inputs`), where compute
+                and memory scale with the number of real tokens. It's recommended to set it as high as your GPU memory
+                allows. The default is None, i.e. mini-batches of ``mini_batch_size`` sequences each.
 
         References:
             - Efficient Natural Language Response Suggestion for Smart Reply, Section 4.4: https://huggingface.co/papers/1705.00652
@@ -324,6 +379,9 @@ class CachedMultipleNegativesRankingLoss(nn.Module):
                     "positive": ["It's so sunny.", "He took the car to the office."],
                 })
                 loss = losses.CachedMultipleNegativesRankingLoss(model, mini_batch_size=64)
+                # Or, when the model runs without padding (e.g. flash attention input flattening),
+                # pack mini-batches by token count for constant memory usage and higher throughput:
+                # loss = losses.CachedMultipleNegativesRankingLoss(model, mini_batch_num_tokens=32768)
 
                 trainer = SentenceTransformerTrainer(
                     model=model,
@@ -343,6 +401,9 @@ class CachedMultipleNegativesRankingLoss(nn.Module):
         self.scale = scale
         self.similarity_fct = similarity_fct
         self.mini_batch_size = mini_batch_size
+        if mini_batch_num_tokens is not None and mini_batch_num_tokens <= 0:
+            raise ValueError("mini_batch_num_tokens must be a positive integer or None.")
+        self.mini_batch_num_tokens = mini_batch_num_tokens
         self.gather_across_devices = gather_across_devices
         valid_directions = {"query_to_doc", "query_to_query", "doc_to_query", "doc_to_doc"}
         if not directions:
@@ -384,6 +445,7 @@ class CachedMultipleNegativesRankingLoss(nn.Module):
 
         self.cache: list[list[Tensor]] | None = None
         self.random_states: list[list[RandContext]] | None = None
+        self.minibatch_ranges: list[list[tuple[int, int]]] | None = None
 
     def embed_minibatch(
         self,
@@ -410,19 +472,18 @@ class CachedMultipleNegativesRankingLoss(nn.Module):
         with_grad: bool,
         copy_random_state: bool,
         random_states: list[RandContext] | None = None,
+        ranges: list[tuple[int, int]] | None = None,
     ) -> Iterator[tuple[Tensor, RandContext | None]]:
         """Do forward pass on all the minibatches of the input features and yield corresponding embeddings."""
-        batch_size = _get_batch_size(sentence_feature)
-        for i, begin in enumerate(
-            tqdm.trange(
-                0,
-                batch_size,
-                self.mini_batch_size,
+        if ranges is None:
+            ranges = _minibatch_ranges(sentence_feature, self.mini_batch_size, self.mini_batch_num_tokens)
+        for i, (begin, end) in enumerate(
+            tqdm.tqdm(
+                ranges,
                 desc="Embed mini-batches",
                 disable=not self.show_progress_bar,
             )
         ):
-            end = begin + self.mini_batch_size
             reps, random_state = self.embed_minibatch(
                 sentence_feature=sentence_feature,
                 begin=begin,
@@ -574,13 +635,22 @@ class CachedMultipleNegativesRankingLoss(nn.Module):
 
         reps = []
         self.random_states = []
-        for sentence_feature in sentence_features:
+        # Compute the mini-batch boundaries once and replay them in the backward hook: modules may
+        # modify the features in-place (e.g. Pooling zeroes prompt tokens in the attention mask when
+        # include_prompt=False), so recomputing boundaries in the second pass could misalign them
+        # with the cached gradients and random states.
+        self.minibatch_ranges = [
+            _minibatch_ranges(sentence_feature, self.mini_batch_size, self.mini_batch_num_tokens)
+            for sentence_feature in sentence_features
+        ]
+        for sentence_feature, ranges in zip(sentence_features, self.minibatch_ranges):
             reps_mbs = []
             random_state_mbs = []
             for reps_mb, random_state in self.embed_minibatch_iter(
                 sentence_feature=sentence_feature,
                 with_grad=False,
                 copy_random_state=True,
+                ranges=ranges,
             ):
                 reps_mbs.append(reps_mb.detach().requires_grad_())
                 random_state_mbs.append(random_state)
@@ -604,6 +674,7 @@ class CachedMultipleNegativesRankingLoss(nn.Module):
             "scale": self.scale,
             "similarity_fct": self.similarity_fct.__name__,
             "mini_batch_size": self.mini_batch_size,
+            "mini_batch_num_tokens": self.mini_batch_num_tokens,
             "gather_across_devices": self.gather_across_devices,
             "directions": self.directions,
             "partition_mode": self.partition_mode,

--- a/sentence_transformers/sentence_transformer/losses/cached_multiple_negatives_symmetric_ranking.py
+++ b/sentence_transformers/sentence_transformer/losses/cached_multiple_negatives_symmetric_ranking.py
@@ -25,6 +25,7 @@ class CachedMultipleNegativesSymmetricRankingLoss(CachedMultipleNegativesRanking
         mini_batch_size: int = 32,
         gather_across_devices: bool = False,
         show_progress_bar: bool = False,
+        mini_batch_num_tokens: int | None = None,
     ) -> None:
         """
         .. warning::
@@ -72,6 +73,9 @@ class CachedMultipleNegativesSymmetricRankingLoss(CachedMultipleNegativesRanking
                 Recommended when training on multiple GPUs, as it allows for larger batch sizes, but it may slow down
                 training due to communication overhead, and can potentially lead to out-of-memory errors.
             show_progress_bar: If True, a progress bar for the mini-batches is shown during training. The default is False.
+            mini_batch_num_tokens: If set, mini-batches are packed by total (non-padding) token count instead of by
+                sequence count, overriding ``mini_batch_size`` for the embedding forward passes. See
+                :class:`CachedMultipleNegativesRankingLoss` for details. The default is None.
 
         Requirements:
             1. (anchor, positive) pairs
@@ -121,6 +125,7 @@ class CachedMultipleNegativesSymmetricRankingLoss(CachedMultipleNegativesRanking
             scale=scale,
             similarity_fct=similarity_fct,
             mini_batch_size=mini_batch_size,
+            mini_batch_num_tokens=mini_batch_num_tokens,
             gather_across_devices=gather_across_devices,
             directions=("query_to_doc", "doc_to_query"),  # Symmetric directions
             partition_mode="per_direction",  # Separate softmax normalization for each direction

--- a/sentence_transformers/sparse_encoder/losses/cached_splade.py
+++ b/sentence_transformers/sparse_encoder/losses/cached_splade.py
@@ -14,7 +14,7 @@ from sentence_transformers.sentence_transformer.losses.cached_multiple_negatives
     RandContext,
     _backward_hook,
     _create_minibatch,
-    _get_batch_size,
+    _minibatch_ranges,
 )
 from sentence_transformers.sparse_encoder.losses.splade import SpladeLoss
 from sentence_transformers.sparse_encoder.model import SparseEncoder
@@ -36,6 +36,7 @@ class CachedSpladeLoss(SpladeLoss):
         use_document_regularizer_only: bool = False,
         mini_batch_size: int = 32,
         show_progress_bar: bool = False,
+        mini_batch_num_tokens: int | None = None,
     ):
         """
         Cached version of :class:`SpladeLoss` that uses the GradCache technique to allow for much larger
@@ -78,6 +79,10 @@ class CachedSpladeLoss(SpladeLoss):
                 training is, but the slower the training will be. It's recommended to set it as high as your GPU
                 memory allows. The default value is 32.
             show_progress_bar: If True, a progress bar for the mini-batches is shown during training.
+            mini_batch_num_tokens: If set, mini-batches are packed by total (non-padding) token count instead of by
+                sequence count, overriding ``mini_batch_size`` for the embedding forward passes. See
+                :class:`~sentence_transformers.sentence_transformer.losses.CachedMultipleNegativesRankingLoss` for
+                details. The default is None.
 
         References:
             - Scaling Deep Contrastive Learning Batch Size under Memory Limited Setup:
@@ -127,9 +132,13 @@ class CachedSpladeLoss(SpladeLoss):
             use_document_regularizer_only=use_document_regularizer_only,
         )
         self.mini_batch_size = mini_batch_size
+        if mini_batch_num_tokens is not None and mini_batch_num_tokens <= 0:
+            raise ValueError("mini_batch_num_tokens must be a positive integer or None.")
+        self.mini_batch_num_tokens = mini_batch_num_tokens
         self.show_progress_bar = show_progress_bar
         self.cache: list[list[Tensor]] | None = None
         self.random_states: list[list[RandContext]] | None = None
+        self.minibatch_ranges: list[list[tuple[int, int]]] | None = None
 
     def embed_minibatch(
         self,
@@ -156,19 +165,18 @@ class CachedSpladeLoss(SpladeLoss):
         with_grad: bool,
         copy_random_state: bool,
         random_states: list[RandContext] | None = None,
+        ranges: list[tuple[int, int]] | None = None,
     ) -> Iterator[tuple[Tensor, RandContext | None]]:
         """Iterate over mini-batches of inputs for embedding."""
-        batch_size = _get_batch_size(sentence_feature)
-        for i, begin in enumerate(
-            tqdm.trange(
-                0,
-                batch_size,
-                self.mini_batch_size,
+        if ranges is None:
+            ranges = _minibatch_ranges(sentence_feature, self.mini_batch_size, self.mini_batch_num_tokens)
+        for i, (begin, end) in enumerate(
+            tqdm.tqdm(
+                ranges,
                 desc="Embed mini-batches",
                 disable=not self.show_progress_bar,
             )
         ):
-            end = begin + self.mini_batch_size
             reps, random_state = self.embed_minibatch(
                 sentence_feature=sentence_feature,
                 begin=begin,
@@ -233,13 +241,21 @@ class CachedSpladeLoss(SpladeLoss):
         # Step (1): Embed all mini-batches without gradients to get all embeddings
         reps = []
         self.random_states = []
-        for sentence_feature in sentence_features:
+        # Compute the mini-batch boundaries once and replay them in the backward hook: modules may
+        # modify the features in-place, so recomputing boundaries in the second pass could misalign
+        # them with the cached gradients and random states.
+        self.minibatch_ranges = [
+            _minibatch_ranges(sentence_feature, self.mini_batch_size, self.mini_batch_num_tokens)
+            for sentence_feature in sentence_features
+        ]
+        for sentence_feature, ranges in zip(sentence_features, self.minibatch_ranges):
             reps_mbs = []
             random_state_mbs = []
             for reps_mb, random_state in self.embed_minibatch_iter(
                 sentence_feature=sentence_feature,
                 with_grad=False,
                 copy_random_state=True,
+                ranges=ranges,
             ):
                 reps_mbs.append(reps_mb.detach().requires_grad_())
                 random_state_mbs.append(random_state)
@@ -300,6 +316,7 @@ class CachedSpladeLoss(SpladeLoss):
     def get_config_dict(self) -> dict[str, Any]:
         config = super().get_config_dict()
         config["mini_batch_size"] = self.mini_batch_size
+        config["mini_batch_num_tokens"] = self.mini_batch_num_tokens
         return config
 
     @property

--- a/tests/sentence_transformer/losses/test_cmnrl.py
+++ b/tests/sentence_transformer/losses/test_cmnrl.py
@@ -16,6 +16,7 @@ from sentence_transformers.sentence_transformer.losses import (
 from sentence_transformers.sentence_transformer.losses.cached_multiple_negatives_ranking import (
     _create_minibatch,
     _get_batch_size,
+    _minibatch_ranges,
 )
 
 
@@ -87,12 +88,20 @@ from sentence_transformers.sentence_transformer.losses.cached_multiple_negatives
         ),
     ],
 )
+@pytest.mark.parametrize(
+    "cmnrl_kwargs",
+    [
+        pytest.param({"mini_batch_size": 2}, id="mini_batch_size"),
+        pytest.param({"mini_batch_num_tokens": 12}, id="mini_batch_num_tokens"),
+    ],
+)
 def test_cmnrl_same_grad(
     train_samples_mnrl: list[tuple[str, str, str]],
     train_samples_cmnrl: list[tuple[str, str, str]],
     same_grad: bool,
     scaler: float,
     precision: float,
+    cmnrl_kwargs: dict,
 ):
     # Given:
     model = SentenceTransformer("distilbert/distilbert-base-uncased")
@@ -114,7 +123,7 @@ def test_cmnrl_same_grad(
     # Then run with this cached version:
     set_seed(42)
     optimizer.zero_grad()
-    loss_cmnrl = CachedMultipleNegativesRankingLoss(model, mini_batch_size=2)
+    loss_cmnrl = CachedMultipleNegativesRankingLoss(model, **cmnrl_kwargs)
     queries_cmnrl, positives_cmnrl, negatives_cmnrl = zip(*train_samples_cmnrl)
     features_cmnrl = [model.preprocess(list(texts)) for texts in (queries_cmnrl, positives_cmnrl, negatives_cmnrl)]
     loss_cmnrl_value = loss_cmnrl(features_cmnrl, labels) * scaler
@@ -135,6 +144,150 @@ def test_cmnrl_same_grad(
         assert nclose == len(grad_expected)
     else:
         assert nclose != len(grad_expected)
+
+
+class TestMinibatchRanges:
+    """Tests for the _minibatch_ranges helper that splits batches into mini-batches."""
+
+    @staticmethod
+    def padded_features(lengths: list[int]) -> dict[str, torch.Tensor]:
+        max_len = max(lengths)
+        attention_mask = torch.zeros(len(lengths), max_len, dtype=torch.long)
+        for row, length in enumerate(lengths):
+            attention_mask[row, :length] = 1
+        return {
+            "input_ids": torch.zeros(len(lengths), max_len, dtype=torch.long),
+            "attention_mask": attention_mask,
+        }
+
+    @staticmethod
+    def flattened_features(lengths: list[int]) -> dict[str, torch.Tensor]:
+        cumulative = [0]
+        for length in lengths:
+            cumulative.append(cumulative[-1] + length)
+        cu_seq_lens = torch.tensor(cumulative, dtype=torch.int32)
+        return {
+            "input_ids": torch.zeros(1, sum(lengths), dtype=torch.long),
+            "cu_seq_lens_q": cu_seq_lens,
+            "cu_seq_lens_k": cu_seq_lens,
+        }
+
+    def test_fixed_mini_batch_size(self):
+        features = self.padded_features([4] * 10)
+        assert _minibatch_ranges(features, mini_batch_size=4) == [(0, 4), (4, 8), (8, 10)]
+
+    def test_token_budget_padded(self):
+        # Cumulative token counts: [5, 8, 10, 14, 20]
+        features = self.padded_features([5, 3, 2, 4, 6])
+        ranges = _minibatch_ranges(features, mini_batch_size=32, mini_batch_num_tokens=8)
+        assert ranges == [(0, 2), (2, 4), (4, 5)]
+        # Padding must not count towards the budget: identical lengths, more padding
+        features["attention_mask"] = torch.cat(
+            [features["attention_mask"], torch.zeros(5, 10, dtype=torch.long)], dim=1
+        )
+        assert _minibatch_ranges(features, mini_batch_size=32, mini_batch_num_tokens=8) == ranges
+
+    def test_token_budget_flattened(self):
+        features = self.flattened_features([5, 3, 2, 4, 6])
+        assert _minibatch_ranges(features, mini_batch_size=32, mini_batch_num_tokens=8) == [(0, 2), (2, 4), (4, 5)]
+
+    def test_token_budget_matches_between_padded_and_flattened(self):
+        lengths = [7, 1, 3, 9, 2, 2, 5, 30, 1, 4]
+        padded = _minibatch_ranges(self.padded_features(lengths), mini_batch_size=32, mini_batch_num_tokens=10)
+        flattened = _minibatch_ranges(self.flattened_features(lengths), mini_batch_size=32, mini_batch_num_tokens=10)
+        assert padded == flattened
+
+    def test_oversized_sequences_get_their_own_mini_batch(self):
+        # Sequences longer than the budget must still be processed, one per mini-batch
+        features = self.padded_features([10, 2, 10, 2])
+        ranges = _minibatch_ranges(features, mini_batch_size=32, mini_batch_num_tokens=4)
+        assert ranges == [(0, 1), (1, 2), (2, 3), (3, 4)]
+
+    def test_budget_larger_than_batch(self):
+        features = self.padded_features([5, 3, 2])
+        assert _minibatch_ranges(features, mini_batch_size=2, mini_batch_num_tokens=1000) == [(0, 3)]
+
+    def test_ranges_cover_batch_exactly(self):
+        lengths = [3, 17, 1, 1, 1, 12, 4, 9, 2, 6]
+        ranges = _minibatch_ranges(self.padded_features(lengths), mini_batch_size=32, mini_batch_num_tokens=13)
+        assert ranges[0][0] == 0
+        assert ranges[-1][1] == len(lengths)
+        for (_, prev_end), (begin, end) in zip(ranges, ranges[1:]):
+            assert begin == prev_end
+            assert end > begin
+        for begin, end in ranges:
+            assert end == begin + 1 or sum(lengths[begin:end]) <= 13
+
+    def test_missing_token_counts_raises(self):
+        features = {"input_ids": torch.zeros(4, 8, dtype=torch.long)}
+        with pytest.raises(ValueError, match="mini_batch_num_tokens"):
+            _minibatch_ranges(features, mini_batch_size=32, mini_batch_num_tokens=8)
+
+    def test_non_positive_budget_raises(self):
+        model = SentenceTransformer("sentence-transformers-testing/stsb-bert-tiny-safetensors")
+        with pytest.raises(ValueError, match="mini_batch_num_tokens"):
+            CachedMultipleNegativesRankingLoss(model, mini_batch_num_tokens=0)
+
+    def test_positional_arguments_unchanged(self):
+        # mini_batch_num_tokens sits at the end of the signature: existing positional calls must
+        # keep binding the fifth argument to gather_across_devices, not to the new parameter.
+        from sentence_transformers import util
+
+        model = SentenceTransformer("sentence-transformers-testing/stsb-bert-tiny-safetensors")
+        loss = CachedMultipleNegativesRankingLoss(model, 20.0, util.cos_sim, 16, True)
+        assert loss.mini_batch_size == 16
+        assert loss.gather_across_devices is True
+        assert loss.mini_batch_num_tokens is None
+
+
+def test_cmnrl_token_budget_ranges_survive_mask_mutation():
+    """With include_prompt=False, Pooling zeroes prompt tokens in the attention mask in-place
+    during the first (no-grad) pass. The backward-hook replay must reuse the mini-batch boundaries
+    computed from the original mask; recomputing them from the mutated mask would misalign the
+    replayed mini-batches with the cached gradients and random states."""
+    model = SentenceTransformer("sentence-transformers-testing/stsb-bert-tiny-safetensors")
+    model.to("cpu")
+    model[1].include_prompt = False
+    optimizer = Adam(model.parameters())
+
+    # Equal-length texts (6 tokens each with [CLS]/[SEP]), so with a budget of two full sequences,
+    # zeroing a 2-token prompt in each mask would let three sequences fit on the second pass.
+    texts_a = ["cat dog bird fish", "red blue green yellow", "one two three four", "north south east west"]
+    texts_b = ["dogs are pets today", "colors are bright now", "numbers are fun too", "maps are useful here"]
+    labels = torch.zeros(len(texts_a), dtype=torch.long)
+
+    def preprocess(texts):
+        features = model.preprocess(texts)
+        features["prompt_length"] = torch.tensor([2] * len(texts))
+        return features
+
+    budget = int(preprocess(texts_a)["attention_mask"].sum(dim=1)[:2].sum())
+
+    set_seed(42)
+    optimizer.zero_grad()
+    loss_tok = CachedMultipleNegativesRankingLoss(model, mini_batch_num_tokens=budget)
+    features = [preprocess(texts_a), preprocess(texts_b)]
+    expected_ranges = [_minibatch_ranges(f, mini_batch_size=32, mini_batch_num_tokens=budget) for f in features]
+    loss_tok_value = loss_tok(features, labels)
+    loss_tok_value.backward()
+    grad_tok = {name: p.grad.clone() for name, p in loss_tok.named_parameters() if p.grad is not None}
+
+    # The replayed boundaries must be the ones computed from the original, unmutated masks
+    assert loss_tok.minibatch_ranges == expected_ranges
+
+    # And the gradients must match a fixed-size run, which is unaffected by the mask mutation
+    set_seed(42)
+    optimizer.zero_grad()
+    loss_fixed = CachedMultipleNegativesRankingLoss(model, mini_batch_size=2)
+    loss_fixed_value = loss_fixed([preprocess(texts_a), preprocess(texts_b)], labels)
+    loss_fixed_value.backward()
+    grad_fixed = {name: p.grad.clone() for name, p in loss_fixed.named_parameters() if p.grad is not None}
+
+    assert pytest.approx(loss_fixed_value.item()) == loss_tok_value.item()
+    # calculate_loss chunks the score matrix by mini_batch_size (32 vs 2 here), so gradients can
+    # differ by float summation order; 1e-5 matches the precision used in test_cmnrl_same_grad.
+    for name in grad_fixed:
+        assert torch.allclose(grad_tok[name], grad_fixed[name], rtol=1e-5, atol=1e-5), name
 
 
 @pytest.mark.parametrize("use_rand_context", [True, False])


### PR DESCRIPTION
Resolves #3389

## Motivation

The cached losses (`CachedMultipleNegativesRankingLoss`, `CachedGISTEmbedLoss`, `CachedSpladeLoss`) split their large batch into mini-batches of a fixed number of sequences, controlled by `mini_batch_size`. When input lengths vary, the work per mini-batch varies with them: a mini-batch of 32 short queries costs a fraction of a mini-batch of 32 long documents. With flash attention input flattening (#3554), compute and memory scale with the number of real tokens, so the cost of a fixed-count mini-batch is directly proportional to however many tokens happen to land in it.

This forces an unpleasant choice when tuning `mini_batch_size` on variable-length data. Sizing it for the longest inputs leaves the GPU badly under-utilized on the short ones, which are typically the majority. Sizing it for the average means an unlucky mini-batch of long documents can OOM hours into a run. In the extreme (see the long-document benchmark below), the worst-case mini-batch is more than 10x the average, and the safe setting wastes most of the hardware.

`mini_batch_num_tokens` replaces the fixed sequence count with a token budget. Each mini-batch greedily packs as many sequences as fit within the budget, so every mini-batch does a near-constant amount of work. The budget can sit close to the GPU's limit and stay there regardless of how lengths are distributed.

## What changed

The mini-batch boundary computation is factored into a module-level helper, `_minibatch_ranges(sentence_feature, mini_batch_size, mini_batch_num_tokens)`, next to the existing `_create_minibatch`. Per-sequence token counts come from `cu_seq_lens_q` for flattened inputs (already cumulative, so each boundary is a bisect away) or from `attention_mask.sum(1).cumsum(0)` for padded inputs.

- `CachedMultipleNegativesRankingLoss` gains `mini_batch_num_tokens: int | None = None`. When set, it overrides `mini_batch_size` for the embedding forward passes. It is also included in `get_config_dict()`, so it shows up in model cards.
- `CachedMultipleNegativesSymmetricRankingLoss` forwards the parameter to its parent.
- `CachedGISTEmbedLoss` and `CachedSpladeLoss` use the same helper, imported the same way they already import `_create_minibatch`.
- Docs: a usage note and example in the Flash Attention tab of `docs/sentence_transformer/usage/efficiency.rst`, plus parameter documentation in all touched docstrings.

The cross-encoder `CachedMultipleNegativesRankingLoss` is not included; it builds mini-batches through a different `predict_minibatch_iter` path and would be a follow-up.

### Semantics and edge cases

- The parameter sits at the end of each `__init__` signature, so existing positional calls keep their meaning.
- A single sequence longer than the budget forms its own mini-batch, so progress is always made and no error is raised.
- Boundaries are computed once in `forward` and replayed in the backward hook, the same way `random_states` is. This matters because modules can modify the features in-place between the two passes: `Pooling` with `include_prompt=False` zeroes prompt tokens in the attention mask, and recomputing boundaries from the mutated mask would misalign the replayed mini-batches with the cached gradients.
- `calculate_loss` still chunks the embedding matrix by `mini_batch_size`; that part is independent of sequence length.
- If the features contain neither `cu_seq_lens_q` nor `attention_mask` (e.g. image-only inputs), a `ValueError` explains that token counts are unavailable.
- `mini_batch_num_tokens <= 0` raises a `ValueError` at construction.

## Benchmarks

Both benchmarks train `answerdotai/ModernBERT-base` (bf16, `attn_implementation="flash_attention_2"`) with `CachedMultipleNegativesRankingLoss` on an RTX 5090 (32 GB), flash-attn 2.8.3, transformers 5.13.1, torch 2.9.1. The timed quantity is `loss(features).backward()`, which covers all three GradCache passes, averaged over the batches after one warmup batch. "Padded" rows set `model[0].unpad_inputs = False`; the rest use flattened inputs. Benchmark script and raw results: https://gist.github.com/mermerico/c062d5fc50958f33bb1a424c7c20001a

### Mixed retrieval data (natural-questions)

Batches of 1024 (query, answer) pairs from [sentence-transformers/natural-questions](https://huggingface.co/datasets/sentence-transformers/natural-questions). Sequence lengths: mean 77 tokens, p50 = 23, p95 = 237, max = 811. This is ordinary retrieval training data, short queries mixed with paragraph-length answers.

| Inputs | Mini-batch setting | Time / batch | Peak observed VRAM | Throughput |
|---|---|---:|---:|---:|
| padded | `mini_batch_size=16` | 14.56 s | 5.6 GB | 10.8k tok/s |
| padded | `mini_batch_size=32` | 11.35 s | 10.5 GB | 13.9k tok/s |
| padded | `mini_batch_size=64` | 10.17 s | 20.2 GB | 15.5k tok/s |
| padded | `mini_batch_size=128` | | OOM | |
| flattened | `mini_batch_size=16` | 8.87 s | 2.3 GB | 17.8k tok/s |
| flattened | `mini_batch_size=32` | 4.51 s | 3.6 GB | 34.9k tok/s |
| flattened | `mini_batch_size=64` | 2.64 s | 5.9 GB | 59.7k tok/s |
| flattened | `mini_batch_size=128` | 2.18 s | 10.8 GB | 72.3k tok/s |
| flattened | `mini_batch_size=256` | 2.07 s | 20.6 GB | 76.1k tok/s |
| flattened | `mini_batch_num_tokens=4096` | 2.92 s | 2.8 GB | 54.0k tok/s |
| flattened | `mini_batch_num_tokens=8192` | 1.88 s | 4.8 GB | 83.8k tok/s |
| flattened | `mini_batch_num_tokens=16384` | 1.86 s | 9.0 GB | 84.9k tok/s |
| flattened | `mini_batch_num_tokens=32768` | 1.98 s | 17.4 GB | 79.6k tok/s |

<img width="1699" height="1082" alt="Benchmark: token-budget vs fixed-size mini-batches" src="https://github.com/user-attachments/assets/6f111004-5e01-4adb-9692-88c1cffdf36d" />


At comparable peak memory (5 to 6 GB), the token budget is 1.4x faster than the best fixed-size setting: `mini_batch_num_tokens=8192` reaches 83.8k tok/s in 4.8 GB, while `mini_batch_size=64` reaches 59.7k tok/s in 5.9 GB. The token budget at 4.8 GB also beats fixed-size at any memory footprint; `mini_batch_size=256` uses 20.6 GB and still tops out at 76.1k tok/s, because its mini-batches remain unbalanced no matter how large they get. Peak memory scales predictably with the budget (2.8 GB at 4k up to 17.4 GB at 32k), so the knob can be tuned once against the GPU and trusted, whereas the memory of a fixed-size setting depends on which sequences happen to land together.

### Long documents with heavy-tailed lengths

When I originally proposed this feature (#3389) I had a corpus whose longest documents are more than 10x the mean, trained at `max_seq_length=8192`. For this benchmark, I generated a synthetic corpus. Each document concatenates randomly sampled natural-questions answers up to a target token count drawn from a lognormal distribution (median 300 tokens, sigma 1.1), clipped at 8192. Document lengths: mean 581 tokens, p50 = 392, p95 = 1771, max = 7993, so the longest document is 13.8x the mean. Batches of 512 (query, document) pairs, flattened inputs throughout.

The worst case of a fixed `mini_batch_size=N` is N x 8192 tokens, so the largest setting guaranteed to fit a given memory limit is very small. A mini-batch of one document costs at most one 8192-token forward pass, about 4.7 GB here. The same guarantee expressed as a token budget is `mini_batch_num_tokens=8192`, which packs an average of 14 documents per mini-batch on this data and only drops to a single document when it actually meets an 8192-token one.

| Mini-batch setting | Worst-case tokens per mini-batch | Time / batch | Peak observed VRAM | Throughput |
|---|---:|---:|---:|---:|
| `mini_batch_size=1` | 8,192 | 75.48 s | 4.7 GB | 4.0k tok/s |
| `mini_batch_size=2` | 16,384 | 35.34 s | 5.5 GB | 8.6k tok/s |
| `mini_batch_size=4` | 32,768 | 17.37 s | 6.1 GB | 17.5k tok/s |
| `mini_batch_size=8` | 65,536 | 9.01 s | 8.3 GB | 33.7k tok/s |
| `mini_batch_size=16` | 131,072 | 5.56 s | 10.7 GB | 54.6k tok/s |
| `mini_batch_size=32` | 262,144 | 4.63 s | 15.7 GB | 65.7k tok/s |
| `mini_batch_num_tokens=8192` | 8,192 | 3.58 s | 4.8 GB | 84.9k tok/s |
| `mini_batch_num_tokens=16384` | 16,384 | 3.62 s | 9.0 GB | 83.9k tok/s |
| `mini_batch_num_tokens=32768` | 32,768 | 3.92 s | 17.4 GB | 77.6k tok/s |
| `mini_batch_num_tokens=49152` | 49,152 | 4.10 s | 25.7 GB | 74.0k tok/s |

<img width="1699" height="1082" alt="benchmark_mini_batch_num_tokens_long" src="https://github.com/user-attachments/assets/d62fc843-1658-4ef3-a4ce-a4ed0d7db538" />


Comparing settings with the same worst-case memory: `mini_batch_num_tokens=8192` is 21x faster than `mini_batch_size=1` (84.9k vs 4.0k tok/s at 4.7 GB), and `mini_batch_num_tokens=16384` is 9.8x faster than `mini_batch_size=2`, the largest fixed setting whose worst case fits a 16 GB card. The observed VRAM peaks for the fixed settings understate their true risk: they reflect the two batches that were sampled, while the worst-case column is what a long training run will eventually hit. `mini_batch_size=32` measured 15.7 GB here, but its worst case is 262k tokens, far beyond any of these budgets, and it is still 23% slower than the 4.8 GB token-budget setting.

## Usage

```python
from sentence_transformers import SentenceTransformer, losses

model = SentenceTransformer(
    "answerdotai/ModernBERT-base",
    model_kwargs={"attn_implementation": "flash_attention_2", "torch_dtype": "bfloat16"},
)
# Pack mini-batches up to ~32k real tokens instead of a fixed number of sequences
loss = losses.CachedMultipleNegativesRankingLoss(model, mini_batch_num_tokens=32768)
```

Pick the budget the way you would pick `mini_batch_size`: as high as the GPU allows. Since memory now scales with the budget rather than with luck, a value tuned on one batch holds for the whole run. A reasonable starting point is the largest `mini_batch_size` that survives your longest inputs, multiplied by your maximum sequence length.

The gains are largest when input lengths vary a lot and the model runs without padding (flash attention input flattening, or models such as ModernBERT that unpad internally). With near-uniform lengths it behaves like an auto-tuned `mini_batch_size`. For padded execution the budget counts non-padding tokens, which still tracks compute for models that unpad internally; for strictly padded models `mini_batch_size` remains the more faithful memory knob.

## Tests

- `test_cmnrl_same_grad` is parametrized over `{"mini_batch_size": 2}` and `{"mini_batch_num_tokens": 12}`; the token-budget path produces gradients identical to plain `MultipleNegativesRankingLoss`.
- New `TestMinibatchRanges` unit tests: fixed-size splitting unchanged, padded and flattened inputs produce identical boundaries, padding does not count toward the budget, oversized sequences get their own mini-batch, budgets larger than the batch, exact batch coverage, positional argument compatibility, and both `ValueError` paths.
- `test_cmnrl_token_budget_ranges_survive_mask_mutation` covers the in-place mask mutation case: with `include_prompt=False` and a prompt, the backward hook must replay the boundaries computed from the original mask. Without the caching, this scenario fails with a tensor size mismatch in the gradient replay.
- `tests/sentence_transformer/losses/test_cmnrl.py` and `test_cached_gist_embed.py` pass; `CachedSpladeLoss` was smoke-tested with a token budget on GPU (forward and backward).
