### PR TITLE
[fix] Load trained PEFT adapter weights when loading an adapter model

### DIFF
--- a/sentence_transformers/base/modules/transformer.py
+++ b/sentence_transformers/base/modules/transformer.py
@@ -1721,18 +1721,34 @@ class Transformer(InputModule):
             model_kwargs (dict[str, Any]): Keyword arguments passed to the Hugging Face Transformers model.
         """
         if backend == "torch":
-            # When loading a PEFT model, we load the base model first. The revision
-            # (e.g. "main") refers to the adapter checkpoint, not the base model, so
-            # we must not pass it to the base model's from_pretrained.
+            model_cls = TRANSFORMER_TASK_TO_AUTO_MODEL[transformer_task]
+
             if is_peft_model:
+                # Load the base model and let transformers' native PEFT integration attach the
+                # adapter, so the underlying model is a `PeftAdapterMixin`-compatible transformers
+                # model (e.g. `BertModel`) rather than a `peft.PeftModel*` wrapper. This keeps
+                # `SentenceTransformer.add_adapter`/`load_adapter`/... working. See #3247.
+                #
+                # We deliberately do NOT pass the PeftConfig as `config=`: it is a PeftConfig, not
+                # a PretrainedConfig, and passing it prevents the base model's config from being
+                # resolved correctly. The adapter's `revision` (e.g. "main") refers to the adapter
+                # checkpoint, not the base model, so it must not reach the base model's
+                # from_pretrained; we keep it for reloading the adapter weights afterwards.
+                adapter_download_kwargs = {
+                    key: model_kwargs[key]
+                    for key in ("revision", "cache_dir", "token", "subfolder", "local_files_only")
+                    if key in model_kwargs
+                }
                 model_kwargs.pop("revision", None)
+                model = model_cls.from_pretrained(model_name_or_path, **model_kwargs)
+                self._reload_peft_adapter_weights(model, model_name_or_path, adapter_download_kwargs)
+                return model
 
             if transformer_task == "feature-extraction":
                 model = self._load_encoder_only_model(model_name_or_path, config, **model_kwargs)
                 if model is not None:
                     return model
 
-            model_cls = TRANSFORMER_TASK_TO_AUTO_MODEL[transformer_task]
             return model_cls.from_pretrained(model_name_or_path, config=config, **model_kwargs)
         elif backend == "onnx":
             return load_onnx_model(
@@ -1750,6 +1766,36 @@ class Transformer(InputModule):
             )
         else:
             raise ValueError(f"Unsupported backend '{backend}'. `backend` should be `torch`, `onnx`, or `openvino`.")
+
+    @staticmethod
+    def _reload_peft_adapter_weights(
+        model: PreTrainedModel, model_name_or_path: str, download_kwargs: dict[str, Any]
+    ) -> None:
+        """Ensure the trained PEFT adapter weights are actually loaded onto ``model``.
+
+        transformers' native PEFT integration attaches the adapter *modules* when loading an
+        adapter repository, but (depending on the transformers/peft versions) it can fail to map
+        the checkpoint's ``base_model.model.``-prefixed keys onto a bare transformers model. When
+        that happens the adapter is left with freshly-initialized (zero-effect) weights and the
+        trained weights are silently discarded, so the model returns base-model embeddings. We
+        re-load the adapter weights and set them explicitly; this is a no-op when they were
+        already loaded correctly. See https://github.com/huggingface/sentence-transformers/issues/3247.
+        """
+        if not getattr(model, "_hf_peft_config_loaded", False):
+            return
+
+        from peft.utils import load_peft_weights, set_peft_model_state_dict
+
+        adapter_weights = load_peft_weights(model_name_or_path, **download_kwargs)
+        # PEFT stores adapter weights under the ``base_model.model.`` prefix used by a full
+        # `PeftModel`, but the adapter is attached directly to the transformers model here, so
+        # its module keys are un-prefixed. Strip the prefix so the state dict lines up.
+        prefix = "base_model.model."
+        remapped = {
+            (key[len(prefix) :] if key.startswith(prefix) else key): value for key, value in adapter_weights.items()
+        }
+        for adapter_name in model.peft_config:
+            set_peft_model_state_dict(model, remapped, adapter_name=adapter_name)
 
     def _load_encoder_only_model(
         self,

--- a/tests/sentence_transformer/test_model.py
+++ b/tests/sentence_transformer/test_model.py
@@ -952,6 +952,58 @@ def test_load_adapter_with_revision():
     assert embeddings.shape == (128,)
 
 
+@pytest.mark.skipif(not is_peft_available(), reason="PEFT must be available to test loading PEFT models.")
+@pytest.mark.skipif(
+    is_ci(), reason="huggingface_hub & PEFT incorrectly set the user agent in the CI, leading to failures."
+)
+def test_load_peft_adapter_model(stsb_bert_tiny_model: SentenceTransformer) -> None:
+    """Loading a PEFT adapter repository must (1) produce a ``PeftAdapterMixin``-compatible
+    transformers model rather than a ``peft.PeftModel*`` wrapper, so the Sentence Transformers
+    PEFT surface keeps working, and (2) actually load the trained adapter weights rather than a
+    freshly-initialized (zero-effect) adapter. Regression test for #3247.
+    """
+    from peft import LoraConfig, PeftModel, TaskType
+    from transformers import AutoModel
+    from transformers.integrations.peft import PeftAdapterMixin
+
+    adapter_id = "sentence-transformers-testing/stsb-bert-tiny-lora"
+    base_id = "sentence-transformers-testing/stsb-bert-tiny-safetensors"
+
+    model = SentenceTransformer(adapter_id)
+    auto_model = model[0].auto_model
+
+    # (1) The underlying model is a transformers model with PEFT support, not a PeftModel wrapper,
+    # so the ST PEFT methods (which check ``isinstance(..., PeftAdapterMixin)``) work.
+    assert isinstance(auto_model, BertModel)
+    assert isinstance(auto_model, PeftAdapterMixin)
+    assert model.has_peft_compatible_model()
+    assert auto_model._hf_peft_config_loaded
+    assert auto_model.active_adapters() == ["default"]
+
+    # (2) The trained adapter weights are loaded: embeddings differ from the base model and match a
+    # reference model where the adapter is loaded via peft's own (correct) ``PeftModel``.
+    features = model[0].preprocess(["Hello there!", "How are you?"])
+    forward_inputs = {
+        key: features[key] for key in ("input_ids", "attention_mask", "token_type_ids") if key in features
+    }
+    reference = PeftModel.from_pretrained(AutoModel.from_pretrained(base_id), adapter_id)
+    base_only = AutoModel.from_pretrained(base_id)
+    auto_model.eval()
+    reference.eval()
+    base_only.eval()
+    with torch.no_grad():
+        adapter_output = auto_model(**forward_inputs).last_hidden_state
+        reference_output = reference(**forward_inputs).last_hidden_state
+        base_output = base_only(**forward_inputs).last_hidden_state
+    assert torch.allclose(adapter_output, reference_output, atol=1e-5)
+    assert not torch.allclose(adapter_output, base_output, atol=1e-3)
+
+    # The ST PEFT surface remains usable, e.g. adding another adapter.
+    peft_config = LoraConfig(target_modules=["value"], task_type=TaskType.FEATURE_EXTRACTION, r=2, lora_alpha=16)
+    model.add_adapter(peft_config, "extra_adapter")
+    assert model.active_adapters() == ["extra_adapter"]
+
+
 def test_clip():
     model = CLIPModel()
     assert model.max_seq_length == 77


### PR DESCRIPTION
Fixes #3247

**Root cause.** When loading a PEFT adapter repo (e.g. `SentenceTransformer("sentence-transformers-testing/stsb-bert-tiny-lora")`), the Transformer module passed the `PeftConfig` as `config=` to `AutoModel.from_pretrained` and relied on transformers' native PEFT integration to attach the adapter. That integration attaches the adapter *modules* but, depending on transformers/peft versions, fails to map the checkpoint's `base_model.model.`-prefixed weight keys onto the bare transformers model — so the adapter is left freshly-initialized (zero-effect) and the trained weights are silently discarded. The model loads without error and `has_peft_compatible_model()` returns True, but `encode` returns **base-model embeddings**, ignoring the fine-tuned adapter. (On older transformers this instead surfaced as the reported `PeftModelForFeatureExtraction`/`ValueError`; on current `main` the class issue is resolved but the silent weight-drop remains.)

**Fix.** Load the base model without passing the `PeftConfig`, then re-load the adapter weights explicitly with the `base_model.model.` prefix stripped. The underlying model stays a `PeftAdapterMixin`-compatible transformers model (so `add_adapter`/`load_adapter`/`active_adapters`/… keep working) and the trained weights are now applied. The reload is a no-op when weights were already loaded correctly, and the adapter's `revision`/download kwargs are preserved for fetching the adapter checkpoint.

**Tests.** Added `test_load_peft_adapter_model`, asserting both that the underlying model is `PeftAdapterMixin`-compatible (not a `PeftModel*` wrapper) and that the trained adapter weights are actually loaded (embeddings match a peft `PeftModel` reference and differ from the base model). It fails on `main` and passes with this change; existing PEFT tests (`test_load_adapter_with_revision`, `test_multiple_adapters`) and model-loading tests still pass. `ruff` clean.

One thing worth flagging: the underlying weight-mapping failure looks like it may also be a transformers-side bug in the native PEFT-attach path (a plain `AutoModel.from_pretrained(adapter_repo)` and `base.load_adapter(repo)` both exhibit it in transformers 5.13.1 / peft 0.19.1). This fix is a robust, idempotent workaround on the Sentence Transformers side; happy to open an upstream transformers issue too if you think it's warranted.

*Disclosure: I used an AI coding assistant while preparing this change; the fix and tests were reviewed and verified locally on CPU with the tiny test model (repro, weight-diff, and before/after test runs).*
