### PR TITLE
[fix] Keep queries aligned in semantic_search_seismic when a query matches nothing

### DIFF
--- a/sentence_transformers/sparse_encoder/search_engines.py
+++ b/sentence_transformers/sparse_encoder/search_engines.py
@@ -299,15 +299,12 @@ def semantic_search_elasticsearch(
 def semantic_search_seismic(
     query_embeddings_decoded: list[list[tuple[str, float]]],
     corpus_embeddings_decoded: list[list[tuple[str, float]]] | None = None,
-    corpus_index: tuple[SeismicIndex, str] | None = None,
+    corpus_index: SeismicIndex | None = None,
     top_k: int = 10,
     output_index: bool = False,
     index_kwargs: dict[str, Any] | None = None,
     search_kwargs: dict[str, Any] | None = None,
-) -> (
-    tuple[list[list[dict[str, int | float]]], float]
-    | tuple[list[list[dict[str, int | float]]], float, tuple[SeismicIndex, str]]
-):
+) -> tuple[list[list[dict[str, int | float]]], float] | tuple[list[list[dict[str, int | float]]], float, SeismicIndex]:
     """
     Performs semantic search using sparse embeddings with Seismic.
 
@@ -322,10 +319,10 @@ def semantic_search_seismic(
         corpus_embeddings_decoded: List of corpus embeddings in format [[("token": value), ...], ...]
             Only used if corpus_index is None
             Can be obtained using the same decode method as query embeddings
-        corpus_index: Tuple of (SeismicIndex, collection_name)
+        corpus_index: An existing SeismicIndex
             If provided, uses this existing index for search
         top_k: Number of top results to retrieve
-        output_index: Whether to return the SeismicIndex client and collection name
+        output_index: Whether to return the SeismicIndex
         index_kwargs: Additional arguments for SeismicIndex passed to build_from_dataset,
             such as centroid_fraction, min_cluster_size, summary_energy, nknn, knn_path,
             batched_indexing, or num_threads.
@@ -336,7 +333,7 @@ def semantic_search_seismic(
         A tuple containing:
         - List of search results in format [[{"corpus_id": int, "score": float}, ...], ...]
         - Time taken for search
-        - (Optional) Tuple of (SeismicIndex, collection_name) if output_index is True
+        - (Optional) The SeismicIndex if output_index is True
     """
     try:
         from seismic import SeismicDataset, SeismicIndex, get_seismic_string
@@ -408,14 +405,16 @@ def semantic_search_seismic(
         **search_kwargs,
     )
 
-    # Sort the results by query index
-    results = sorted(results, key=lambda x: int(x[0][0]))
-
-    # Format results
-    all_results = [
-        [{"corpus_id": int(corpus_id), "score": score} for query_idx, score, corpus_id in query_result]
-        for query_result in results
-    ]
+    # Seismic returns the queries out of order, and a query that matches no document comes back as an empty
+    # list that carries no query id, so each result is placed by the query id inside it rather than sorted.
+    all_results = [[] for _ in range(num_queries)]
+    for query_result in results:
+        if not query_result:
+            continue
+        query_idx = int(query_result[0][0])
+        all_results[query_idx] = [
+            {"corpus_id": int(corpus_id), "score": score} for _, score, corpus_id in query_result
+        ]
 
     search_time = time.time() - search_start_time
 

--- a/tests/sparse_encoder/test_search_engines.py
+++ b/tests/sparse_encoder/test_search_engines.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+from sentence_transformers.sparse_encoder.search_engines import semantic_search_seismic
+
+
+class StubSeismicIndex:
+    """Returns what Seismic returns: one row per query, in arbitrary order, empty rows for misses."""
+
+    def __init__(self, rows):
+        self.rows = rows
+
+    def batch_search(self, **kwargs):
+        return self.rows
+
+
+@pytest.fixture
+def stub_seismic_module(monkeypatch):
+    """Seismic is not a test dependency, so stand in for the import that the function performs."""
+    module = types.ModuleType("seismic")
+    module.SeismicDataset = object
+    module.SeismicIndex = StubSeismicIndex
+    module.get_seismic_string = lambda: "U30"
+    monkeypatch.setitem(sys.modules, "seismic", module)
+
+
+def test_seismic_query_without_matches(stub_seismic_module) -> None:
+    """A query that matches no document comes back as an empty row that carries no query id."""
+    # Seismic hands back the rows for queries 2, <none> and 0, in that order.
+    rows = [
+        [("2", 0.9, "2"), ("2", 0.6, "3")],
+        [],
+        [("0", 0.8, "0"), ("0", 0.7, "1")],
+    ]
+    queries = [[("fruit", 1.0)], [("nomatch", 1.0)], [("veg", 1.0)]]
+
+    results, _ = semantic_search_seismic(queries, corpus_index=StubSeismicIndex(rows), top_k=2)
+
+    assert results == [
+        [{"corpus_id": 0, "score": 0.8}, {"corpus_id": 1, "score": 0.7}],
+        [],
+        [{"corpus_id": 2, "score": 0.9}, {"corpus_id": 3, "score": 0.6}],
+    ]
+
+
+def test_seismic_orders_results_by_query(stub_seismic_module) -> None:
+    """Every row carries its query id, so out-of-order rows still land on the right query."""
+    rows = [
+        [("1", 0.5, "7")],
+        [("0", 0.4, "9")],
+    ]
+    queries = [[("a", 1.0)], [("b", 1.0)]]
+
+    results, _ = semantic_search_seismic(queries, corpus_index=StubSeismicIndex(rows), top_k=1)
+
+    assert results == [[{"corpus_id": 9, "score": 0.4}], [{"corpus_id": 7, "score": 0.5}]]
+
+
+def test_seismic_all_queries_without_matches(stub_seismic_module) -> None:
+    """With no query matching anything there is no id to order by at all."""
+    queries = [[("a", 1.0)], [("b", 1.0)]]
+
+    results, _ = semantic_search_seismic(queries, corpus_index=StubSeismicIndex([[], []]), top_k=3)
+
+    assert results == [[], []]


### PR DESCRIPTION
## Summary

`semantic_search_seismic` raises `IndexError` when a query matches no document:

```python
semantic_search_seismic(
    [[("fruit", 1.0)], [("nomatch", 1.0)], [("veg", 1.0)]],
    corpus_embeddings_decoded=corpus,
    top_k=2,
)
# IndexError: list index out of range   (search_engines.py:412)
```

Seismic returns the queries out of order, so the results were sorted with `sorted(results, key=lambda x: int(x[0][0]))`. A query that matches nothing comes back as an empty list, and an empty list carries no query id, so there is nothing to sort it by. Each row is now placed by the query id it already contains, which drops the sort and keeps empty results in the right position instead of shifting the other queries.

I also corrected the `corpus_index` type hint and docstring. They describe a `tuple[SeismicIndex, str]`, but the function builds, uses and returns a bare `SeismicIndex`, so passing the documented tuple raises `AttributeError: 'tuple' object has no attribute 'batch_search'`. Worth noting the other three engines here really do use `(client, name)` tuples, so if you would rather Seismic match them I am happy to change the code instead of the docstring.

## Notes

- Not a behaviour change: every input that returned results before returns identical results now, only the crashing cases differ. Checked against real `pyseismic-lsr` on single/multiple queries, all-empty results, and `top_k` larger than the corpus.
- The tests stub `batch_search` rather than requiring Seismic, since it is not a test dependency. The stubbed rows use the shape a real index returns, including the out-of-order rows.
- `tests/sparse_encoder/` passes (361 passed, 4 skipped), `ruff check` and `ruff format --check` are clean.

Heads up, this PR was AI-assisted and human-reviewed.
