### PR TITLE
Include query/corpus prompts in mine_hard_negatives cache key

### DIFF
--- a/sentence_transformers/util/hard_negatives.py
+++ b/sentence_transformers/util/hard_negatives.py
@@ -393,11 +393,11 @@ def mine_hard_negatives(
 
         model_name = model.model_card_data.base_model or ""
         query_hash = hashlib.sha256(
-            (repr((model_name, query_prompt, query_prompt_name)) + "".join(queries)).encode(),
+            repr((model_name, query_prompt, query_prompt_name, queries)).encode(),
             usedforsecurity=False,
         ).hexdigest()
         corpus_hash = hashlib.sha256(
-            (repr((model_name, corpus_prompt, corpus_prompt_name)) + "".join(corpus)).encode(),
+            repr((model_name, corpus_prompt, corpus_prompt_name, corpus)).encode(),
             usedforsecurity=False,
         ).hexdigest()
 

--- a/sentence_transformers/util/hard_negatives.py
+++ b/sentence_transformers/util/hard_negatives.py
@@ -244,7 +244,9 @@ def mine_hard_negatives(
         cache_folder (str, optional): Directory path for caching embeddings. If provided, the function will save
             ``query_embeddings_{hash}.npy`` and ``corpus_embeddings_{hash}.npy`` under this folder after the first run,
             and on subsequent calls will load from these files if they exist to avoid recomputation. The hashes are
-            computed based on the model name and the queries/corpus. Defaults to None.
+            computed based on the model name, the query/corpus prompts, and the queries/corpus, so changing the prompt
+            arguments invalidates the cache rather than silently returning embeddings from a different prompt.
+            Defaults to None.
         as_triplets (bool, optional): Deprecated. Use `output_format` instead. Defaults to None.
         margin (float, optional): Deprecated. Use `absolute_margin` or `relative_margin` instead. Defaults to None.
 
@@ -390,8 +392,14 @@ def mine_hard_negatives(
         os.makedirs(cache_folder, exist_ok=True)
 
         model_name = model.model_card_data.base_model or ""
-        query_hash = hashlib.sha256((model_name + "".join(queries)).encode(), usedforsecurity=False).hexdigest()
-        corpus_hash = hashlib.sha256((model_name + "".join(corpus)).encode(), usedforsecurity=False).hexdigest()
+        query_hash = hashlib.sha256(
+            (repr((model_name, query_prompt, query_prompt_name)) + "".join(queries)).encode(),
+            usedforsecurity=False,
+        ).hexdigest()
+        corpus_hash = hashlib.sha256(
+            (repr((model_name, corpus_prompt, corpus_prompt_name)) + "".join(corpus)).encode(),
+            usedforsecurity=False,
+        ).hexdigest()
 
         query_cache_file = os.path.join(cache_folder, f"query_embeddings_{query_hash}.npy")
         corpus_cache_file = os.path.join(cache_folder, f"corpus_embeddings_{corpus_hash}.npy")

--- a/tests/util/test_hard_negatives.py
+++ b/tests/util/test_hard_negatives.py
@@ -922,6 +922,37 @@ def test_cache(dataset: Dataset, static_retrieval_mrl_en_v1_model: SentenceTrans
     assert len(result1) == len(result2)
 
 
+def test_cache_respects_prompt(
+    dataset: Dataset, static_retrieval_mrl_en_v1_model: SentenceTransformer, tmp_path: Path
+) -> None:
+    """The cache key must incorporate the prompt arguments, so a different query_prompt/corpus_prompt
+    produces its own cache file rather than silently reusing embeddings computed with a different prompt."""
+    model = static_retrieval_mrl_en_v1_model
+    cache_dir = os.path.join(tmp_path, "embeddings_cache")
+
+    mine_hard_negatives(
+        dataset=dataset,
+        model=model,
+        cache_folder=cache_dir,
+        query_prompt="Represent this question for retrieval: ",
+        verbose=False,
+    )
+    query_files_a = {f for f in os.listdir(cache_dir) if f.startswith("query_embeddings")}
+
+    mine_hard_negatives(
+        dataset=dataset,
+        model=model,
+        cache_folder=cache_dir,
+        query_prompt="Represent this statement for retrieval: ",
+        verbose=False,
+    )
+    query_files_b = {f for f in os.listdir(cache_dir) if f.startswith("query_embeddings")}
+
+    # A second, distinct query_prompt must add a new cache file, not reuse the first prompt's.
+    assert query_files_a != query_files_b
+    assert query_files_a.issubset(query_files_b)
+
+
 def test_multiple_positives_per_query(
     queries: list[str], passages: list[str], static_retrieval_mrl_en_v1_model: SentenceTransformer
 ):

--- a/tests/util/test_hard_negatives.py
+++ b/tests/util/test_hard_negatives.py
@@ -925,7 +925,7 @@ def test_cache(dataset: Dataset, static_retrieval_mrl_en_v1_model: SentenceTrans
 def test_cache_respects_prompt(
     dataset: Dataset, static_retrieval_mrl_en_v1_model: SentenceTransformer, tmp_path: Path
 ) -> None:
-    """The cache key must incorporate the prompt arguments, so a different query_prompt/corpus_prompt
+    """The cache key must incorporate the prompt arguments, so a different `query_prompt`
     produces its own cache file rather than silently reusing embeddings computed with a different prompt."""
     model = static_retrieval_mrl_en_v1_model
     cache_dir = os.path.join(tmp_path, "embeddings_cache")


### PR DESCRIPTION
Fixes #3870.

## Change

`mine_hard_negatives`'s `cache_folder` key is now derived from `repr((model_name, query_prompt, query_prompt_name))` / `repr((model_name, corpus_prompt, corpus_prompt_name))` concatenated with the queries/corpus, following the approach suggested in the issue. A different prompt now produces a different cache file instead of silently reusing embeddings computed with another prompt.

Also updated the `cache_folder` docstring to describe what actually goes into the hash, since that's user-facing behavior someone might reasonably want to know before relying on the cache across script runs.

## Testing

Added `test_cache_respects_prompt` in `tests/util/test_hard_negatives.py`, right next to the existing `test_cache`. It runs `mine_hard_negatives` twice with the same dataset/cache folder but two different `query_prompt` values and asserts the second run adds a new query cache file rather than reusing the first, catching a hash collision directly rather than only checking the mined results happen to differ.

Ran both against the real `static-retrieval-mrl-en-v1` model (same fixture `test_cache` already uses):
```
tests/util/test_hard_negatives.py::test_cache PASSED
tests/util/test_hard_negatives.py::test_cache_respects_prompt PASSED
```

Also ran the full `tests/util/test_hard_negatives.py` file to check the hash format change doesn't affect anything else that touches `cache_folder`.

One intentional side effect worth flagging: since the hash inputs changed, any embeddings cached by an older version under a `cache_folder` will no longer be found by this version (new hash, new filename), so the first run after upgrading will recompute rather than hit stale cache files. That's the correct behavior here rather than something to work around, but calling it out in case it's worth a changelog note.
