### PR TITLE
Drop FAISS padding placeholders from `semantic_search_faiss` results

### DIFF
--- a/sentence_transformers/util/quantization.py
+++ b/sentence_transformers/util/quantization.py
@@ -144,10 +144,25 @@ def semantic_search_faiss(
     start_t = time.time()
     scores, indices = corpus_index.search(query_embeddings, k)
 
+    # FAISS pads `indices` with -1 when the index holds fewer vectors than requested. These are
+    # not corpus ids: `reconstruct(-1)` returns a garbage vector instead of raising, and a caller
+    # indexing their corpus with -1 silently gets the *last* document. Track them so they are
+    # neither rescored nor returned.
+    padded = indices == -1
+
     # If rescoring is enabled, we need to rescore the results using the rescore_embeddings
     if rescore_embeddings is not None:
+        # Padded slots get a zero placeholder rather than a `reconstruct` call: `reconstruct(-1)`
+        # reads out of bounds, and on an empty index it segfaults outright.
+        if corpus_precision == "ubinary":
+            zero_embedding = np.zeros(corpus_index.d // 8, dtype=np.uint8)
+        else:
+            zero_embedding = np.zeros(corpus_index.d, dtype=np.float32)
         top_k_embeddings = np.array(
-            [[corpus_index.reconstruct(idx.item()) for idx in query_indices] for query_indices in indices]
+            [
+                [corpus_index.reconstruct(idx.item()) if idx != -1 else zero_embedding for idx in query_indices]
+                for query_indices in indices
+            ]
         )
         # If the corpus precision is binary, we need to unpack the bits
         if corpus_precision == "ubinary":
@@ -161,9 +176,12 @@ def semantic_search_faiss(
         # We use einsum to calculate the dot product between the query and the top_k embeddings, equivalent to looping
         # over the queries and calculating 'rescore_embeddings[i] @ top_k_embeddings[i].T'
         rescored_scores = np.einsum("ij,ikj->ik", rescore_embeddings, top_k_embeddings)
+        # A padded slot must never outrank a real hit, whatever its garbage vector scored.
+        rescored_scores = np.where(padded, -np.inf, rescored_scores)
         rescored_indices = np.argsort(-rescored_scores)[:, :top_k]
         indices = indices[np.arange(len(query_embeddings))[:, None], rescored_indices]
         scores = rescored_scores[np.arange(len(query_embeddings))[:, None], rescored_indices]
+        padded = indices == -1
 
     delta_t = time.time() - start_t
 
@@ -171,7 +189,8 @@ def semantic_search_faiss(
         [
             [
                 {"corpus_id": int(neighbor), "score": float(score)}
-                for score, neighbor in zip(scores[query_id], indices[query_id])
+                for score, neighbor, is_padded in zip(scores[query_id], indices[query_id], padded[query_id])
+                if not is_padded
             ]
             for query_id in range(len(query_embeddings))
         ],

--- a/sentence_transformers/util/quantization.py
+++ b/sentence_transformers/util/quantization.py
@@ -140,20 +140,14 @@ def semantic_search_faiss(
             "Rescoring is enabled but the query embeddings are quantized. Either pass `rescore=False` or don't quantize the query embeddings."
         )
 
-    # Perform the search using the usearch index
+    # Perform the search using the FAISS index
     start_t = time.time()
     scores, indices = corpus_index.search(query_embeddings, k)
 
-    # FAISS pads `indices` with -1 when the index holds fewer vectors than requested. These are
-    # not corpus ids: `reconstruct(-1)` returns a garbage vector instead of raising, and a caller
-    # indexing their corpus with -1 silently gets the *last* document. Track them so they are
-    # neither rescored nor returned.
-    padded = indices == -1
-
     # If rescoring is enabled, we need to rescore the results using the rescore_embeddings
     if rescore_embeddings is not None:
-        # Padded slots get a zero placeholder rather than a `reconstruct` call: `reconstruct(-1)`
-        # reads out of bounds, and on an empty index it segfaults outright.
+        # FAISS pads short result sets with index -1, and reconstruct(-1) reads out of bounds
+        # (or segfaults on an empty index), so the padding slots get a zero placeholder instead
         if corpus_precision == "ubinary":
             zero_embedding = np.zeros(corpus_index.d // 8, dtype=np.uint8)
         else:
@@ -176,21 +170,21 @@ def semantic_search_faiss(
         # We use einsum to calculate the dot product between the query and the top_k embeddings, equivalent to looping
         # over the queries and calculating 'rescore_embeddings[i] @ top_k_embeddings[i].T'
         rescored_scores = np.einsum("ij,ikj->ik", rescore_embeddings, top_k_embeddings)
-        # A padded slot must never outrank a real hit, whatever its garbage vector scored.
-        rescored_scores = np.where(padded, -np.inf, rescored_scores)
+        # Disqualify the padding slots so their placeholder scores cannot outrank real candidates
+        rescored_scores[indices == -1] = -np.inf
         rescored_indices = np.argsort(-rescored_scores)[:, :top_k]
         indices = indices[np.arange(len(query_embeddings))[:, None], rescored_indices]
         scores = rescored_scores[np.arange(len(query_embeddings))[:, None], rescored_indices]
-        padded = indices == -1
 
     delta_t = time.time() - start_t
 
+    # FAISS pads short result sets with index -1, which would otherwise resolve to the last corpus entry
     outputs = (
         [
             [
                 {"corpus_id": int(neighbor), "score": float(score)}
-                for score, neighbor, is_padded in zip(scores[query_id], indices[query_id], padded[query_id])
-                if not is_padded
+                for score, neighbor in zip(scores[query_id], indices[query_id])
+                if neighbor != -1
             ]
             for query_id in range(len(query_embeddings))
         ],

--- a/tests/util/test_quantization.py
+++ b/tests/util/test_quantization.py
@@ -9,6 +9,8 @@ the flattened 2-D array, and the following ``.reshape(n, -1)`` raises a
 
 from __future__ import annotations
 
+import importlib.util
+
 import numpy as np
 import pytest
 
@@ -103,3 +105,83 @@ def test_quantize_clips_out_of_range_values(precision: str) -> None:
         expected = np.array([[0, 170, 255]], dtype=np.uint8)
 
     np.testing.assert_array_equal(result, expected)
+
+
+skip_without_faiss = pytest.mark.skipif(importlib.util.find_spec("faiss") is None, reason="faiss not installed")
+
+QUERIES = np.random.default_rng(seed=1).random((2, 16), dtype=np.float32)
+CALIBRATION = np.random.default_rng(seed=2).random((100, 16), dtype=np.float32)
+
+
+def _corpus(n_docs: int, precision: str, seed: int = 0) -> np.ndarray:
+    embeddings = np.random.default_rng(seed=seed).random((n_docs, 16), dtype=np.float32)
+    return quantize_embeddings(embeddings, precision=precision, calibration_embeddings=CALIBRATION)
+
+
+@skip_without_faiss
+@pytest.mark.parametrize("corpus_precision", ["ubinary", "uint8"])
+@pytest.mark.parametrize("rescore", [True, False])
+def test_semantic_search_faiss_drops_padded_indices(corpus_precision: str, rescore: bool) -> None:
+    """A corpus smaller than ``top_k`` must not produce ``corpus_id=-1`` entries.
+
+    FAISS pads its ``indices`` array with -1 when the index holds fewer vectors than
+    were requested. Those are not corpus ids: ``reconstruct(-1)`` reads out of bounds
+    rather than raising, and a caller doing ``corpus[corpus_id]`` with -1 silently gets
+    the *last* document back instead of an error.
+    """
+    from sentence_transformers.util.quantization import semantic_search_faiss
+
+    results, _ = semantic_search_faiss(
+        QUERIES,
+        corpus_embeddings=_corpus(3, corpus_precision),
+        corpus_precision=corpus_precision,
+        top_k=5,  # deliberately larger than the 3-document corpus
+        rescore=rescore,
+        rescore_multiplier=2,
+        calibration_embeddings=CALIBRATION,
+    )
+
+    for query_results in results:
+        corpus_ids = [entry["corpus_id"] for entry in query_results]
+        assert -1 not in corpus_ids
+        # Every existing document is returned exactly once, and nothing else is.
+        assert sorted(corpus_ids) == [0, 1, 2]
+
+
+@skip_without_faiss
+@pytest.mark.parametrize("rescore", [True, False])
+def test_semantic_search_faiss_empty_corpus(rescore: bool) -> None:
+    """An empty corpus yields empty result lists rather than phantom hits."""
+    from sentence_transformers.util.quantization import semantic_search_faiss
+
+    results, _ = semantic_search_faiss(
+        QUERIES,
+        corpus_embeddings=np.empty((0, 2), dtype=np.uint8),
+        corpus_precision="ubinary",
+        top_k=5,
+        rescore=rescore,
+        rescore_multiplier=2,
+    )
+
+    assert results == [[], []]
+
+
+@skip_without_faiss
+@pytest.mark.parametrize("corpus_precision", ["ubinary", "uint8"])
+def test_semantic_search_faiss_returns_top_k_when_corpus_is_large_enough(corpus_precision: str) -> None:
+    """The padding check must not shorten results for a corpus larger than ``top_k``."""
+    from sentence_transformers.util.quantization import semantic_search_faiss
+
+    results, _ = semantic_search_faiss(
+        QUERIES,
+        corpus_embeddings=_corpus(50, corpus_precision, seed=3),
+        corpus_precision=corpus_precision,
+        top_k=5,
+        rescore=True,
+        rescore_multiplier=2,
+        calibration_embeddings=CALIBRATION,
+    )
+
+    for query_results in results:
+        assert len(query_results) == 5
+        assert all(0 <= entry["corpus_id"] < 50 for entry in query_results)

--- a/tests/util/test_quantization.py
+++ b/tests/util/test_quantization.py
@@ -14,7 +14,7 @@ import importlib.util
 import numpy as np
 import pytest
 
-from sentence_transformers.util.quantization import quantize_embeddings
+from sentence_transformers.util.quantization import quantize_embeddings, semantic_search_faiss
 
 
 @pytest.mark.parametrize("precision", ["binary", "ubinary"])
@@ -109,12 +109,12 @@ def test_quantize_clips_out_of_range_values(precision: str) -> None:
 
 skip_without_faiss = pytest.mark.skipif(importlib.util.find_spec("faiss") is None, reason="faiss not installed")
 
-QUERIES = np.random.default_rng(seed=1).random((2, 16), dtype=np.float32)
-CALIBRATION = np.random.default_rng(seed=2).random((100, 16), dtype=np.float32)
+QUERIES = np.random.default_rng(seed=1).standard_normal((2, 16), dtype=np.float32)
+CALIBRATION = np.random.default_rng(seed=2).standard_normal((100, 16), dtype=np.float32)
 
 
 def _corpus(n_docs: int, precision: str, seed: int = 0) -> np.ndarray:
-    embeddings = np.random.default_rng(seed=seed).random((n_docs, 16), dtype=np.float32)
+    embeddings = np.random.default_rng(seed=seed).standard_normal((n_docs, 16), dtype=np.float32)
     return quantize_embeddings(embeddings, precision=precision, calibration_embeddings=CALIBRATION)
 
 
@@ -122,15 +122,11 @@ def _corpus(n_docs: int, precision: str, seed: int = 0) -> np.ndarray:
 @pytest.mark.parametrize("corpus_precision", ["ubinary", "uint8"])
 @pytest.mark.parametrize("rescore", [True, False])
 def test_semantic_search_faiss_drops_padded_indices(corpus_precision: str, rescore: bool) -> None:
-    """A corpus smaller than ``top_k`` must not produce ``corpus_id=-1`` entries.
+    """A corpus smaller than ``top_k`` must not produce ``corpus_id: -1`` entries.
 
-    FAISS pads its ``indices`` array with -1 when the index holds fewer vectors than
-    were requested. Those are not corpus ids: ``reconstruct(-1)`` reads out of bounds
-    rather than raising, and a caller doing ``corpus[corpus_id]`` with -1 silently gets
-    the *last* document back instead of an error.
+    FAISS pads short result sets with index -1, which would resolve to the last corpus
+    entry when used to index the corpus.
     """
-    from sentence_transformers.util.quantization import semantic_search_faiss
-
     results, _ = semantic_search_faiss(
         QUERIES,
         corpus_embeddings=_corpus(3, corpus_precision),
@@ -152,8 +148,6 @@ def test_semantic_search_faiss_drops_padded_indices(corpus_precision: str, resco
 @pytest.mark.parametrize("rescore", [True, False])
 def test_semantic_search_faiss_empty_corpus(rescore: bool) -> None:
     """An empty corpus yields empty result lists rather than phantom hits."""
-    from sentence_transformers.util.quantization import semantic_search_faiss
-
     results, _ = semantic_search_faiss(
         QUERIES,
         corpus_embeddings=np.empty((0, 2), dtype=np.uint8),
@@ -170,8 +164,6 @@ def test_semantic_search_faiss_empty_corpus(rescore: bool) -> None:
 @pytest.mark.parametrize("corpus_precision", ["ubinary", "uint8"])
 def test_semantic_search_faiss_returns_top_k_when_corpus_is_large_enough(corpus_precision: str) -> None:
     """The padding check must not shorten results for a corpus larger than ``top_k``."""
-    from sentence_transformers.util.quantization import semantic_search_faiss
-
     results, _ = semantic_search_faiss(
         QUERIES,
         corpus_embeddings=_corpus(50, corpus_precision, seed=3),


### PR DESCRIPTION
`semantic_search_faiss` returns `corpus_id: -1` entries whenever the corpus has fewer vectors than the requested `k`.

FAISS pads its `indices` array with `-1` for the slots it couldn't fill. The function passes those straight into the output, so a search over a 3-document corpus with `top_k=5` comes back with five results instead of three:

```python
import numpy as np
from sentence_transformers.util import quantize_embeddings, semantic_search_faiss

rng = np.random.default_rng(0)
corpus = quantize_embeddings(rng.random((3, 16), dtype=np.float32), precision="ubinary")
queries = rng.random((2, 16), dtype=np.float32)

results, _ = semantic_search_faiss(queries, corpus_embeddings=corpus,
                                   corpus_precision="ubinary", top_k=5, rescore=True)
print([[hit["corpus_id"] for hit in r] for r in results])
```

```
main:  [[0, 1, 2, -1, -1], [0, 1, 2, -1, -1]]
here:  [[0, 1, 2], [0, 1, 2]]
```

Two problems with letting `-1` through:

1. It isn't a sentinel the caller can trip over. The documented pattern is `corpus[hit["corpus_id"]]`, and `corpus[-1]` silently returns the **last** document. Nothing raises, so a small corpus quietly produces duplicate results with a plausible-looking score attached (`2147483647.0` for binary indices, i.e. `INT_MAX` sitting in the padding slot).
2. On the rescore path, `corpus_index.reconstruct(-1)` reads out of bounds rather than raising. The placeholder gets a garbage vector, that vector goes through the same `einsum` as the real candidates, and it can outrank an actual hit in the `argsort`. With `corpus_precision="uint8"` the garbage also trips `RuntimeWarning: invalid value encountered in cast` on the `astype(int)` a few lines below. On an empty index `reconstruct()` segfaults the process.

Reproduces on every combination I tried, `ubinary` and `uint8`, `exact=True` and `exact=False`, `rescore=True` and `rescore=False`:

```
ubinary  exact=True   rescore=True   -> [[0, 1, 2, -1, -1], [0, 1, 2, -1, -1]]
ubinary  exact=True   rescore=False  -> [[0, 1, 2, -1, -1], [0, 1, 2, -1, -1]]
ubinary  exact=False  rescore=True   -> [[0, 1, 2, -1, -1], [0, 1, 2, -1, -1]]
ubinary  exact=False  rescore=False  -> [[0, 1, 2, -1, -1], [0, 1, 2, -1, -1]]
uint8    exact=True   rescore=True   -> [[0, 1, 2, -1, -1], [0, 1, 2, -1, -1]]
uint8    exact=True   rescore=False  -> [[0, 1, 2, -1, -1], [0, 1, 2, -1, -1]]
uint8    exact=False  rescore=True   -> [[0, 1, 2, -1, -1], [0, 1, 2, -1, -1]]
uint8    exact=False  rescore=False  -> [[0, 1, 2, -1, -1], [2, 0, 1, -1, -1]]
```

All eight are clean after the change.

## What the patch does

Record `padded = indices == -1` right after `corpus_index.search`, then:

- feed padded slots a zero placeholder instead of calling `reconstruct` on them,
- set their rescored score to `-inf` so they can't win the `argsort`,
- recompute the mask after the reorder and skip them when building the output dicts.

The zero placeholder is built from `corpus_index.d` rather than `reconstruct(0)`, so it also works when the index is empty. That case previously segfaulted with `rescore=True` and returned five phantom hits with `rescore=False`; it now returns `[]`.

Nothing changes for a corpus larger than `top_k` — `padded` is all-`False` and every added line is a no-op.

`semantic_search_usearch` is untouched. usearch returns a ragged `Matches` object rather than padding out to `k`, so it doesn't have the same problem.

## Tests

Added to `tests/util/test_quantization.py`, behind the same `find_spec("faiss")` skip guard used in `test_hard_negatives.py`:

- `test_semantic_search_faiss_drops_padded_indices` — parametrized over `["ubinary", "uint8"]` x `[rescore True, False]`, asserts the 3-document corpus returns exactly `[0, 1, 2]`.
- `test_semantic_search_faiss_empty_corpus` — asserts `[[], []]`.
- `test_semantic_search_faiss_returns_top_k_when_corpus_is_large_enough` — the no-regression guard: a 50-document corpus still returns 5 hits per query.

Reverting only the `quantization.py` hunk (`git stash push -- sentence_transformers/util/quantization.py`) fails the four `drops_padded` cases and segfaults on the empty-corpus one. The `top_k` guard stays green either way, which is what you'd want from it.

---

Unrelated so I left it alone, but flagging it while I'm in this file: the `semantic_search_faiss` docstring lists the `corpus_precision` options as `"float32", "int8", "binary"`, while the signature says `Literal["float32", "uint8", "ubinary"]`. Looks like it was copied over from `semantic_search_usearch`, which does use `int8`/`binary`. Happy to fold a one-line docstring fix into this PR or send it separately, whichever you prefer.
