### PR TITLE
Fix inverted Euclidean/Manhattan metrics in BinaryClassificationEvaluator

### DIFF
--- a/examples/sparse_encoder/evaluation/sparse_classification_evaluator.py
+++ b/examples/sparse_encoder/evaluation/sparse_classification_evaluator.py
@@ -33,27 +33,27 @@ Average Precision with Cosine-Similarity:    67.81
 Matthews Correlation with Cosine-Similarity: 49.56
 
 Accuracy with Dot-Product:             76.50    (Threshold: 23.4236)
-F1 with Dot-Product:                   67.00    (Threshold: 19.0095)
+F1 with Dot-Product:                   67.00    (Threshold: 19.0094)
 Precision with Dot-Product:            55.93
 Recall with Dot-Product:               83.54
 Average Precision with Dot-Product:    65.89
 Matthews Correlation with Dot-Product: 48.88
 
-Accuracy with Euclidean-Distance:             67.70     (Threshold: -10.0041)
-F1 with Euclidean-Distance:                   48.60     (Threshold: -0.1876)
-Precision with Euclidean-Distance:            32.13
-Recall with Euclidean-Distance:               99.69
-Average Precision with Euclidean-Distance:    20.52
-Matthews Correlation with Euclidean-Distance: -4.59
+Accuracy with Euclidean-Distance:             74.40     (Threshold: 2.5143)
+F1 with Euclidean-Distance:                   63.38     (Threshold: 5.2380)
+Precision with Euclidean-Distance:            48.98
+Recall with Euclidean-Distance:               89.75
+Average Precision with Euclidean-Distance:    65.34
+Matthews Correlation with Euclidean-Distance: 43.09
 
-Accuracy with Manhattan-Distance:             67.70     (Threshold: -103.0263)
-F1 with Manhattan-Distance:                   48.60     (Threshold: -0.8532)
-Precision with Manhattan-Distance:            32.13
-Recall with Manhattan-Distance:               99.69
-Average Precision with Manhattan-Distance:    21.05
-Matthews Correlation with Manhattan-Distance: -4.59
+Accuracy with Manhattan-Distance:             72.40     (Threshold: 11.8888)
+F1 with Manhattan-Distance:                   62.62     (Threshold: 31.5751)
+Precision with Manhattan-Distance:            48.09
+Recall with Manhattan-Distance:               89.75
+Average Precision with Manhattan-Distance:    60.15
+Matthews Correlation with Manhattan-Distance: 41.73
 
-Model Sparsity: Active Dimensions: 61.2, Sparsity Ratio: 0.9980
+Model Sparsity: Active Dimensions: 61.3, Sparsity Ratio: 0.9980
 """
 # Print the results
 print(f"Primary metric: {binary_acc_evaluator.primary_metric}")

--- a/sentence_transformers/sentence_transformer/evaluation/binary_classification.py
+++ b/sentence_transformers/sentence_transformer/evaluation/binary_classification.py
@@ -247,13 +247,15 @@ class BinaryClassificationEvaluator(BaseEvaluator):
                 "name": "Dot-Product",
                 "greater_is_better": True,
             },
+            # The pairwise_*_sim functions return negative distances (i.e. similarities), so negate
+            # them back into positive distances to match "greater_is_better": False (#3702).
             SimilarityFunction.MANHATTAN.value: {
-                "score_fn": lambda x, y: pairwise_manhattan_sim(x, y),
+                "score_fn": lambda x, y: -pairwise_manhattan_sim(x, y),
                 "name": "Manhattan-Distance",
                 "greater_is_better": False,
             },
             SimilarityFunction.EUCLIDEAN.value: {
-                "score_fn": lambda x, y: pairwise_euclidean_sim(x, y),
+                "score_fn": lambda x, y: -pairwise_euclidean_sim(x, y),
                 "name": "Euclidean-Distance",
                 "greater_is_better": False,
             },

--- a/sentence_transformers/sentence_transformer/evaluation/binary_classification.py
+++ b/sentence_transformers/sentence_transformer/evaluation/binary_classification.py
@@ -247,8 +247,7 @@ class BinaryClassificationEvaluator(BaseEvaluator):
                 "name": "Dot-Product",
                 "greater_is_better": True,
             },
-            # The pairwise_*_sim functions return negative distances (i.e. similarities), so negate
-            # them back into positive distances to match "greater_is_better": False (#3702).
+            # pairwise_*_sim returns negative distances, so negate them back into positive distances (#3702)
             SimilarityFunction.MANHATTAN.value: {
                 "score_fn": lambda x, y: -pairwise_manhattan_sim(x, y),
                 "name": "Manhattan-Distance",

--- a/sentence_transformers/sparse_encoder/evaluation/sparse_binary_classification.py
+++ b/sentence_transformers/sparse_encoder/evaluation/sparse_binary_classification.py
@@ -79,27 +79,27 @@ class SparseBinaryClassificationEvaluator(BinaryClassificationEvaluator):
             Matthews Correlation with Cosine-Similarity: 49.56
 
             Accuracy with Dot-Product:             76.50    (Threshold: 23.4236)
-            F1 with Dot-Product:                   67.00    (Threshold: 19.0095)
+            F1 with Dot-Product:                   67.00    (Threshold: 19.0094)
             Precision with Dot-Product:            55.93
             Recall with Dot-Product:               83.54
             Average Precision with Dot-Product:    65.89
             Matthews Correlation with Dot-Product: 48.88
 
-            Accuracy with Euclidean-Distance:             67.70     (Threshold: -10.0041)
-            F1 with Euclidean-Distance:                   48.60     (Threshold: -0.1876)
-            Precision with Euclidean-Distance:            32.13
-            Recall with Euclidean-Distance:               99.69
-            Average Precision with Euclidean-Distance:    20.52
-            Matthews Correlation with Euclidean-Distance: -4.59
+            Accuracy with Euclidean-Distance:             74.40     (Threshold: 2.5143)
+            F1 with Euclidean-Distance:                   63.38     (Threshold: 5.2380)
+            Precision with Euclidean-Distance:            48.98
+            Recall with Euclidean-Distance:               89.75
+            Average Precision with Euclidean-Distance:    65.34
+            Matthews Correlation with Euclidean-Distance: 43.09
 
-            Accuracy with Manhattan-Distance:             67.70     (Threshold: -103.0263)
-            F1 with Manhattan-Distance:                   48.60     (Threshold: -0.8532)
-            Precision with Manhattan-Distance:            32.13
-            Recall with Manhattan-Distance:               99.69
-            Average Precision with Manhattan-Distance:    21.05
-            Matthews Correlation with Manhattan-Distance: -4.59
+            Accuracy with Manhattan-Distance:             72.40     (Threshold: 11.8888)
+            F1 with Manhattan-Distance:                   62.62     (Threshold: 31.5751)
+            Precision with Manhattan-Distance:            48.09
+            Recall with Manhattan-Distance:               89.75
+            Average Precision with Manhattan-Distance:    60.15
+            Matthews Correlation with Manhattan-Distance: 41.73
 
-            Model Sparsity: Active Dimensions: 61.2, Sparsity Ratio: 0.9980
+            Model Sparsity: Active Dimensions: 61.3, Sparsity Ratio: 0.9980
             '''
             # Print the results
             print(f"Primary metric: {binary_acc_evaluator.primary_metric}")

--- a/tests/sentence_transformer/evaluation/test_binary_classification_evaluator.py
+++ b/tests/sentence_transformer/evaluation/test_binary_classification_evaluator.py
@@ -46,6 +46,50 @@ def test_BinaryClassificationEvaluator_find_best_accuracy_and_threshold() -> Non
     assert np.abs(max_acc - sklearn_acc) < 1e-6
 
 
+@pytest.mark.parametrize("similarity_fn_name", ["euclidean", "manhattan"])
+def test_BinaryClassificationEvaluator_distance_metrics_direction(similarity_fn_name: str) -> None:
+    """The euclidean/manhattan metrics must treat smaller distances as more similar.
+
+    ``pairwise_euclidean_sim``/``pairwise_manhattan_sim`` return negative distances (i.e.
+    similarities), but were passed unnegated to the ``greater_is_better=False`` metric
+    computations, which expect positive distances. That inverted the ranking, so accuracy,
+    F1, precision, recall, AP and MCC were all computed for the opposite classifier
+    ("larger distance means similar") and the reported thresholds were negative.
+    """
+    embeddings = {
+        "a1": [0.0, 0.0],
+        "a2": [1.0, 0.0],  # distance 1 to a1, similar pair (label 1)
+        "b1": [0.0, 10.0],
+        "b2": [0.0, 12.0],  # distance 2 to b1, similar pair (label 1)
+        "c1": [0.0, 0.0],
+        "c2": [10.0, 0.0],  # distance 10 to c1, dissimilar pair (label 0)
+        "d1": [5.0, 5.0],
+        "d2": [5.0, 25.0],  # distance 20 to d1, dissimilar pair (label 0)
+    }
+
+    class MockEncoder:
+        def encode(self, sentences, **kwargs):
+            return np.array([embeddings[sentence] for sentence in sentences], dtype=np.float32)
+
+    evaluator = evaluation.BinaryClassificationEvaluator(
+        sentences1=["a1", "b1", "c1", "d1"],
+        sentences2=["a2", "b2", "c2", "d2"],
+        labels=[1, 1, 0, 0],
+        similarity_fn_names=[similarity_fn_name],
+    )
+    scores = evaluator.compute_metrics(MockEncoder())[similarity_fn_name]
+
+    # The similar pairs (distances 1 and 2) are perfectly separable from the
+    # dissimilar pairs (distances 10 and 20), so every metric should be perfect.
+    for metric in ["accuracy", "f1", "precision", "recall", "ap", "mcc"]:
+        assert scores[metric] == pytest.approx(1.0), f"{metric}: {scores[metric]}"
+
+    # The thresholds should be positive distances separating the similar from the
+    # dissimilar pairs: (2 + 10) / 2 = 6 for both euclidean and manhattan.
+    assert scores["accuracy_threshold"] == pytest.approx(6.0)
+    assert scores["f1_threshold"] == pytest.approx(6.0)
+
+
 @pytest.mark.parametrize(
     "similarity_fn_names",
     [["dot", "euclidean"], ["cosine", "dot"], ["cosine", "dot", "euclidean", "manhattan"]],


### PR DESCRIPTION
Hello!

## Pull Request overview
* Fix inverted Euclidean/Manhattan distance direction in `BinaryClassificationEvaluator`
* Add a regression test for the distance metric direction

## Details

`BinaryClassificationEvaluator.compute_metrics` passes the raw output of `pairwise_manhattan_sim` / `pairwise_euclidean_sim` into metric computations flagged with `"greater_is_better": False` (`sentence_transformers/sentence_transformer/evaluation/binary_classification.py:250-259`). Those functions return *negative* distances (i.e. similarities), while `greater_is_better=False` expects positive distances. This is the same sim/distance mismatch as #3702, which #3704 fixed for `TripletLoss`; the evaluator has the analogous problem. It was introduced in v3.3.0, when the score functions changed from `paired_manhattan_distances(x, y)` to `-paired_manhattan_distances(x, y)` without flipping `greater_is_better`.

As a result, every metric reported for the `"euclidean"` and `"manhattan"` similarity functions is computed for the opposite classifier ("larger distance means similar"):

* `find_best_acc_and_threshold` / `find_best_f1_and_threshold` sort ascending and sweep the most *distant* pairs first, so accuracy, F1, precision, recall and both thresholds are wrong,
* `average_precision_score(labels, scores * -1)` negates the scores a second time, ranking the most distant pairs as most similar,
* the MCC predictions `scores <= f1_threshold` label the most distant pairs as positives,
* the reported thresholds are negative and unusable as distance cutoffs.

Failing example on `main`, with 4 pairs whose similar pairs (distances 1 and 2) are perfectly separable from the dissimilar pairs (distances 10 and 20):

```python
import numpy as np
from sentence_transformers.sentence_transformer.evaluation import BinaryClassificationEvaluator

embeddings = {
    "a1": [0.0, 0.0],  "a2": [1.0, 0.0],   # distance 1, similar (label 1)
    "b1": [0.0, 10.0], "b2": [0.0, 12.0],  # distance 2, similar (label 1)
    "c1": [0.0, 0.0],  "c2": [10.0, 0.0],  # distance 10, dissimilar (label 0)
    "d1": [5.0, 5.0],  "d2": [5.0, 25.0],  # distance 20, dissimilar (label 0)
}

class MockEncoder:
    def encode(self, sentences, **kwargs):
        return np.array([embeddings[sentence] for sentence in sentences], dtype=np.float32)

evaluator = BinaryClassificationEvaluator(
    sentences1=["a1", "b1", "c1", "d1"],
    sentences2=["a2", "b2", "c2", "d2"],
    labels=[1, 1, 0, 0],
    similarity_fn_names=["euclidean"],
)
print(evaluator.compute_metrics(MockEncoder())["euclidean"])
```

Observed on `main` (every metric should be 1.0 for this perfectly separable data):

```
accuracy: 0.25, accuracy_threshold: -15.0, f1: 0.4, f1_threshold: -1.0,
precision: 0.333, recall: 0.5, ap: 0.5, mcc: 0.0
```

The symptom is also visible on real data in the docstring example output of `SparseBinaryClassificationEvaluator` (which inherits `compute_metrics`): `Matthews Correlation with Euclidean-Distance: -4.59`, recall 99.69 at precision 32.13, and thresholds of `-10.0041` / `-103.0263`.

## The fix

Negate the two `pairwise_*_sim` outputs back into positive distances, mirroring the #3704 fix for `TripletDistanceMetric`. This restores the pre-v3.3.0 behavior: metrics are computed on true distances and the reported `accuracy_threshold` / `f1_threshold` are positive distance cutoffs again. With the fix, the example above yields 1.0 for all six metrics and thresholds of 6.0 (between distance 2 and distance 10).

`EmbeddingSimilarityEvaluator` and `TripletEvaluator` use the `pairwise_*_sim` outputs sign-consistently (correlation with gold scores, and sim(a, p) > sim(a, n) comparison respectively), so only this evaluator was affected.

## Tests

Added `test_BinaryClassificationEvaluator_distance_metrics_direction`, parametrized over `euclidean` and `manhattan`. It fails on `main` (accuracy 0.25 instead of 1.0) and passes with this fix; the rest of the test file passes as well.
