### PR TITLE
[`trainer`] Fix eval DataLoader worker leak with dataloader_persistent_workers

### DIFF
--- a/sentence_transformers/base/trainer.py
+++ b/sentence_transformers/base/trainer.py
@@ -619,14 +619,16 @@ class BaseTrainer(Trainer, ABC):
 
     def evaluate(
         self,
-        eval_dataset: Dataset | dict[str, Dataset] | None = None,
+        eval_dataset: str | Dataset | dict[str, Dataset] | None = None,
         ignore_keys: list[str] | None = None,
         metric_key_prefix: str = "eval",
     ) -> dict[str, float]:
-        if eval_dataset is not None:
+        # If eval_dataset is None, we keep it as None: with a dict `self.eval_dataset` (already preprocessed
+        # in __init__), the superclass then recurses per dataset with its *name*, so `get_eval_dataloader`
+        # can cache eval DataLoaders per dataset name when `dataloader_persistent_workers` is used.
+        # A str eval_dataset comes from that recursion and is resolved in `get_eval_dataloader`.
+        if eval_dataset is not None and not isinstance(eval_dataset, str):
             eval_dataset = self.preprocess_dataset(eval_dataset, dataset_name="eval")
-        else:
-            eval_dataset = self.eval_dataset
         return super().evaluate(eval_dataset, ignore_keys, metric_key_prefix)
 
     def evaluation_loop(
@@ -925,15 +927,18 @@ class BaseTrainer(Trainer, ABC):
         )
         return self._train_dataloader
 
-    def get_eval_dataloader(self, eval_dataset: Dataset | DatasetDict | IterableDataset | None = None) -> DataLoader:
+    def get_eval_dataloader(
+        self, eval_dataset: str | Dataset | DatasetDict | IterableDataset | None = None
+    ) -> DataLoader:
         """
         Returns the evaluation [`~torch.utils.data.DataLoader`].
 
         Subclass and override this method if you want to inject some custom behavior.
 
         Args:
-            eval_dataset (`torch.utils.data.Dataset`, *optional*):
-                If provided, will override `self.eval_dataset`. If it is a [`~datasets.Dataset`], columns not accepted
+            eval_dataset (`str` or `torch.utils.data.Dataset`, *optional*):
+                If a `str`, will use `self.eval_dataset[eval_dataset]` as the evaluation dataset. If provided
+                otherwise, will override `self.eval_dataset`. If it is a [`~datasets.Dataset`], columns not accepted
                 by the `model.forward()` method are automatically removed. It must implement `__len__`.
         """
         if eval_dataset is None and self.eval_dataset is None:
@@ -942,15 +947,38 @@ class BaseTrainer(Trainer, ABC):
                 return DataLoader([])
             raise ValueError(f"Evaluation requires specifying an eval_dataset to the {self.__class__.__name__}.")
 
+        # If we have persistent workers, don't do a fork bomb especially as eval datasets
+        # don't change during training. Mirrors the transformers Trainer behaviour, see
+        # https://github.com/huggingface/transformers/pull/30627 and
+        # https://github.com/huggingface/transformers/pull/39717
+        dataloader_key = eval_dataset if isinstance(eval_dataset, str) else "eval"
+        if (
+            hasattr(self, "_eval_dataloaders")
+            and dataloader_key in self._eval_dataloaders
+            and self.args.dataloader_persistent_workers
+        ):
+            return self._eval_dataloaders[dataloader_key]
+
+        if isinstance(eval_dataset, str):
+            eval_dataset = self.eval_dataset[eval_dataset]
         eval_dataset = eval_dataset if eval_dataset is not None else self.eval_dataset
 
         # If 'even_batches' is True, it will use the initial few samples to pad out the last sample. This can
         # cause issues with multi-dataset training, so we want to set this to False during training.
         # For evaluation, setting 'even_batches' to False results in hanging, so we keep it as True here.
         self.accelerator.even_batches = True
-        return self.accelerator.prepare(
+        dataloader = self.accelerator.prepare(
             self._build_dataloader(eval_dataset, self.args.eval_batch_size, dataset_kind="eval")
         )
+
+        # Store the prepared dataloader for subsequent evaluations if using persistent workers.
+        if self.args.dataloader_persistent_workers:
+            if hasattr(self, "_eval_dataloaders"):
+                self._eval_dataloaders[dataloader_key] = dataloader
+            else:
+                self._eval_dataloaders = {dataloader_key: dataloader}
+
+        return dataloader
 
     def get_test_dataloader(self, test_dataset: Dataset | DatasetDict | IterableDataset) -> DataLoader:
         """

--- a/sentence_transformers/base/trainer.py
+++ b/sentence_transformers/base/trainer.py
@@ -327,6 +327,7 @@ class BaseTrainer(Trainer, ABC):
             self.train_dataset = self.preprocess_dataset(train_dataset, dataset_name="train")
         if self.eval_dataset is not None:
             self.eval_dataset = self.preprocess_dataset(eval_dataset, dataset_name="eval")
+        self._eval_dataloaders: dict[str, DataLoader] = {}
         self.add_model_card_callback(default_args_dict)
 
     def get_data_collator(
@@ -623,10 +624,7 @@ class BaseTrainer(Trainer, ABC):
         ignore_keys: list[str] | None = None,
         metric_key_prefix: str = "eval",
     ) -> dict[str, float]:
-        # If eval_dataset is None, we keep it as None: with a dict `self.eval_dataset` (already preprocessed
-        # in __init__), the superclass then recurses per dataset with its *name*, so `get_eval_dataloader`
-        # can cache eval DataLoaders per dataset name when `dataloader_persistent_workers` is used.
-        # A str eval_dataset comes from that recursion and is resolved in `get_eval_dataloader`.
+        # None and str pass through: the superclass recurses over a dict self.eval_dataset by name
         if eval_dataset is not None and not isinstance(eval_dataset, str):
             eval_dataset = self.preprocess_dataset(eval_dataset, dataset_name="eval")
         return super().evaluate(eval_dataset, ignore_keys, metric_key_prefix)
@@ -947,21 +945,18 @@ class BaseTrainer(Trainer, ABC):
                 return DataLoader([])
             raise ValueError(f"Evaluation requires specifying an eval_dataset to the {self.__class__.__name__}.")
 
-        # If we have persistent workers, don't do a fork bomb especially as eval datasets
-        # don't change during training. Mirrors the transformers Trainer behaviour, see
-        # https://github.com/huggingface/transformers/pull/30627 and
-        # https://github.com/huggingface/transformers/pull/39717
+        # With persistent workers, reuse prepared dataloaders so repeated evaluations don't leak
+        # workers, see https://github.com/huggingface/transformers/pull/39717
         dataloader_key = eval_dataset if isinstance(eval_dataset, str) else "eval"
-        if (
-            hasattr(self, "_eval_dataloaders")
-            and dataloader_key in self._eval_dataloaders
-            and self.args.dataloader_persistent_workers
-        ):
+        # Explicitly passed datasets all share the "eval" key, so never cache those
+        cacheable = isinstance(eval_dataset, str) or eval_dataset is None or eval_dataset is self.eval_dataset
+        if cacheable and self.args.dataloader_persistent_workers and dataloader_key in self._eval_dataloaders:
             return self._eval_dataloaders[dataloader_key]
 
         if isinstance(eval_dataset, str):
             eval_dataset = self.eval_dataset[eval_dataset]
-        eval_dataset = eval_dataset if eval_dataset is not None else self.eval_dataset
+        elif eval_dataset is None:
+            eval_dataset = self.eval_dataset
 
         # If 'even_batches' is True, it will use the initial few samples to pad out the last sample. This can
         # cause issues with multi-dataset training, so we want to set this to False during training.
@@ -971,12 +966,8 @@ class BaseTrainer(Trainer, ABC):
             self._build_dataloader(eval_dataset, self.args.eval_batch_size, dataset_kind="eval")
         )
 
-        # Store the prepared dataloader for subsequent evaluations if using persistent workers.
-        if self.args.dataloader_persistent_workers:
-            if hasattr(self, "_eval_dataloaders"):
-                self._eval_dataloaders[dataloader_key] = dataloader
-            else:
-                self._eval_dataloaders = {dataloader_key: dataloader}
+        if cacheable and self.args.dataloader_persistent_workers:
+            self._eval_dataloaders[dataloader_key] = dataloader
 
         return dataloader
 

--- a/tests/sentence_transformer/test_trainer.py
+++ b/tests/sentence_transformer/test_trainer.py
@@ -1026,3 +1026,55 @@ def test_trainer_call_model_init_multi_loss(
         assert isinstance(loss_fn, torch.nn.Module), f"Loss '{key}' is not an nn.Module"
         assert loss_fn.model is trainer.model, f"Loss '{key}' model was not updated to the trainer's model"
         assert loss_fn.model is not model, f"Loss '{key}' model was not updated from the original model"
+
+
+@pytest.mark.parametrize("persistent_workers", [True, False])
+def test_trainer_get_eval_dataloader_with_persistent_workers(
+    stsb_bert_tiny_model: SentenceTransformer,
+    stsb_dataset_dict: DatasetDict,
+    persistent_workers: bool,
+    tmp_path: Path,
+) -> None:
+    # With `dataloader_persistent_workers=True`, eval dataloaders must be reused across evaluations,
+    # cached per dataset name. Otherwise, every evaluation of every dataset leaks its persistent
+    # worker processes, eventually exhausting file descriptors and memory.
+    model = stsb_bert_tiny_model
+    train_dataset = stsb_dataset_dict["train"].select(range(8))
+    eval_dataset = DatasetDict(
+        {
+            "first": stsb_dataset_dict["validation"].select(range(8)),
+            "second": stsb_dataset_dict["validation"].select(range(12)),
+        }
+    )
+    loss = CosineSimilarityLoss(model=model)
+    args = SentenceTransformerTrainingArguments(
+        output_dir=tmp_path,
+        dataloader_persistent_workers=persistent_workers,
+        dataloader_num_workers=1,
+    )
+    trainer = SentenceTransformerTrainer(
+        model=model,
+        args=args,
+        train_dataset=train_dataset,
+        eval_dataset=eval_dataset,
+        loss=loss,
+    )
+    # Mocking the prepare method to avoid the dataloader changing with each call to get_eval_dataloader
+    trainer.accelerator.prepare = lambda x: x
+
+    first_dataloader = trainer.get_eval_dataloader("first")
+    first_dataloader_repeated = trainer.get_eval_dataloader("first")
+    second_dataloader = trainer.get_eval_dataloader("second")
+    second_dataloader_repeated = trainer.get_eval_dataloader("second")
+
+    # Each dataset name must resolve to its own dataset, never another entry of the dict
+    assert len(first_dataloader.dataset) == 8
+    assert len(second_dataloader.dataset) == 12
+    assert first_dataloader is not second_dataloader
+
+    if persistent_workers:
+        assert first_dataloader is first_dataloader_repeated
+        assert second_dataloader is second_dataloader_repeated
+    else:
+        assert first_dataloader is not first_dataloader_repeated
+        assert second_dataloader is not second_dataloader_repeated

--- a/tests/sentence_transformer/test_trainer.py
+++ b/tests/sentence_transformer/test_trainer.py
@@ -8,8 +8,11 @@ from pathlib import Path
 
 import pytest
 import torch
+from packaging.version import parse as parse_version
 from tokenizers.processors import TemplateProcessing
 from torch.utils.data import ConcatDataset
+from transformers import __version__ as transformers_version
+from transformers.trainer_utils import EvalLoopOutput
 
 from sentence_transformers import SentenceTransformer, SentenceTransformerTrainer
 from sentence_transformers.base.sampler import (
@@ -1034,6 +1037,7 @@ def test_trainer_get_eval_dataloader_with_persistent_workers(
     stsb_dataset_dict: DatasetDict,
     persistent_workers: bool,
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     # With `dataloader_persistent_workers=True`, eval dataloaders must be reused across evaluations,
     # cached per dataset name. Otherwise, every evaluation of every dataset leaks its persistent
@@ -1060,7 +1064,7 @@ def test_trainer_get_eval_dataloader_with_persistent_workers(
         loss=loss,
     )
     # Mocking the prepare method to avoid the dataloader changing with each call to get_eval_dataloader
-    trainer.accelerator.prepare = lambda x: x
+    monkeypatch.setattr(trainer.accelerator, "prepare", lambda x: x)
 
     first_dataloader = trainer.get_eval_dataloader("first")
     first_dataloader_repeated = trainer.get_eval_dataloader("first")
@@ -1078,3 +1082,87 @@ def test_trainer_get_eval_dataloader_with_persistent_workers(
     else:
         assert first_dataloader is not first_dataloader_repeated
         assert second_dataloader is not second_dataloader_repeated
+
+    # Datasets passed explicitly (like the per-dataset recursion of `evaluate(eval_dataset=some_dict)`)
+    # all share the "eval" cache key, so they must never be cached in place of one another
+    explicit_first = trainer.get_eval_dataloader(eval_dataset["first"])
+    explicit_second = trainer.get_eval_dataloader(eval_dataset["second"])
+    assert len(explicit_first.dataset) == 8
+    assert len(explicit_second.dataset) == 12
+    if persistent_workers:
+        assert sorted(trainer._eval_dataloaders) == ["first", "second"]
+    else:
+        assert trainer._eval_dataloaders == {}
+
+
+@pytest.mark.skipif(
+    parse_version(transformers_version) < parse_version("4.42.0"),
+    reason="transformers only recurses over dict eval datasets by name since v4.42.0",
+)
+@pytest.mark.parametrize("persistent_workers", [True, False])
+def test_trainer_evaluate_caches_eval_dataloaders_per_dataset(
+    stsb_bert_tiny_model: SentenceTransformer,
+    stsb_dataset_dict: DatasetDict,
+    persistent_workers: bool,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # End to end variant of the test above: evaluate() must reach get_eval_dataloader with dataset
+    # names via the superclass dict recursion, otherwise the per-name caching never engages
+    model = stsb_bert_tiny_model
+    train_dataset = stsb_dataset_dict["train"].select(range(8))
+    eval_dataset = DatasetDict(
+        {
+            "first": stsb_dataset_dict["validation"].select(range(8)),
+            "second": stsb_dataset_dict["validation"].select(range(12)),
+        }
+    )
+    loss = CosineSimilarityLoss(model=model)
+    args = SentenceTransformerTrainingArguments(
+        output_dir=tmp_path,
+        dataloader_persistent_workers=persistent_workers,
+        dataloader_num_workers=1,
+    )
+    trainer = SentenceTransformerTrainer(
+        model=model,
+        args=args,
+        train_dataset=train_dataset,
+        eval_dataset=eval_dataset,
+        loss=loss,
+    )
+
+    # Stub the evaluation loop: dataloaders are still built, prepared, and cached for real, but
+    # nothing is iterated, so no worker processes are spawned
+    seen = {}
+
+    def evaluation_loop_stub(dataloader, *loop_args, metric_key_prefix="eval", **loop_kwargs):
+        seen.setdefault(metric_key_prefix, []).append(dataloader)
+        return EvalLoopOutput(
+            predictions=None,
+            label_ids=None,
+            metrics={f"{metric_key_prefix}_loss": 0.0},
+            num_samples=len(dataloader.dataset),
+        )
+
+    monkeypatch.setattr(trainer, "evaluation_loop", evaluation_loop_stub)
+
+    metrics = trainer.evaluate()
+    trainer.evaluate()
+
+    # Each dataset must be evaluated under its own name, on its own data, in both evaluations
+    assert {prefix: [len(dl.dataset) for dl in dls] for prefix, dls in seen.items()} == {
+        "eval_first": [8, 8],
+        "eval_second": [12, 12],
+    }
+    assert "eval_first_loss" in metrics
+    assert "eval_second_loss" in metrics
+
+    if persistent_workers:
+        # The second evaluate() must consume the same prepared dataloaders, not rebuild or re-prepare
+        assert seen["eval_first"][0] is seen["eval_first"][1]
+        assert seen["eval_second"][0] is seen["eval_second"][1]
+        assert sorted(trainer._eval_dataloaders) == ["first", "second"]
+    else:
+        assert seen["eval_first"][0] is not seen["eval_first"][1]
+        assert seen["eval_second"][0] is not seen["eval_second"][1]
+        assert trainer._eval_dataloaders == {}


### PR DESCRIPTION
Hello from Japan, @tomaarsen!

## Pull Request overview

* Fix a DataLoader worker process leak when training with `dataloader_persistent_workers=True` and a dict `eval_dataset`: every evaluation leaked `num_eval_datasets × dataloader_num_workers` worker processes, eventually exhausting file descriptors (`OSError: [Errno 24] Too many open files`) or host memory.
* Mirror the `transformers` eval dataloader caching (huggingface/transformers#30627, huggingface/transformers#39717): resolve dataset names in `get_eval_dataloader`, and reuse the prepared DataLoader per eval dataset name while persistent workers are enabled.
* Add a regression test following the style of the `transformers` test suite for this behaviour.

## Details

`BaseTrainer.get_eval_dataloader()` fully overrides the `transformers` implementation, which is necessary for the custom batch samplers, multi-dataset handling and `even_batches` toggling. However, the override predates the fork bomb protection that `transformers` added in huggingface/transformers#29538 / huggingface/transformers#30627 / huggingface/transformers#39717 (see huggingface/transformers#28469 for the original report), so it builds and `accelerator.prepare()`s a fresh DataLoader on every call. Since `Accelerator.prepare()` keeps a reference to every prepared dataloader in `accelerator._dataloaders`, the dataloaders are never garbage collected, and with `persistent_workers=True` their worker processes stay alive forever.

Reproduction with a tiny model, 3 eval datasets and 2 workers per dataloader (script below), on v5.6.1 (the code is identical on current `main`) with `transformers` v5.14.1 and `accelerate` v1.14.0:

```text
after evaluate #1: children=8   accelerator._dataloaders=3
after evaluate #2: children=14  accelerator._dataloaders=6
after evaluate #3: children=20  accelerator._dataloaders=9   <- +6 workers per evaluation
```

In a real training run (60 eval datasets × 4 workers, evaluating every 10k steps) this leaked ~230 processes per evaluation and repeatedly killed multi-day training runs through fd exhaustion and OOM.

## The fix

Two coordinated changes, matching the semantics `transformers` converged on:

1. `evaluate()` no longer materializes `self.eval_dataset` when no `eval_dataset` argument is passed. The superclass then recurses over dict eval datasets with their *names*, exactly like `transformers` does (huggingface/transformers#30627). `self.eval_dataset` is already preprocessed in `__init__`, so no preprocessing is lost. A `str` coming back from that recursion is passed through.
2. `get_eval_dataloader()` resolves `str` names via `self.eval_dataset[name]`, and while `dataloader_persistent_workers=True`, caches the **prepared** dataloader per dataset name (storing the prepared dataloader rather than the raw one follows huggingface/transformers#39717, which fixed the remaining leak in the original transformers fix).

Note that simply removing the override in favour of the `transformers` implementation is not possible, and neither is keeping `evaluate()` passing dataset objects: in that case all datasets of a dict collapse onto the `"eval"` cache key, and every dataset silently reuses the first dataset's dataloader, corrupting the per-dataset metrics. This is why the cache is keyed by dataset name and the name propagation in `evaluate()` is part of the fix. The added regression test asserts that each name resolves to its own dataset to guard against this.

With `dataloader_persistent_workers=False` (the default), behaviour is unchanged: no caching, dataloaders are built per evaluation as before.

After the fix, the reproduction shows stable worker counts and per-name cached dataloaders:

```text
after evaluate #1: children=8  accelerator._dataloaders=3
after evaluate #2: children=8  accelerator._dataloaders=3
after evaluate #3: children=8  accelerator._dataloaders=3
```

and a training run with periodic evaluation (18 steps, eval every 2 steps, 3 eval datasets) ends with the expected `1 + 3` prepared dataloaders instead of one per evaluation.

<details>
<summary>Reproduction script and steps</summary>

Runs on CPU only, no GPU required (`use_cpu=True` is set in the script; tested on macOS arm64 — the original failures occurred on Linux x86_64). The only dependency besides `sentence-transformers[train]` is `psutil` for counting child processes.

Save the script below as `repro_worker_leak.py`, then reproduce with a single [uv](https://docs.astral.sh/uv/) command (or install the same requirements with `pip` into a fresh environment):

```bash
# Reproduce the leak on the latest release
uv run --no-project --with "sentence-transformers[train]==5.6.1" --with psutil repro_worker_leak.py

# ... or against the current main branch
uv run --no-project --with "sentence-transformers[train] @ git+https://github.com/huggingface/sentence-transformers.git@main" --with psutil repro_worker_leak.py

# Verify the fix by installing directly from this PR's branch
uv run --no-project --with "sentence-transformers[train] @ git+https://github.com/mjun0812/sentence-transformers.git@fix-eval-dataloader-worker-leak" --with psutil repro_worker_leak.py
```

Expected output on v5.6.1 / current `main` (leak: +6 children per evaluation):

```text
[case persistent_workers=True] datasets=3, num_workers=2
  after evaluate #1: children=8, accelerator._dataloaders=3
  after evaluate #2: children=14, accelerator._dataloaders=6
  after evaluate #3: children=20, accelerator._dataloaders=9
```

Expected output with this PR (workers are reused, count stays flat):

```text
[case persistent_workers=True] datasets=3, num_workers=2
  after evaluate #1: children=8, accelerator._dataloaders=3
  after evaluate #2: children=8, accelerator._dataloaders=3
  after evaluate #3: children=8, accelerator._dataloaders=3
```

```python
"""Reproduce the eval DataLoader worker leak with persistent_workers.

Calls trainer.evaluate() repeatedly and counts child processes after each call.
With the transformers Trainer the eval dataloaders are cached and reused, so the
count stays flat; before this fix, sentence-transformers rebuilt them every time.
"""

import os
import sys
import tempfile


def build_trainer(persistent: bool, num_workers: int, n_datasets: int):
    import datasets as hf_datasets
    from transformers import BertConfig, BertModel, BertTokenizerFast
    from sentence_transformers import SentenceTransformer, SentenceTransformerTrainer
    from sentence_transformers.models import Transformer, Pooling
    from sentence_transformers.losses import MultipleNegativesRankingLoss
    from sentence_transformers.training_args import (
        SentenceTransformerTrainingArguments,
        BatchSamplers,
    )

    vocab = ["[PAD]", "[UNK]", "[CLS]", "[SEP]", "[MASK]"] + [f"tok{i}" for i in range(50)]
    vocab_dir = tempfile.mkdtemp()
    with open(os.path.join(vocab_dir, "vocab.txt"), "w") as f:
        f.write("\n".join(vocab))
    tok = BertTokenizerFast(vocab_file=os.path.join(vocab_dir, "vocab.txt"))
    config = BertConfig(
        vocab_size=len(vocab), hidden_size=8, num_hidden_layers=1,
        num_attention_heads=2, intermediate_size=16, max_position_embeddings=32,
    )
    BertModel(config).save_pretrained(vocab_dir)
    tok.save_pretrained(vocab_dir)

    model = SentenceTransformer(modules=[
        Transformer(vocab_dir, max_seq_length=16),
        Pooling(8),
    ])

    def make_ds(name: str, n: int):
        return hf_datasets.Dataset.from_dict({
            "anchor": [f"{name} anchor {i}" for i in range(n)],
            "positive": [f"{name} positive {i}" for i in range(n)],
        })

    val_datasets = {f"ds_{i}": make_ds(f"ds_{i}", 8) for i in range(n_datasets)}
    train_datasets = {f"ds_{i}": make_ds(f"ds_{i}", 8) for i in range(n_datasets)}

    args = SentenceTransformerTrainingArguments(
        output_dir=tempfile.mkdtemp(),
        per_device_eval_batch_size=2,
        dataloader_persistent_workers=persistent,
        dataloader_num_workers=num_workers,
        dataloader_pin_memory=False,
        batch_sampler=BatchSamplers.NO_DUPLICATES,
        report_to=[],
        remove_unused_columns=False,
        use_cpu=True,
    )

    return SentenceTransformerTrainer(
        model=model,
        args=args,
        train_dataset=train_datasets,
        eval_dataset=val_datasets,
        loss=MultipleNegativesRankingLoss(model),
    )


def run_case(persistent: bool, n_datasets: int = 3, num_workers: int = 2) -> None:
    import psutil

    trainer = build_trainer(persistent, num_workers, n_datasets)
    proc = psutil.Process()
    print(f"[case persistent_workers={persistent}] datasets={n_datasets}, num_workers={num_workers}")
    print(f"  before any evaluate: children={len(proc.children(recursive=True))}")
    for round_idx in range(3):
        trainer.evaluate()
        n_children = len(proc.children(recursive=True))
        n_dl = len(trainer.accelerator._dataloaders)
        print(
            f"  after evaluate #{round_idx + 1}: children={n_children}, "
            f"accelerator._dataloaders={n_dl}"
        )


if __name__ == "__main__":
    import transformers
    import sentence_transformers
    import accelerate
    import torch

    print(
        f"versions: transformers={transformers.__version__}, "
        f"sentence-transformers={sentence_transformers.__version__}, "
        f"accelerate={accelerate.__version__}, torch={torch.__version__}, "
        f"python={sys.version.split()[0]}, platform={sys.platform}"
    )
    run_case(persistent=True)
    print()
    run_case(persistent=False)
```

</details>

## Tests

* Added `test_trainer_get_eval_dataloader_with_persistent_workers` (parametrized over `persistent_workers`), following the style of the equivalent `transformers` test from huggingface/transformers#30627. It fails on `main` and passes with this PR.
* `tests/base/test_trainer.py`, `tests/sentence_transformer/test_trainer.py`, `tests/cross_encoder/test_trainer.py` and `tests/sparse_encoder/test_trainer.py` all pass locally (72 passed).
