### PR TITLE
fix: prevent mine_hard_negatives crash when candidates exceed corpus size

### DIFF
--- a/sentence_transformers/util/hard_negatives.py
+++ b/sentence_transformers/util/hard_negatives.py
@@ -489,17 +489,29 @@ def mine_hard_negatives(
         scores_list = []
         indices_list = []
         corpus_embeddings = torch.as_tensor(corpus_embeddings)
+        # torch.topk cannot return more candidates than there are corpus entries, so we cap k at the
+        # corpus size. This mirrors the FAISS branch above, which is allowed to request more
+        # candidates than the corpus holds and pads the shortfall with an index of -1.
+        k = min(range_max + max_positives, len(corpus))
         # Compute the similarity scores between the queries and the corpus in batches, to avoid
         # materializing the full (n_queries, n_corpus) similarity matrix
         for i in trange(0, len(query_embeddings), faiss_batch_size, desc="Computing similarity scores"):
             chunk_scores = model.similarity(query_embeddings[i : i + faiss_batch_size], corpus_embeddings).to(device)
 
             # Keep only the range_max + max_positives highest scores. We offset by max_positives to leave room for the positive pair(s).
-            chunk_scores, chunk_indices = torch.topk(chunk_scores, k=range_max + max_positives, dim=1)
+            chunk_scores, chunk_indices = torch.topk(chunk_scores, k=k, dim=1)
             scores_list.append(chunk_scores)
             indices_list.append(chunk_indices)
         scores = torch.cat(scores_list, dim=0)
         indices = torch.cat(indices_list, dim=0)
+
+        # If the corpus was smaller than range_max + max_positives, pad the candidate set up to the
+        # expected width with an index of -1, exactly as the FAISS branch does. These padded
+        # candidates are masked out (scored -inf) below.
+        missing = (range_max + max_positives) - scores.size(1)
+        if missing > 0:
+            scores = torch.cat([scores, scores.new_full((scores.size(0), missing), -float("inf"))], dim=1)
+            indices = torch.cat([indices, indices.new_full((indices.size(0), missing), -1)], dim=1)
 
     # As we may have duplicated queries (i.e., a single query with multiple positives),
     # We keep track, for each unique query, of where their positives are in the list of positives (positive_indices).
@@ -561,10 +573,10 @@ def mine_hard_negatives(
         if use_multi_process:
             cross_encoder.stop_multi_process_pool(pool)
 
-    if use_faiss:
-        # FAISS pads short result sets with index -1, which would resolve to the last corpus entry.
-        # Applied after the CrossEncoder rescoring, as that overwrites the score of every candidate.
-        scores[indices == -1] = -float("inf")
+    # Both branches pad short result sets with index -1, which would otherwise resolve to the last
+    # corpus entry. Applied after the CrossEncoder rescoring, as that overwrites the score of every
+    # candidate.
+    scores[indices == -1] = -float("inf")
 
     if not include_positives:
         # for each query, create a mask that is True for the positives and False for the negatives in the indices

--- a/sentence_transformers/util/hard_negatives.py
+++ b/sentence_transformers/util/hard_negatives.py
@@ -489,9 +489,7 @@ def mine_hard_negatives(
         scores_list = []
         indices_list = []
         corpus_embeddings = torch.as_tensor(corpus_embeddings)
-        # torch.topk cannot return more candidates than there are corpus entries, so we cap k at the
-        # corpus size. This mirrors the FAISS branch above, which is allowed to request more
-        # candidates than the corpus holds and pads the shortfall with an index of -1.
+        # torch.topk raises if k exceeds the corpus size, so cap it here and pad back up below.
         k = min(range_max + max_positives, len(corpus))
         # Compute the similarity scores between the queries and the corpus in batches, to avoid
         # materializing the full (n_queries, n_corpus) similarity matrix
@@ -505,9 +503,7 @@ def mine_hard_negatives(
         scores = torch.cat(scores_list, dim=0)
         indices = torch.cat(indices_list, dim=0)
 
-        # If the corpus was smaller than range_max + max_positives, pad the candidate set up to the
-        # expected width with an index of -1, exactly as the FAISS branch does. These padded
-        # candidates are masked out (scored -inf) below.
+        # Pad back up to range_max + max_positives columns with index -1, mirroring the FAISS branch.
         missing = (range_max + max_positives) - scores.size(1)
         if missing > 0:
             scores = torch.cat([scores, scores.new_full((scores.size(0), missing), -float("inf"))], dim=1)

--- a/tests/util/test_hard_negatives.py
+++ b/tests/util/test_hard_negatives.py
@@ -1572,3 +1572,28 @@ def test_relative_margin_with_negative_positive_score() -> None:
     positive_score, negative_score = row["scores"]
     assert row["negative"] == "n_far"
     assert negative_score < positive_score
+
+
+def test_range_max_larger_than_corpus_does_not_crash() -> None:
+    """Requesting more candidates than the corpus holds must not crash the default (non-FAISS)
+    path. `torch.topk` cannot return more columns than the corpus size, so the candidate set is
+    capped at the corpus size and padded up, mirroring the FAISS branch."""
+    dataset = Dataset.from_dict({"query": ["q"], "positive": ["p"]})
+    # The corpus has only 3 unique entries, yet range_max + max_positives (11) asks for far more.
+    result = mine_hard_negatives(
+        dataset=dataset,
+        model=ControlledNegativeScoreModel(),
+        anchor_column_name="query",
+        positive_column_name="positive",
+        corpus=["p", "n_more_similar", "n_far"],
+        range_max=10,
+        num_negatives=1,
+        use_faiss=False,
+        output_scores=True,
+        verbose=False,
+    )
+    row = result[0]
+    # A real (non-padded) negative must be returned and the positive excluded.
+    assert row["negative"] in {"n_more_similar", "n_far"}
+    positive_score, negative_score = row["scores"]
+    assert math.isfinite(negative_score)

--- a/tests/util/test_hard_negatives.py
+++ b/tests/util/test_hard_negatives.py
@@ -193,7 +193,6 @@ def test_separate_corpus(
     result = mine_hard_negatives(
         dataset=dataset,
         model=model,
-        range_max=3,  # Limit range to avoid k out of range error
         corpus=passages[5:],  # Use different passages as corpus
         verbose=False,
     )
@@ -218,7 +217,6 @@ def test_cross_encoder(
         dataset=dataset,
         model=model,
         cross_encoder=cross_encoder,
-        range_max=3,  # Limit the range to avoid k out of range error
         max_score=0.8,  # Need a filtering criterion for cross-encoder to be used
         verbose=False,
     )
@@ -241,7 +239,6 @@ def test_cross_encoder_detailed(
         model=model,
         cross_encoder=cross_encoder,
         range_min=1,
-        range_max=3,  # Keep range_max small to avoid k out of range error
         max_score=0.7,
         min_score=0.2,
         num_negatives=2,
@@ -268,7 +265,6 @@ def test_cross_encoder_with_multiple_positives_non_faiss(
         dataset=multiple_positive_dataset,
         model=model,
         cross_encoder=cross_encoder,
-        range_max=3,  # keep small to avoid k out of range
         max_score=0.9,  # ensure CrossEncoder path is exercised
         num_negatives=2,
         verbose=False,
@@ -303,7 +299,6 @@ def test_score_filters(dataset: Dataset, static_retrieval_mrl_en_v1_model: Sente
     result = mine_hard_negatives(
         dataset=dataset,
         model=model,
-        range_max=3,  # Limit range to avoid k out of range error
         max_score=0.8,  # Only consider candidates with score <= 0.8
         min_score=0.1,  # Only consider candidates with score >= 0.1
         verbose=False,
@@ -322,7 +317,6 @@ def test_margin_parameters(dataset: Dataset, static_retrieval_mrl_en_v1_model: S
     result_abs = mine_hard_negatives(
         dataset=dataset,
         model=model,
-        range_max=3,  # Limit range to avoid k out of range error
         absolute_margin=0.1,  # Negative must be at least 0.1 less similar than positive
         verbose=False,
     )
@@ -331,7 +325,6 @@ def test_margin_parameters(dataset: Dataset, static_retrieval_mrl_en_v1_model: S
     result_rel = mine_hard_negatives(
         dataset=dataset,
         model=model,
-        range_max=3,  # Limit range to avoid k out of range error
         relative_margin=0.05,  # Negative must be at most 95% as similar as positive
         verbose=False,
     )
@@ -413,7 +406,6 @@ def test_include_positives_with_labeled_formats(
         model=model,
         include_positives=True,
         output_format="labeled-pair",
-        range_max=3,  # Limit range to avoid k out of range error
         verbose=False,
     )
 
@@ -433,7 +425,6 @@ def test_include_positives_with_labeled_formats(
         model=model,
         include_positives=True,
         output_format="labeled-list",
-        range_max=3,  # Limit range to avoid k out of range error
         verbose=False,
     )
 
@@ -1107,14 +1098,16 @@ def test_deprecated_parameters(dataset: Dataset, static_retrieval_mrl_en_v1_mode
     assert "negative" in result_margin.column_names
 
 
-def test_margin_with_safe_range(dataset: Dataset, static_retrieval_mrl_en_v1_model: SentenceTransformer) -> None:
-    """Test margin parameter with safe range values to avoid k out of range error."""
+def test_margin_with_default_range_max(
+    dataset: Dataset, static_retrieval_mrl_en_v1_model: SentenceTransformer
+) -> None:
+    """Test the deprecated margin parameter with the auto-derived range_max, which exceeds the
+    corpus size and relies on the candidate set being capped at the corpus size."""
     model = static_retrieval_mrl_en_v1_model
     result = mine_hard_negatives(
         dataset=dataset,
         model=model,
         margin=0.2,  # Use deprecated margin parameter
-        range_max=3,  # Small range_max to avoid k out of range error
         verbose=False,
     )
 
@@ -1141,7 +1134,6 @@ def test_multi_process(
         dataset=dataset,
         model=model,
         cross_encoder=cross_encoder,
-        range_max=3,  # Reduced to avoid k out of range error
         num_negatives=2,
         relative_margin=0.1,
         use_multi_process=True,
@@ -1178,12 +1170,12 @@ def test_larger_dataset_with_combinations(
 
     larger_dataset = Dataset.from_dict({"query": queries_large, "passage": passages_large})
 
-    # Test combination of parameters - using smaller range_max to avoid k out of range error
+    # Test a combination of parameters
     result = mine_hard_negatives(
         dataset=larger_dataset,
         model=model,
         range_min=1,
-        range_max=3,  # Reduced from 15 to avoid k out of range error
+        range_max=15,
         max_score=0.9,
         min_score=0.1,
         absolute_margin=0.05,
@@ -1592,8 +1584,10 @@ def test_range_max_larger_than_corpus_does_not_crash() -> None:
         output_scores=True,
         verbose=False,
     )
+    assert len(result) == 1
     row = result[0]
-    # A real (non-padded) negative must be returned and the positive excluded.
-    assert row["negative"] in {"n_more_similar", "n_far"}
+    # The top real negative must be returned, with the positive excluded and no padding leaking through.
+    assert row["negative"] == "n_more_similar"
     positive_score, negative_score = row["scores"]
-    assert math.isfinite(negative_score)
+    assert positive_score == pytest.approx(-0.50)
+    assert negative_score == pytest.approx(-0.49)


### PR DESCRIPTION
## Summary

On the default (non-FAISS) path, `mine_hard_negatives` crashes with `RuntimeError: selected index k out of range` whenever the number of requested candidates exceeds the corpus size.

In `sentence_transformers/util/hard_negatives.py` the `use_faiss=False` branch runs:

```python
chunk_scores, chunk_indices = torch.topk(chunk_scores, k=range_max + max_positives, dim=1)
```

`chunk_scores` has one column per corpus entry, and `torch.topk` raises when `k > chunk_scores.size(1)`. `range_max` is either user-supplied or auto-derived (`range_min + num_negatives + max_positives`, or `range_min + num_negatives * 10 + max_positives` when a margin/score filter is set) and is **never** clamped to the corpus size on this path — the only existing cap is the FAISS-only `2048` limit.

## Reproduction

```python
from datasets import Dataset
from sentence_transformers import SentenceTransformer
from sentence_transformers.util import mine_hard_negatives

model = SentenceTransformer("sentence-transformers/static-retrieval-mrl-en-v1")
dataset = Dataset.from_dict({"query": QUERIES, "answer": PASSAGES})  # small corpus

# Uses the docstring's own recommended setting; crashes on a modest corpus:
mine_hard_negatives(dataset, model, num_negatives=10)
# RuntimeError: selected index k out of range
```

This is reachable from the public API with realistic inputs (the docstring recommends `num_negatives=10`, and describes `range_max` as only affecting how many candidates are considered — never warning that it must not exceed the corpus size). The existing test suite works around it, using `range_max=3, # ... to avoid k out of range error` in ~14 places, which suggests the crash is a known limitation rather than intended behavior.

## Why the FAISS branch is unaffected

The `use_faiss=True` branch already supports requesting more candidates than the corpus holds: `index.search(..., k=range_max + max_positives)` returns rows padded with an index of `-1`, and those are later masked to `-inf`. The torch branch simply lacks the equivalent handling.

## Fix

- Cap `k` at the corpus size on the torch path so `torch.topk` never over-requests.
- Pad the candidate set back up to `range_max + max_positives` columns with an index of `-1`, mirroring the FAISS branch, so downstream shapes and masking are unchanged.
- Apply the existing `-1 -> -inf` masking on both branches (it is a no-op when no padding is present).

The result is that a small corpus now mines as many negatives as the corpus allows (matching the FAISS path) instead of crashing.

## Test

Added `test_range_max_larger_than_corpus_does_not_crash`, which requests far more candidates than the (deduplicated) corpus holds on the `use_faiss=False` path using the existing lightweight deterministic model. It raises `RuntimeError` before the fix and passes after.

The full `tests/util/test_hard_negatives.py` suite passes locally (93 passed, 5 skipped).
