### PR TITLE
Expand the community window when similarities equal the threshold

### DIFF
--- a/sentence_transformers/util/retrieval.py
+++ b/sentence_transformers/util/retrieval.py
@@ -330,7 +330,7 @@ def community_detection(
                     top_val_large, top_idx_large = cos_scores[i].topk(k=sort_max_size, largest=True)
 
                     # Check if we need to increase sort_max_size
-                    while top_val_large[-1] > threshold and sort_max_size < len(embeddings):
+                    while top_val_large[-1] >= threshold and sort_max_size < len(embeddings):
                         sort_max_size = min(2 * sort_max_size, len(embeddings))
                         top_val_large, top_idx_large = cos_scores[i].topk(k=sort_max_size, largest=True)
 

--- a/tests/util/test_retrieval.py
+++ b/tests/util/test_retrieval.py
@@ -163,6 +163,25 @@ def test_community_detection_large_batch_size():
     assert all(len(community) >= 10 for community in result)
 
 
+@pytest.mark.parametrize("min_community_size", [5, 10, 30])
+def test_community_detection_similarities_equal_to_threshold(min_community_size: int):
+    """Members whose similarity equals the threshold exactly must not be truncated.
+
+    The candidate window grew only while the smallest candidate was strictly greater than
+    the threshold, while membership used >=. Similarities landing exactly on the threshold
+    were therefore eligible but never triggered an expansion, capping the community at
+    sort_max_size.
+    """
+    num_embeddings = 200
+    # Identical rows give a cosine similarity of exactly 1.0.
+    embeddings = torch.ones(num_embeddings, 16)
+
+    result = community_detection(embeddings, threshold=1.0, min_community_size=min_community_size)
+
+    assert len(result) == 1
+    assert len(result[0]) == num_embeddings
+
+
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="GPU not available")
 def test_community_detection_gpu_support():
     """Test case for GPU support (if available)."""


### PR DESCRIPTION
Fixes #3899.

Heads up, this PR was AI-assisted and human-reviewed.

## Summary

- Widen the community candidate window while the smallest candidate is `>=` the threshold, matching the `>=` used to select members.
- Add a regression test covering `min_community_size` of 5, 10 and 30.

The window previously grew only while the smallest candidate was strictly greater than the threshold, while membership used `>=`. Similarities equal to the threshold were therefore included but never triggered an expansion, so a community was silently capped at `sort_max_size`.

```python
community_detection(torch.ones(200, 16), threshold=1.0, min_community_size=10)
# before: one community of 50
# after:  one community of 200
```

The `sort_max_size < len(embeddings)` guard is unchanged, so the loop still terminates.

The new test fails on `main` for all three parameters and passes with the fix. `tests/util/` is green (521 passed, 32 skipped), and `ruff check` / `ruff format --check` are clean. Timings on random and clustered inputs are unchanged; only the tie case behaves differently.

I don't have a GPU, so the CUDA/NPU branch is untested here. It counts members with `(cos_scores >= threshold).sum(1)` and takes `topk(k=row_wise_count.max())`, so by inspection it has no equivalent cap and should be unaffected.
