### PR TITLE
Fix misaligned results CSV in BinaryClassificationEvaluator

### DIFF
--- a/sentence_transformers/sentence_transformer/evaluation/binary_classification.py
+++ b/sentence_transformers/sentence_transformer/evaluation/binary_classification.py
@@ -183,7 +183,7 @@ class BinaryClassificationEvaluator(BaseEvaluator):
         file_output_data = [epoch, steps]
 
         for header_name in self.csv_headers:
-            if header_name.count("_") == 1:
+            if header_name.count("_") >= 1:
                 sim_fct, metric = header_name.split("_", maxsplit=1)
                 if sim_fct in scores:
                     file_output_data.append(scores[sim_fct][metric])

--- a/sentence_transformers/sentence_transformer/evaluation/binary_classification.py
+++ b/sentence_transformers/sentence_transformer/evaluation/binary_classification.py
@@ -183,7 +183,7 @@ class BinaryClassificationEvaluator(BaseEvaluator):
         file_output_data = [epoch, steps]
 
         for header_name in self.csv_headers:
-            if header_name.count("_") >= 1:
+            if header_name not in ("epoch", "steps"):
                 sim_fct, metric = header_name.split("_", maxsplit=1)
                 if sim_fct in scores:
                     file_output_data.append(scores[sim_fct][metric])

--- a/tests/sentence_transformer/evaluation/test_binary_classification_evaluator.py
+++ b/tests/sentence_transformer/evaluation/test_binary_classification_evaluator.py
@@ -4,6 +4,8 @@ Tests the correct computation of evaluation scores from BinaryClassificationEval
 
 from __future__ import annotations
 
+import csv
+
 import numpy as np
 import pytest
 from sklearn.metrics import accuracy_score, f1_score
@@ -64,3 +66,29 @@ def test_BinaryClassificationEvaluator_multiple_similarity_fn_names(
     assert evaluator.primary_metric == "max_ap"
     for metric in ["accuracy", "f1", "precision", "recall", "ap", "mcc"]:
         assert metrics[f"max_{metric}"] == max(metrics[f"{name}_{metric}"] for name in similarity_fn_names)
+
+
+@pytest.mark.parametrize("similarity_fn_names", [["cosine"], ["cosine", "dot", "euclidean", "manhattan"]])
+def test_BinaryClassificationEvaluator_csv_columns_are_aligned(
+    stsb_bert_tiny_model: SentenceTransformer, tmp_path, similarity_fn_names: list[str]
+) -> None:
+    """The results CSV data row must have as many columns as the header row.
+
+    The ``*_accuracy_threshold`` and ``*_f1_threshold`` metrics contain a second underscore, so a
+    ``count("_") == 1`` filter dropped them from the data row while keeping them in the header,
+    shifting every later column and leaving the trailing ``*_ap``/``*_mcc`` columns empty.
+    """
+    model = stsb_bert_tiny_model
+    evaluator = evaluation.BinaryClassificationEvaluator(
+        sentences1=["A man is eating food.", "A cat sits outside.", "The girl plays guitar."],
+        sentences2=["A man eats something.", "The sky is blue.", "A woman plays a guitar."],
+        labels=[1, 0, 1],
+        similarity_fn_names=similarity_fn_names,
+    )
+    evaluator(model, output_path=str(tmp_path))
+
+    with open(tmp_path / evaluator.csv_file, newline="", encoding="utf-8") as f:
+        rows = list(csv.reader(f))
+
+    assert len(rows) == 2
+    assert len(rows[1]) == len(rows[0])


### PR DESCRIPTION
## Summary

`BinaryClassificationEvaluator` writes a results CSV whose header row lists every metric for every requested similarity function, but the data row is misaligned: the `*_accuracy_threshold` and `*_f1_threshold` columns are missing, so every later value lands under the wrong header and the trailing `*_ap`/`*_mcc` columns are left empty.

## Root cause

The data row is assembled by filtering the headers with `header_name.count("_") == 1`:

```python
for header_name in self.csv_headers:
    if header_name.count("_") == 1:
        sim_fct, metric = header_name.split("_", maxsplit=1)
        if sim_fct in scores:
            file_output_data.append(scores[sim_fct][metric])
```

Two of the eight metrics, `accuracy_threshold` and `f1_threshold`, already contain an underscore, so their headers (for example `cosine_accuracy_threshold`) have two underscores and are skipped, while the header row still includes them. The data row therefore has two fewer columns per similarity function than the header, shifting each subsequent value one column left and leaving the final `*_ap`/`*_mcc` cells blank.

With `similarity_fn_names=["cosine"]` the header has 10 columns but the data row has 8, so `cosine_accuracy_threshold` shows the F1 value, `cosine_f1` shows precision, and so on, with `cosine_ap`/`cosine_mcc` empty. The returned `metrics` dict a few lines below is built from all of `scores.items()`, confirming the intent is to emit every metric.

## Fix

Accept any header with at least one underscore (`count("_") >= 1`). Similarity-function names never contain an underscore, so `split("_", maxsplit=1)` still splits correctly into `(sim_fct, metric)`; `epoch`/`steps` (no underscore) stay excluded, and all metric columns, including the `_threshold` ones, are now written.

## Test

Added a parametrized test that runs the evaluator with `output_path` set (for `["cosine"]` and for all four similarity functions), reads the CSV back, and asserts the data row has the same number of columns as the header. It fails on the current code (10 vs 8 columns for a single function) and passes with the fix. The existing evaluator tests are unchanged.
