### PR TITLE
Don't render text pairs through chat templates that lack the query/document roles

### DIFF
--- a/sentence_transformers/base/modules/transformer.py
+++ b/sentence_transformers/base/modules/transformer.py
@@ -635,6 +635,7 @@ class Transformer(InputModule):
         self._prompt_length_mapping = {}
         self._method_signature_cache: dict[str, set[str]] = {}
         self._chat_template_suffix_cache: dict[Any, list[int]] = {}
+        self._chat_template_supports_pair_roles: bool | None = None
 
         config, is_peft_model = self._load_config(model_name_or_path, backend, config_kwargs)
         self._warn_on_unsupported_attention_config(config)
@@ -976,7 +977,12 @@ class Transformer(InputModule):
 
         # Always convert to the message format if it's supported, since it's most flexible with e.g. defaults
         if "message" in self.modality_config and modality != "message":
-            modality, processor_inputs = self.input_formatter.batch_to_message(modality, processor_inputs)
+            # Text pairs are the exception: they map to the "query"/"document" roles, which only purpose-built
+            # reranker chat templates understand. A backbone that merely carries a generic instruct template
+            # would silently render those roles as an empty string, leaving the model with zero-length inputs,
+            # so fall back to the tokenizer's native text-pair handling there.
+            if not self._is_text_pair_batch(modality, processor_inputs) or self._supports_pair_roles():
+                modality, processor_inputs = self.input_formatter.batch_to_message(modality, processor_inputs)
         elif modality not in self.modality_config:
             raise_unsupported_modality_error(inputs, modality, list(self.modality_config.keys()), "Transformer module")
 
@@ -1361,6 +1367,39 @@ class Transformer(InputModule):
             f"Could not determine how to call processor of type {type(self.processor).__name__} "
             f"for modality '{format_modality(modality)}'"
         )
+
+    @staticmethod
+    def _is_text_pair_batch(modality: Modality, processor_inputs: dict[str, list]) -> bool:
+        """Whether the batch is purely text pairs, i.e. cross-encoder ``(query, document)`` input."""
+        if modality != "text":
+            return False
+        texts = processor_inputs.get("text") or []
+        return bool(texts) and all(
+            isinstance(text, (tuple, list)) and len(text) == 2 and all(isinstance(part, str) for part in text)
+            for text in texts
+        )
+
+    def _supports_pair_roles(self) -> bool:
+        """Whether the processor's chat template renders the ``"query"``/``"document"`` roles.
+
+        Reranker templates (e.g. Qwen3-Reranker) select on those roles explicitly, while a generic
+        instruct template only handles ``system``/``user``/``assistant`` and drops them, producing an
+        empty prompt. Probed once by rendering a sentinel pair and cached for subsequent calls.
+        """
+        if self._chat_template_supports_pair_roles is None:
+            query_probe = "cf1a4b2e-query"
+            document_probe = "cf1a4b2e-document"
+            messages = [self.input_formatter.pair_to_messages((query_probe, document_probe))]
+            try:
+                rendered = self.processor.apply_chat_template(messages, tokenize=False)
+            except Exception:
+                # Templates that raise on unknown roles clearly do not support them
+                self._chat_template_supports_pair_roles = False
+            else:
+                if not isinstance(rendered, str):
+                    rendered = "".join(rendered)
+                self._chat_template_supports_pair_roles = query_probe in rendered and document_probe in rendered
+        return self._chat_template_supports_pair_roles
 
     def _process_chat_messages(
         self,

--- a/tests/cross_encoder/test_model.py
+++ b/tests/cross_encoder/test_model.py
@@ -788,6 +788,55 @@ def test_predict_per_call_processing_kwargs(reranker_bert_tiny_model: CrossEncod
     assert not np.isclose(truncated[0], full[0])
 
 
+def test_predict_ignores_chat_template_without_pair_roles(reranker_bert_tiny_model: CrossEncoder) -> None:
+    """A generic instruct chat template must not be used to render ``(query, document)`` pairs.
+
+    Backbones such as the Qwen3 chat models carry a template that only handles the
+    ``system``/``user``/``assistant`` roles. Rendering the ``query``/``document`` roles through it
+    yields an empty prompt, so the model used to receive zero-length inputs and crash somewhere deep
+    in the attention implementation. Such a template should be ignored in favour of the tokenizer's
+    native text-pair handling.
+    """
+    generic_chat_template = (
+        "{% for message in messages %}"
+        "{% if message['role'] == 'user' %}<|user|>\n{{ message['content'] }}\n{% endif %}"
+        "{% endfor %}"
+    )
+    model = CrossEncoder(
+        "cross-encoder-testing/reranker-bert-tiny-gooaq-bce",
+        processor_kwargs={"chat_template": generic_chat_template},
+    )
+    transformer = model[0]
+    # The template is picked up, but it cannot render the roles that text pairs map to
+    assert "message" in transformer.modality_config
+
+    pairs = [
+        ["How many people live in Berlin?", "Berlin has a population of 3,520,031 registered inhabitants."],
+        ["How many people live in Berlin?", "Berlin is well known for its museums."],
+    ]
+    features = transformer.preprocess(pairs)
+    assert features["input_ids"].shape[1] > 0
+
+    # The stray template is ignored, so the scores match those of the very same model without it
+    assert model.predict(pairs) == pytest.approx(reranker_bert_tiny_model.predict(pairs), abs=1e-6)
+
+
+def test_predict_applies_chat_template_with_pair_roles() -> None:
+    """A template that does select on the ``query``/``document`` roles must still be applied."""
+    reranker_chat_template = (
+        '<Query>: {{ messages | selectattr("role", "eq", "query") | map(attribute="content") | first }}\n'
+        '<Document>: {{ messages | selectattr("role", "eq", "document") | map(attribute="content") | first }}'
+    )
+    model = CrossEncoder(
+        "cross-encoder-testing/reranker-bert-tiny-gooaq-bce",
+        processor_kwargs={"chat_template": reranker_chat_template},
+    )
+    transformer = model[0]
+    pairs = [["How many people live in Berlin?", "Berlin has 3,520,031 registered inhabitants."]]
+    decoded = transformer.tokenizer.decode(transformer.preprocess(pairs)["input_ids"][0], skip_special_tokens=True)
+    assert "query" in decoded and "document" in decoded
+
+
 # Test suite converted from demo_3406_simple_og.py
 def format_queries(query, instruction=None):
     """Helper function to format queries with the template."""


### PR DESCRIPTION
## Summary

Refs #3881. A CrossEncoder whose backbone carries a chat template that drops unknown roles renders its text pairs to an empty string, so the model receives zero-length input and every token of the query and document is lost before the forward pass.

```python
from sentence_transformers import CrossEncoder

model = CrossEncoder("trl-internal-testing/tiny-Qwen3ForCausalLM")   # stock Qwen3 template, 21MB, ungated
model.predict([("What is the capital of France?", "Paris is the capital of France.")])
```

```
main   : IndexError: index -1 is out of bounds for dimension 1 with size 0
         input_ids.shape (2, 0), decoded ''
branch : input_ids.shape (2, 14), decoded 'What is the capital of France?Paris is the capital of France.'
```

Same on a sequence-classification reranker given such a template: `(2, 0)` and `RuntimeError: cannot reshape tensor of 0 elements` on main, `(2, 17)` and `[CLS] what is the capital of france? [SEP] paris is the capital of france. [SEP]` here.

`pair_to_messages` assigns the `query` and `document` roles, which only purpose-built reranker templates select on. A general instruct template falls through every branch and renders `''`, and since `apply_chat_template` tokenizes with `add_special_tokens=False` the result is zero-length for any tokenizer family.

## Change

`Transformer._supports_pair_roles()` renders a sentinel pair through the template once and checks both probe strings survive; `preprocess` keeps its existing message conversion unless the batch is a text pair whose roles would be dropped. Result cached per instance, so one extra template render per model.

It can only skip the message path in the case where content would otherwise be lost, so a false positive leaves current behaviour intact. Verified unchanged for models with no template, purpose-built reranker templates (`Qwen/Qwen3-Reranker-0.6B`), and templates that emit the role verbatim rather than branching (`HuggingFaceTB/SmolLM2-135M-Instruct`).

## Design question

Silent fallback or a raised error? The fallback makes these models work; raising makes the misconfiguration obvious. I went with the fallback since the alternative today is silent data loss either way, but this is your call and I am happy to switch it.

## Tests

Two in `tests/cross_encoder/test_model.py`: one asserting content survives for a template without pair roles, one asserting models with a working reranker template still take the message path.

```
tests/cross_encoder/test_model.py, branch        : 66 passed, 8 skipped
tests/cross_encoder/test_model.py, main + tests  : 1 failed, 65 passed, 8 skipped   (the behavioural test)
tests/base/modules/test_transformer.py + tests/base/test_modality.py : 317 passed, 6 skipped
```

The base suites matter because the change is in shared base code. The one pre-existing failure in `tests/cross_encoder`, `test_cached_ce_mnrl_prompt_reaches_the_backward_pass`, fails the same way on an unmodified checkout.

## Note

This does not make jina-reranker-v3 work and does not try to; you have already covered why that model is out of scope in #3849. It is where the zero-length input was first noticed.

AI-assisted. I reviewed every line, ran the repro and the suites above myself, and corrected the mechanism once when the first explanation did not survive checking.
