### PR TITLE
Use a pairwise similarity as the SparseCoSENTLoss default

### DIFF
--- a/sentence_transformers/sparse_encoder/losses/sparse_cosent.py
+++ b/sentence_transformers/sparse_encoder/losses/sparse_cosent.py
@@ -10,7 +10,7 @@ from sentence_transformers.sparse_encoder.model import SparseEncoder
 
 
 class SparseCoSENTLoss(CoSENTLoss):
-    def __init__(self, model: SparseEncoder, scale: float = 20.0, similarity_fct=util.cos_sim) -> None:
+    def __init__(self, model: SparseEncoder, scale: float = 20.0, similarity_fct=util.pairwise_cos_sim) -> None:
         """
         This class implements CoSENT (Cosine Sentence).
         It expects that each of the inputs consists of a pair of inputs (e.g., texts) and a float valued label,

--- a/tests/sparse_encoder/losses/test_sparse_cosent.py
+++ b/tests/sparse_encoder/losses/test_sparse_cosent.py
@@ -6,32 +6,20 @@ from sentence_transformers import SparseEncoder, util
 from sentence_transformers.sparse_encoder.losses import SparseCoSENTLoss
 
 
-def _sparse_embeddings() -> list[torch.Tensor]:
-    torch.manual_seed(12)
-    return [torch.randn(4, 8).relu().to_sparse(), torch.randn(4, 8).relu().to_sparse()]
-
-
-def test_sparse_cosent_loss_default_similarity_fct_is_pairwise(
-    splade_bert_tiny_model: SparseEncoder,
-) -> None:
-    # CoSENT compares one similarity per input pair, so the default must be a pairwise
-    # function, as this loss' own docstring and the parent CoSENTLoss both say.
-    loss = SparseCoSENTLoss(splade_bert_tiny_model)
-
-    assert loss.similarity_fct is util.pairwise_cos_sim
-
-
 def test_sparse_cosent_loss_default_matches_explicit_pairwise(
     splade_bert_tiny_model: SparseEncoder,
 ) -> None:
-    # A full cos_sim matrix makes the score difference a 3-D tensor that the 2-D label
-    # mask silently broadcasts over, so the loss stays finite while optimizing a
-    # different objective. The default must give the same loss as the pairwise function.
-    embeddings = _sparse_embeddings()
-    labels = torch.tensor([0.9, 0.1, 0.8, 0.2])
-
+    # CoSENT needs one similarity per input pair. The old cos_sim default returned a
+    # full similarity matrix that silently broadcast into a different objective.
     default = SparseCoSENTLoss(splade_bert_tiny_model)
     reference = SparseCoSENTLoss(splade_bert_tiny_model, similarity_fct=util.pairwise_cos_sim)
+
+    assert default.similarity_fct is util.pairwise_cos_sim
+    assert reference.similarity_fct is util.pairwise_cos_sim
+
+    torch.manual_seed(12)
+    embeddings = [torch.randn(4, 8).relu().to_sparse(), torch.randn(4, 8).relu().to_sparse()]
+    labels = torch.tensor([0.9, 0.1, 0.8, 0.2])
 
     assert torch.allclose(
         default.compute_loss_from_embeddings(embeddings, labels),

--- a/tests/sparse_encoder/losses/test_sparse_cosent.py
+++ b/tests/sparse_encoder/losses/test_sparse_cosent.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import torch
+
+from sentence_transformers import SparseEncoder, util
+from sentence_transformers.sparse_encoder.losses import SparseCoSENTLoss
+
+
+def _sparse_embeddings() -> list[torch.Tensor]:
+    torch.manual_seed(12)
+    return [torch.randn(4, 8).relu().to_sparse(), torch.randn(4, 8).relu().to_sparse()]
+
+
+def test_sparse_cosent_loss_default_similarity_fct_is_pairwise(
+    splade_bert_tiny_model: SparseEncoder,
+) -> None:
+    # CoSENT compares one similarity per input pair, so the default must be a pairwise
+    # function, as this loss' own docstring and the parent CoSENTLoss both say.
+    loss = SparseCoSENTLoss(splade_bert_tiny_model)
+
+    assert loss.similarity_fct is util.pairwise_cos_sim
+
+
+def test_sparse_cosent_loss_default_matches_explicit_pairwise(
+    splade_bert_tiny_model: SparseEncoder,
+) -> None:
+    # A full cos_sim matrix makes the score difference a 3-D tensor that the 2-D label
+    # mask silently broadcasts over, so the loss stays finite while optimizing a
+    # different objective. The default must give the same loss as the pairwise function.
+    embeddings = _sparse_embeddings()
+    labels = torch.tensor([0.9, 0.1, 0.8, 0.2])
+
+    default = SparseCoSENTLoss(splade_bert_tiny_model)
+    reference = SparseCoSENTLoss(splade_bert_tiny_model, similarity_fct=util.pairwise_cos_sim)
+
+    assert torch.allclose(
+        default.compute_loss_from_embeddings(embeddings, labels),
+        reference.compute_loss_from_embeddings(embeddings, labels),
+    )


### PR DESCRIPTION
## Summary

`SparseCoSENTLoss` defaults to `similarity_fct=util.cos_sim`, but CoSENT needs a **pairwise** similarity (one score per input pair). `util.cos_sim` returns a full `(B, B)` matrix instead of a `(B,)` vector, which silently changes the objective rather than raising.

The class already documents the intended default in its own docstring:

> `similarity_fct`: Function to compute the **PAIRWISE** similarity between embeddings. Default is `util.pairwise_cos_sim`.

## Why this is a bug, not a deliberate choice

Four places in the codebase already agree the metric should be `pairwise_cos_sim`:

1. `SparseCoSENTLoss`'s own docstring (quoted above).
2. Its `See also` note: "`SparseAnglELoss` is `SparseCoSENTLoss` with `pairwise_angle_sim` as the metric, rather than **`pairwise_cos_sim`**".
3. The same statement in `sparse_cosine_similarity.py`.
4. The parent `CoSENTLoss` defaults to `util.pairwise_cos_sim`.

`SparseAnglELoss` subclasses `SparseCoSENTLoss` and passes `similarity_fct=util.pairwise_angle_sim` explicitly to `super().__init__`, so it never exercises the broken default. That is likely why this went unnoticed. It also shows a pairwise function is correct for sparse embeddings, and `util.pairwise_cos_sim` has an explicit `if a.is_sparse or b.is_sparse` branch for exactly this case.

## Effect

In `CoSENTLoss.compute_loss_from_embeddings`:

```python
scores = self.similarity_fct(embeddings[0], embeddings[1])
scores = scores * self.scale
scores = scores[:, None] - scores[None, :]
labels = labels[:, None] < labels[None, :]
scores = scores - (1 - labels) * 1e12
```

| step | `pairwise_cos_sim` (intended) | `cos_sim` (current default) |
|---|---|---|
| `similarity_fct(...)` | `(B,)` | `(B, B)` |
| `scores[:, None] - scores[None, :]` | `(B, B)` | `(B, B, B)` |
| `scores - (1 - labels) * 1e12` | `(B, B)` | `(B, B, B)`, mask broadcasts |

The `(B, B)` label mask broadcasts cleanly against the `(B, B, B)` tensor, so nothing fails. The loss just optimizes a different objective: the intended CoSENT terms `s_i - s_j` are never formed, and the label mask no longer lines up with the score pairs it is meant to select. The wrong default is also visible in `get_config_dict()` output as `'similarity_fct': 'cos_sim'`.

This path is live in the documented usage, `SpladeLoss(model=model, loss=SparseCoSENTLoss(model), ...)`, which is the snippet in the class docstring.

## Fix

One identifier, `util.cos_sim` to `util.pairwise_cos_sim`, making the code match its own docstring, the parent and the sibling. `util` is already imported.

## Tests

Added `tests/sparse_encoder/losses/test_sparse_cosent.py` using the existing `splade_bert_tiny_model` fixture (CPU only):

- the default `similarity_fct` is `util.pairwise_cos_sim`
- on sparse embeddings, the default gives the same loss as passing `util.pairwise_cos_sim` explicitly

Both fail before this change and pass after. `tests/sparse_encoder/losses/` is green (12 passed), and `ruff check` / `ruff format` are clean.
