### PR TITLE
Fix video_metadata misalignment when a batch mixes metadata-carrying and raw videos

### DIFF
--- a/sentence_transformers/base/modality.py
+++ b/sentence_transformers/base/modality.py
@@ -133,23 +133,28 @@ def _unwrap_video(video_value: VideoInput, extra_modality_kwargs: dict[str, dict
     """Unwrap dict-wrapped video or a ``VideoDecoder`` into a raw array, collecting ``video_metadata``.
 
     Passes through unchanged if ``video_value`` is already a raw array/tensor/URL/path.
+
+    Appends one ``video_metadata`` entry per video (``None`` when the video carries no
+    metadata) so the collected list stays index-aligned with the batch. Otherwise a raw
+    video contributes no entry, the list ends up shorter than the batch, and the processor
+    (which pairs metadata to videos by index) attaches metadata to the wrong video.
     """
+    metadata: Any = None
+    result: Any = video_value
     if isinstance(video_value, dict):
-        if "video_metadata" in video_value:
-            extra_modality_kwargs["video"].setdefault("video_metadata", []).append(video_value["video_metadata"])
-        return video_value["array"]
-    if VideoDecoder is not None and isinstance(video_value, VideoDecoder):
+        metadata = video_value.get("video_metadata")
+        result = video_value["array"]
+    elif VideoDecoder is not None and isinstance(video_value, VideoDecoder):
         frame_batch = video_value.get_frames_in_range(0, len(video_value))
-        extra_modality_kwargs["video"].setdefault("video_metadata", []).append(
-            {
-                "fps": video_value.metadata.average_fps,
-                "total_num_frames": video_value.metadata.num_frames,
-                "duration": video_value.metadata.duration_seconds,
-                "frames_indices": list(range(frame_batch.data.shape[0])),
-            }
-        )
-        return frame_batch.data
-    return video_value
+        metadata = {
+            "fps": video_value.metadata.average_fps,
+            "total_num_frames": video_value.metadata.num_frames,
+            "duration": video_value.metadata.duration_seconds,
+            "frames_indices": list(range(frame_batch.data.shape[0])),
+        }
+        result = frame_batch.data
+    extra_modality_kwargs["video"].setdefault("video_metadata", []).append(metadata)
+    return result
 
 
 class InputFormatter:
@@ -298,6 +303,15 @@ class InputFormatter:
                 value = item
 
             typed_inputs.append((modality, value))
+
+        # A ``video_metadata`` entry is collected per video (``None`` for videos without
+        # metadata) to keep the list index-aligned with the batch; if no video provided any
+        # metadata, drop the list so the processor keeps its default per-video handling.
+        video_kwargs = extra_modality_kwargs.get("video")
+        if video_kwargs is not None:
+            video_metadata = video_kwargs.get("video_metadata")
+            if video_metadata is not None and all(entry is None for entry in video_metadata):
+                del video_kwargs["video_metadata"]
 
         # Non-text pairs require conversion to message format. When the batch contains any
         # non-text pairs, ALL items must be converted to messages for consistency. Text pairs

--- a/tests/base/test_modality.py
+++ b/tests/base/test_modality.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections import defaultdict
+
 import numpy as np
 import pytest
 import torch
@@ -8,6 +10,7 @@ from PIL import Image
 from sentence_transformers.base.modality import (
     InputFormatter,
     _is_non_text_pair,
+    _unwrap_video,
     infer_batch_modality,
     infer_modality,
     is_audio_url_or_path,
@@ -1231,3 +1234,18 @@ class TestIsTextOnlyMessages:
             ]
         ]
         assert InputFormatter.is_text_only_messages(batch) is True
+
+
+class TestUnwrapVideoMetadata:
+    def test_metadata_stays_aligned_when_batch_mixes_metadata_and_raw_videos(self):
+        # Regression for #3874: a raw video contributed no video_metadata entry, so a batch
+        # mixing metadata-carrying and raw videos produced a list shorter than the batch and
+        # the processor paired metadata with the wrong video by index. Every video now gets one
+        # entry (None for a raw video), keeping the list index-aligned with the batch.
+        extra_modality_kwargs = defaultdict(dict)
+        first = {"fps": 1.0}
+        second = {"fps": 2.0}
+        _unwrap_video({"array": np.zeros((1, 2, 2, 3)), "video_metadata": first}, extra_modality_kwargs)
+        _unwrap_video(np.zeros((1, 2, 2, 3)), extra_modality_kwargs)
+        _unwrap_video({"array": np.zeros((1, 2, 2, 3)), "video_metadata": second}, extra_modality_kwargs)
+        assert extra_modality_kwargs["video"]["video_metadata"] == [first, None, second]


### PR DESCRIPTION
Fixes #3874.

`_unwrap_video` only appended a `video_metadata` entry for metadata-carrying videos (dict-wrapped or `VideoDecoder`), so when a batch mixes those with raw videos (paths/arrays) the collected list ends up shorter than the batch. The processor pairs metadata to videos by index, so each metadata entry then lands on the wrong video.

This appends one entry per video — `None` for a raw video — so the list stays index-aligned with the batch, and drops the list entirely when no video carries metadata (leaving the all-raw case behaving exactly as before).

Added a regression test in `tests/base/test_modality.py` asserting the mixed-batch alignment yields `[meta1, None, meta2]`; it fails against the old `[meta1, meta2]` output.