### PR TITLE
[fix] Treat a 1-dimensional query embedding as a single query in semantic_search_qdrant

### DIFF
--- a/sentence_transformers/sparse_encoder/search_engines.py
+++ b/sentence_transformers/sparse_encoder/search_engines.py
@@ -68,8 +68,6 @@ def semantic_search_qdrant(
     if not query_embeddings.is_sparse or query_embeddings.layout != torch.sparse_coo:
         raise ValueError("Query embeddings must be a sparse COO tensor")
 
-    # Encoding a single query returns a 1-dimensional tensor, whose size(0) is the vocabulary rather
-    # than the number of queries. Promoting it to a batch of one keeps the loop below over queries.
     if query_embeddings.ndim == 1:
         query_embeddings = query_embeddings.unsqueeze(0)
 
@@ -132,11 +130,14 @@ def semantic_search_qdrant(
     search_start_time = time.time()
 
     # Process each query
+    query_embeddings = query_embeddings.coalesce()
+    query_indices = query_embeddings.indices().cpu().numpy()
+    query_values = query_embeddings.values().cpu().numpy()
     for q_idx in range(query_embeddings.size(0)):
         # Extract query vector
-        mask = query_embeddings.coalesce().indices()[0].cpu().numpy() == q_idx
-        q_indices = query_embeddings.coalesce().indices()[1][mask].cpu().numpy().tolist()
-        q_values = query_embeddings.coalesce().values()[mask].cpu().numpy().tolist()
+        mask = query_indices[0] == q_idx
+        q_indices = query_indices[1][mask].tolist()
+        q_values = query_values[mask].tolist()
 
         # Perform search
         search_results = client.query_points(

--- a/sentence_transformers/sparse_encoder/search_engines.py
+++ b/sentence_transformers/sparse_encoder/search_engines.py
@@ -68,6 +68,11 @@ def semantic_search_qdrant(
     if not query_embeddings.is_sparse or query_embeddings.layout != torch.sparse_coo:
         raise ValueError("Query embeddings must be a sparse COO tensor")
 
+    # Encoding a single query returns a 1-dimensional tensor, whose size(0) is the vocabulary rather
+    # than the number of queries. Promoting it to a batch of one keeps the loop below over queries.
+    if query_embeddings.ndim == 1:
+        query_embeddings = query_embeddings.unsqueeze(0)
+
     if corpus_index is None:
         if corpus_embeddings is None:
             raise ValueError("Either corpus_embeddings or corpus_index must be provided")
@@ -129,13 +134,9 @@ def semantic_search_qdrant(
     # Process each query
     for q_idx in range(query_embeddings.size(0)):
         # Extract query vector
-        if query_embeddings.sparse_dim() == 1:
-            q_indices = query_embeddings.coalesce().indices()[0].cpu().numpy().tolist()
-            q_values = query_embeddings.coalesce().values().cpu().numpy().tolist()
-        else:
-            mask = query_embeddings.coalesce().indices()[0].cpu().numpy() == q_idx
-            q_indices = query_embeddings.coalesce().indices()[1][mask].cpu().numpy().tolist()
-            q_values = query_embeddings.coalesce().values()[mask].cpu().numpy().tolist()
+        mask = query_embeddings.coalesce().indices()[0].cpu().numpy() == q_idx
+        q_indices = query_embeddings.coalesce().indices()[1][mask].cpu().numpy().tolist()
+        q_values = query_embeddings.coalesce().values()[mask].cpu().numpy().tolist()
 
         # Perform search
         search_results = client.query_points(

--- a/sentence_transformers/sparse_encoder/search_engines.py
+++ b/sentence_transformers/sparse_encoder/search_engines.py
@@ -70,6 +70,8 @@ def semantic_search_qdrant(
 
     if query_embeddings.ndim == 1:
         query_embeddings = query_embeddings.unsqueeze(0)
+    elif query_embeddings.ndim != 2:
+        raise ValueError(f"Query embeddings must be a 1D or 2D sparse tensor, got {query_embeddings.ndim}D")
 
     if corpus_index is None:
         if corpus_embeddings is None:

--- a/tests/sparse_encoder/test_search_engines.py
+++ b/tests/sparse_encoder/test_search_engines.py
@@ -142,6 +142,15 @@ def test_qdrant_batch_of_queries(stub_qdrant_module) -> None:
     assert client.searched == [([3, 8], [0.5, 0.25]), ([5], [0.75])]
 
 
+def test_qdrant_rejects_3d_query_embeddings(stub_qdrant_module) -> None:
+    """A 3D tensor, like two stacked batches, must fail loudly rather than search with row ids as token ids."""
+    batch = torch.sparse_coo_tensor(torch.tensor([[0, 1], [3, 8]]), torch.tensor([0.5, 0.25]), (2, VOCAB_SIZE))
+    query = torch.stack([batch, batch])
+
+    with pytest.raises(ValueError, match="must be a 1D or 2D sparse tensor"):
+        semantic_search_qdrant(query, corpus_index=(StubQdrantClient(), "collection"), top_k=1)
+
+
 def test_qdrant_single_query_searches_same_vector_as_batch_of_one(stub_qdrant_module) -> None:
     """The promoted 1-dimensional tensor must search for the same vector as an explicit batch of one."""
     indices = torch.tensor([3, 8])

--- a/tests/sparse_encoder/test_search_engines.py
+++ b/tests/sparse_encoder/test_search_engines.py
@@ -4,8 +4,9 @@ import sys
 import types
 
 import pytest
+import torch
 
-from sentence_transformers.sparse_encoder.search_engines import semantic_search_seismic
+from sentence_transformers.sparse_encoder.search_engines import semantic_search_qdrant, semantic_search_seismic
 
 
 class StubSeismicIndex:
@@ -67,3 +68,92 @@ def test_seismic_all_queries_without_matches(stub_seismic_module) -> None:
     results, _ = semantic_search_seismic(queries, corpus_index=StubSeismicIndex([[], []]), top_k=3)
 
     assert results == [[], []]
+
+
+VOCAB_SIZE = 100
+
+
+class StubSparseVector:
+    """Stands in for the Qdrant sparse vector, so a test can read back what was searched for."""
+
+    def __init__(self, indices=None, values=None):
+        self.indices = indices
+        self.values = values
+
+
+class StubHit:
+    def __init__(self, corpus_id, score):
+        self.id = corpus_id
+        self.score = score
+
+
+class StubResponse:
+    def __init__(self, points):
+        self.points = points
+
+
+class StubQdrantClient:
+    """Records the query vector of every search, and answers each one with the same single hit."""
+
+    def __init__(self, *args, **kwargs):
+        self.searched = []
+
+    def query_points(self, query, **kwargs):
+        self.searched.append((query.indices, query.values))
+        return StubResponse([StubHit(0, 1.0)])
+
+
+@pytest.fixture
+def stub_qdrant_module(monkeypatch):
+    """Qdrant is not a test dependency, so stand in for the imports that the function performs."""
+    module = types.ModuleType("qdrant_client")
+    module.QdrantClient = StubQdrantClient
+    http = types.ModuleType("qdrant_client.http")
+    models = types.ModuleType("qdrant_client.http.models")
+    models.SparseVector = StubSparseVector
+    http.models = models
+    module.http = http
+    monkeypatch.setitem(sys.modules, "qdrant_client", module)
+    monkeypatch.setitem(sys.modules, "qdrant_client.http", http)
+    monkeypatch.setitem(sys.modules, "qdrant_client.http.models", models)
+
+
+def test_qdrant_single_query_embedding(stub_qdrant_module) -> None:
+    """Encoding a single query gives a 1-dimensional tensor, whose size(0) is the vocabulary."""
+    query = torch.sparse_coo_tensor(torch.tensor([[3, 8]]), torch.tensor([0.5, 0.25]), (VOCAB_SIZE,)).coalesce()
+    client = StubQdrantClient()
+
+    results, _ = semantic_search_qdrant(query, corpus_index=(client, "collection"), top_k=1)
+
+    assert results == [[{"corpus_id": 0, "score": 1.0}]]
+    assert client.searched == [([3, 8], [0.5, 0.25])]
+
+
+def test_qdrant_batch_of_queries(stub_qdrant_module) -> None:
+    """A batch is searched once per query, each with only the tokens of that query."""
+    query = torch.sparse_coo_tensor(
+        torch.tensor([[0, 0, 1], [3, 8, 5]]), torch.tensor([0.5, 0.25, 0.75]), (2, VOCAB_SIZE)
+    ).coalesce()
+    client = StubQdrantClient()
+
+    results, _ = semantic_search_qdrant(query, corpus_index=(client, "collection"), top_k=1)
+
+    assert results == [[{"corpus_id": 0, "score": 1.0}], [{"corpus_id": 0, "score": 1.0}]]
+    assert client.searched == [([3, 8], [0.5, 0.25]), ([5], [0.75])]
+
+
+def test_qdrant_single_query_searches_same_vector_as_batch_of_one(stub_qdrant_module) -> None:
+    """The promoted 1-dimensional tensor must search for the same vector as an explicit batch of one."""
+    indices = torch.tensor([3, 8])
+    values = torch.tensor([0.5, 0.25])
+    single = torch.sparse_coo_tensor(indices.unsqueeze(0), values, (VOCAB_SIZE,)).coalesce()
+    batched = torch.sparse_coo_tensor(
+        torch.stack([torch.zeros_like(indices), indices]), values, (1, VOCAB_SIZE)
+    ).coalesce()
+
+    single_client = StubQdrantClient()
+    batched_client = StubQdrantClient()
+    semantic_search_qdrant(single, corpus_index=(single_client, "collection"), top_k=1)
+    semantic_search_qdrant(batched, corpus_index=(batched_client, "collection"), top_k=1)
+
+    assert single_client.searched == batched_client.searched


### PR DESCRIPTION
`semantic_search_qdrant` loops with `for q_idx in range(query_embeddings.size(0))`. Encoding a single query returns a 1-dimensional tensor, where `size(0)` is the vocabulary size rather than the number of queries, so the loop runs once per vocabulary entry.

With a 30522 token vocabulary that is 30522 searches against Qdrant for one query, and 30522 identical rows in the returned list instead of one. Nothing raises, so it surfaces as a very slow search and a result list of the wrong length.

```python
model = SparseEncoder("sparse-encoder-testing/splade-bert-tiny-nq")
corpus = model.encode_document(corpus_texts)

query = model.encode_query("what is the capital of france")  # 1-dimensional
results, _ = semantic_search_qdrant(query, corpus_embeddings=corpus, top_k=5)
len(results)  # 30522, expected 1
```

Passing `["what is the capital of france"]` gives a 2-dimensional tensor and works correctly, so this only affects the single query form.

The function already had a `sparse_dim() == 1` branch inside the loop to read a 1-dimensional tensor, so this input was expected, but the loop bound was never adjusted to match. This promotes the tensor to a batch of one right after the input validation, which is how `decode` and `sparsity` already handle 1-dimensional input, and drops the branch that is now unreachable.

The tests stub the Qdrant client the same way the Seismic tests stub Seismic, so they add no test dependency. They cover the single query, a batch of queries, and that the promoted tensor searches for the same vector as an explicit batch of one.
