### PR TITLE
Raise when a chat template cannot carry query/document pairs

### DIFF
--- a/sentence_transformers/base/modality.py
+++ b/sentence_transformers/base/modality.py
@@ -47,9 +47,8 @@ KNOWN_MODEL_TYPES_MESSAGE_FORMATS = {
 
 # The roles pair_to_messages assigns to the two halves of a pair.
 PAIR_ROLES = ("query", "document")
-# Rendered through the chat template to see whether each half of a pair reaches the prompt: a baseline,
-# then one probe per role varying only that role's content. Varied values differ from their baseline in
-# first character and in length, so even a render that truncates hard still moves.
+# A baseline pair, then one probe per role varying only that role's content. Varied values differ from
+# their baseline in first character and in length, so even a render that truncates hard still moves.
 PAIR_ROLE_PROBES = (("alpha", "bravo"), ("charlie", "bravo"), ("alpha", "foxtrot"))
 
 
@@ -353,26 +352,16 @@ class InputFormatter:
     def pair_roles_failure(self, chat_template_kwargs: dict[str, Any] | None = None) -> str | None:
         """Why the chat template cannot carry a ``query``/``document`` pair, or None when it can.
 
-        Rendered rather than read off the template source. Templates that never mention the roles can
-        still pass their content through (ChatML emits ``message['role']`` verbatim), and templates that
-        do mention them may only use them in branches a pair never reaches, so the source text answers a
-        different question than the one that matters.
+        Decided by rendering probe pairs and diffing the outputs, never by reading the template source:
+        templates can pass roles through without naming them (ChatML) or name them in branches a pair
+        never reaches, and may transform content beyond recognition, so only a render that fails to move
+        with its input proves the content goes nowhere. A template that raises is reported with the
+        exception instead. The verdict is cached against a snapshot of the template and kwargs, so
+        fixing either on a loaded model takes effect, which is the documented remedy.
 
-        Decided by varying one half of the pair at a time and diffing the renders, rather than by hunting
-        for a sentinel in the output. A template is free to transform what it renders (``| upper``,
-        ``| truncate``), which leaves no sentinel to find even though every character of the real content
-        would have reached the prompt. A render that does not move when its input does is the only
-        reliable sign that the content goes nowhere. A template that raises on the probe is reported with
-        the exception instead, so the two problems are not conflated.
-
-        Probed with the ``chat_template_kwargs`` the real render passes, because they can change which
-        template renders: models may ship several named templates and select one through these kwargs,
-        the way Qwen3-VL-Reranker selects its ``reranker`` template next to a ``default`` that drops
-        the pair roles.
-
-        Keyed on a snapshot of the template and kwargs rather than cached outright, so replacing the
-        template on a loaded model takes effect, whether by assignment or by editing a named-template
-        dict in place. That is the documented remedy when the pair-role check rejects a model.
+        Args:
+            chat_template_kwargs: The ``apply_chat_template`` kwargs the real render passes. These can
+                select between named templates, so the probe must render with them.
         """
         template = getattr(self.processor, "chat_template", None)
         if template is None:
@@ -407,11 +396,8 @@ class InputFormatter:
     def has_pair_roles(self, messages_batch: list[list[dict[str, Any]]]) -> bool:
         """Whether any conversation in a batch carries both of the ``query``/``document`` pair roles.
 
-        Anchored on the produced messages rather than on the raw inputs, so it covers both routes into
-        :meth:`pair_to_messages`: text pairs converted by :meth:`batch_to_message`, and non-text pairs
-        that :meth:`parse_inputs` already turned into messages. Both roles are required because that is
-        the shape :meth:`pair_to_messages` produces, so a hand-written message using one of the roles
-        alone is not held to a check about pairs.
+        Anchored on produced messages so both routes into :meth:`pair_to_messages` are covered, and
+        requiring both roles keeps hand-written single-role messages outside a check about pairs.
         """
         pair_roles = set(PAIR_ROLES)
         return any(pair_roles <= {message.get("role") for message in messages} for messages in messages_batch)

--- a/sentence_transformers/base/modality.py
+++ b/sentence_transformers/base/modality.py
@@ -44,6 +44,14 @@ KNOWN_MODEL_TYPES_MESSAGE_FORMATS = {
 }
 
 
+# The roles pair_to_messages assigns to the two halves of a pair.
+PAIR_ROLES = ("query", "document")
+# Rendered through the chat template to see whether each half of a pair reaches the prompt: a baseline,
+# then one probe per role varying only that role's content. Varied values differ from their baseline in
+# first character and in length, so even a render that truncates hard still moves.
+PAIR_ROLE_PROBES = (("alpha", "bravo"), ("charlie", "bravo"), ("alpha", "foxtrot"))
+
+
 def _looks_like_url(text: str) -> bool:
     """Check if a string looks like a valid URL (starts with http(s) and has no spaces)."""
     return text.startswith(("http://", "https://")) and " " not in text
@@ -190,6 +198,7 @@ class InputFormatter:
         self.model_type = model_type
         self.processor = processor
         self.supported_modalities = supported_modalities
+        self._pair_role_probe: tuple[Any, str | None] | None = None
         if message_format == "auto":
             self.message_format = self._infer_format(processor) if processor else "structured"
         else:
@@ -307,7 +316,7 @@ class InputFormatter:
             for mod, value in typed_inputs:
                 if mod == "pair":
                     messages.append(self.pair_to_messages(value))
-                elif mod == "text" and isinstance(value, (tuple, list)) and len(value) == 2:
+                elif mod == "text" and self.is_text_pair(value):
                     messages.append(self.pair_to_messages(value))
                 elif mod == "message":
                     messages.append(value)
@@ -340,6 +349,61 @@ class InputFormatter:
 
         return modality, processed_inputs, extra_modality_kwargs
 
+    @property
+    def pair_roles_failure(self) -> str | None:
+        """Why the chat template cannot carry a ``query``/``document`` pair, or None when it can.
+
+        Rendered rather than read off the template source. Templates that never mention the roles can
+        still pass their content through (ChatML emits ``message['role']`` verbatim), and templates that
+        do mention them may only use them in branches a pair never reaches, so the source text answers a
+        different question than the one that matters.
+
+        Decided by varying one half of the pair at a time and diffing the renders, rather than by hunting
+        for a sentinel in the output. A template is free to transform what it renders (``| upper``,
+        ``| truncate``), which leaves no sentinel to find even though every character of the real content
+        would have reached the prompt. A render that does not move when its input does is the only
+        reliable sign that the content goes nowhere. A template that raises on the probe is reported with
+        the exception instead, so the two problems are not conflated.
+
+        Keyed on the template rather than cached outright, so assigning a working template to a loaded
+        model takes effect. That is the documented remedy when the pair-role check rejects a model.
+        """
+        template = getattr(self.processor, "chat_template", None)
+        if template is None:
+            return "the model has no chat template"
+        if self._pair_role_probe is not None and self._pair_role_probe[0] == template:
+            return self._pair_role_probe[1]
+
+        try:
+            base, *varied = [
+                str(self.processor.apply_chat_template(self.pair_to_messages(pair), tokenize=False))
+                for pair in PAIR_ROLE_PROBES
+            ]
+        except Exception as exc:
+            failure = f"it raised {type(exc).__name__}: {exc}"
+        else:
+            dropped = [role for role, render in zip(PAIR_ROLES, varied) if render == base]
+            if dropped:
+                roles = " and ".join(repr(role) for role in dropped)
+                failure = f"the {roles} content does not reach the rendered prompt"
+            else:
+                failure = None
+        logger.debug(f"Pair-role probe for the chat template: {failure or 'pair content survives'}")
+        self._pair_role_probe = (template, failure)
+        return failure
+
+    def has_pair_roles(self, messages_batch: list[list[dict[str, Any]]]) -> bool:
+        """Whether any conversation in a batch carries both of the ``query``/``document`` pair roles.
+
+        Anchored on the produced messages rather than on the raw inputs, so it covers both routes into
+        :meth:`pair_to_messages`: text pairs converted by :meth:`batch_to_message`, and non-text pairs
+        that :meth:`parse_inputs` already turned into messages. Both roles are required because that is
+        the shape :meth:`pair_to_messages` produces, so a hand-written message using one of the roles
+        alone is not held to a check about pairs.
+        """
+        pair_roles = set(PAIR_ROLES)
+        return any(pair_roles <= {message.get("role") for message in messages} for messages in messages_batch)
+
     def pair_to_messages(self, pair: tuple | list) -> list[dict[str, Any]]:
         """Convert a pair of inputs to query/document message format.
 
@@ -353,14 +417,15 @@ class InputFormatter:
         Returns:
             List of two message dictionaries with ``"query"`` and ``"document"`` roles.
         """
+        query_role, doc_role = PAIR_ROLES
         query_item, doc_item = pair
         query_modality = infer_modality(query_item)
         doc_modality = infer_modality(doc_item)
 
         if self.message_format == "flat":
             return [
-                {"role": "query", "content": query_item},
-                {"role": "document", "content": doc_item},
+                {"role": query_role, "content": query_item},
+                {"role": doc_role, "content": doc_item},
             ]
 
         def _to_content(modality, item):
@@ -374,8 +439,8 @@ class InputFormatter:
             return [{"type": modality, modality: item}]
 
         return [
-            {"role": "query", "content": _to_content(query_modality, query_item)},
-            {"role": "document", "content": _to_content(doc_modality, doc_item)},
+            {"role": query_role, "content": _to_content(query_modality, query_item)},
+            {"role": doc_role, "content": _to_content(doc_modality, doc_item)},
         ]
 
     def to_message(self, typed_input: dict[Modality, Any], role: str = "user") -> list[dict[str, Any]]:
@@ -431,16 +496,16 @@ class InputFormatter:
             # Text pairs (e.g. ("query", "document")) are routed to pair_to_messages instead
             if len(typed_input) == 1:
                 mod, value = next(iter(typed_input.items()))
-                if (
-                    mod == "text"
-                    and isinstance(value, (tuple, list))
-                    and len(value) == 2
-                    and all(isinstance(v, str) for v in value)
-                ):
+                if mod == "text" and self.is_text_pair(value):
                     messages.append(self.pair_to_messages(value))
                     continue
             messages.append(self.to_message(typed_input))  # type: ignore[arg-type]
         return "message", {"message": messages}
+
+    @staticmethod
+    def is_text_pair(value: Any) -> bool:
+        """Whether a single input is a text pair, i.e. cross-encoder ``(query, document)`` input."""
+        return isinstance(value, (tuple, list)) and len(value) == 2 and all(isinstance(part, str) for part in value)
 
     @staticmethod
     def is_text_only_messages(messages_batch: list[list[dict[str, Any]]]) -> bool:

--- a/sentence_transformers/base/modality.py
+++ b/sentence_transformers/base/modality.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import copy
 import logging
 import os
 from collections import defaultdict
@@ -198,7 +199,7 @@ class InputFormatter:
         self.model_type = model_type
         self.processor = processor
         self.supported_modalities = supported_modalities
-        self._pair_role_probe: tuple[Any, str | None] | None = None
+        self._pair_role_probe: tuple[tuple[Any, dict[str, Any]], str | None] | None = None
         if message_format == "auto":
             self.message_format = self._infer_format(processor) if processor else "structured"
         else:
@@ -349,8 +350,7 @@ class InputFormatter:
 
         return modality, processed_inputs, extra_modality_kwargs
 
-    @property
-    def pair_roles_failure(self) -> str | None:
+    def pair_roles_failure(self, chat_template_kwargs: dict[str, Any] | None = None) -> str | None:
         """Why the chat template cannot carry a ``query``/``document`` pair, or None when it can.
 
         Rendered rather than read off the template source. Templates that never mention the roles can
@@ -365,18 +365,30 @@ class InputFormatter:
         reliable sign that the content goes nowhere. A template that raises on the probe is reported with
         the exception instead, so the two problems are not conflated.
 
-        Keyed on the template rather than cached outright, so assigning a working template to a loaded
-        model takes effect. That is the documented remedy when the pair-role check rejects a model.
+        Probed with the ``chat_template_kwargs`` the real render passes, because they can change which
+        template renders: models may ship several named templates and select one through these kwargs,
+        the way Qwen3-VL-Reranker selects its ``reranker`` template next to a ``default`` that drops
+        the pair roles.
+
+        Keyed on a snapshot of the template and kwargs rather than cached outright, so replacing the
+        template on a loaded model takes effect, whether by assignment or by editing a named-template
+        dict in place. That is the documented remedy when the pair-role check rejects a model.
         """
         template = getattr(self.processor, "chat_template", None)
         if template is None:
             return "the model has no chat template"
-        if self._pair_role_probe is not None and self._pair_role_probe[0] == template:
+        chat_template_kwargs = chat_template_kwargs or {}
+        key = (template, chat_template_kwargs)
+        if self._pair_role_probe is not None and self._pair_role_probe[0] == key:
             return self._pair_role_probe[1]
 
         try:
             base, *varied = [
-                str(self.processor.apply_chat_template(self.pair_to_messages(pair), tokenize=False))
+                str(
+                    self.processor.apply_chat_template(
+                        self.pair_to_messages(pair), tokenize=False, **chat_template_kwargs
+                    )
+                )
                 for pair in PAIR_ROLE_PROBES
             ]
         except Exception as exc:
@@ -389,7 +401,7 @@ class InputFormatter:
             else:
                 failure = None
         logger.debug(f"Pair-role probe for the chat template: {failure or 'pair content survives'}")
-        self._pair_role_probe = (template, failure)
+        self._pair_role_probe = (copy.deepcopy(key), failure)
         return failure
 
     def has_pair_roles(self, messages_batch: list[list[dict[str, Any]]]) -> bool:

--- a/sentence_transformers/base/modules/transformer.py
+++ b/sentence_transformers/base/modules/transformer.py
@@ -980,6 +980,10 @@ class Transformer(InputModule):
         elif modality not in self.modality_config:
             raise_unsupported_modality_error(inputs, modality, list(self.modality_config.keys()), "Transformer module")
 
+        # Checked after the conversion so it covers pairs that parse_inputs already turned into messages
+        if modality == "message":
+            self._verify_pair_roles_supported(processor_inputs["message"])
+
         # Incorporate prompt into inputs if applicable
         prompt_length = None
         if prompt and modality == "message":
@@ -1031,6 +1035,30 @@ class Transformer(InputModule):
             processor_output["logits_to_keep"] = 1
 
         return processor_output
+
+    def _verify_pair_roles_supported(self, messages_batch: list[list[dict[str, Any]]]) -> None:
+        """Raise if the chat template cannot carry the ``query``/``document`` roles a pair is mapped to.
+
+        A template that only branches on ``system``/``user``/``assistant`` renders a pair to an empty
+        prompt, so the model would score an input holding neither the query nor the document. Published
+        rerankers ship a template that handles both roles, so this is reached when a backbone is used,
+        or fine-tuned, without one.
+        """
+        # Checked before the probe, which costs a render, so batches without a pair never pay for it
+        if not self.input_formatter.has_pair_roles(messages_batch):
+            return
+        failure = self.input_formatter.pair_roles_failure
+        if failure is None:
+            return
+        model_name = getattr(self.config, "name_or_path", None) or "this model"
+        raise ValueError(
+            f"The chat template of {model_name} cannot carry a 'query'/'document' pair ({failure}). Pair inputs "
+            "are mapped to one message per role, so set a chat template that renders both roles, e.g.:\n"
+            '    <Query>: {{ messages | selectattr("role", "eq", "query") | map(attribute="content") | first }}\n'
+            '    <Document>: {{ messages | selectattr("role", "eq", "document") | map(attribute="content") | first }}\n'
+            'via `processor_kwargs={"chat_template": ...}` when loading, `model.processor.chat_template = ...` '
+            "afterwards, or a `chat_template.jinja` file alongside the model."
+        )
 
     def _verify_left_padding(
         self,

--- a/sentence_transformers/base/modules/transformer.py
+++ b/sentence_transformers/base/modules/transformer.py
@@ -1049,8 +1049,7 @@ class Transformer(InputModule):
         # Checked before the probe, which costs a render, so batches without a pair never pay for it
         if not self.input_formatter.has_pair_roles(messages_batch):
             return
-        # Strip what never reaches the real Jinja render: size kwargs only affect tokenization, which
-        # the probe skips, and restore_suffix is a Sentence Transformers flag popped before rendering
+        # Drop what never reaches the Jinja render: size kwargs (tokenization only) and the ST-only restore_suffix
         probe_kwargs = {
             key: value
             for key, value in chat_template_kwargs.items()

--- a/sentence_transformers/base/modules/transformer.py
+++ b/sentence_transformers/base/modules/transformer.py
@@ -982,7 +982,7 @@ class Transformer(InputModule):
 
         # Checked after the conversion so it covers pairs that parse_inputs already turned into messages
         if modality == "message":
-            self._verify_pair_roles_supported(processor_inputs["message"])
+            self._verify_pair_roles_supported(processor_inputs["message"], chat_template_kwargs)
 
         # Incorporate prompt into inputs if applicable
         prompt_length = None
@@ -1036,7 +1036,9 @@ class Transformer(InputModule):
 
         return processor_output
 
-    def _verify_pair_roles_supported(self, messages_batch: list[list[dict[str, Any]]]) -> None:
+    def _verify_pair_roles_supported(
+        self, messages_batch: list[list[dict[str, Any]]], chat_template_kwargs: dict[str, Any]
+    ) -> None:
         """Raise if the chat template cannot carry the ``query``/``document`` roles a pair is mapped to.
 
         A template that only branches on ``system``/``user``/``assistant`` renders a pair to an empty
@@ -1047,7 +1049,14 @@ class Transformer(InputModule):
         # Checked before the probe, which costs a render, so batches without a pair never pay for it
         if not self.input_formatter.has_pair_roles(messages_batch):
             return
-        failure = self.input_formatter.pair_roles_failure
+        # Strip what never reaches the real Jinja render: size kwargs only affect tokenization, which
+        # the probe skips, and restore_suffix is a Sentence Transformers flag popped before rendering
+        probe_kwargs = {
+            key: value
+            for key, value in chat_template_kwargs.items()
+            if key not in _APPLY_CHAT_TEMPLATE_TOP_LEVEL_KWARGS and key != "restore_suffix"
+        }
+        failure = self.input_formatter.pair_roles_failure(probe_kwargs)
         if failure is None:
             return
         model_name = getattr(self.config, "name_or_path", None) or "this model"

--- a/sentence_transformers/base/modules/transformer.py
+++ b/sentence_transformers/base/modules/transformer.py
@@ -1059,11 +1059,20 @@ class Transformer(InputModule):
         if failure is None:
             return
         model_name = getattr(self.config, "name_or_path", None) or "this model"
+        if self.input_formatter.message_format == "structured":
+            example = (
+                '    <Query>: {{ (messages | selectattr("role", "eq", "query") | first).content[0].text }}\n'
+                '    <Document>: {{ (messages | selectattr("role", "eq", "document") | first).content[0].text }}\n'
+            )
+        else:
+            example = (
+                '    <Query>: {{ messages | selectattr("role", "eq", "query") | map(attribute="content") | first }}\n'
+                '    <Document>: {{ messages | selectattr("role", "eq", "document") | map(attribute="content") | first }}\n'
+            )
         raise ValueError(
             f"The chat template of {model_name} cannot carry a 'query'/'document' pair ({failure}). Pair inputs "
             "are mapped to one message per role, so set a chat template that renders both roles, e.g.:\n"
-            '    <Query>: {{ messages | selectattr("role", "eq", "query") | map(attribute="content") | first }}\n'
-            '    <Document>: {{ messages | selectattr("role", "eq", "document") | map(attribute="content") | first }}\n'
+            f"{example}"
             'via `processor_kwargs={"chat_template": ...}` when loading, `model.processor.chat_template = ...` '
             "afterwards, or a `chat_template.jinja` file alongside the model."
         )

--- a/tests/base/test_modality.py
+++ b/tests/base/test_modality.py
@@ -1241,8 +1241,11 @@ class FakeProcessor:
     def __init__(self, chat_template):
         self.chat_template = chat_template
 
-    def apply_chat_template(self, messages, tokenize=False):
-        return Environment().from_string(self.chat_template).render(messages=messages)
+    def apply_chat_template(self, messages, tokenize=False, chat_template=None, **kwargs):
+        template = self.chat_template
+        if isinstance(template, dict):
+            template = template[chat_template or "default"]
+        return Environment().from_string(template).render(messages=messages, **kwargs)
 
 
 class TestPairRolesFailure:
@@ -1277,7 +1280,7 @@ class TestPairRolesFailure:
         ],
     )
     def test_detection(self, template, supported):
-        assert (InputFormatter("bert", processor=FakeProcessor(template)).pair_roles_failure is None) is supported
+        assert (InputFormatter("bert", processor=FakeProcessor(template)).pair_roles_failure() is None) is supported
 
     @pytest.mark.parametrize(
         "filter_expression",
@@ -1286,43 +1289,77 @@ class TestPairRolesFailure:
     def test_transformed_content_still_counts_as_rendered(self, filter_expression):
         """A template may reshape what it renders, and the content still reaches the model."""
         template = "{% for m in messages %}{{ m.content " + filter_expression + " }}\n{% endfor %}"
-        assert InputFormatter("bert", processor=FakeProcessor(template)).pair_roles_failure is None
+        assert InputFormatter("bert", processor=FakeProcessor(template)).pair_roles_failure() is None
+
+    def test_probe_covers_structured_message_format(self):
+        """Structured-format processors probe through typed content items rather than plain strings."""
+        pass_through = "{% for m in messages %}{{ m.content[0].text }}\n{% endfor %}"
+        formatter = InputFormatter("bert", processor=FakeProcessor(pass_through))
+        assert formatter.message_format == "structured"
+        assert formatter.pair_roles_failure() is None
+
+        user_only = "{% for m in messages %}{% if m.role == 'user' %}{{ m.content[0].text }}{% endif %}{% endfor %}"
+        formatter = InputFormatter("bert", processor=FakeProcessor(user_only))
+        assert formatter.message_format == "structured"
+        assert formatter.pair_roles_failure() is not None
+
+    def test_probe_uses_the_render_kwargs(self):
+        """Kwargs can select a named template, so the probe must measure the one the render uses.
+
+        Qwen3-VL-Reranker ships a ``reranker`` template next to a ``default`` that drops the pair
+        roles, selected through its configured ``processing_kwargs``.
+        """
+        processor = FakeProcessor({"default": GENERIC_INSTRUCT_TEMPLATE, "reranker": RERANKER_TEMPLATE})
+        formatter = InputFormatter("bert", processor=processor)
+        assert formatter.pair_roles_failure() is not None
+        assert formatter.pair_roles_failure({"chat_template": "reranker"}) is None
+        # Verdicts for different kwargs must not serve each other from the cache
+        assert formatter.pair_roles_failure() is not None
 
     def test_failure_names_the_half_that_is_dropped(self):
         query_only = "{% for m in messages %}{% if m.role == 'query' %}{{ m.content }}{% endif %}{% endfor %}"
-        assert "'document' content" in InputFormatter("bert", processor=FakeProcessor(query_only)).pair_roles_failure
+        assert "'document' content" in InputFormatter("bert", processor=FakeProcessor(query_only)).pair_roles_failure()
 
         both = InputFormatter("bert", processor=FakeProcessor(GENERIC_INSTRUCT_TEMPLATE))
-        assert "'query' and 'document' content" in both.pair_roles_failure
+        assert "'query' and 'document' content" in both.pair_roles_failure()
 
     def test_no_processor_has_no_pair_roles(self):
-        assert InputFormatter("bert").pair_roles_failure is not None
+        assert InputFormatter("bert").pair_roles_failure() is not None
 
     def test_probe_is_rendered_lazily(self):
         """A template assigned after construction must still be picked up."""
         processor = FakeProcessor(GENERIC_INSTRUCT_TEMPLATE)
         formatter = InputFormatter("bert", processor=processor)
         processor.chat_template = "{% for m in messages %}{{ m.content }}{% endfor %}"
-        assert formatter.pair_roles_failure is None
+        assert formatter.pair_roles_failure() is None
 
     def test_probe_reruns_after_a_rejected_template_is_replaced(self):
         """Replacing a rejected template is the documented remedy, so a stale verdict must not pin it."""
         processor = FakeProcessor(GENERIC_INSTRUCT_TEMPLATE)
         formatter = InputFormatter("bert", processor=processor)
-        assert formatter.pair_roles_failure is not None
+        assert formatter.pair_roles_failure() is not None
 
         processor.chat_template = "{% for m in messages %}{{ m.content }}{% endfor %}"
-        assert formatter.pair_roles_failure is None
+        assert formatter.pair_roles_failure() is None
+
+    def test_probe_reruns_after_a_named_template_is_edited_in_place(self):
+        """Fixing one entry of a named-template dict edits it in place, and must not hit a stale verdict."""
+        processor = FakeProcessor({"default": GENERIC_INSTRUCT_TEMPLATE})
+        formatter = InputFormatter("bert", processor=processor)
+        assert formatter.pair_roles_failure() is not None
+
+        processor.chat_template["default"] = "{% for m in messages %}{{ m.content }}{% endfor %}"
+        assert formatter.pair_roles_failure() is None
 
     def test_failure_distinguishes_an_empty_render_from_a_raise(self):
         dropped = InputFormatter("bert", processor=FakeProcessor(GENERIC_INSTRUCT_TEMPLATE))
-        assert "does not reach the rendered prompt" in dropped.pair_roles_failure
+        assert "does not reach the rendered prompt" in dropped.pair_roles_failure()
 
         raised = InputFormatter("bert", processor=FakeProcessor("{{ nope() }}"))
-        assert "it raised" in raised.pair_roles_failure
+        assert "it raised" in raised.pair_roles_failure()
 
-        assert InputFormatter("bert").pair_roles_failure == "the model has no chat template"
-        assert InputFormatter("bert", processor=FakeProcessor(RERANKER_TEMPLATE)).pair_roles_failure is None
+        assert InputFormatter("bert").pair_roles_failure() == "the model has no chat template"
+        assert InputFormatter("bert", processor=FakeProcessor(RERANKER_TEMPLATE)).pair_roles_failure() is None
 
 
 class TestHasPairRoles:

--- a/tests/base/test_modality.py
+++ b/tests/base/test_modality.py
@@ -1323,9 +1323,6 @@ class TestPairRolesFailure:
         both = InputFormatter("bert", processor=FakeProcessor(GENERIC_INSTRUCT_TEMPLATE))
         assert "'query' and 'document' content" in both.pair_roles_failure()
 
-    def test_no_processor_has_no_pair_roles(self):
-        assert InputFormatter("bert").pair_roles_failure() is not None
-
     def test_probe_is_rendered_lazily(self):
         """A template assigned after construction must still be picked up."""
         processor = FakeProcessor(GENERIC_INSTRUCT_TEMPLATE)

--- a/tests/base/test_modality.py
+++ b/tests/base/test_modality.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import numpy as np
 import pytest
 import torch
+from jinja2 import Environment
 from PIL import Image
 
 from sentence_transformers.base.modality import (
@@ -15,6 +16,7 @@ from sentence_transformers.base.modality import (
     is_video_url_or_path,
 )
 from sentence_transformers.base.modality_types import MODALITY_TO_PROCESSOR_ARG
+from tests.utils import GENERIC_INSTRUCT_TEMPLATE, RERANKER_TEMPLATE
 
 
 class TestIsImageUrlOrPath:
@@ -1231,3 +1233,123 @@ class TestIsTextOnlyMessages:
             ]
         ]
         assert InputFormatter.is_text_only_messages(batch) is True
+
+
+class FakeProcessor:
+    """Minimal stand-in exposing the two attributes the pair-role probe touches."""
+
+    def __init__(self, chat_template):
+        self.chat_template = chat_template
+
+    def apply_chat_template(self, messages, tokenize=False):
+        return Environment().from_string(self.chat_template).render(messages=messages)
+
+
+class TestPairRolesFailure:
+    @pytest.mark.parametrize(
+        ("template", "supported"),
+        [
+            # Reranker templates select on both roles, either via a filter or a branch
+            (RERANKER_TEMPLATE, True),
+            (
+                "{% for m in messages %}{% if m.role == 'query' %}Q{{ m.content }}"
+                "{% elif m.role == 'document' %}D{{ m.content }}{% endif %}{% endfor %}",
+                True,
+            ),
+            # Never mentions the roles yet passes both through, as ChatML templates do
+            ("{% for m in messages %}{{ m.role }}: {{ m.content }}{% endfor %}", True),
+            # Addresses the pair positionally rather than by role name
+            ("Q: {{ messages[0].content }}\nD: {{ messages[1].content }}", True),
+            ("{% for m in messages %}{{ m.content }}\n{% endfor %}", True),
+            # Mentions both roles, but only in a branch a pair never reaches
+            (
+                "{% for m in messages %}{% if m.role == 'user' %}{{ m.content }}"
+                "{% elif m.role == 'query' or m.role == 'document' %}{% endif %}{% endfor %}",
+                False,
+            ),
+            # Half a pair is no better than none, the other side is still dropped
+            ("{% for m in messages %}{% if m.role == 'query' %}{{ m.content }}{% endif %}{% endfor %}", False),
+            (GENERIC_INSTRUCT_TEMPLATE, False),
+            # Anything unrenderable is treated as unable to carry a pair
+            ("{% for m in messages %}{{ m.content }}", False),
+            ("{{ nope.missing.attribute }}", False),
+            (None, False),
+        ],
+    )
+    def test_detection(self, template, supported):
+        assert (InputFormatter("bert", processor=FakeProcessor(template)).pair_roles_failure is None) is supported
+
+    @pytest.mark.parametrize(
+        "filter_expression",
+        ["| upper", "| capitalize", "| truncate(10)", "| wordwrap(4)", "| replace('a', 'z')", "| trim", "[:8]"],
+    )
+    def test_transformed_content_still_counts_as_rendered(self, filter_expression):
+        """A template may reshape what it renders, and the content still reaches the model."""
+        template = "{% for m in messages %}{{ m.content " + filter_expression + " }}\n{% endfor %}"
+        assert InputFormatter("bert", processor=FakeProcessor(template)).pair_roles_failure is None
+
+    def test_failure_names_the_half_that_is_dropped(self):
+        query_only = "{% for m in messages %}{% if m.role == 'query' %}{{ m.content }}{% endif %}{% endfor %}"
+        assert "'document' content" in InputFormatter("bert", processor=FakeProcessor(query_only)).pair_roles_failure
+
+        both = InputFormatter("bert", processor=FakeProcessor(GENERIC_INSTRUCT_TEMPLATE))
+        assert "'query' and 'document' content" in both.pair_roles_failure
+
+    def test_no_processor_has_no_pair_roles(self):
+        assert InputFormatter("bert").pair_roles_failure is not None
+
+    def test_probe_is_rendered_lazily(self):
+        """A template assigned after construction must still be picked up."""
+        processor = FakeProcessor(GENERIC_INSTRUCT_TEMPLATE)
+        formatter = InputFormatter("bert", processor=processor)
+        processor.chat_template = "{% for m in messages %}{{ m.content }}{% endfor %}"
+        assert formatter.pair_roles_failure is None
+
+    def test_probe_reruns_after_a_rejected_template_is_replaced(self):
+        """Replacing a rejected template is the documented remedy, so a stale verdict must not pin it."""
+        processor = FakeProcessor(GENERIC_INSTRUCT_TEMPLATE)
+        formatter = InputFormatter("bert", processor=processor)
+        assert formatter.pair_roles_failure is not None
+
+        processor.chat_template = "{% for m in messages %}{{ m.content }}{% endfor %}"
+        assert formatter.pair_roles_failure is None
+
+    def test_failure_distinguishes_an_empty_render_from_a_raise(self):
+        dropped = InputFormatter("bert", processor=FakeProcessor(GENERIC_INSTRUCT_TEMPLATE))
+        assert "does not reach the rendered prompt" in dropped.pair_roles_failure
+
+        raised = InputFormatter("bert", processor=FakeProcessor("{{ nope() }}"))
+        assert "it raised" in raised.pair_roles_failure
+
+        assert InputFormatter("bert").pair_roles_failure == "the model has no chat template"
+        assert InputFormatter("bert", processor=FakeProcessor(RERANKER_TEMPLATE)).pair_roles_failure is None
+
+
+class TestHasPairRoles:
+    @pytest.mark.parametrize(
+        ("messages_batch", "expected"),
+        [
+            ([[{"role": "query", "content": "q"}, {"role": "document", "content": "d"}]], True),
+            # One pair anywhere in the batch is enough, its content would be dropped just the same
+            (
+                [
+                    [{"role": "user", "content": "hi"}],
+                    [{"role": "query", "content": "q"}, {"role": "document", "content": "d"}],
+                ],
+                True,
+            ),
+            # One pair role alone is not a pair, e.g. a hand-written query message with no document
+            ([[{"role": "query", "content": "q"}]], False),
+            ([[{"role": "user", "content": "hi"}, {"role": "assistant", "content": "yo"}]], False),
+            ([[{"content": "no role at all"}]], False),
+            ([], False),
+        ],
+    )
+    def test_batches(self, messages_batch, expected):
+        assert InputFormatter("bert").has_pair_roles(messages_batch) is expected
+
+    def test_covers_non_text_pairs(self):
+        """Non-text pairs reach pair_to_messages by a different route, but take the same roles."""
+        formatter = InputFormatter("bert")
+        messages = formatter.pair_to_messages((Image.new("RGB", (4, 4)), "a document"))
+        assert formatter.has_pair_roles([messages]) is True

--- a/tests/cross_encoder/test_model.py
+++ b/tests/cross_encoder/test_model.py
@@ -796,6 +796,11 @@ CHATML_TEMPLATE = (
     "{{ '<|im_start|>' + message['role'] + '\n' + message['content'] + '<|im_end|>' + '\n' }}"
     "{% endfor %}"
 )
+# Structured-content variant of a rerank template, as a multimodal processor would need
+STRUCTURED_RERANKER_TEMPLATE = (
+    '<Query>: {{ (messages | selectattr("role", "eq", "query") | first).content[0].text }}\n'
+    '<Document>: {{ (messages | selectattr("role", "eq", "document") | first).content[0].text }}'
+)
 BERLIN_PAIRS = [
     ["How many people live in Berlin?", "Berlin has a population of 3,520,031 registered inhabitants."],
     ["How many people live in Berlin?", "Berlin is well known for its museums."],
@@ -848,7 +853,7 @@ def test_predict_raises_on_chat_template_without_pair_roles() -> None:
     transformer = model[0]
     # The template is picked up, it just cannot render the roles that text pairs take
     assert "message" in transformer.modality_config
-    assert transformer.input_formatter.pair_roles_failure is not None
+    assert transformer.input_formatter.pair_roles_failure() is not None
 
     with pytest.raises(ValueError, match=PAIR_ROLES_DROPPED):
         model.predict(BERLIN_PAIRS)
@@ -875,7 +880,7 @@ def test_predict_applies_chat_template_with_pair_roles() -> None:
         processor_kwargs={"chat_template": RERANKER_TEMPLATE},
     )
     transformer = model[0]
-    assert transformer.input_formatter.pair_roles_failure is None
+    assert transformer.input_formatter.pair_roles_failure() is None
 
     features = transformer.preprocess(BERLIN_PAIRS[:1])
     decoded = transformer.tokenizer.decode(features["input_ids"][0], skip_special_tokens=True)
@@ -895,7 +900,7 @@ def test_predict_applies_chat_template_that_only_echoes_the_role() -> None:
         processor_kwargs={"chat_template": CHATML_TEMPLATE},
     )
     transformer = model[0]
-    assert transformer.input_formatter.pair_roles_failure is None
+    assert transformer.input_formatter.pair_roles_failure() is None
 
     features = transformer.preprocess(BERLIN_PAIRS[:1])
     decoded = transformer.tokenizer.decode(features["input_ids"][0], skip_special_tokens=True)
@@ -918,6 +923,28 @@ def test_message_input_with_a_single_pair_role_is_not_checked() -> None:
     features = model[0].preprocess([[{"role": "query", "content": "hello world"}]])
     decoded = model[0].tokenizer.decode(features["input_ids"][0], skip_special_tokens=True)
     assert "instruct : hello world" in decoded
+
+
+def test_probe_uses_the_configured_chat_template_kwargs() -> None:
+    """A model may select a named rerank template via processing kwargs, as Qwen3-VL-Reranker does.
+
+    The probe must measure the selected template rather than the default one, since rejecting the
+    model for a default that drops the pair roles would break a correctly configured reranker.
+    """
+    model = CrossEncoder(
+        "cross-encoder-testing/reranker-bert-tiny-gooaq-bce",
+        processor_kwargs={
+            "chat_template": {"default": GENERIC_INSTRUCT_TEMPLATE, "reranker": STRUCTURED_RERANKER_TEMPLATE}
+        },
+    )
+    transformer = model[0]
+    with pytest.raises(ValueError, match=PAIR_ROLES_DROPPED):
+        transformer.preprocess(BERLIN_PAIRS[:1])
+
+    transformer.processing_kwargs["chat_template"] = {"chat_template": "reranker"}
+    features = transformer.preprocess(BERLIN_PAIRS[:1])
+    decoded = transformer.tokenizer.decode(features["input_ids"][0], skip_special_tokens=True)
+    assert "< query > : how many people live in berlin?" in decoded
 
 
 # Test suite converted from demo_3406_simple_og.py

--- a/tests/cross_encoder/test_model.py
+++ b/tests/cross_encoder/test_model.py
@@ -12,6 +12,7 @@ import pytest
 import torch
 from huggingface_hub import CommitInfo, HfApi, RepoUrl
 from packaging.version import Version, parse
+from PIL import Image
 from pytest import FixtureRequest
 from transformers import __version__ as transformers_version
 
@@ -22,6 +23,7 @@ from sentence_transformers.util.decorators import (
     cross_encoder_init_args_decorator,
     cross_encoder_predict_rank_args_decorator,
 )
+from tests.utils import GENERIC_INSTRUCT_TEMPLATE, RERANKER_TEMPLATE
 
 
 def test_classifier_dropout_is_set() -> None:
@@ -786,6 +788,136 @@ def test_predict_per_call_processing_kwargs(reranker_bert_tiny_model: CrossEncod
     )
     full = model.predict([pair])
     assert not np.isclose(truncated[0], full[0])
+
+
+# ChatML emits the role rather than branching on it, so unknown roles carry their content through
+CHATML_TEMPLATE = (
+    "{% for message in messages %}"
+    "{{ '<|im_start|>' + message['role'] + '\n' + message['content'] + '<|im_end|>' + '\n' }}"
+    "{% endfor %}"
+)
+BERLIN_PAIRS = [
+    ["How many people live in Berlin?", "Berlin has a population of 3,520,031 registered inhabitants."],
+    ["How many people live in Berlin?", "Berlin is well known for its museums."],
+]
+PAIR_ROLES_DROPPED = "cannot carry a 'query'/'document' pair"
+
+
+def test_replacing_a_rejected_chat_template_takes_effect() -> None:
+    """The error names a remedy, so applying it to a loaded model has to work."""
+    model = CrossEncoder(
+        "cross-encoder-testing/reranker-bert-tiny-gooaq-bce",
+        processor_kwargs={"chat_template": GENERIC_INSTRUCT_TEMPLATE},
+    )
+    with pytest.raises(ValueError, match=PAIR_ROLES_DROPPED):
+        model.predict(BERLIN_PAIRS)
+
+    model.processor.chat_template = RERANKER_TEMPLATE
+    decoded = model[0].tokenizer.decode(
+        model[0].preprocess(BERLIN_PAIRS[:1])["input_ids"][0], skip_special_tokens=True
+    )
+    assert "< query > : how many people live in berlin?" in decoded
+
+
+def test_preprocess_raises_on_non_text_pair_without_pair_roles() -> None:
+    """Non-text pairs reach the roles by a different route, and are dropped just the same."""
+    model = CrossEncoder(
+        "cross-encoder-testing/reranker-bert-tiny-gooaq-bce",
+        processor_kwargs={"chat_template": GENERIC_INSTRUCT_TEMPLATE},
+    )
+    image = Image.new("RGB", (16, 16))
+    with pytest.raises(ValueError, match=PAIR_ROLES_DROPPED):
+        model[0].preprocess([(image, "a document")])
+    # A text pair sharing a batch with a non-text one takes the same route
+    with pytest.raises(ValueError, match=PAIR_ROLES_DROPPED):
+        model[0].preprocess([(image, "a document"), ("a query", "a document")])
+
+
+def test_predict_raises_on_chat_template_without_pair_roles() -> None:
+    """A chat template that drops the pair roles must be reported, not worked around.
+
+    Backbones such as the Qwen3 instruct models carry a template that only branches on
+    ``system``/``user``/``assistant``. Rendering the ``query``/``document`` roles through it drops both
+    messages, leaving the model with a zero-length input. Tokenizing the pair directly instead would
+    score an input the model was never trained on, so the misconfiguration is raised rather than hidden.
+    """
+    model = CrossEncoder(
+        "cross-encoder-testing/reranker-bert-tiny-gooaq-bce",
+        processor_kwargs={"chat_template": GENERIC_INSTRUCT_TEMPLATE},
+    )
+    transformer = model[0]
+    # The template is picked up, it just cannot render the roles that text pairs take
+    assert "message" in transformer.modality_config
+    assert transformer.input_formatter.pair_roles_failure is not None
+
+    with pytest.raises(ValueError, match=PAIR_ROLES_DROPPED):
+        model.predict(BERLIN_PAIRS)
+
+    # Single texts never take those roles, so they are unaffected
+    features = transformer.preprocess(["a solo text"])
+    assert "a solo text" in transformer.tokenizer.decode(features["input_ids"][0], skip_special_tokens=True)
+
+
+def test_predict_raises_on_mixed_batch_containing_a_pair() -> None:
+    """One pair in a batch is enough, its content would be dropped just the same."""
+    model = CrossEncoder(
+        "cross-encoder-testing/reranker-bert-tiny-gooaq-bce",
+        processor_kwargs={"chat_template": GENERIC_INSTRUCT_TEMPLATE},
+    )
+    with pytest.raises(ValueError, match=PAIR_ROLES_DROPPED):
+        model[0].preprocess(["a solo text", ("How many people live in Berlin?", "Berlin has 3.5M.")])
+
+
+def test_predict_applies_chat_template_with_pair_roles() -> None:
+    """A template that does reference the ``query``/``document`` roles must still be applied."""
+    model = CrossEncoder(
+        "cross-encoder-testing/reranker-bert-tiny-gooaq-bce",
+        processor_kwargs={"chat_template": RERANKER_TEMPLATE},
+    )
+    transformer = model[0]
+    assert transformer.input_formatter.pair_roles_failure is None
+
+    features = transformer.preprocess(BERLIN_PAIRS[:1])
+    decoded = transformer.tokenizer.decode(features["input_ids"][0], skip_special_tokens=True)
+    assert "< query > : how many people live in berlin?" in decoded
+    assert "< document > : berlin has a population" in decoded
+
+
+def test_predict_applies_chat_template_that_only_echoes_the_role() -> None:
+    """A template that carries unknown roles through must keep working, not raise.
+
+    Pass-through ChatML templates such as SmolLM2's emit ``message['role']`` verbatim, so they never
+    mention ``query``/``document`` yet render both messages in full. Deciding from the template source
+    rather than from a render would break models that are fine today.
+    """
+    model = CrossEncoder(
+        "cross-encoder-testing/reranker-bert-tiny-gooaq-bce",
+        processor_kwargs={"chat_template": CHATML_TEMPLATE},
+    )
+    transformer = model[0]
+    assert transformer.input_formatter.pair_roles_failure is None
+
+    features = transformer.preprocess(BERLIN_PAIRS[:1])
+    decoded = transformer.tokenizer.decode(features["input_ids"][0], skip_special_tokens=True)
+    assert "query" in decoded and "how many people live in berlin?" in decoded
+    assert "document" in decoded and "berlin has a population" in decoded
+
+
+def test_message_input_with_a_single_pair_role_is_not_checked() -> None:
+    """A hand-written message may use one pair role alone, and that is not a pair.
+
+    The check guards the pair mapping, which always produces both roles in one conversation, so a
+    template rendering just the role the user actually sent must not be rejected for dropping a role
+    the batch never uses.
+    """
+    query_only = "{% for m in messages %}{% if m.role == 'query' %}Instruct: {{ m.content }}{% endif %}{% endfor %}"
+    model = CrossEncoder(
+        "cross-encoder-testing/reranker-bert-tiny-gooaq-bce",
+        processor_kwargs={"chat_template": query_only},
+    )
+    features = model[0].preprocess([[{"role": "query", "content": "hello world"}]])
+    decoded = model[0].tokenizer.decode(features["input_ids"][0], skip_special_tokens=True)
+    assert "instruct : hello world" in decoded
 
 
 # Test suite converted from demo_3406_simple_og.py

--- a/tests/cross_encoder/test_model.py
+++ b/tests/cross_encoder/test_model.py
@@ -938,8 +938,10 @@ def test_probe_uses_the_configured_chat_template_kwargs() -> None:
         },
     )
     transformer = model[0]
-    with pytest.raises(ValueError, match=PAIR_ROLES_DROPPED):
+    with pytest.raises(ValueError, match=PAIR_ROLES_DROPPED) as excinfo:
         transformer.preprocess(BERLIN_PAIRS[:1])
+    # The dict template infers structured format, so the remedy example must read typed content
+    assert "content[0].text" in str(excinfo.value)
 
     transformer.processing_kwargs["chat_template"] = {"chat_template": "reranker"}
     features = transformer.preprocess(BERLIN_PAIRS[:1])

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2,6 +2,19 @@ from __future__ import annotations
 
 import os
 
+# A chat template in the style of instruct backbones: branches on the chat roles only, so the
+# query/document roles that pairs are mapped to render to nothing.
+GENERIC_INSTRUCT_TEMPLATE = (
+    "{% for message in messages %}"
+    "{% if message['role'] == 'user' %}<|user|>\n{{ message['content'] }}\n{% endif %}"
+    "{% endfor %}"
+)
+# A chat template in the style of published rerankers: selects the query/document roles explicitly.
+RERANKER_TEMPLATE = (
+    '<Query>: {{ messages | selectattr("role", "eq", "query") | map(attribute="content") | first }}\n'
+    '<Document>: {{ messages | selectattr("role", "eq", "document") | map(attribute="content") | first }}'
+)
+
 
 def is_ci() -> bool:
     """


### PR DESCRIPTION
Resolves #3881
Supersedes #3882

Hello!

Heads up, this PR was AI-generated and human-reviewed.

## Pull Request overview
* Raise an actionable error when a chat template cannot render the `query`/`document` roles that pairs are mapped to
* Detect this by rendering probe pairs through the template and diffing the outputs, not by reading the template source
* Probe with the model's configured chat template kwargs, so named-template rerankers like Qwen3-VL-Reranker keep working

## Details
When a model carries a chat template, text pairs are converted to messages with the `query` and `document` roles via `pair_to_messages`. Purpose-built reranker templates select on those roles, but general instruct templates (Qwen2.5, Qwen3, and most others) only branch on `system`/`user`/`assistant` and render both messages to nothing. The model then receives an input holding neither the query nor the document: a fully empty render crashes with a cryptic `IndexError`, and a template that still emits its default system prompt (Qwen2.5) produces scores that mean nothing. Anyone turning an instruct LLM into a reranker hits this on their first `predict` call or training batch.

#3882 detects the same failure with a sentinel probe, but resolves it by silently falling back to tokenizing the pair directly, and explicitly left the fallback-or-raise decision open. I went with raising: the fallback scores an input the backbone was never trained on, so it trades one silent wrong number for another, while the error names the problem and includes a working template to copy. The probe-the-render detection idea comes from that PR, so the commit carries a Co-authored-by credit for @ishan-1010.

The probe renders three pairs through the template (a baseline, then one variation per role) and diffs the outputs: if varying a role's content does not move the render, that content never reaches the prompt. It renders with the same chat template kwargs the real render passes (minus the size kwargs, which only affect tokenization), because those kwargs can select which template renders at all: Qwen3-VL-Reranker ships a `reranker` template that carries both roles next to a `default` that drops them, selected through its configured `processing_kwargs`. I chose rendering over reading the template source because the source answers the wrong question, as measured on real models:

| Model | Pair content survives the template? | Probe verdict |
|---|---|---|
| `HuggingFaceTB/SmolLM2-135M-Instruct` | yes, emits `message['role']` verbatim | supported |
| `Qwen/Qwen2.5-0.5B-Instruct` | no, renders only its default system prompt | rejected |
| `Qwen/Qwen3-Reranker-0.6B` | yes, its template selects both roles | supported |
| `Qwen/Qwen3-VL-Reranker-2B` | yes, once its configured kwargs select the named `reranker` template | supported |
| `mistralai/Mistral-7B-Instruct-v0.3` | no, the template raises on the roles | rejected, with the raise reason in the error |

A source check in either direction misfires on these: SmolLM2 works without ever naming the roles, Qwen2.5 contains the literal word "query" in its tools prose while dropping both messages, and the valid Qwen3-Reranker template also mentions `user` and `assistant`. Diffing rather than searching for a sentinel also keeps templates that transform content (`| upper`, `| truncate`) working. The verdict is keyed on a snapshot of the template and kwargs, so fixing either on a loaded model re-probes and recovers, including in-place edits of a named-template dict, which is exactly the remedy the error message documents. The check only fires when a conversation carries both pair roles (the shape `pair_to_messages` produces), so hand-written messages that use one of the roles alone, non-pair batches, and models without a chat template are unaffected. Cost is three template renders once per model and a sub-microsecond role scan per batch afterwards. Tested at the formatter level (probe verdicts across template shapes and transforms) and end to end through `CrossEncoder.predict` (rejection, recovery after replacing the template, ChatML pass-through, non-text pairs, mixed batches, and named-template kwargs).

To measure the blast radius, I swept the Hub for sentence-transformers models tagged text-ranking whose `sentence_bert_config.json` declares the `message` modality: 47 models. I probed the 20 most downloaded (the Qwen3-Reranker and Qwen3-VL-Reranker families, zerank-2, mxbai-rerank-v2, ctxl-rerank-v2, llama-nemotron-rerank-vl, and others) with their configured kwargs, and all 20 pass. The only two that fail a bare probe are the Qwen3-VL-Reranker sizes, which is exactly the case the kwargs handling exists for.

One conscious limitation: there is no bypass flag if the probe wrongly rejects a working template. That requires a template whose render is conditional on properties of the content rather than its value, and no published reranker template does this. Editing the template or the kwargs re-probes, since the verdict is keyed on a snapshot of both.

cc @ishan-1010

- Tom Aarsen
