### PR TITLE
[`fix`] Support mixed sparse/dense inputs in euclidean and manhattan similarity

### DIFF
--- a/sentence_transformers/util/similarity.py
+++ b/sentence_transformers/util/similarity.py
@@ -16,6 +16,41 @@ from .tensor import _convert_to_batch_tensor, _convert_to_tensor, normalize_embe
 logger = logging.get_logger(__name__)
 
 
+def _row_squared_norms(a: Tensor) -> Tensor:
+    """
+    Computes the row-wise sum of squares for either a sparse or a dense tensor.
+
+    Args:
+        a (Tensor): A 2-dimensional sparse or dense tensor.
+
+    Returns:
+        Tensor: Dense vector with res[i] = sum(a[i] ** 2)
+    """
+    if a.is_sparse:
+        return torch.sparse.sum(a * a, dim=1).to_dense()
+    return (a * a).sum(dim=1)
+
+
+def _match_layouts(a: Tensor, b: Tensor) -> tuple[Tensor, Tensor]:
+    """
+    Densifies the sparse tensor if exactly one of the two inputs is sparse, as element-wise operations require both
+    operands to share a layout. Both inputs have the same shape here, so the dense one already accounts for the
+    memory that densifying the other one takes.
+
+    Args:
+        a (Tensor): The first tensor.
+        b (Tensor): The second tensor.
+
+    Returns:
+        tuple[Tensor, Tensor]: The two tensors, using the same layout.
+    """
+    if a.is_sparse and not b.is_sparse:
+        return a.to_dense(), b
+    if b.is_sparse and not a.is_sparse:
+        return a, b.to_dense()
+    return a, b
+
+
 def pytorch_cos_sim(a: Tensor, b: Tensor) -> Tensor:
     """
     Computes the cosine similarity between two tensors.
@@ -124,8 +159,8 @@ def manhattan_sim(a: list | np.ndarray | Tensor, b: list | np.ndarray | Tensor) 
     if a.is_sparse or b.is_sparse:
         logger.warning_once("Using scipy for sparse Manhattan similarity computation.")
 
-        a_coo = to_scipy_coo(a)
-        b_coo = to_scipy_coo(b)
+        a_coo = to_scipy_coo(a if a.is_sparse else a.to_sparse())
+        b_coo = to_scipy_coo(b if b.is_sparse else b.to_sparse())
         dist = pairwise_distances(a_coo, b_coo, metric="manhattan")
         return torch.from_numpy(-dist).float().to(a.device).to_dense()
 
@@ -146,6 +181,7 @@ def pairwise_manhattan_sim(a: list | np.ndarray | Tensor, b: list | np.ndarray |
     """
     a = _convert_to_tensor(a)
     b = _convert_to_tensor(b)
+    a, b = _match_layouts(a, b)
 
     return -torch.sum(torch.abs(a - b), dim=-1).to_dense()
 
@@ -165,9 +201,9 @@ def euclidean_sim(a: list | np.ndarray | Tensor, b: list | np.ndarray | Tensor) 
     a = _convert_to_batch_tensor(a)
     b = _convert_to_batch_tensor(b)
 
-    if a.is_sparse:
-        a_norm_sq = torch.sparse.sum(a * a, dim=1).to_dense().unsqueeze(1)  # Shape (N, 1)
-        b_norm_sq = torch.sparse.sum(b * b, dim=1).to_dense().unsqueeze(0)  # Shape (1, M)
+    if a.is_sparse or b.is_sparse:
+        a_norm_sq = _row_squared_norms(a).unsqueeze(1)  # Shape (N, 1)
+        b_norm_sq = _row_squared_norms(b).unsqueeze(0)  # Shape (1, M)
         dot_product = torch.matmul(a, b.t()).to_dense()  # Shape (N, M)
 
         # Calculate squared distance
@@ -194,6 +230,7 @@ def pairwise_euclidean_sim(a: list | np.ndarray | Tensor, b: list | np.ndarray |
     """
     a = _convert_to_tensor(a)
     b = _convert_to_tensor(b)
+    a, b = _match_layouts(a, b)
 
     return -torch.sqrt(torch.sum((a - b) ** 2, dim=-1)).to_dense()
 

--- a/sentence_transformers/util/similarity.py
+++ b/sentence_transformers/util/similarity.py
@@ -16,26 +16,12 @@ from .tensor import _convert_to_batch_tensor, _convert_to_tensor, normalize_embe
 logger = logging.get_logger(__name__)
 
 
-def _row_squared_norms(a: Tensor) -> Tensor:
-    """
-    Computes the row-wise sum of squares for either a sparse or a dense tensor.
-
-    Args:
-        a (Tensor): A 2-dimensional sparse or dense tensor.
-
-    Returns:
-        Tensor: Dense vector with res[i] = sum(a[i] ** 2)
-    """
-    if a.is_sparse:
-        return torch.sparse.sum(a * a, dim=1).to_dense()
-    return (a * a).sum(dim=1)
-
-
 def _match_layouts(a: Tensor, b: Tensor) -> tuple[Tensor, Tensor]:
     """
-    Densifies the sparse tensor if exactly one of the two inputs is sparse, as element-wise operations require both
-    operands to share a layout. Both inputs have the same shape here, so the dense one already accounts for the
-    memory that densifying the other one takes.
+    Converts the dense tensor to sparse COO if exactly one of the two inputs is sparse, so that mixed inputs can
+    reuse the all-sparse computations. The lone dense operand in such a mix typically still holds mostly zeros
+    (e.g. sparse embeddings encoded with ``convert_to_sparse_tensor=False``), making the conversion cheap, whereas
+    densifying the sparse operand would allocate a second full-size dense tensor.
 
     Args:
         a (Tensor): The first tensor.
@@ -45,9 +31,9 @@ def _match_layouts(a: Tensor, b: Tensor) -> tuple[Tensor, Tensor]:
         tuple[Tensor, Tensor]: The two tensors, using the same layout.
     """
     if a.is_sparse and not b.is_sparse:
-        return a.to_dense(), b
+        return a, b.to_sparse()
     if b.is_sparse and not a.is_sparse:
-        return a, b.to_dense()
+        return a.to_sparse(), b
     return a, b
 
 
@@ -159,8 +145,9 @@ def manhattan_sim(a: list | np.ndarray | Tensor, b: list | np.ndarray | Tensor) 
     if a.is_sparse or b.is_sparse:
         logger.warning_once("Using scipy for sparse Manhattan similarity computation.")
 
-        a_coo = to_scipy_coo(a if a.is_sparse else a.to_sparse())
-        b_coo = to_scipy_coo(b if b.is_sparse else b.to_sparse())
+        a, b = _match_layouts(a, b)
+        a_coo = to_scipy_coo(a)
+        b_coo = to_scipy_coo(b)
         dist = pairwise_distances(a_coo, b_coo, metric="manhattan")
         return torch.from_numpy(-dist).float().to(a.device).to_dense()
 
@@ -202,8 +189,9 @@ def euclidean_sim(a: list | np.ndarray | Tensor, b: list | np.ndarray | Tensor) 
     b = _convert_to_batch_tensor(b)
 
     if a.is_sparse or b.is_sparse:
-        a_norm_sq = _row_squared_norms(a).unsqueeze(1)  # Shape (N, 1)
-        b_norm_sq = _row_squared_norms(b).unsqueeze(0)  # Shape (1, M)
+        a, b = _match_layouts(a, b)
+        a_norm_sq = torch.sparse.sum(a * a, dim=1).to_dense().unsqueeze(1)  # Shape (N, 1)
+        b_norm_sq = torch.sparse.sum(b * b, dim=1).to_dense().unsqueeze(0)  # Shape (1, M)
         dot_product = torch.matmul(a, b.t()).to_dense()  # Shape (N, M)
 
         # Calculate squared distance
@@ -247,10 +235,12 @@ def pairwise_angle_sim(x: Tensor, y: Tensor) -> Tensor:
     Returns:
         Tensor: Vector with res[i] = angle_sim(a[i], b[i])
     """
-    if x.is_sparse:
+    if x.is_sparse or y.is_sparse:
         logger.warning_once("Pairwise angle similarity does not support sparse tensors. Converting to dense.")
-        x = x.coalesce().to_dense()
-        y = y.coalesce().to_dense()
+        if x.is_sparse:
+            x = x.to_dense()
+        if y.is_sparse:
+            y = y.to_dense()
 
     x = _convert_to_tensor(x)
     y = _convert_to_tensor(y)

--- a/tests/util/test_similarity.py
+++ b/tests/util/test_similarity.py
@@ -275,6 +275,21 @@ def test_similarity_mixed_sparse_dense(sparse_tensors, similarity_fn, pairwise_s
     assert torch.allclose(pairwise_mixed, pairwise_dense, rtol=1e-5, atol=1e-5)
 
 
+@pytest.mark.parametrize("sparse_first", [True, False])
+def test_pairwise_angle_sim_mixed_sparse_dense(sparse_tensors, sparse_first) -> None:
+    """Test that mixing a sparse and a dense operand matches the all-dense result."""
+    tensor1, tensor2 = sparse_tensors
+
+    dense1 = tensor1.to_dense()
+    dense2 = tensor2.to_dense()
+
+    x, y = (tensor1, dense2) if sparse_first else (dense1, tensor2)
+
+    sim_mixed = pairwise_angle_sim(x, y)
+    sim_dense = pairwise_angle_sim(dense1, dense2)
+    assert torch.allclose(sim_mixed, sim_dense, rtol=1e-5, atol=1e-5)
+
+
 def test_pairwise_angle_sim_even_and_odd_sparse_embeddings(splade_bert_tiny_model: SparseEncoder) -> None:
     """Ensure pairwise_angle_sim works for even and artificially odd dims."""
 

--- a/tests/util/test_similarity.py
+++ b/tests/util/test_similarity.py
@@ -247,6 +247,34 @@ def test_pairwise_euclidean_sim_sparse(sparse_tensors):
     assert torch.allclose(sim_sparse, sim_dense, rtol=1e-5, atol=1e-5)
 
 
+@pytest.mark.parametrize(
+    ("similarity_fn", "pairwise_similarity_fn"),
+    [
+        (cos_sim, pairwise_cos_sim),
+        (dot_score, pairwise_dot_score),
+        (manhattan_sim, pairwise_manhattan_sim),
+        (euclidean_sim, pairwise_euclidean_sim),
+    ],
+)
+@pytest.mark.parametrize("sparse_first", [True, False])
+def test_similarity_mixed_sparse_dense(sparse_tensors, similarity_fn, pairwise_similarity_fn, sparse_first) -> None:
+    """Test that mixing a sparse and a dense operand matches the all-dense result."""
+    tensor1, tensor2 = sparse_tensors
+
+    dense1 = tensor1.to_dense()
+    dense2 = tensor2.to_dense()
+
+    a, b = (tensor1, dense2) if sparse_first else (dense1, tensor2)
+
+    sim_mixed = similarity_fn(a, b)
+    sim_dense = similarity_fn(dense1, dense2)
+    assert torch.allclose(sim_mixed, sim_dense, rtol=1e-5, atol=1e-5)
+
+    pairwise_mixed = pairwise_similarity_fn(a, b)
+    pairwise_dense = pairwise_similarity_fn(dense1, dense2)
+    assert torch.allclose(pairwise_mixed, pairwise_dense, rtol=1e-5, atol=1e-5)
+
+
 def test_pairwise_angle_sim_even_and_odd_sparse_embeddings(splade_bert_tiny_model: SparseEncoder) -> None:
     """Ensure pairwise_angle_sim works for even and artificially odd dims."""
 


### PR DESCRIPTION
`euclidean_sim` and `manhattan_sim` (and their pairwise variants) raise when one operand is sparse and the other is dense, while `cos_sim` and `dot_score` handle that combination fine. `SparseEncoder` documents `similarity_fn_name` as `Literal["cosine", "dot", "euclidean", "manhattan"]` and `encode` exposes `convert_to_sparse_tensor=False`, so mixing the two representations is reachable from public API:

```python
from sentence_transformers import SparseEncoder

model = SparseEncoder("sparse-encoder-testing/splade-bert-tiny-nq")
query = model.encode_query(["What is the capital of France?"])
docs = model.encode_document(["Paris is the capital of France.", "Berlin is the capital of Germany."],
                             convert_to_sparse_tensor=False)

model.similarity_fn_name = "euclidean"
model.similarity(query, docs)   # NotImplementedError: Could not run 'aten::_indices' ...
model.similarity_fn_name = "manhattan"
model.similarity(query, docs)   # RuntimeError: coalesce expected sparse coordinate tensor layout but got Strided
```

Three separate causes:

- `manhattan_sim` enters its sparse branch when *either* input is sparse, but then calls `to_scipy_coo` on both, which requires a COO tensor.
- `euclidean_sim` only checks `a.is_sparse`. With a dense `a` and sparse `b` it falls through to `torch.cdist`, which has no sparse kernel; with a sparse `a` and dense `b` its `torch.sparse.sum(b * b, ...)` gets a strided tensor.
- `pairwise_manhattan_sim` and `pairwise_euclidean_sim` compute `a - b`, and subtraction between a sparse and a dense operand is unsupported.

The fix keeps every existing path byte-for-byte and only handles the mixed case: `manhattan_sim` sparsifies whichever operand is dense before converting to SciPy, `euclidean_sim` computes its row norms through a small layout-agnostic helper and now tests both operands, and the two pairwise functions densify the sparse side. For the pairwise ones both inputs have the same shape, so the dense operand already accounts for that memory; the matrix versions keep their sparse paths so an (N, D) x (M, D) comparison is never densified.

Verified on the model above: `euclidean` and `manhattan` now return `[-2.8787, -5.6926]` and `[-18.4137, -43.7693]` for both sparse/sparse and sparse/dense, matching what the all-sparse path already returned.

## Tests

`test_similarity_mixed_sparse_dense` is parametrized over the four metrics and both mixed orders, asserting the mixed result matches the all-dense result for the matrix and pairwise form. It fails on `main` for euclidean and manhattan in both orders (4 failed, 4 passed) and passes with this change.

```sh
pytest tests/util/test_similarity.py
# 25 passed

pytest tests/util/ tests/sparse_encoder/test_model.py tests/sparse_encoder/losses/test_sparse_cosent.py \
       tests/sentence_transformer/evaluation/test_binary_classification_evaluator.py \
       tests/sentence_transformer/evaluation/test_information_retrieval_evaluator.py
# 968 passed, 36 skipped   (960 passed, 36 skipped on main — the 8 new cases are the only difference)

pre-commit run --files sentence_transformers/util/similarity.py tests/util/test_similarity.py
# ruff check / ruff format / typos all Passed
```

I ran the tests that touch these functions rather than the whole suite, since the full run pulls a lot of models. Everything here was on CPU; I have no GPU to check the CUDA paths.
