### PR TITLE
Keep per-sample video_metadata aligned with the batch, raise on conflicting audio sampling rates

### DIFF
--- a/sentence_transformers/base/modality.py
+++ b/sentence_transformers/base/modality.py
@@ -112,6 +112,22 @@ def _is_non_text_pair(sample: Any) -> bool:
     return True
 
 
+def _record_sampling_rate(sampling_rate: int, extra_modality_kwargs: dict[str, dict[str, Any]]) -> None:
+    """Record the batch-level ``sampling_rate``, raising if samples disagree.
+
+    Feature extractors accept a single ``sampling_rate`` for the whole batch, so conflicting
+    per-sample rates cannot be honored and would silently process some audio at the wrong rate.
+    """
+    existing = extra_modality_kwargs["audio"].get("sampling_rate")
+    if existing is not None and existing != sampling_rate:
+        raise ValueError(
+            f"This batch mixes audio with different sampling rates ({existing} and {sampling_rate}), but the "
+            "processor accepts a single sampling rate per batch. Resample the audio to a common rate, or "
+            "encode each sampling rate in a separate call."
+        )
+    extra_modality_kwargs["audio"]["sampling_rate"] = sampling_rate
+
+
 def _unwrap_audio(audio_value: AudioInput, extra_modality_kwargs: dict[str, dict[str, Any]]) -> Any:
     """Unwrap dict-wrapped audio or an ``AudioDecoder`` into a raw array, collecting ``sampling_rate``.
 
@@ -119,12 +135,12 @@ def _unwrap_audio(audio_value: AudioInput, extra_modality_kwargs: dict[str, dict
     """
     if isinstance(audio_value, dict):
         if "sampling_rate" in audio_value:
-            extra_modality_kwargs["audio"]["sampling_rate"] = audio_value["sampling_rate"]
+            _record_sampling_rate(audio_value["sampling_rate"], extra_modality_kwargs)
         return audio_value["array"]
     if AudioDecoder is not None and isinstance(audio_value, AudioDecoder):
         samples = audio_value.get_all_samples()
         # AudioDecoder returns (channels, samples); mean over channels to get 1D numpy
-        extra_modality_kwargs["audio"]["sampling_rate"] = samples.sample_rate
+        _record_sampling_rate(samples.sample_rate, extra_modality_kwargs)
         return samples.data.mean(dim=0).numpy()
     return audio_value
 
@@ -132,15 +148,18 @@ def _unwrap_audio(audio_value: AudioInput, extra_modality_kwargs: dict[str, dict
 def _unwrap_video(video_value: VideoInput, extra_modality_kwargs: dict[str, dict[str, Any]]) -> Any:
     """Unwrap dict-wrapped video or a ``VideoDecoder`` into a raw array, collecting ``video_metadata``.
 
-    Passes through unchanged if ``video_value`` is already a raw array/tensor/URL/path.
+    Passes through unchanged if ``video_value`` is already a raw array/tensor/URL/path. Appends one
+    metadata entry per video (``None`` when the sample carries none) so the batch-level list stays
+    index-aligned with the videos; :func:`_reconcile_video_metadata` resolves the ``None`` entries
+    once the whole batch has been parsed.
     """
+    metadata_list = extra_modality_kwargs["video"].setdefault("video_metadata", [])
     if isinstance(video_value, dict):
-        if "video_metadata" in video_value:
-            extra_modality_kwargs["video"].setdefault("video_metadata", []).append(video_value["video_metadata"])
+        metadata_list.append(video_value.get("video_metadata"))
         return video_value["array"]
     if VideoDecoder is not None and isinstance(video_value, VideoDecoder):
         frame_batch = video_value.get_frames_in_range(0, len(video_value))
-        extra_modality_kwargs["video"].setdefault("video_metadata", []).append(
+        metadata_list.append(
             {
                 "fps": video_value.metadata.average_fps,
                 "total_num_frames": video_value.metadata.num_frames,
@@ -149,7 +168,51 @@ def _unwrap_video(video_value: VideoInput, extra_modality_kwargs: dict[str, dict
             }
         )
         return frame_batch.data
+    metadata_list.append(None)
     return video_value
+
+
+def _reconcile_video_metadata(
+    typed_inputs: list[tuple[Modality | Literal["pair"], Any]],
+    extra_modality_kwargs: dict[str, dict[str, Any]],
+) -> None:
+    """Resolve the per-sample video metadata entries collected by :func:`_unwrap_video`.
+
+    If no video in the batch carried metadata, the key is dropped so the processor infers defaults
+    itself. Otherwise every ``None`` entry is filled with the same defaults transformers would build,
+    which requires the video to be in memory; path/URL videos without metadata raise instead, as
+    passing a partial list would attach metadata to the wrong videos.
+    """
+    video_kwargs = extra_modality_kwargs.get("video")
+    if not video_kwargs or "video_metadata" not in video_kwargs:
+        return
+    metadata_list = video_kwargs["video_metadata"]
+    if all(entry is None for entry in metadata_list):
+        del video_kwargs["video_metadata"]
+        if not video_kwargs:
+            del extra_modality_kwargs["video"]
+        return
+    videos = [
+        value["video"] if isinstance(mod, tuple) else value
+        for mod, value in typed_inputs
+        if mod == "video" or (isinstance(mod, tuple) and "video" in mod)
+    ]
+    for index, (entry, video) in enumerate(zip(metadata_list, videos)):
+        if entry is not None:
+            continue
+        if isinstance(video, str) or not hasattr(video, "__len__"):
+            raise ValueError(
+                "This batch mixes videos that carry per-sample 'video_metadata' with videos that do not. "
+                "Default metadata can only be inferred for in-memory videos (frame arrays or lists), so "
+                "either pass 'video_metadata' for every video in the batch or for none of them."
+            )
+        num_frames = len(video)
+        metadata_list[index] = {
+            "total_num_frames": num_frames,
+            "fps": None,
+            "duration": None,
+            "frames_indices": list(range(num_frames)),
+        }
 
 
 class InputFormatter:
@@ -298,6 +361,8 @@ class InputFormatter:
                 value = item
 
             typed_inputs.append((modality, value))
+
+        _reconcile_video_metadata(typed_inputs, extra_modality_kwargs)
 
         # Non-text pairs require conversion to message format. When the batch contains any
         # non-text pairs, ALL items must be converted to messages for consistency. Text pairs

--- a/sentence_transformers/base/modality.py
+++ b/sentence_transformers/base/modality.py
@@ -150,7 +150,7 @@ def _unwrap_video(video_value: VideoInput, extra_modality_kwargs: dict[str, dict
 
     Passes through unchanged if ``video_value`` is already a raw array/tensor/URL/path. Appends one
     metadata entry per video (``None`` when the sample carries none) so the batch-level list stays
-    index-aligned with the videos; :func:`_reconcile_video_metadata` resolves the ``None`` entries
+    index-aligned with the videos. :func:`_reconcile_video_metadata` resolves the ``None`` entries
     once the whole batch has been parsed.
     """
     metadata_list = extra_modality_kwargs["video"].setdefault("video_metadata", [])
@@ -180,7 +180,7 @@ def _reconcile_video_metadata(
 
     If no video in the batch carried metadata, the key is dropped so the processor infers defaults
     itself. Otherwise every ``None`` entry is filled with the same defaults transformers would build,
-    which requires the video to be in memory; path/URL videos without metadata raise instead, as
+    which requires the video to be in memory. Path/URL videos without metadata raise instead, as
     passing a partial list would attach metadata to the wrong videos.
     """
     video_kwargs = extra_modality_kwargs.get("video")
@@ -197,7 +197,7 @@ def _reconcile_video_metadata(
         for mod, value in typed_inputs
         if mod == "video" or (isinstance(mod, tuple) and "video" in mod)
     ]
-    for index, (entry, video) in enumerate(zip(metadata_list, videos)):
+    for index, (entry, video) in enumerate(zip(metadata_list, videos, strict=True)):
         if entry is not None:
             continue
         if isinstance(video, str) or not hasattr(video, "__len__"):

--- a/sentence_transformers/base/modality.py
+++ b/sentence_transformers/base/modality.py
@@ -179,9 +179,10 @@ def _reconcile_video_metadata(
     """Resolve the per-sample video metadata entries collected by :func:`_unwrap_video`.
 
     If no video in the batch carried metadata, the key is dropped so the processor infers defaults
-    itself. Otherwise every ``None`` entry is filled with the same defaults transformers would build,
-    which requires the video to be in memory. Path/URL videos without metadata raise instead, as
-    passing a partial list would attach metadata to the wrong videos.
+    itself. Otherwise every ``None`` entry is filled with the frame count of that video, matching what
+    transformers infers for a metadata-less video. This requires the video to be in memory, so
+    path/URL videos without metadata raise instead, as passing a partial list would attach metadata
+    to the wrong videos.
     """
     video_kwargs = extra_modality_kwargs.get("video")
     if not video_kwargs or "video_metadata" not in video_kwargs:

--- a/tests/base/test_modality.py
+++ b/tests/base/test_modality.py
@@ -606,6 +606,54 @@ class TestParseInputs:
         assert len(inputs["video"]) == 2
         assert extra["video"]["video_metadata"] == [{"fps": 30}, {"fps": 24}]
 
+    def test_video_metadata_stays_aligned_when_mixing_wrapped_and_raw(self):
+        """A raw video before a dict-wrapped one must not shift the metadata onto the wrong video.
+
+        https://github.com/huggingface/sentence-transformers/issues/3874
+        """
+        raw = np.zeros((4, 3, 8, 8))
+        wrapped = {"array": np.ones((6, 3, 8, 8)), "video_metadata": {"fps": 15, "total_num_frames": 6}}
+        modality, inputs, extra = self.fmt.parse_inputs([raw, wrapped])
+        assert modality == "video"
+        assert len(inputs["video"]) == 2
+        metadata = extra["video"]["video_metadata"]
+        assert len(metadata) == 2
+        # The raw video gets inferred defaults, mirroring what transformers builds without metadata
+        assert metadata[0]["total_num_frames"] == 4
+        assert metadata[0]["fps"] is None
+        assert metadata[0]["frames_indices"] == [0, 1, 2, 3]
+        # The explicit metadata stays with the video it was attached to
+        assert metadata[1] == {"fps": 15, "total_num_frames": 6}
+
+    def test_video_metadata_key_dropped_when_no_sample_carries_it(self):
+        samples = [np.zeros((8, 3, 224, 224)), np.zeros((8, 3, 224, 224))]
+        modality, inputs, extra = self.fmt.parse_inputs(samples)
+        assert modality == "video"
+        assert dict(extra) == {}
+
+    def test_video_metadata_with_metadata_less_path_raises(self):
+        wrapped = {"array": np.ones((4, 3, 8, 8)), "video_metadata": {"fps": 15, "total_num_frames": 4}}
+        with pytest.raises(ValueError, match="every video"):
+            self.fmt.parse_inputs(["https://example.com/a.mp4", wrapped])
+
+    def test_conflicting_sampling_rates_raise(self):
+        """https://github.com/huggingface/sentence-transformers/issues/3874"""
+        audio_dicts = [
+            {"array": np.zeros(1600), "sampling_rate": 16000},
+            {"array": np.zeros(4410), "sampling_rate": 44100},
+        ]
+        with pytest.raises(ValueError, match="sampling rates"):
+            self.fmt.parse_inputs(audio_dicts)
+
+    def test_matching_sampling_rates_do_not_raise(self):
+        audio_dicts = [
+            {"array": np.zeros(1600), "sampling_rate": 16000},
+            {"array": np.zeros(3200), "sampling_rate": 16000},
+        ]
+        modality, inputs, extra = self.fmt.parse_inputs(audio_dicts)
+        assert modality == "audio"
+        assert extra["audio"]["sampling_rate"] == 16000
+
     def test_message_dict_inputs(self):
         messages = [
             {"role": "user", "content": "hello"},

--- a/tests/base/test_modality.py
+++ b/tests/base/test_modality.py
@@ -625,6 +625,16 @@ class TestParseInputs:
         # The explicit metadata stays with the video it was attached to
         assert metadata[1] == {"fps": 15, "total_num_frames": 6}
 
+    def test_video_metadata_filled_for_frame_list_video(self):
+        frames = [np.zeros((3, 8, 8)) for _ in range(4)]
+        wrapped = {"array": np.ones((6, 3, 8, 8)), "video_metadata": {"fps": 15, "total_num_frames": 6}}
+        modality, inputs, extra = self.fmt.parse_inputs([{"video": frames}, wrapped])
+        assert modality == "video"
+        metadata = extra["video"]["video_metadata"]
+        assert metadata[0]["total_num_frames"] == 4
+        assert metadata[0]["frames_indices"] == [0, 1, 2, 3]
+        assert metadata[1] == {"fps": 15, "total_num_frames": 6}
+
     def test_video_metadata_key_dropped_when_no_sample_carries_it(self):
         samples = [np.zeros((8, 3, 224, 224)), np.zeros((8, 3, 224, 224))]
         modality, inputs, extra = self.fmt.parse_inputs(samples)


### PR DESCRIPTION
Fixes #3874

`_unwrap_video` only appended a `video_metadata` entry for the samples that carried one, so a batch mixing dict-wrapped and raw videos handed the processor a metadata list shorter than the batch. Since `make_batched_metadata` in transformers pairs metadata with videos purely by index, the metadata of a later sample was silently applied to an earlier one. Audio had the same problem in a different shape: `_unwrap_audio` let every dict-wrapped sample overwrite the batch-level `sampling_rate`, so a batch mixing rates would quietly process all audio at whichever rate came last.

Changes:

- `_unwrap_video` now appends one entry per video (`None` when the sample has no metadata), so the list can never fall out of alignment with the batch.
- A new `_reconcile_video_metadata` step at the end of `parse_inputs` resolves the `None` entries. If no sample carried metadata the key is dropped entirely, which keeps the previous behavior of letting transformers infer its own defaults. Otherwise each `None` is filled with the same defaults transformers would build itself (`total_num_frames` from `len(video)`, `frames_indices`, `fps` and `duration` left as `None`). For a metadata-less path/URL video in a mixed batch the frame count cannot be known without decoding, so that case raises a clear error asking to pass metadata for every video or for none.
- `_unwrap_audio` goes through a new `_record_sampling_rate` helper that raises when two samples disagree, since the feature extractor API only accepts a single rate per batch. That seemed better than silently resampling some of the audio at the wrong rate, but happy to downgrade it to a warning if you prefer.

Added five regression tests to `tests/base/test_modality.py`, covering the mixed wrapped/raw alignment, the key being dropped when no sample has metadata, the path/URL error, and both the conflicting and matching sampling rate cases. Ran `tests/base/` locally (excluding the per-architecture matrix in `tests/base/modules/transformer/`): 469 passed, 15 skipped.
