### PR TITLE
Fix FAISS hard-negative mining retrieving too few candidates

### DIFF
--- a/sentence_transformers/util/hard_negatives.py
+++ b/sentence_transformers/util/hard_negatives.py
@@ -470,7 +470,8 @@ def mine_hard_negatives(
         # Iterate over query embeddings in batches so we can track the progress
         for i in trange(0, len(query_embeddings), faiss_batch_size, desc="Querying FAISS index"):
             query_chunk = query_embeddings[i : i + faiss_batch_size]
-            scores, indices = index.search(query_chunk, k=range_max + 1)
+            # Keep the range_max + max_positives highest scores. We offset by max_positives to leave room for the positive pair(s).
+            scores, indices = index.search(query_chunk, k=range_max + max_positives)
             scores_list.append(scores)
             indices_list.append(indices)
         scores = torch.from_numpy(np.concatenate(scores_list, axis=0)).to(device)

--- a/sentence_transformers/util/hard_negatives.py
+++ b/sentence_transformers/util/hard_negatives.py
@@ -553,6 +553,11 @@ def mine_hard_negatives(
         if use_multi_process:
             cross_encoder.stop_multi_process_pool(pool)
 
+    if use_faiss:
+        # FAISS pads short result sets with index -1, which would resolve to the last corpus entry.
+        # Applied after the CrossEncoder rescoring, as that overwrites the score of every candidate.
+        scores[indices == -1] = -float("inf")
+
     if not include_positives:
         # for each query, create a mask that is True for the positives and False for the negatives in the indices
         positive_mask = torch.stack(

--- a/tests/util/test_hard_negatives.py
+++ b/tests/util/test_hard_negatives.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib.util
 import math
 import os
+from collections import defaultdict
 from copy import deepcopy
 from pathlib import Path
 from types import SimpleNamespace
@@ -962,13 +963,95 @@ def test_faiss_multiple_positives_matches_non_faiss(
     passages_dup = passages[:3] + passages[5:7]
     dataset_dup = Dataset.from_dict({"query": queries_dup, "passage": passages_dup})
 
-    kwargs = dict(dataset=dataset_dup, model=model, num_negatives=1, range_max=3, faiss_batch_size=2, verbose=False)
+    # num_negatives must reach into the tail of the candidate pool (num_negatives == range_max), otherwise the
+    # missing candidates are never selected and the assertion below passes even without the fix.
+    kwargs = dict(dataset=dataset_dup, model=model, num_negatives=3, range_max=3, faiss_batch_size=2, verbose=False)
     faiss_result = mine_hard_negatives(use_faiss=True, **kwargs)
     non_faiss_result = mine_hard_negatives(use_faiss=False, **kwargs)
 
     # The invariant the fix restores: both paths mine the same number of negatives for the same input
     # (default "triplet" output_format yields one negative per row, so len == number of mined negatives).
     assert len(faiss_result) == len(non_faiss_result)
+
+
+@pytest.mark.skipif(importlib.util.find_spec("faiss") is None, reason="faiss not installed")
+@pytest.mark.parametrize("range_max", [3, 10])
+def test_faiss_corpus_smaller_than_k(
+    queries: list[str], passages: list[str], static_retrieval_mrl_en_v1_model: SentenceTransformer, range_max: int
+) -> None:
+    """Candidates must never include a query's own positives when ``k`` exceeds the corpus size.
+
+    FAISS pads short result sets with index -1 and score -3.4e38. The score survives the -inf filters and
+    the index resolves to the last corpus entry, so the final document could be mined as a negative for
+    every query, including for the query it is a positive of.
+    """
+    model = static_retrieval_mrl_en_v1_model
+    corpus = passages[:4]
+    # The first query has two positives (max_positives == 2), so k = range_max + 2 overruns the 4 document corpus.
+    queries_dup = queries[:3] + queries[:1]
+    passages_dup = [passages[0], passages[1], passages[2], passages[3]]
+    dataset_dup = Dataset.from_dict({"query": queries_dup, "passage": passages_dup})
+
+    result = mine_hard_negatives(
+        dataset=dataset_dup,
+        model=model,
+        corpus=corpus,
+        num_negatives=3,
+        range_max=range_max,
+        use_faiss=True,
+        faiss_batch_size=2,
+        verbose=False,
+    )
+
+    positives_per_query = defaultdict(set)
+    for query, positive in zip(dataset_dup["query"], dataset_dup["passage"]):
+        positives_per_query[query].add(positive)
+
+    for row in result:
+        assert row["negative"] != row["passage"]
+        assert row["negative"] not in positives_per_query[row["query"]]
+
+
+@pytest.mark.skipif(importlib.util.find_spec("faiss") is None, reason="faiss not installed")
+def test_faiss_corpus_smaller_than_k_with_cross_encoder(
+    queries: list[str],
+    passages: list[str],
+    static_retrieval_mrl_en_v1_model: SentenceTransformer,
+    reranker_bert_tiny_model: CrossEncoder,
+) -> None:
+    """The FAISS -1 padding must stay disqualified after the CrossEncoder rescoring.
+
+    The rescoring assigns a fresh score to every candidate, so disqualifying the padding at search time
+    is not enough: the padded slots get a genuine score back and can be mined as negatives. A negative
+    ``absolute_margin`` keeps the margin filter from incidentally removing them.
+    """
+    model = static_retrieval_mrl_en_v1_model
+    corpus = passages[:4]
+    # The first query has two positives (max_positives == 2), so k = 3 + 2 overruns the 4 document corpus.
+    queries_dup = queries[:3] + queries[:1]
+    passages_dup = [passages[0], passages[1], passages[2], passages[3]]
+    dataset_dup = Dataset.from_dict({"query": queries_dup, "passage": passages_dup})
+
+    result = mine_hard_negatives(
+        dataset=dataset_dup,
+        model=model,
+        corpus=corpus,
+        cross_encoder=reranker_bert_tiny_model,
+        num_negatives=3,
+        range_max=3,
+        absolute_margin=-10.0,
+        use_faiss=True,
+        faiss_batch_size=2,
+        verbose=False,
+    )
+
+    positives_per_query = defaultdict(set)
+    for query, positive in zip(dataset_dup["query"], dataset_dup["passage"]):
+        positives_per_query[query].add(positive)
+
+    for row in result:
+        assert row["negative"] != row["passage"]
+        assert row["negative"] not in positives_per_query[row["query"]]
 
 
 def test_deprecated_parameters(dataset: Dataset, static_retrieval_mrl_en_v1_model: SentenceTransformer) -> None:

--- a/tests/util/test_hard_negatives.py
+++ b/tests/util/test_hard_negatives.py
@@ -944,6 +944,33 @@ def test_multiple_positives_per_query(
     assert len(result) >= len(dataset_dup)
 
 
+@pytest.mark.skipif(importlib.util.find_spec("faiss") is None, reason="faiss not installed")
+def test_faiss_multiple_positives_matches_non_faiss(
+    queries: list[str], passages: list[str], static_retrieval_mrl_en_v1_model: SentenceTransformer
+) -> None:
+    """FAISS and non-FAISS paths must mine the same number of negatives when queries have multiple positives.
+
+    Regression test for the FAISS branch requesting only ``range_max + 1`` candidates from
+    ``index.search`` instead of ``range_max + max_positives`` (as the non-FAISS ``torch.topk`` sibling
+    does). With 2+ positives per query the FAISS path retrieved too few candidates and could mine fewer
+    negatives than the non-FAISS path for the same input. This crosses ``use_faiss=True`` with the
+    multi-positive case, which neither ``test_faiss`` nor ``test_multiple_positives_per_query`` covered.
+    """
+    model = static_retrieval_mrl_en_v1_model
+    # Duplicate queries with different positives -> repeated queries have multiple positives (max_positives == 2).
+    queries_dup = queries[:3] + queries[:2]
+    passages_dup = passages[:3] + passages[5:7]
+    dataset_dup = Dataset.from_dict({"query": queries_dup, "passage": passages_dup})
+
+    kwargs = dict(dataset=dataset_dup, model=model, num_negatives=1, range_max=3, faiss_batch_size=2, verbose=False)
+    faiss_result = mine_hard_negatives(use_faiss=True, **kwargs)
+    non_faiss_result = mine_hard_negatives(use_faiss=False, **kwargs)
+
+    # The invariant the fix restores: both paths mine the same number of negatives for the same input
+    # (default "triplet" output_format yields one negative per row, so len == number of mined negatives).
+    assert len(faiss_result) == len(non_faiss_result)
+
+
 def test_deprecated_parameters(dataset: Dataset, static_retrieval_mrl_en_v1_model: SentenceTransformer) -> None:
     """Test deprecated parameters: as_triplets and margin."""
     model = static_retrieval_mrl_en_v1_model


### PR DESCRIPTION
## Problem

`mine_hard_negatives` (`sentence_transformers/util/hard_negatives.py`) retrieves the top-scoring corpus candidates per query, then removes each query's own positive(s) so that `range_max` genuine negatives remain. The number retrieved must therefore leave room for the positives.

The **non-FAISS** path does this correctly:

```python
# Keep only the range_max + max_positives highest scores. We offset by max_positives to leave room for the positive pair(s).
chunk_scores, chunk_indices = torch.topk(chunk_scores, k=range_max + max_positives, dim=1)
```

The **FAISS** path offsets by only `1`:

```python
scores, indices = index.search(query_chunk, k=range_max + 1)
```

When a query has multiple positives (`max_positives > 1`, i.e. a dataset with several positive passages per anchor), the FAISS branch retrieves up to `max_positives - 1` fewer candidates than the sequential sibling. After the positives are filtered out, it can then yield fewer hard negatives than requested — and the two `use_faiss=True`/`False` paths produce different results for the same input.

## Fix

Mirror the sibling's offset so both paths retrieve the same number of candidates:

```python
scores, indices = index.search(query_chunk, k=range_max + max_positives)
```

`max_positives` is computed earlier in the function (`max(positives_per_query)`), so it's in scope here. For single-positive datasets (`max_positives == 1`) behavior is unchanged.
