### PR TITLE
Fix ReciprocalRankFusionEvaluator primary_metric not being prefixed

### DIFF
--- a/sentence_transformers/sparse_encoder/evaluation/reciprocal_rank_fusion.py
+++ b/sentence_transformers/sparse_encoder/evaluation/reciprocal_rank_fusion.py
@@ -337,12 +337,6 @@ class ReciprocalRankFusionEvaluator(BaseEvaluator):
 
         return mrr, ndcg, ap
 
-    def prefix_name_to_metrics(self, metrics: dict[str, float], prefix: str) -> dict[str, float]:
-        """Prefix all metric names with the evaluator name."""
-        if not prefix:
-            return metrics
-        return {f"{prefix}_{k}": v for k, v in metrics.items()}
-
     def get_config_dict(self):
         return {
             "at_k": self.at_k,

--- a/tests/sparse_encoder/test_reciprocal_rank_fusion.py
+++ b/tests/sparse_encoder/test_reciprocal_rank_fusion.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from sentence_transformers.sparse_encoder.evaluation import ReciprocalRankFusionEvaluator
+
+
+def _make_samples():
+    dense_samples = [
+        {"query_id": "q1", "query": "a", "positive": ["d1"], "documents": ["d1", "d2", "d3"]},
+        {"query_id": "q2", "query": "b", "positive": ["e1"], "documents": ["e2", "e1", "e3"]},
+    ]
+    sparse_samples = [
+        {"query_id": "q1", "query": "a", "positive": ["d1"], "documents": ["d2", "d1", "d3"]},
+        {"query_id": "q2", "query": "b", "positive": ["e1"], "documents": ["e1", "e2", "e3"]},
+    ]
+    return dense_samples, sparse_samples
+
+
+def test_primary_metric_is_prefixed_and_present_with_name():
+    """With a name, the returned metric keys are prefixed with it, so
+    primary_metric must be updated to the prefixed key; otherwise the documented
+    ``results[evaluator.primary_metric]`` access raises KeyError."""
+    dense_samples, sparse_samples = _make_samples()
+    evaluator = ReciprocalRankFusionEvaluator(
+        dense_samples=dense_samples,
+        sparse_samples=sparse_samples,
+        at_k=10,
+        name="my_eval",
+        write_csv=False,
+    )
+    results = evaluator()
+    assert evaluator.primary_metric == "my_eval_ndcg@10"
+    assert evaluator.primary_metric in results
+
+
+def test_primary_metric_is_present_without_name():
+    """Without a name the metric keys are unprefixed, and primary_metric stays
+    ``ndcg@10`` and is still present in the results."""
+    dense_samples, sparse_samples = _make_samples()
+    evaluator = ReciprocalRankFusionEvaluator(
+        dense_samples=dense_samples,
+        sparse_samples=sparse_samples,
+        at_k=10,
+        write_csv=False,
+    )
+    results = evaluator()
+    assert evaluator.primary_metric == "ndcg@10"
+    assert evaluator.primary_metric in results


### PR DESCRIPTION
### Problem

`ReciprocalRankFusionEvaluator` is the only evaluator that overrides `prefix_name_to_metrics`:

```python
def prefix_name_to_metrics(self, metrics, prefix):
    """Prefix all metric names with the evaluator name."""
    if not prefix:
        return metrics
    return {f"{prefix}_{k}": v for k, v in metrics.items()}
```

The base implementation does three things: prefix each metric key with the name, coerce values with `maybe_to_float`, and **rewrite `self.primary_metric` to the prefixed form**. The override only does the first.

So when the evaluator is given a `name`, `__call__` returns keys like `my_eval_ndcg@10`, but `self.primary_metric` stays the unprefixed `ndcg@10`. The standard access pattern `results[evaluator.primary_metric]` (used by the trainer, and by `tests/sparse_encoder/test_train_stsb.py`) then raises `KeyError`.

```python
evaluator = ReciprocalRankFusionEvaluator(dense_samples, sparse_samples, name="my_eval")
results = evaluator()
results[evaluator.primary_metric]   # KeyError: 'ndcg@10'  (results has 'my_eval_ndcg@10')
```

With `name=""` it works only by accident (no prefixing happens).

### Fix

Remove the override so the class inherits the base `prefix_name_to_metrics`, which prefixes the keys, updates `primary_metric`, and adds the float coercion every sibling evaluator already gets. This matches how every other evaluator behaves and reduces surface.

### Test

Adds `tests/sparse_encoder/test_reciprocal_rank_fusion.py`, which constructs the evaluator from precomputed ranked lists (no model needed) and asserts `evaluator.primary_metric in results` (and that it equals `my_eval_ndcg@10`) for the named case, plus the unnamed case as a guard. The named test fails before this change (`KeyError` / unprefixed `primary_metric`) and passes after.
